### PR TITLE
fix regex in autocomplete shell scripts

### DIFF
--- a/shell/opam_completion.sh
+++ b/shell/opam_completion.sh
@@ -13,7 +13,7 @@ _opam_global_options()
 _opam_commands()
 {
   local res
-  res="$( opam --help 2>/dev/null | grep '^  ' | sed 's/ *//;s/ .*//' | grep -v '^-' )"
+  res="$( opam --help 2>/dev/null | grep '^  [^ ]' | sed 's/ *//;s/ .*//' | grep -v '^-' )"
   _opam_add "$res"
 }
 

--- a/shell/opam_completion_zsh.sh
+++ b/shell/opam_completion_zsh.sh
@@ -13,7 +13,7 @@ _opam_global_options()
 _opam_commands()
 {
   local res
-  res="$( opam --help 2>/dev/null | grep '^  ' | sed 's/ *//;s/ .*//' | grep -v '^-' )"
+  res="$( opam --help 2>/dev/null | grep '^  [^ ]' | sed 's/ *//;s/ .*//' | grep -v '^-' )"
   _opam_add "$res"
 }
 


### PR DESCRIPTION
the regex was wrong in case of mutiline description (opam --help)
In the following, "(default" was considered as a subcommand in the shell autocomplete
<code>
$opam --help
  ....
  --makecmd        Set the 'make' program used when compiling packages
                  (default is make)
  ....
</code>
