### PR TITLE
Repo file

### DIFF
--- a/src/core/opamFile.mli
+++ b/src/core/opamFile.mli
@@ -431,7 +431,11 @@ module Repo: sig
 
   include IO_FILE
 
-  val create: ?browse:string -> ?upstream:string -> unit -> t
+  val create:
+    ?browse:string -> ?upstream:string -> ?opam_version:string -> unit -> t
+
+  (** The minimum OPAM version required for this repository *)
+  val opam_version : t -> OpamVersion.t
 
   (** Base URL for browsing packages on the WWW *)
   val browse: t -> string option

--- a/src/core/opamPath.ml
+++ b/src/core/opamPath.ml
@@ -183,11 +183,6 @@ module Repository = struct
 
   let create root name = root / "repo" / OpamRepositoryName.to_string name
 
-  let version t = root t // "version"
-
-  let remote_version t =
-    OpamFilename.raw_dir (fst t.repo_address) // "version"
-
   let repo t = root t // "repo"
 
   let remote_repo t =

--- a/src/core/opamPath.mli
+++ b/src/core/opamPath.mli
@@ -251,12 +251,6 @@ module Repository: sig
   (** Update cache *)
   val update_cache: repository -> filename
 
-  (** Return the version file *)
-  val version: repository -> filename
-
-  (** Remote version file *)
-  val remote_version: repository -> filename
-
   (** Return the repo file *)
   val repo: repository -> filename
 

--- a/src/core/opamRepository.ml
+++ b/src/core/opamRepository.ml
@@ -159,15 +159,12 @@ let pull_archive repo nv =
   B.pull_archive repo filename
 
 let check_version repo =
-  let repo_version =
-    try
-      repo
-      |> OpamPath.Repository.version
-      |> OpamFilename.read
-      |> OpamMisc.strip
-      |> OpamVersion.of_string
-    with _ ->
-      OpamVersion.of_string "0.7.5" in
+  let repo_version = begin
+    repo
+    |> OpamPath.Repository.repo
+    |> OpamFile.Repo.safe_read
+    |> OpamFile.Repo.opam_version
+  end in
   if OpamVersion.compare repo_version OpamVersion.current > 0 then
     OpamGlobals.error_and_exit
       "\nThe current version of OPAM cannot read the repository. \

--- a/src/repositories/opamHTTP.ml
+++ b/src/repositories/opamHTTP.ml
@@ -39,8 +39,7 @@ let index_archive local_path = local_path // "index.tar.gz"
 
 let local_files repo =
   let all =
-    OpamPath.Repository.version repo ::
-      OpamPath.Repository.repo  repo ::
+    OpamPath.Repository.repo repo ::
       OpamFilename.rec_files (OpamPath.Repository.packages_dir repo) @
       OpamFilename.rec_files (OpamPath.Repository.archives_dir repo) @
       OpamFilename.rec_files (OpamPath.Repository.compilers_dir repo) in

--- a/src/repositories/opamLocal.ml
+++ b/src/repositories/opamLocal.ml
@@ -82,7 +82,6 @@ module B = struct
     OpamGlobals.msg "%-10s Synchronizing with %s\n"
       (OpamRepositoryName.to_string repo.repo_name)
       (string_of_address repo.repo_address);
-    ignore (pull_file_quiet repo.repo_root (OpamPath.Repository.remote_version repo));
     ignore (pull_file_quiet repo.repo_root (OpamPath.Repository.remote_repo repo));
     List.iter
       (fun (local, remote) -> ignore (pull_dir_quiet (local repo) (remote repo)))


### PR DESCRIPTION
OpamFile Repo module to access `repo` metadata files.

OpamPath.Repository.repo accessor to find `repo` metadata files.

HTTP and Local backend awareness of `repo` metadata file so it gets installed and updated with any backend.

Fix `version` file update bug.
