### PR TITLE
more informative curl error messages closes #905

### DIFF
--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -525,11 +525,11 @@ let download_command =
       "-OL"; src
     ] in
     match read_command_output curl with
-    | [] -> internal_error "curl: empty response."
+    | [] -> internal_error "curl: empty response while downloading %s" src
     | l  ->
       let code = List.hd (List.rev l) in
-      try if int_of_string code >= 400 then internal_error "curl: error %s." code
-      with _ -> internal_error "curl: %s is not a valid return code." code in
+      try if int_of_string code >= 400 then raise Exit
+      with _ -> internal_error "curl: code %s while downloading %s" code src in
   lazy (
     if command_exists "curl" then
       curl


### PR DESCRIPTION
This gets a bit redundant with some errors though:

```
=-=-= Installing hweak.1.1 =-=-=
hweak.1.1  Downloading http://aspellfr.free.fr/hweak/hweak-1.2.tar.gz
[ERROR] curl: code 404 while downloading http://aspellfr.free.fr/hweak/hweak-1.2.tar.gz
[ERROR] http://aspellfr.free.fr/hweak/hweak-1.2.tar.gz is not available
[ERROR] The compilation of hweak.1.1 failed.
```
