### PR TITLE
Teach opamGlobal and opamSystem.patch about NetBSD and DragonFlyBSD

### DIFF
--- a/src/core/opamGlobals.ml
+++ b/src/core/opamGlobals.ml
@@ -108,6 +108,8 @@ type os =
   | Linux
   | FreeBSD
   | OpenBSD
+  | NetBSD
+  | DragonFly
   | Cygwin
   | Win32
   | Unix
@@ -125,6 +127,8 @@ let os () =
           | Some "Linux"   -> Linux
           | Some "FreeBSD" -> FreeBSD
           | Some "OpenBSD" -> OpenBSD
+          | Some "NetBSD" -> NetBSD
+          | Some "DragonFly" -> DragonFly
           | _              -> Unix
         end
       | "Win32"  -> Win32
@@ -138,7 +142,9 @@ let string_of_os = function
   | Darwin  -> "darwin"
   | Linux   -> "linux"
   | FreeBSD
-  | OpenBSD -> "bsd"
+  | OpenBSD
+  | NetBSD
+  | DragonFly -> "bsd"
   | Cygwin  -> "cygwin"
   | Win32   -> "win32"
   | Unix    -> "unix"
@@ -150,7 +156,9 @@ let os_string () =
 let makecmd = ref (fun () ->
   match os () with
   | FreeBSD
-  | OpenBSD -> "gmake"
+  | OpenBSD
+  | NetBSD
+  | DragonFly -> "gmake"
   | _ -> "make"
 )
 

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -483,7 +483,7 @@ let patch p =
     let opts = if dryrun then
         let open OpamGlobals in
         match OpamGlobals.os () with
-        | FreeBSD | OpenBSD     -> [ "-t"; "-C" ]
+        | FreeBSD | OpenBSD | NetBSD | DragonFly -> [ "-t"; "-C" ]
         | Unix | Linux | Darwin -> [ "--dry-run" ]
         | Win32 | Cygwin (* this is probably broken *)
         | Other _               -> [ "--dry-run" ]


### PR DESCRIPTION
This commit teach opamGlobal about NetBSD and DragonFlyBSD system, and let opam use a correct make version by default on these systems, and the right arguments to patch(1).
