### PR TITLE
Permit csh/fish to be overridden via an explicit `opam config env --sh`.

### DIFF
--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -584,7 +584,7 @@ let config =
         installed libraries, update the $(b,PATH), and substitute \
         variables used in OPAM packages.";
     `P "Apart from $(b,opam config env), most of these commands are used \
-        by POAM internally, and are of limited interest for the casual \
+        by OPAM internally, and are of limited interest for the casual \
         user.";
   ] @ mk_subdoc ~names:"DOMAINS" commands in
 


### PR DESCRIPTION
Followup to a11b712225c1a56f5bf3edbb2aaf7f865ec53a11
