### PR TITLE
support fish shell in client configure command

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -873,8 +873,8 @@ module SafeAPI = struct
     let config option =
       read_lock (fun () -> API.CONFIG.config option)
 
-    let env ~csh ~sexp =
-      read_lock (fun () -> API.CONFIG.env ~csh ~sexp)
+    let env ~csh ~sexp ~fish =
+      read_lock (fun () -> API.CONFIG.env ~csh ~sexp ~fish)
 
     let setup local global =
       global_lock (fun () -> API.CONFIG.setup local global)

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -64,7 +64,7 @@ module API: sig
     val config: config -> unit
 
     (** Display environment. *)
-    val env: csh:bool -> sexp:bool -> unit
+    val env: csh:bool -> sexp:bool -> fish:bool -> unit
 
     (** Global and user setup of OPAM. *)
     val setup: user_config option -> global_config option -> unit

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -254,7 +254,12 @@ let print_sexp_env env =
   ) env;
   OpamGlobals.msg ")\n"
 
-let env ~csh ~sexp =
+let print_fish_env env =
+  List.iter (fun (k,v) ->
+    OpamGlobals.msg "set -x %s %s;\n" k (String.concat " " (OpamMisc.split v ':'));
+  ) env
+
+let env ~csh ~sexp ~fish=
   log "config-env";
   let t = OpamState.load_env_state "config-env" in
   let env = OpamState.get_opam_env t in
@@ -262,6 +267,8 @@ let env ~csh ~sexp =
     print_sexp_env env
   else if csh then
     print_csh_env env
+  else if fish then
+    print_fish_env env
   else
     print_env env
 

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -19,7 +19,7 @@
 open OpamTypes
 
 (** Display the current environment *)
-val env: csh:bool -> sexp:bool -> unit
+val env: csh:bool -> sexp:bool -> fish:bool -> unit
 
 (** Display the content of all available variables *)
 val list: name list -> unit

--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -845,11 +845,13 @@ let variables_csh  = "variables.csh"
 let init_sh        = "init.sh"
 let init_zsh       = "init.zsh"
 let init_csh       = "init.csh"
+let init_fish      = "init.fish"
 let init_file = function
   | `sh   -> init_sh
   | `csh  -> init_csh
   | `zsh  -> init_zsh
   | `bash -> init_sh
+  | `fish -> init_fish
 
 let source t ?(interactive_only=false) f =
   let file f = OpamFilename.to_string (OpamPath.init t.root // f) in

--- a/src/core/opamMisc.ml
+++ b/src/core/opamMisc.ml
@@ -383,6 +383,7 @@ let shell_of_string = function
   | "csh"  -> `csh
   | "zsh"  -> `zsh
   | "bash" -> `bash
+  | "fish" -> `fish
   | _      -> `sh
 
 let guess_shell_compat () =
@@ -394,6 +395,7 @@ let guess_dot_profile shell =
     try Filename.concat (getenv "HOME") f
     with _ -> f in
   match shell with
+  | `fish -> List.fold_left Filename.concat (home ".config") ["fish"; "config.fish"]
   | `zsh  -> home ".zshrc"
   | `bash ->
     let bash_profile = home ".bash_profile" in

--- a/src/core/opamMisc.mli
+++ b/src/core/opamMisc.mli
@@ -221,7 +221,7 @@ val terminal_columns : unit -> int
 val uname_s: unit -> string option
 
 (** Guess the shell compat-mode *)
-val guess_shell_compat: unit -> [`csh|`zsh|`sh|`bash]
+val guess_shell_compat: unit -> [`csh|`zsh|`sh|`bash|`fish]
 
 (** Guess the location of .profile *)
-val guess_dot_profile: [`csh|`zsh|`sh|`bash] -> string
+val guess_dot_profile: [`csh|`zsh|`sh|`bash|`fish] -> string

--- a/src/core/opamTypes.ml
+++ b/src/core/opamTypes.ml
@@ -138,9 +138,10 @@ type ppflag =
   | Camlp4 of string list
   | Cmd of string list
 
-type shell = [`csh|`zsh|`sh|`bash]
+type shell = [`fish|`csh|`zsh|`sh|`bash]
 
 let string_of_shell = function
+  | `fish -> "fish"
   | `csh  -> "csh"
   | `zsh  -> "zsh"
   | `sh   -> "sh"

--- a/src/core/opamTypes.mli
+++ b/src/core/opamTypes.mli
@@ -354,7 +354,7 @@ type config = {
 
 
 (** Shell compatibility modes *)
-type shell = [`csh|`zsh|`sh|`bash]
+type shell = [`fish|`csh|`zsh|`sh|`bash]
 
 (** Pretty-print *)
 val string_of_shell: shell -> string


### PR DESCRIPTION
these changes add support for the fish shell in the client configure
command. the main additions are a printer for exporting enviroment
variables (opamConfigcommand:print_fish_env) and a modification to the
dot file finder heuristic (opamMisc:guess_dot_profile).
