### PR TITLE
Use "path" instead of "url" in the opam-pin manpage to avoid misleading ...

### DIFF
--- a/doc/man-src/opam-pin.md
+++ b/doc/man-src/opam-pin.md
@@ -10,7 +10,7 @@ opam-pin - Pin a package to a specific version
 
 *opam pin* \<package\> \<version\>
 
-*opam pin* \<package\> \<url\>
+*opam pin* \<package\> \<path\>
 
 *opam pin* \<package\> none
 
@@ -29,10 +29,10 @@ specific source path for installing and upgrading the package. Using
 \<version\>
 :   Pin the selected package to a specific version.
 
-\<url\>
-:   Use the specified url for installing or upgrading the package. This
+\<path\>
+:   Use the specified path for installing or upgrading the package. This
     means that from now on, *opam install* and *opam upgrade* will use the
-    specified url to install (respectively upgrade) the package.
+    specified path to install (respectively upgrade) the package.
 
 none
 :   Unpin the package, i.e. use the default sources and version for the

--- a/doc/man/opam-pin.1
+++ b/doc/man/opam-pin.1
@@ -6,7 +6,7 @@ opam-pin - Pin a package to a specific version
 .PP
 \f[I]opam pin\f[] <package> <version>
 .PP
-\f[I]opam pin\f[] <package> <url>
+\f[I]opam pin\f[] <package> <path>
 .PP
 \f[I]opam pin\f[] <package> none
 .SH DESCRIPTION
@@ -27,11 +27,11 @@ Pin the selected package to a specific version.
 .RS
 .RE
 .TP
-.B <url>
-Use the specified url for installing or upgrading the package.
+.B <path>
+Use the specified path for installing or upgrading the package.
 This means that from now on, \f[I]opam install\f[] and \f[I]opam
-upgrade\f[] will use the specified url to install (respectively upgrade)
-the package.
+upgrade\f[] will use the specified path to install (respectively
+upgrade) the package.
 .RS
 .RE
 .TP


### PR DESCRIPTION
...the user, opam pin works only with paths in the filesystem
