### PR TITLE
truncate `opam list` output w.r.t. the size of the current terminal

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -352,17 +352,20 @@ let list ~print_short ~installed_only ?(name_only = true) ?(case_sensitive = fal
     ) names (0,0) in
   OpamPackage.Name.Map.iter (
     if print_short then
-      fun name _ -> OpamGlobals.msg "%s " (OpamPackage.Name.to_string name)
+      fun name _ -> Printf.printf "%s " (OpamPackage.Name.to_string name)
     else
+      let synop_len =
+        let col = OpamMisc.terminal_columns () in
+        max 0 (col - max_n - max_v - 4) in
       fun name (version, synopsis, _) ->
         let name = OpamPackage.Name.to_string name in
         let version = match version with
           | None   -> s_not_installed
           | Some v -> OpamPackage.Version.to_string v in
-        OpamGlobals.msg "%s  %s  %s\n"
+        Printf.printf "%s  %s  %s\n"
           (OpamMisc.indent_left name max_n)
           (OpamMisc.indent_right version max_v)
-          (OpamMisc.sub_at 100 synopsis)
+          (OpamMisc.sub_at synop_len synopsis)
   ) names
 
 let info ~fields regexps =

--- a/src/core/opamMisc.mli
+++ b/src/core/opamMisc.mli
@@ -196,3 +196,7 @@ module OP: sig
   val finally: (unit -> 'a) -> (unit -> unit) -> 'a
 
 end
+
+(** When [stdout] refers to a terminal, query the number of columns.
+    Otherwise return [max_int]. *)
+val terminal_columns : unit -> int


### PR DESCRIPTION
I find that the output of `opam list` isn't very legible: many descriptions are quite long and end up being wrapped in the terminal.

This patch tries to truncate the descriptions to adjust them to the terminal size. I wasn't too sure about the best way to obtain the terminal size ; rather than add C bindings, I simply use external commands. It seems to work fine on linux but no idea how it fares on OS X :)
