### PR TITLE
initial mercurial support

### DIFF
--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -233,6 +233,7 @@ let repo_kind_flag =
     "local", `local;
     "git"  , `git;
     "darcs"  , `darcs;
+    "hg"   , `hg;
 
     (* aliases *)
     "wget" , `http;
@@ -241,7 +242,7 @@ let repo_kind_flag =
   ] in
   mk_opt ["k";"kind"]
     "KIND" "Specify the kind of the repository to be set (the main ones \
-            are 'http', 'local', 'git' or 'darcs')."
+            are 'http', 'local', 'git', 'darcs' or 'hg')."
     Arg.(some (enum kinds)) None
 
 let jobs_flag =
@@ -364,6 +365,8 @@ let guess_repository_kind kind address =
       if OpamMisc.starts_with ~prefix:"git" address
       || OpamMisc.ends_with ~suffix:"git" address then
         `git
+      else if OpamMisc.starts_with ~prefix:"hg" address then
+        `hg
       else
         `http
   | Some k -> k
@@ -1022,6 +1025,7 @@ let pin =
       "version", `version;
       "local"  , `local;
       "rsync"  , `local;
+      "hg"     , `hg
     ] in
     Arg.(value & opt (some & enum kinds) None & doc) in
   let force = mk_flag ["f";"force"] "Disable consistency checks." in
@@ -1075,8 +1079,8 @@ let default =
     `P "OPAM is a package manager for OCaml. It uses the powerful mancoosi \
         tools to handle dependencies, including support for version \
         constraints, optional dependencies, and conflict management.";
-    `P "It has support for different remote repositories such as HTTP, rsync, git \
-        and darcs. It handles multiple OCaml versions concurrently, and is \
+    `P "It has support for different remote repositories such as HTTP, rsync, git, \
+        darcs and mercurial. It handles multiple OCaml versions concurrently, and is \
         flexible enough to allow you to use your own repositories and packages \
         in addition to the central ones it provides.";
     `P "Use either $(b,opam <command> --help) or $(b,opam help <command>) \

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -72,7 +72,7 @@ let pin ~force action =
               (OpamPackage.Name.to_string name)
               (OpamPackage.Version.to_string (OpamPackage.version nv))
               (OpamPackage.Version.to_string version);
-      | Git _ | Darcs _ | Local _ ->
+      | Git _ | Darcs _ | Local _ | Hg _ ->
         if not force && OpamState.mem_installed_package_by_name t name then
           OpamGlobals.error_and_exit
             "Cannot pin %s to a dev version as it is already installed. You must uninstall it first (or use --force)."

--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -25,7 +25,8 @@ let () =
   OpamHTTP.register ();
   OpamGit.register ();
   OpamDarcs.register();
-  OpamLocal.register ()
+  OpamLocal.register ();
+  OpamHg.register ()
 
 let confirm fmt =
   Printf.ksprintf (fun msg ->
@@ -273,7 +274,8 @@ let pinned_path t name =
     match OpamPackage.Name.Map.find name t.pinned with
     | Local d
     | Darcs d
-    | Git d -> Some d
+    | Git d
+    | Hg d -> Some d
     | _     -> None
   else
     None
@@ -282,7 +284,7 @@ let pinned_path t name =
 let is_locally_pinned t name =
   if OpamPackage.Name.Map.mem name t.pinned then
     match OpamPackage.Name.Map.find name t.pinned with
-    | Local _ | Darcs _ | Git _ -> true
+    | Local _ | Darcs _ | Git _ | Hg _ -> true
     | _ -> false
   else
     false
@@ -1667,7 +1669,7 @@ let update_pinned_package t n =
   if OpamPackage.Name.Map.mem n t.pinned then
     let pin = OpamPackage.Name.Map.find n t.pinned in
     match kind_of_pin_option pin with
-    | (`git|`darcs|`local as k) ->
+    | (`git|`darcs|`local|`hg as k) ->
       let path = OpamFilename.raw_dir (path_of_pin_option pin) in
       let dst = OpamPath.Switch.pinned_dir t.root t.switch n in
       let module B = (val OpamRepository.find_backend k: OpamRepository.BACKEND) in

--- a/src/core/opamFile.ml
+++ b/src/core/opamFile.ml
@@ -170,12 +170,14 @@ module X = struct
     let s_checksum = "checksum"
     let s_git = "git"
     let s_darcs = "darcs"
+    let s_hg = "hg"
 
     let valid_fields = [
       s_archive;
       s_checksum;
       s_git;
       s_darcs;
+      s_hg
     ]
 
     let of_string filename str =
@@ -187,20 +189,30 @@ module X = struct
         OpamFormat.assoc_option s.file_contents s_git OpamFormat.parse_string in
       let darcs =
         OpamFormat.assoc_option s.file_contents s_darcs OpamFormat.parse_string in
+      let hg =
+        OpamFormat.assoc_option s.file_contents s_hg OpamFormat.parse_string in
       let checksum =
         OpamFormat.assoc_option s.file_contents s_checksum OpamFormat.parse_string in
-      let url, kind = match archive, git, darcs with
-        | None  , None  , None   -> OpamGlobals.error_and_exit "Missing URL"
-        | Some x, None  , None   -> x, Some `http
-        | None  , Some x, None   -> x, Some `git
-        | None  , None  , Some x -> x, Some `darcs
-        | _ -> OpamGlobals.error_and_exit "Too many URLS" in
+      let url, kind = match archive, git, darcs, hg with
+        | None  , None  , None  , None ->
+            OpamGlobals.error_and_exit "Missing URL"
+        | Some x, None  , None  , None   ->
+            x, Some `http
+        | None  , Some x, None  , None   ->
+            x, Some `git
+        | None  , None  , Some x, None   ->
+            x, Some `darcs
+        | None  , None  , None  , Some x ->
+            x, Some `hg
+        | _ ->
+            OpamGlobals.error_and_exit "Too many URLS" in
       { url; kind; checksum }
 
     let to_string filename t =
       let url_name = match t.kind with
         | Some `git   -> "git"
         | Some `darcs -> "darcs"
+        | Some `hg    -> "hg"
         | None
         | Some `http  -> "archive"
         | Some `local -> OpamGlobals.error_and_exit

--- a/src/core/opamFile.mli
+++ b/src/core/opamFile.mli
@@ -411,7 +411,7 @@ module URL: sig
   (** URL address *)
   val url: t -> string
 
-  (** Backend kind (could be curl/rsync/git/darcs at the moment) *)
+  (** Backend kind (could be curl/rsync/git/darcs/hg at the moment) *)
   val kind: t -> repository_kind option
 
   (** Archive checksum *)

--- a/src/core/opamMisc.ml
+++ b/src/core/opamMisc.ml
@@ -327,6 +327,10 @@ let git_of_string a =
   | None       -> a, None
   | Some (a,c) -> a, Some c
 
+(* maybe paths processing will become different for git and hg, so here is
+   a separate function. *)
+let hg_of_string = git_of_string
+
 let pretty_backtrace () =
   match Printexc.get_backtrace () with
   | "" -> ""

--- a/src/core/opamMisc.mli
+++ b/src/core/opamMisc.mli
@@ -173,6 +173,9 @@ val sub_at: int -> string -> string
 (** Cut a git string of the form /git/address[#SHA] into (address * commit) *)
 val git_of_string: string -> string * string option
 
+(** same as [git_of_string] but for mercurial paths *)
+val hg_of_string: string -> string * string option
+
 (** {2 Misc} *)
 
 (** Remove from a ':' separated list of string the one with the given prefix *)

--- a/src/core/opamTypes.mli
+++ b/src/core/opamTypes.mli
@@ -149,13 +149,13 @@ type repository_name = OpamRepositoryName.t
 type 'a repository_name_map = 'a OpamRepositoryName.Map.t
 
 (** Repository kind *)
-type repository_kind = [`http|`local|`git|`darcs]
+type repository_kind = [`http|`local|`git|`darcs|`hg]
 
 (** Pretty-print repository kinds. *)
-val string_of_repository_kind: [`http|`local|`git|`darcs] -> string
+val string_of_repository_kind: [`http|`local|`git|`darcs|`hg] -> string
 
 (** Parser of repository kinds. Raise an error if the kind is not valid. *)
-val repository_kind_of_string: string -> [`http|`local|`git|`darcs]
+val repository_kind_of_string: string -> [`http|`local|`git|`darcs|`hg]
 
 (** Repository address *)
 type address = dirname
@@ -316,6 +316,7 @@ type pin_option =
   | Local of dirname
   | Git of address
   | Darcs of address
+  | Hg of address
   | Unpin
 
 (** Pinned packages *)
@@ -328,7 +329,7 @@ type pin = {
 val string_of_pin: pin -> string
 
 (** Pin kind *)
-type pin_kind = [`version|`git|`darcs|`local|`unpin]
+type pin_kind = [`version|`git|`darcs|`hg|`local|`unpin]
 
 (** Pretty-printing of pin kinds. *)
 val pin_kind_of_string: string -> pin_kind

--- a/src/repositories/opamHg.ml
+++ b/src/repositories/opamHg.ml
@@ -1,0 +1,97 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2012-2013 OCamlPro                                        *)
+(*    Copyright 2012 INRIA                                                *)
+(*                                                                        *)
+(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  GNU Lesser General Public License version 3.0 with linking            *)
+(*  exception.                                                            *)
+(*                                                                        *)
+(*  OPAM is distributed in the hope that it will be useful, but WITHOUT   *)
+(*  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY    *)
+(*  or FITNESS FOR A PARTICULAR PURPOSE.See the GNU General Public        *)
+(*  License for more details.                                             *)
+(*                                                                        *)
+(**************************************************************************)
+
+open OpamTypes
+open OpamFilename.OP
+
+let log fmt = OpamGlobals.log "HG" fmt
+
+module Hg = struct
+
+  type address = {
+    address: dirname;
+    commit : string option;
+  }
+
+  (* A hg address could be of the form: hg://path/to/the/repository/#SHA *)
+  let address repo =
+    let address = OpamFilename.Dir.to_string repo.repo_address in
+    let address, commit = OpamMisc.hg_of_string address in
+    { address = OpamFilename.raw_dir address; commit }
+
+  let exists repo =
+    OpamFilename.exists_dir (repo.repo_root / ".hg")
+
+  let init repo =
+    let address = address repo in
+    let repo = OpamFilename.Dir.to_string address.address in
+    ( OpamSystem.command [ "hg" ; "init" ];
+      OpamFilename.write (OpamFilename.of_string ".hg/hgrc")
+        (Printf.sprintf "[paths]\ndefault = %s\n" repo)
+    )
+
+  let fetch repo =
+    let address = address repo in
+    OpamGlobals.msg "Synchronizing %s with %s%s.\n"
+      (OpamFilename.prettify_dir repo.repo_root)
+      (OpamFilename.prettify_dir address.address)
+      (match address.commit with
+       | None   -> ""
+       | Some c -> Printf.sprintf " [%s]" c);
+    OpamFilename.in_dir repo.repo_root (fun () ->
+      OpamSystem.command [ "hg" ; "pull" ]
+    )
+
+  let unknown_commit commit =
+    OpamSystem.internal_error "Unknown mercurial revision/branch/bookmark: %s."
+      commit
+
+  let merge repo =
+    let address = address repo in
+    let merge commit =
+      try OpamSystem.command [ "hg" ; "update" ; commit ]; true
+      with _ -> false in
+    let commit = match address.commit with
+      | None   -> "tip"
+      | Some c -> c in
+    OpamFilename.in_dir repo.repo_root (fun () ->
+      if not (merge commit) then
+        unknown_commit commit
+    )
+
+  let diff repo =
+    let address = address repo in
+    let diff commit =
+      try Some (
+        OpamSystem.read_command_output
+          ["hg" ; "diff" ; "--stat" ; "-r" ; commit ])
+      with _ -> None in
+    let commit = match address.commit with
+      | None   -> "tip"
+      | Some c -> c in
+    OpamFilename.in_dir repo.repo_root (fun () ->
+      match diff commit with
+      | Some [] -> false
+      | Some _  -> true
+      | None    -> unknown_commit commit
+    )
+
+end
+
+module B = OpamVCS.Make(Hg)
+
+let register () =
+  OpamRepository.register_backend `hg (module B: OpamRepository.BACKEND)

--- a/src/repositories/opamHg.mli
+++ b/src/repositories/opamHg.mli
@@ -1,0 +1,19 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2012-2013 OCamlPro                                        *)
+(*    Copyright 2012 INRIA                                                *)
+(*                                                                        *)
+(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  GNU Lesser General Public License version 3.0 with linking            *)
+(*  exception.                                                            *)
+(*                                                                        *)
+(*  OPAM is distributed in the hope that it will be useful, but WITHOUT   *)
+(*  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY    *)
+(*  or FITNESS FOR A PARTICULAR PURPOSE.See the GNU General Public        *)
+(*  License for more details.                                             *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Git repository backend *)
+
+val register: unit -> unit

--- a/src/repositories/repositories.ocp
+++ b/src/repositories/repositories.ocp
@@ -8,6 +8,7 @@ begin library "opam-repositories"
     "opamVCS.ml"
     "opamGit.ml"
     "opamDarcs.ml"
+    "opamHg.ml"
   ]
 
   requires = [

--- a/src/scripts/opam_mk_repo.ml
+++ b/src/scripts/opam_mk_repo.ml
@@ -21,7 +21,8 @@ let () =
   OpamHTTP.register ();
   OpamGit.register ();
   OpamDarcs.register ();
-  OpamLocal.register ()
+  OpamLocal.register ();
+  OpamHg.register ()
 
 let log fmt = OpamGlobals.log "OPAM-MK-REPO" fmt
 


### PR DESCRIPTION
It works in my setup.  I've tested it with `opam repo add -k hg testing-hg https://bitbucket.org/gds/testing-opam-hg-repo && opam update && opam install amall` (it's my almost private repos).  (note that 1. it doesn't work with ocaml 4; I'll fix it later, but now `opam switch 3.12.1` helps to test mercurial repositories support on this example.  2. I've tested "ssh://..." repo urls too, maybe you don't have access to some repos with ssh, but you can replace it with `https://bitbucket.org/gds/repo-name#optional_revision`).
