### PR TITLE
Add python-based unit tests

### DIFF
--- a/tests/README.unittest
+++ b/tests/README.unittest
@@ -1,0 +1,28 @@
+
+# to create a new unit test
+
+* clean the test repository : 
+
+      ./init-repo.sh -c
+
+* init the test repository : 
+
+      ./init-repo.sh -i
+
+* load a inital scenario (this command can be invoked multiple times): 
+
+      ./init-repo.sh -s 1
+      ./init-repo.sh -s 2
+
+* install/remove/upgrade : 
+
+    OPAM_ROOT=/tmp/OPAM.ROOT PATH=/tmp/OPAM.BIN:$PATH opam --yes --root /tmp/OPAM.ROOT install P4
+
+* crearte a new expected result file in as
+
+      OPAM_ROOT=/tmp/OPAM.ROOT PATH=/tmp/OPAM.BIN:$PATH \
+      opam --yes --root /tmp/OPAM.ROOT list > results/new-expected-result
+
+* Make sure that the result correct !
+
+* Add a new test case in the file tests.py

--- a/tests/init-repo.sh
+++ b/tests/init-repo.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+TEST_DIR=/tmp
+OPAM_ROOT=$TEST_DIR/OPAM.ROOT
+OPAM_REPO=$TEST_DIR/OPAM.REPO
+BIN=$TEST_DIR/OPAM.BIN
+REPO=test
+ 
+BINARIES=opam
+ 
+# opam in the path should not be a requirement
+ENV="OCAMLRUNPARAM=b OPAMDEBUG=2 OPAM_ROOT=$OPAM_ROOT PATH=$BIN:$PATH"
+ENV="OCAMLRUNPARAM=b OPAM_ROOT=$OPAM_ROOT PATH=$BIN:$PATH"
+OPAM="$ENV opam --yes --root $OPAM_ROOT"
+ 
+function binaries() {
+  mkdir -p $BIN
+  for bin in $BINARIES; do \
+    cp ../_obuild/$bin/$bin.asm $BIN/$bin ; \
+  done
+}
+
+function opam_clean() {
+  rm -rf $ARCHIVES
+  rm -rf $OPAM_ROOT $BIN
+  rm -rf $OPAM_REPO
+}
+
+function opam_init() {
+  mkdir -p $OPAM_REPO
+  binaries
+  eval $OPAM init -no-base-packages $REPO $OPAM_REPO -kind rsync
+}
+
+function opam_upload_stage1() {
+
+  cd packages
+  eval $OPAM upload -opam P1-1.opam -descr P1-1/README -archive P1-1.tar.gz -repo $REPO
+  eval $OPAM upload -opam P2.opam -descr P2/README -archive P2.tar.gz -repo $REPO
+  eval $OPAM upload -opam P3.opam -descr P3/README -archive P3.tar.gz -repo $REPO
+  eval $OPAM upload -opam P4-1.opam -descr P4/README -archive P4.tar.gz -repo $REPO
+  eval $OPAM upload -opam P5.opam -descr P5/README -archive P5.tar.gz -repo $REPO
+  cd -
+
+  cp compilers/* $OPAM_REPO/compilers/
+  # update the list of available packages with the one being updated
+  eval $OPAM update 
+}
+
+function opam_upload_stage2() {
+
+  cd packages
+  eval $OPAM upload -opam P1-2.opam -descr P1-2/README -archive P1-2.tar.gz -repo $REPO
+  eval $OPAM upload -opam P4-2.opam -descr P4/README -archive P4.tar.gz -repo $REPO
+  eval $OPAM upload -opam P4-3.opam -descr P4/README -archive P4.tar.gz -repo $REPO
+  cd -
+
+  # update the list of available packages with the one being updated
+  eval $OPAM update 
+}
+function usage() {
+DESCRIPTION="Opam unittest init functions"
+cat << EOF
+usage: $0 options
+ 
+$DESCRIPTION
+ 
+OPTIONS:
+   -h      Show this message
+   -v      Verbose
+   -d      Debug
+   -i      Init
+   -c      Clean
+EOF
+}
+ 
+VERBOSE=
+DEBUG=
+INIT=
+CLEAN=
+STAGE=
+
+while getopts "vhdcis:" flag
+do
+  case "$flag" in
+    d) set -x ; DEBUG=true;;
+    v) VERBOSE=true ;;
+    i) INIT=true ;;
+    s) STAGE=$OPTARG ;;
+    c) CLEAN=true ;;
+    h) usage ; exit 0 ;;
+  esac
+#  echo "$flag" $OPTIND $OPTARG
+done
+ 
+if [ -n "$INIT" ]; then
+  opam_clean
+  opam_init
+fi
+
+if [ -n "$STAGE" ]; then
+  if [ $STAGE = "1" ]; then
+    opam_upload_stage1
+  fi
+
+  if [ $STAGE = "2" ]; then
+    opam_upload_stage2
+  fi
+fi
+
+if [ -n "$CLEAN" ]; then
+  opam_clean
+fi
+
+exit 0
+
+

--- a/tests/results/README.tests
+++ b/tests/results/README.tests
@@ -1,0 +1,30 @@
+
+# All tests are performed in a clean repository
+
+Initial state of the repository
+
+    Available packages for system:
+    P1  --  A very useful package
+    P2  --  An other very useful package
+    P3  --  Testing version names
+    P4  --  Testing transitive closure
+    P5  --  Testing optional dependencies
+
+
+* install-P1
+  install P1 
+
+* install-P1-P2-P3-P4
+  install P1, P2, P3, P4
+
+* install-remove-P1
+  install P1 and then remove P1
+
+* install-upgrade-P2
+  install P4 and then upgrade P2
+
+* reinstall-P2
+  install P2 and the re-install P2
+
+* install_opt
+  install P5 , install P2, remove P5, remove P2, remove P1

--- a/tests/results/install-P1
+++ b/tests/results/install-P1
@@ -1,0 +1,6 @@
+Available packages for system:
+P1   1  A very useful package
+P2  --  An other very useful package
+P3  --  Testing version names
+P4  --  Testing transitive closure
+P5  --  Testing optional dependencies

--- a/tests/results/install-P1-P2-P3-P4
+++ b/tests/results/install-P1-P2-P3-P4
@@ -1,0 +1,6 @@
+Available packages for system:
+P1                     1  A very useful package
+P2                     1  An other very useful package
+P3  1~weird-version.test  Testing version names
+P4                     1  Testing transitive closure
+P5                    --  Testing optional dependencies

--- a/tests/results/install-opt
+++ b/tests/results/install-opt
@@ -1,0 +1,6 @@
+Available packages for system:
+P1  --  A very useful package
+P2  --  An other very useful package
+P3  --  Testing version names
+P4  --  Testing transitive closure
+P5  --  Testing optional dependencies

--- a/tests/results/install-remove-P1
+++ b/tests/results/install-remove-P1
@@ -1,0 +1,6 @@
+Available packages for system:
+P1  --  A very useful package
+P2  --  An other very useful package
+P3  --  Testing version names
+P4  --  Testing transitive closure
+P5  --  Testing optional dependencies

--- a/tests/results/install-upgrade-P2
+++ b/tests/results/install-upgrade-P2
@@ -1,0 +1,6 @@
+Available packages for system:
+P1                     1  A very useful package
+P2                     1  An other very useful package
+P3  1~weird-version.test  Testing version names
+P4                     1  Testing transitive closure
+P5                    --  Testing optional dependencies

--- a/tests/results/reinstall-P2
+++ b/tests/results/reinstall-P2
@@ -1,0 +1,6 @@
+Available packages for system:
+P1   1  A very useful package
+P2   1  An other very useful package
+P3  --  Testing version names
+P4  --  Testing transitive closure
+P5  --  Testing optional dependencies

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,0 +1,152 @@
+#!/usr/bin/python
+ 
+import unittest
+from subprocess import Popen, STDOUT, PIPE
+from subprocess import call
+import uuid
+import os,sys,time
+import argparse
+import difflib
+
+tmpdir = "/tmp/OPAM.UNITTEST"
+results = "results"
+opamcmd = "/tmp/OPAM.BIN/opam --yes --root /tmp/OPAM.ROOT"
+
+verbose=0
+FNULL=open(os.devnull, "w")
+
+def diff(fromfile,tofile,verbose=0):
+    fromdate = time.ctime(os.stat(fromfile).st_mtime)
+    todate = time.ctime(os.stat(tofile).st_mtime)
+    fromlines = open(fromfile, 'U').readlines()
+    tolines = open(tofile, 'U').readlines()
+
+    diff = difflib.unified_diff(fromlines, tolines, fromfile, tofile)#, fromdate, todate)
+    l = list(diff)
+
+    if l :
+        print "File Differences : "
+        print ''.join(l)
+        return False
+    else :
+        return True
+
+def opam(cmd, diffile=None,verbose=0):
+    # first we exectute the action, then
+    # we compare the output of list with
+    # the diffile
+    env = os.environ.copy()
+    env['PATH'] = ':'.join(['/tmp/OPAM.BIN',env['PATH']])
+    env['OPAM_ROOT'] = '/tmp/OPAM.ROOT'
+    cmd = opamcmd.split() + cmd
+    if verbose > 1 :
+        print "Env\nPATH=%s\nOPAM_ROOT=%s" % (env['PATH'],env['OPAM_ROOT'])
+        print "CMD=%s" % (' '.join(cmd))
+    if verbose <= 1 :
+        call(cmd, stdout=FNULL, env=env)
+    else :
+        call(cmd, env=env)
+
+    if diffile :
+        f = "%s/%s.opamtest" % (tmpdir,uuid.uuid1())
+        output = open(f,'w')
+
+        call(opamcmd.split() + ["list"], stdout=output, env=env)
+
+        output.close()
+        d = diff(f,diffile,verbose)
+        os.remove(f)
+        return d
+
+    return None
+
+def load_scenario(scenario,verbose=0):
+    if verbose > 0 :
+        print "Loading scenario %d" % scenario
+    if verbose <= 1 :
+        call(["./init-repo.sh", "-s", str(scenario)],stdout=FNULL)
+    else :
+        call(["./init-repo.sh", "-s", str(scenario)])
+
+class OpamTests(unittest.TestCase):
+
+    def setUp(self):
+        if verbose > 0 : print "\nsetting up repository"
+        call(["./init-repo.sh", "-i"], stdout=FNULL)
+        if not os.path.exists(tmpdir):
+            os.makedirs(tmpdir)
+
+    def tearDown(self):
+        if verbose > 0 : print "tearing down repository"
+        call(["./init-repo.sh", "-c"], stdout=FNULL)
+
+    def test_install(self):
+        load_scenario(1,verbose)
+        diffile="%s/install-P1" % results
+        d = opam(["install", "P1"],diffile,verbose)
+        self.assertTrue(d)
+
+    def test_install_many(self):
+        load_scenario(1,verbose)
+        diffile="%s/install-P1-P2-P3-P4" % results
+        opam(["install", "P1"])
+        opam(["install", "P2"])
+        opam(["install", "P3"])
+        d = opam(["install", "P4"], diffile,verbose)
+        self.assertTrue(d)
+
+    def test_remove(self):
+        load_scenario(1,verbose)
+        diffile="%s/install-remove-P1" % results
+        opam(["install", "P1"])
+        d = opam(["remove", "P1"],diffile,verbose)
+        self.assertTrue(d)
+
+    def test_upgrade(self):
+        load_scenario(1,verbose)
+        diffile="%s/install-upgrade-P2" % results
+        opam(["install", "P4"])
+        d = opam(["upgrade", "P2"],diffile,verbose)
+        self.assertTrue(d)
+
+#    @unittest.skip("skipping")
+    def test_reinstall(self):
+        load_scenario(1,verbose)
+        diffile="%s/reinstall-P2" % results
+        opam(["install", "P2"])
+        d = opam(["reinstall", "P2"],diffile,verbose)
+        self.assertTrue(d)
+
+    def test_install_opt(self):
+        load_scenario(1,verbose)
+        load_scenario(2,verbose)
+        diffile="%s/install-opt" % results
+        opam(["install", "P5"])
+        opam(["install", "P2"])
+        opam(["remove", "P5"])
+        opam(["remove", "P2"])
+        d = opam(["remove", "P1"],diffile,verbose)
+        self.assertTrue(d)
+
+def main():
+    global verbose
+
+    parser = argparse.ArgumentParser(description='description of you program')
+    parser.add_argument('-v', '--verbose', action='store_true')
+    parser.add_argument('-d', '--debug', action='store_true')
+    args = parser.parse_args()
+
+    verbosity=0
+    if args.verbose == True :
+        verbose = 1
+        verbosity=2
+
+    if args.debug == True :
+        verbose = 2
+
+    suite = unittest.TestLoader().loadTestsFromTestCase(OpamTests)
+    unittest.TextTestRunner(verbosity=verbosity).run(suite)
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
This path adds a python based unit test framework for opam. 

I've added few simple tests based on the existing makefile.
Extending it with new test should be easy in less error prone
then writing a makefile.

All tests are run in a clean environment. The unit test can be
run in silent mode, verbose or with a lot of debugging information.
