### PR TITLE
Display an error on "opam installed|remove" when no package is specified

### DIFF
--- a/src/client.ml
+++ b/src/client.ml
@@ -86,7 +86,7 @@ let current_ocaml_version t =
   List.assoc alias aliases
 
 let confirm fmt =
-  Printf.kprintf (fun msg ->
+  Printf.ksprintf (fun msg ->
     Globals.msg "%s [Y/n] " msg;
     if not !Globals.yes then
       match read_line () with

--- a/src/file_format.ml
+++ b/src/file_format.ml
@@ -60,7 +60,7 @@ let sections items =
 exception Bad_format of string
 
 let bad_format fmt =
-  Printf.kprintf
+  Printf.ksprintf
     (fun str -> raise (Bad_format (Printf.sprintf "Bad format! %s" str)))
     fmt
 

--- a/src/globals.ml.in
+++ b/src/globals.ml.in
@@ -6,7 +6,7 @@
 (*  All rights reserved.  This file is distributed under the terms of  *)
 (*  the GNU Public License version 3.0.                                *)
 (*                                                                     *)
-(*  OPAM is distributed in the hope that it will be useful,            y*)
+(*  OPAM is distributed in the hope that it will be useful,            *)
 (*  but WITHOUT ANY WARRANTY; without even the implied warranty of     *)
 (*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the      *)
 (*  GNU General Public License for more details.                       *)
@@ -47,25 +47,25 @@ let default_opam_path = Filename.concat home ".opam"
 let root_path = ref default_opam_path
 
 let log section fmt =
-  Printf.kprintf (fun str ->
+  Printf.ksprintf (fun str ->
     if !debug then
       Printf.eprintf "[%d] %-20s %s\n%!" (Unix.getpid ()) section str
   ) fmt
 
 let error fmt =
-  Printf.kprintf (fun str ->
+  Printf.ksprintf (fun str ->
     Printf.eprintf "%s\n%!" str
   ) fmt
 
 let warning fmt =
-  Printf.kprintf (fun str ->
+  Printf.ksprintf (fun str ->
     Printf.eprintf "[WARNING] %s\n%!" str
   ) fmt
 
 exception Exit of int
   
 let error_and_exit fmt =
-  Printf.kprintf (fun str ->
+  Printf.ksprintf (fun str ->
     error "%s" str;
     raise (Exit 66)
   ) fmt
@@ -73,7 +73,7 @@ let error_and_exit fmt =
 let exit i = raise (Exit i)
 
 let msg fmt =
-  Printf.kprintf (fun str ->
+  Printf.ksprintf (fun str ->
     Printf.printf "%s%!" str
   ) fmt
 

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -38,7 +38,7 @@ let anon s =
 exception Bad of string * string
 
 let bad_argument cmd fmt =
-  Printf.kprintf (fun msg -> raise (Bad (cmd, msg))) fmt
+  Printf.ksprintf (fun msg -> raise (Bad (cmd, msg))) fmt
 
 let noanon cmd s =
   raise (Bad (cmd, s ^ " is not expected"))
@@ -239,8 +239,10 @@ let install = {
   specs    = [];
   anon;
   main     = parse_args (fun names ->
-    let names = List.map N.of_string names in
-    Client.install (N.Set.of_list names)
+    if names <> [] then
+      let names = List.map N.of_string names in
+      Client.install (N.Set.of_list names)
+    else Globals.error_and_exit "You need to specify at least one package to install."
   )
 }
 
@@ -324,8 +326,10 @@ let remove = {
   specs    = [];
   anon;
   main     = parse_args (fun names ->
-    let names = List.map N.of_string names in
-    Client.remove (N.Set.of_list names)
+    if names <> [] then
+      let names = List.map N.of_string names in
+      Client.remove (N.Set.of_list names)
+    else Globals.error_and_exit "You need to specify at least one package to remove."
   )
 }
 

--- a/src/run.ml
+++ b/src/run.ml
@@ -17,7 +17,7 @@ exception Process_error of Process.result
 exception Internal_error of string
 
 let internal_error fmt =
-  Printf.kprintf (fun str -> raise (Internal_error str)) fmt
+  Printf.ksprintf (fun str -> raise (Internal_error str)) fmt
 
 let process_error r =
   raise (Process_error r)


### PR DESCRIPTION
...so changed deprecated function kprintf into new version ksprintf in different files.
