### PR TITLE
the Jenkins scripts weren't initialising ocaml4 PATH early enough

### DIFF
--- a/jenkins/30-opam-packages.sh
+++ b/jenkins/30-opam-packages.sh
@@ -3,11 +3,24 @@ PREFIX=$1
 OPAM=$HOME/opam-bin/$PREFIX/bin/opam
 ROOT=`echo /x/${JOB_NAME} | sed -e "s,=,_,g" -e "s/,/-/g"`
 rm -rf ${ROOT}
+
+case "${compiler}" in
+system4)
+  export PATH=/x/ocaml-4.00.1/bin:$PATH
+  ;;
+esac
+
 $OPAM --yes --root $ROOT init $2
-if [ "${compiler}" != "system" ]; then
+$OPAM config -list-vars
+
+case "${compiler}" in
+system)
+  ;;
+system4)
+  ;;
+*)
   $OPAM --yes --root $ROOT switch ${compiler}
-fi
-if [ "${packages}" = "all" ]; then
-  packages=`$OPAM --root $ROOT list -short`
-fi
+  ;;
+esac
+
 $OPAM --verbose --yes --root $ROOT install ${packages}


### PR DESCRIPTION
...So the OPAM/config system-ocaml-version was incorrect.  The PATH was set to ocaml4 only after the init before.

For some reason, the detections of 'incorrect system ocaml version' was not output here. Is this because of the `--yes` flag?
