### PR TITLE
"opam config -env" now explicitly exports the variables it prints

### DIFF
--- a/src/client.ml
+++ b/src/client.ml
@@ -788,7 +788,7 @@ let get_env t =
 
 let print_env env =
   List.iter (fun (k,v) ->
-    Globals.msg "%s=%s\n" k v
+    Globals.msg "%s=%s; export %s;\n" k v k;
   ) env.new_env
 
 let rec proceed_tochange t nv_old nv =


### PR DESCRIPTION
Closes #47
