### PR TITLE
Extend "opam list" to make it able to list only packages that match one of the regexps provided as arguments

### DIFF
--- a/src/client.ml
+++ b/src/client.ml
@@ -704,9 +704,10 @@ let indent_right s nb =
 
 let s_not_installed = "--"
 
-let list print_short =
+let list print_short pkg_str =
   log "list";
   let t = load_state () in
+  let re = Re_perl.compile_pat ~opts:[`Caseless] pkg_str in
   (* Get all the installed packages *)
   let installed = File.Installed.read (Path.C.installed t.compiler) in
   let map, max_n, max_v =
@@ -736,16 +737,21 @@ let list print_short =
   in
   N.Map.iter (
     if print_short then
-      fun name _ -> Globals.msg "%s " (N.to_string name)
+      fun name _ -> 
+        let name = N.to_string name in
+        (if Re.execp re name 
+        then Globals.msg "%s " name)
     else
       fun name (version, description) ->
+        let name = N.to_string name in
         let version = match version with
           | None   -> s_not_installed
           | Some v -> V.to_string v in
-        Globals.msg "%s  %s  %s\n"
-          (indent_left (N.to_string name) max_n)
-          (indent_right version max_v)
-          description) map
+        (if Re.execp re name || Re.execp re description then
+            Globals.msg "%s  %s  %s\n"
+              (indent_left name max_n)
+              (indent_right version max_v)
+              description)) map
 
 let info package =
   log "info %s" (N.to_string package);
@@ -1882,8 +1888,8 @@ let switch clone alias ocaml_version =
 (** We protect each main functions with a lock depending on its access
 on some read/write data. *)
 
-let list print_short =
-  check (Read_only (fun () -> list print_short))
+let list print_short pkg_str =
+  check (Read_only (fun () -> list print_short pkg_str))
 
 let info package =
   check (Read_only (fun () -> info package))

--- a/src/client.mli
+++ b/src/client.mli
@@ -25,10 +25,8 @@ open Types
     - [cores] is the number of cores *)
 val init : repository -> Alias.t option -> OCaml_V.t option -> int -> unit
 
-(** Displays all available packages. 
-    If [bool] is [true], then we only display 
-    packages that are known to exist. *)
-val list : bool -> unit
+(** Displays all available packages that matches [string]. *)
+val list : bool -> string -> unit
 
 (** Displays a general summary of a package. *)
 val info : N.t -> unit

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -108,19 +108,22 @@ let init =
     | _ -> bad_argument "init" "Need a repository name and address")
 }
 
-(* opam list *)
+(* opam list [PACKAGE_REGEXP]* *)
 let list = 
   let short = ref false in
 {
   name     = "list";
-  usage    = "";
-  synopsis = "Display information about all available packages";
+  usage    = "[package-regexp]*";
+  synopsis = "Display information about all available packages that match package-regexp, or all available packages if no regexp is provided";
   help     = "";
   specs    = [
     ("-short", Arg.Set short, " Minimize the output by displaying only package name (installed and not installed)");
   ];
-  anon     = noanon "list";
-  main     = parse_args (fun _ -> Client.list !short);
+  anon;
+  main     = 
+    parse_args (function
+    | [] -> Client.list !short ""
+    | l  -> List.iter (fun name -> Client.list !short name) l)
 }
 
 (* opam info [PACKAGE] *)


### PR DESCRIPTION
Provides the "opam search" feature as an extended version of the opam list command. Now, opam list [package_rexexp]\* only returns the packages that match at least one of the regexps provided. The original behaviour of opam list is provided (equivalent of matching regexp "")
