### PR TITLE
Do not attempt to use the -bin-annot flag in OCaml < 4.00.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,6 @@ src/core/opamGitVersion.ml
 src/core/opamScript.ml
 src/core/opamVersion.ml
 src/globals.ml
+src/opam.ocp
 src_ext/depends.ocp
+autom4te.cache/

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1,0 +1,16 @@
+# generated automatically by aclocal 1.11.6 -*- Autoconf -*-
+
+# Copyright (C) 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004,
+# 2005, 2006, 2007, 2008, 2009, 2010, 2011 Free Software Foundation,
+# Inc.
+# This file is free software; the Free Software Foundation
+# gives unlimited permission to copy and/or distribute it,
+# with or without modifications, as long as this notice is preserved.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY, to the extent permitted by law; without
+# even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.
+
+m4_include([m4/ax_compare_version.m4])
+m4_include([m4/ocaml.m4])

--- a/configure
+++ b/configure
@@ -587,6 +587,7 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 fetch
 FETCH
+binannot
 AWK
 CAMLP4RF
 CAMLP4R
@@ -4408,6 +4409,43 @@ x$ax_compare_version_B" | sed 's/^ *//' | sort -r | sed "s/x${ax_compare_version
 
 fi
 
+
+
+
+  # Used to indicate true or false condition
+  ax_compare_version=false
+
+  # Convert the two version strings to be compared into a format that
+  # allows a simple string comparison.  The end result is that a version
+  # string of the form 1.12.5-r617 will be converted to the form
+  # 0001001200050617.  In other words, each number is zero padded to four
+  # digits, and non digits are removed.
+
+  ax_compare_version_A=`echo "$OCAMLVERSION" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
+                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/[^0-9]//g'`
+
+
+  ax_compare_version_B=`echo "3.12.1" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
+                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/[^0-9]//g'`
+
+
+    ax_compare_version=`echo "x$ax_compare_version_A
+x$ax_compare_version_B" | sed 's/^ *//' | sort | sed "s/x${ax_compare_version_A}/false/;s/x${ax_compare_version_B}/true/;1q"`
+
+
+
+    if test "$ax_compare_version" = "true" ; then
+    binannot="\"-bin-annot\""
+
+      fi
+
+
 # Check whether --enable-certificate_check was given.
 if test "${enable_certificate_check+set}" = set; then :
   enableval=$enable_certificate_check;
@@ -4475,7 +4513,7 @@ else
   as_fn_error $? "You must have either curl or wget installed." "$LINENO" 5
 fi
 
-ac_config_files="$ac_config_files Makefile.config src/core/opamVersion.ml doc/man-ext/opam-check.md"
+ac_config_files="$ac_config_files Makefile.config src/core/opamVersion.ml doc/man-ext/opam-check.md src/opam.ocp"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -5186,6 +5224,7 @@ do
     "Makefile.config") CONFIG_FILES="$CONFIG_FILES Makefile.config" ;;
     "src/core/opamVersion.ml") CONFIG_FILES="$CONFIG_FILES src/core/opamVersion.ml" ;;
     "doc/man-ext/opam-check.md") CONFIG_FILES="$CONFIG_FILES doc/man-ext/opam-check.md" ;;
+    "src/opam.ocp") CONFIG_FILES="$CONFIG_FILES src/opam.ocp" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,8 @@ AS_IF([test "x${enable_version_check}" != "xno"], [
     AC_MSG_ERROR([Your version of OCaml: $OCAMLVERSION is not supported]))
 ])
 
+AX_COMPARE_VERSION([$OCAMLVERSION], [gt], [3.12.1], AC_SUBST(binannot,"\"-bin-annot\""))
+
 AC_ARG_ENABLE([certificate_check],
   AS_HELP_STRING([--disable-certificate-check],
                  [Do not check the certificate of OPAM's dependency archives])
@@ -49,6 +51,7 @@ AC_CONFIG_FILES(
   Makefile.config
   src/core/opamVersion.ml
   doc/man-ext/opam-check.md
+  src/opam.ocp
 )
 AC_OUTPUT
 

--- a/src/opam.ocp
+++ b/src/opam.ocp
@@ -1,2 +1,0 @@
-comp += [ "-g" "-bin-annot" ]
-link += [ "-g"]

--- a/src/opam.ocp.in
+++ b/src/opam.ocp.in
@@ -1,0 +1,2 @@
+comp += [ "-g" @binannot@ ]
+link += [ "-g"]


### PR DESCRIPTION
The configure script now rewrites opam.ocp.in to reflect the
appropriate flags.

Closes #861
