### PR TITLE
MacOS X fixes

### DIFF
--- a/src/scripts/opam_mk_repo.ml
+++ b/src/scripts/opam_mk_repo.ml
@@ -75,8 +75,7 @@ let tmp_dir nv =
 
 let wget src =
   match Globals.os with
-  (* ftp cannot read https github tarball address *)
-  (*  | Globals.Darwin -> [ "ftp" ; src ] *)
+  | Globals.Darwin -> [ "curl"; "-OL"; src ]
   | _              -> [ "wget"; src ]
 
 let archive_name src =


### PR DESCRIPTION
This works with both HTTP/HTTPS, but will fail if the remote filename is blank (e.g. http://foo.com/).  This should never happen with tarball downloads.
