### PR TITLE
doc/dev-manual: Fix typo

### DIFF
--- a/doc/dev-manual/dev-manual.tex
+++ b/doc/dev-manual/dev-manual.tex
@@ -467,7 +467,7 @@ Where:
   http});
 \item \verb+$REPO+ is the name of the repository (default is {\tt
   default}); and
-\item \verb+ADDRESS+ is the repository address (default is
+\item \verb+$ADDRESS+ is the repository address (default is
   \verb+http://opam.ocamlpro.com/pub+).
 \item \verb+$COMP+ is the compiler version to use (default is the
   version of the compiler installed on the system).


### PR DESCRIPTION
Wasn't able to recompile the resulting PDF and HTML files, since I do not have `pdfswitch.sty`.
