### PR TITLE
make the build more robust to git failure

### DIFF
--- a/shell/get-git-id.sh
+++ b/shell/get-git-id.sh
@@ -1,9 +1,11 @@
 #!/bin/sh -e
 
+trap 'echo "let version = None"' INT TERM EXIT
+
 if [ -e .git/logs/HEAD ]; then
-    describe=`git describe`
+    describe=`git describe --tags`
     echo let version = Some \"${describe}\"
+    trap - INT TERM EXIT
 else
     echo "let version = None"
-
 fi


### PR DESCRIPTION
This fixes a problem where it fails if there are no local annotated tags
