### PR TITLE
Fixed bug where changes to the package could not be seen after update (#894)

### DIFF
--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -442,8 +442,10 @@ let package_state t =
       OpamPackage.Map.add nv state map
     ) (all_installed t) OpamPackage.Map.empty in
   OpamPackage.Map.fold (fun nv (repo, prefix) map ->
-      if OpamPackage.Map.mem nv map then
-        map
+      if OpamPackage.Map.mem nv map then map
+      else if OpamFilename.exists (OpamPath.opam t.root nv) then
+        let state = package_state_one t `all nv in
+        OpamPackage.Map.add nv state map
       else
         let repo = find_repository_exn t repo in
         let state = OpamRepository.package_state repo prefix nv `all in


### PR DESCRIPTION
Actually there were two bugs, both related to the fact that we now keep files in
OPAMROOT/packages for uninstalled packages (the update in OPAMROOT/repo/... was ok):
- the package state was not looked up there when the package was not
  installed, instead looking in the repo dir (which was already updated)
  and concluded that no modifications were made
- the uninstalled packages were not kept in the set of changed
  packages, and not updated by
  OpamRepositoryCommand.fix_package_descriptions

fix_package_descriptions now removes such obsolete files if the package is installed
nowhere, since there is little point in keeping them up-to-date forever.
