### PR TITLE
fix repeated make distclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include Makefile.config
+-include Makefile.config
 
 LOCAL_OCPBUILD=./ocp-build/ocp-build
 OCPBUILD ?= $(LOCAL_OCPBUILD)


### PR DESCRIPTION
The `Makefile.config` include can be conditional.
