### PR TITLE
Make judicious use of U+1F42B on darwin.

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -380,7 +380,11 @@ let remove_all_packages t ~update_metadata sol =
    error traces, and let the repo in a state that the user can
    explore.  Do not try to recover yet. *)
 let build_and_install_package_aux t ~update_metadata nv =
-  OpamGlobals.msg "\n=-=-= Installing %s =-=-=\n" (OpamPackage.to_string nv);
+  let left, right = match !OpamGlobals.utf8_msgs with
+  | true -> "\xF0\x9F\x90\xAB " (* UTF-8 <U+1F42B, U+0020> *), ""
+  | false -> "=-=-=", "=-=-="
+  in
+  OpamGlobals.msg "\n%s Installing %s %s\n" left (OpamPackage.to_string nv) right;
 
   let opam = OpamState.opam t nv in
 

--- a/src/core/opamGlobals.ml
+++ b/src/core/opamGlobals.ml
@@ -40,6 +40,7 @@ let build_doc        = check "BUILDDOC"
 let dryrun           = check "DRYRUN"
 let fake             = check "FAKE"
 let print_stats      = check "STATS"
+let utf8_msgs        = check "UTF8MSGS"
 
 let cudf_file = ref (None: string option)
 let aspcud_criteria =


### PR DESCRIPTION
Only tested on osx 10.8, maybe 10.7 has the glyph. Before is hopless,
at best unassigned code point glyph at worse garbage. Also it assumes
an UTF-8 terminal. Well... if rejected, just an opportunity to plug the code point
beyond uucd's docs.

![opam-bactrian-log](https://f.cloud.github.com/assets/485596/77900/1aa48722-6161-11e2-8ebd-db4e4aa293a0.png)
