### PR TITLE
Add an --sexp option to "opam config env"

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -873,8 +873,8 @@ module SafeAPI = struct
     let config option =
       read_lock (fun () -> API.CONFIG.config option)
 
-    let env ~csh =
-      read_lock (fun () -> API.CONFIG.env ~csh)
+    let env ~csh ~sexp =
+      read_lock (fun () -> API.CONFIG.env ~csh ~sexp)
 
     let setup local global =
       global_lock (fun () -> API.CONFIG.setup local global)

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -64,7 +64,7 @@ module API: sig
     val config: config -> unit
 
     (** Display environment. *)
-    val env: csh:bool -> unit
+    val env: csh:bool -> sexp:bool -> unit
 
     (** Global and user setup of OPAM. *)
     val setup: user_config option -> global_config option -> unit

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -247,11 +247,20 @@ let print_csh_env env =
     OpamGlobals.msg "setenv %s %S;\n" k v;
   ) env
 
-let env ~csh =
+let print_sexp_env env =
+  OpamGlobals.msg "(\n";
+  List.iter (fun (k,v) ->
+    OpamGlobals.msg "  (%S %S)\n" k v;
+  ) env;
+  OpamGlobals.msg ")\n"
+
+let env ~csh ~sexp =
   log "config-env";
   let t = OpamState.load_env_state "config-env" in
   let env = OpamState.get_opam_env t in
-  if csh then
+  if sexp then
+    print_sexp_env env
+  else if csh then
     print_csh_env env
   else
     print_env env

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -19,7 +19,7 @@
 open OpamTypes
 
 (** Display the current environment *)
-val env: csh:bool -> unit
+val env: csh:bool -> sexp:bool -> unit
 
 (** Display the content of all available variables *)
 val list: name list -> unit

--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -584,6 +584,7 @@ let config =
   let no_eval_doc     = "Do not install `opam-switch-eval` to switch & eval using a single command." in
   let dot_profile_doc = "Select which configuration file to update (default is ~/.profile)." in
   let list_doc        = "List the current configuration." in
+  let sexp_doc        = "Display environment variables as an s-expression" in
   let profile         = mk_flag ["profile"]        profile_doc in
   let ocamlinit       = mk_flag ["ocamlinit"]      ocamlinit_doc in
   let no_complete     = mk_flag ["no-complete"]    no_complete_doc in
@@ -592,11 +593,12 @@ let config =
   let user            = mk_flag ["u";"user"]       user_doc in
   let global          = mk_flag ["g";"global"]     global_doc in
   let list            = mk_flag ["l";"list"]       list_doc in
+  let sexp            = mk_flag ["sexp"]           sexp_doc in
   let env    =
     mk_opt ["e"] "" "Backward-compatible option, equivalent to $(b,opam config env)." Arg.string "" in
 
   let config global_options
-      command env is_rec sh csh zsh
+      command env is_rec sh csh zsh sexp
       dot_profile_o list all global user
       profile ocamlinit no_complete no_switch_eval
       params =
@@ -610,10 +612,10 @@ let config =
     match command with
     | None           ->
       if env="nv" then
-        OpamConfigCommand.env ~csh
+        OpamConfigCommand.env ~csh ~sexp
       else
         OpamGlobals.error_and_exit "Missing subcommand. Usage: 'opam config <SUBCOMMAND>'"
-    | Some `env   -> Client.CONFIG.env ~csh
+    | Some `env   -> Client.CONFIG.env ~csh ~sexp
     | Some `setup ->
       let user        = all || user in
       let global      = all || global in
@@ -677,7 +679,7 @@ let config =
     | Some `asmlink  -> Client.CONFIG.config (mk ~is_byte:false ~is_link:true) in
 
   Term.(pure config
-    $global_options $command $env $is_rec $sh_flag $csh_flag $zsh_flag
+    $global_options $command $env $is_rec $sh_flag $csh_flag $zsh_flag $sexp
     $dot_profile_flag $list $all $global $user
     $profile $ocamlinit $no_complete $no_switch_eval
     $params),


### PR DESCRIPTION
This patch adds an "--sexp" option to "opam config env" that prints the new environment as an s-expression. This is useful for allowing things like emacs to read the new environment.

Example output:

```
$ opam config env --sexp
(
  ("CAML_LD_LIBRARY_PATH" "/home/leo/.opam/4.00.1/lib/stublibs")
  ("OCAML_TOPLEVEL_PATH" "/home/leo/.opam/4.00.1/lib/toplevel")
  ("MANPATH" ":/home/leo/.opam/4.00.1/man")
  ("PATH" "/home/leo/.opam/4.00.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/usr/NX/bin")
)
```
