### PR TITLE
Fix tarball/master URLs for opam switch

### DIFF
--- a/src/run.ml
+++ b/src/run.ml
@@ -278,7 +278,9 @@ module Tar = struct
 
   let extensions =
     [ [ "tar.gz" ; "tgz" ], 'z'
-    ; [ "tar.bz2" ; "tbz" ], 'j' ]
+    ; [ "tar.bz2" ; "tbz" ], 'j' 
+    ; [ "" ], 'z' 
+    ]
 
   let match_ext file ext =
     List.exists (Filename.check_suffix file) ext


### PR DESCRIPTION
This just tries a best-effort tar -z on such tarballs instead of immediately failing.
