### PR TITLE
`opam config env` shell autodetection

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 1.0.1 (trunk)
+* `opam config env` now detects the current shell and outputs a sensible default if no override is provided.
 * Improve `opam pin` stability and start display information about dev revisions
 * Add a new `man` field in `.install` files
 * Support hierarchical installation in `.install` files

--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -625,6 +625,16 @@ let config =
       conf_is_byte = is_byte;
       conf_options = List.map OpamVariable.Section.Full.of_string params;
     } in
+    let csh, fish =
+      match sh, csh, sexp, fish with
+      | false, false, false, false ->
+        (* No overrides have been provided, so guess which shell is active *)
+        (match OpamMisc.guess_shell_compat () with
+         | `csh                -> true , false
+         | `fish               -> false, true
+         | `sh | `bash | `zsh  -> false, false)
+      | _ -> false, false
+    in
     match command with
     | None           ->
       if env="nv" then


### PR DESCRIPTION
`opam config env` now detects the current shell and outputs a sensible default if no override is provided.

This fixes the default installation on FreeBSD, which has csh as its default root shell.
