### PR TITLE
Pinned repositories with multiple authors

### DIFF
--- a/src/core/opamFile.ml
+++ b/src/core/opamFile.ml
@@ -894,8 +894,7 @@ module X = struct
           Variable (s_maintainer  , OpamFormat.make_string t.maintainer);
         ] @ name_and_version
           @ option  t.homepage      s_homepage      OpamFormat.make_string
-          @ list    t.authors       s_authors
-              (String.concat ", " |> OpamFormat.make_string)
+          @ list    t.authors       s_authors       OpamFormat.make_string_list
           @ option  t.license       s_license       OpamFormat.make_string
           @ option  t.doc           s_doc           OpamFormat.make_string
           @ list    t.tags          s_tags          OpamFormat.make_string_list


### PR DESCRIPTION
When pinning a package, if the latest metadata in the opam repository contains an authors field with more than a single author, that field is not properly reserialized into the pinned.cache directory. Instead of serializing as a comma-separated string, the authors should be serialized as a string list. This patch does that.
