### PR TITLE
use rsync -a instead of cp -a, as its behaviour is more consistent across platforms

### DIFF
--- a/src/types.ml
+++ b/src/types.ml
@@ -196,7 +196,7 @@ end = struct
 
   let copy src dst =
     with_tmp_dir (fun tmp ->
-      let err = Run.command [ "cp"; "-a"; Filename.concat (to_string src) ""; to_string tmp ] in
+      let err = Run.command [ "rsync"; "-a"; Filename.concat (to_string src) "/"; to_string tmp ] in
       if err <> 0 then
         Globals.exit err;
       match list tmp with


### PR DESCRIPTION
Closes #77
