### PR TITLE
do not delete .opam/$SWITCH when installing 'opam switch install $SWITCH' and 'preinstalled' is true

### DIFF
--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -1307,12 +1307,15 @@ let install_compiler t ~quiet switch compiler =
       (OpamCompiler.to_string compiler);
     OpamGlobals.exit 0;
   );
+  let comp = OpamFile.Comp.read comp_f in
 
   let switch_dir = OpamPath.Switch.root t.root switch in
 
   (* Do some clean-up if necessary *)
-  if not (OpamSwitch.Map.mem switch t.aliases) && OpamFilename.exists_dir switch_dir then
-    OpamFilename.rmdir switch_dir;
+  if not OpamSwitch.Map.mem switch t.aliases
+  && not (OpamFile.Comp.preinstalled comp)
+  && OpamFilename.exists_dir switch_dir
+  then OpamFilename.rmdir switch_dir;
 
   if OpamFilename.exists_dir switch_dir then (
     OpamGlobals.msg "The compiler %s is already installed.\n" (OpamSwitch.to_string switch);
@@ -1336,7 +1339,6 @@ let install_compiler t ~quiet switch compiler =
 
   install_conf_ocaml_config t.root switch;
 
-  let comp = OpamFile.Comp.read comp_f in
   begin try
     if not (OpamFile.Comp.preinstalled comp) then begin
 


### PR DESCRIPTION
This commit reverts some defensive logic introduced in commit

> commit 720daaf4e14983cec1138ad9f9c06c548208ded9
> Author: Thomas Gazagnaire thomas@gazagnaire.org
> Date:   Thu Nov 15 13:17:41 2012 +0100
> 
> Be more robust when a switch 's' does not appear in ~/.opam/aliases
> but there is a ~/.opam/s directory. This is the sign that something
> bad happened.

in the case where 'preinstalled' is set.

The rationale is to enable new use-cases for 'preinstalled' (that is
currently only used to describe the system compiler), more precisely
the fact of exposing development builds of OCaml as opam compilers:
configure the OCaml trunk with --prefix=~/.opam/foo, create a config
file for compiler 'foo' with 'preinstalled: true', then install the
OCaml distribution (make install) and finally 'opam switch foo'.

The current clean-up logic makes the last step remove the OCaml
binaries that have been installed in ~/.opam/foo/bin by OCaml's
installation step.

There is a compromise between "safety" (the current behavior that is
resilient to install failures) and this new, advanced
use-case. I think it is okay to say that people installing compilers
with 'preinstalled: true' (currently nobody, I believe) are in expert
situations, and let them clean ~/.opam/foo by hand if something goes
wrong.

(There is in fact a work-around to support this advanced use-case
without applying this patch: you could run "opam switch install foo"
_before_ OCaml's "make install". But this exposes 'foo' as an existing
OPAM compiler before it actually makes sense to do so, as no compiler
is installed yet. I believe fixing this behavior is a better way to go
forward with interesting uses of 'preinstalled'.)
