### PR TITLE
Revert "Enabling content compression in curl"

### DIFF
--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -521,7 +521,7 @@ let download_command =
     let curl = [
       "curl";
       "--write-out"; "%{http_code}\\n"; "--insecure";
-      "--retry"; retry; "--retry-delay"; "2"; "--compress";
+      "--retry"; retry; "--retry-delay"; "2";
       "-OL"; src
     ] in
     match read_command_output curl with


### PR DESCRIPTION
 since it breaks untarring distfiles.

This reverts commit 3c5e80c5c9fa4cc14691a3ac3912d316d1e1af34.  See #757
