### PR TITLE
Drop the leading '/' from the prefix

### DIFF
--- a/src/core/opamPackage.ml
+++ b/src/core/opamPackage.ml
@@ -213,7 +213,8 @@ let prefixes dir =
               OpamMisc.remove_prefix ~prefix:(OpamFilename.Dir.to_string dir) suffix
             with
             | "" -> None
-            | p  -> Some p in
+            | p  -> (* drop the leading '/' from the prefix *)
+              Some String.(sub p 1 (length p - 1)) in
           Map.add p prefix map
       ) Map.empty files
   ) else


### PR DESCRIPTION
The prefix, if not empty, would contain a leading slash. The `OpamPath` functions then would use this prefix with the `/` operator yielding paths with double slashes in them. This just drops the first character of the prefix if it's not empty. This first character should always be a slash unless the prefix directory is somehow a prefix of a sibling directory name. I don't think this condition can ever occur, however.
