### PR TITLE
Added patch to sanitize external solver criteria.

### DIFF
--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -63,7 +63,7 @@ $(DOSE).tar.gz:
 
 dose.stamp: $(DOSE).tar.gz
 	tar xfz $(DOSE).tar.gz
-	cd $(DOSE) && patch -p1  < ../dose-pcre2re.diff && patch -p1 < ../dose-mktemp.diff && cd ..
+	cd $(DOSE) && patch -p1  < ../dose-pcre2re.diff && patch -p1 < ../dose-mktemp.diff && patch -p1 < ../dose-quotecriteria.diff && cd ..
 	rm -rf dose
 	mv $(DOSE) dose
 	@touch $@

--- a/src_ext/dose-quotecriteria.diff
+++ b/src_ext/dose-quotecriteria.diff
@@ -1,0 +1,33 @@
+diff --git a/common/cudfSolver.ml b/common/cudfSolver.ml
+index 9bfda7e..548ee12 100644
+--- a/common/cudfSolver.ml
++++ b/common/cudfSolver.ml
+@@ -53,10 +53,14 @@ let rec input_all_lines acc chan =
+ (** Solver "exec:" line. Contains three named wildcards to be interpolated:
+    "$in", "$out", and "$pref"; corresponding to, respectively, input CUDF
+    document, output CUDF universe, user preferences. *)
++
++(* quote string for the shell, after removing all characters disallowed in criteria *)
++let sanitize s = Printf.sprintf "\"%s\"" (Pcre.substitute ~rex:(Pcre.regexp "[^+()a-z,\"-]") ~subst:(fun _ -> "") s);;
++
+ let interpolate_solver_pat exec cudf_in cudf_out pref =
+   let _, exec = String.replace ~str:exec ~sub:"$in"   ~by:cudf_in  in
+   let _, exec = String.replace ~str:exec ~sub:"$out"  ~by:cudf_out in
+-  let _, exec = String.replace ~str:exec ~sub:"$pref" ~by:pref     in
++  let _, exec = String.replace ~str:exec ~sub:"$pref" ~by:(sanitize pref) in
+   exec
+ ;;
+ 
+diff --git a/common/cudfSolver.ml b/common/cudfSolver.ml
+index 548ee12..2caf76a 100644
+--- a/common/cudfSolver.ml
++++ b/common/cudfSolver.ml
+@@ -55,7 +55,7 @@ let rec input_all_lines acc chan =
+    document, output CUDF universe, user preferences. *)
+ 
+ (* quote string for the shell, after removing all characters disallowed in criteria *)
+-let sanitize s = Printf.sprintf "\"%s\"" (Pcre.substitute ~rex:(Pcre.regexp "[^+()a-z,\"-]") ~subst:(fun _ -> "") s);;
++let sanitize s = Printf.sprintf "\"%s\"" (Re_pcre.substitute ~rex:(Re_pcre.regexp "[^+()a-z,\"-]") ~subst:(fun _ -> "") s);;
+ 
+ let interpolate_solver_pat exec cudf_in cudf_out pref =
+   let _, exec = String.replace ~str:exec ~sub:"$in"   ~by:cudf_in  in


### PR DESCRIPTION
Added patch to backport commit 4f3a7808fccad1b9dc9b3756ee0fa47c4090d1cf of dose upstream onto the version used by opam.
Includes change from pcre to re
