### PR TITLE
Added a share_root installation destination

### DIFF
--- a/doc/dev-manual/dev-manual.tex
+++ b/doc/dev-manual/dev-manual.tex
@@ -1001,16 +1001,17 @@ in \S\ref{file:general} with the following restrictions:
 {\small
 \begin{Verbatim}[frame=single]
 <file> :=
-    ?lib:      [ <mv>+ ]
-    ?bin:      [ <mv>+ ]
-    ?sbin:     [ <mv>+ ]
-    ?toplevel: [ <mv>+ ]
-    ?share:    [ <mv>+ ]
-    ?etc:      [ <mv>+ ]
-    ?doc:      [ <mv>+ ]
-    ?misc:     [ <mv>+ ]
-    ?stublibs: [ <mv>+ ]
-    ?man:      [ <mv>+ ]
+    ?lib:        [ <mv>+ ]
+    ?bin:        [ <mv>+ ]
+    ?sbin:       [ <mv>+ ]
+    ?toplevel:   [ <mv>+ ]
+    ?share:      [ <mv>+ ]
+    ?share_root: [ <mv>+ ]
+    ?etc:        [ <mv>+ ]
+    ?doc:        [ <mv>+ ]
+    ?misc:       [ <mv>+ ]
+    ?stublibs:   [ <mv>+ ]
+    ?man:        [ <mv>+ ]
 
 <mv> := STRING
       | STRING { STRING }
@@ -1023,8 +1024,9 @@ in \S\ref{file:general} with the following restrictions:
 \item Files listed under {\tt sbin} are copied into \verb+$opam/$SWITCH/sbin/+.
 \item Files listed under {\tt doc} are copied into \verb+$opam/$SWITCH/doc/$NAME/+.
 \item Files listed under {\tt share} are copied into \verb+$opam/$SWITCH/share/$NAME/+.
+\item Files listed under {\tt share_root} are copied into \verb+$opam/$SWITCH/share/+.
 \item Files listed under {\tt etc} are copied into \verb+$opam/$SWITCH/etc/$NAME/+.
-\item Files listed under {\tt toplevel} are copied into \verb+$opam/$SWITCH/toplevel+.
+\item Files listed under {\tt toplevel} are copied into \verb+$opam/$SWITCH/lib/toplevel/+.
 \item Files lister under {\tt stublibs} are copied into \verb+$opam/$SWITCH/lib/stublibs/+
 \item Files listed under {\tt man} are copied into
   \verb+$opam/$SWITCH/man/man3+. You can change the sub-directory by setting

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -161,6 +161,8 @@ let install_package t nv =
 
       (* Shared files *)
       install_files false OpamPath.Switch.share OpamFile.Dot_install.share;
+      install_files false (fun r s _ -> OpamPath.Switch.share_dir r s)
+        OpamFile.Dot_install.share_root;
 
       (* Etc files *)
       install_files false OpamPath.Switch.etc OpamFile.Dot_install.etc;
@@ -445,7 +447,12 @@ let remove_package_aux t ~metadata ~rm_build ?(silent=false) nv =
     ) (OpamFile.Dot_install.misc install);
 
   (* Removing the shared dir *)
+  (* This one shouldn't be needed (we remove the dir). Yet some packages
+     currently install using '%{share}%/..' to workaround the lack of
+     [share_root] in previous versions *)
+  remove_files (fun t s -> OpamPath.Switch.share t s name) OpamFile.Dot_install.share;
   OpamFilename.rmdir (OpamPath.Switch.share t.root t.switch name);
+  remove_files OpamPath.Switch.share_dir OpamFile.Dot_install.share_root;
 
   (* Removing the etc dir *)
   OpamFilename.rmdir (OpamPath.Switch.etc t.root t.switch name);

--- a/src/core/opamFile.ml
+++ b/src/core/opamFile.ml
@@ -1106,6 +1106,7 @@ module X = struct
       toplevel: (basename optional * basename option) list;
       stublibs: (basename optional * basename option) list;
       share   : (basename optional * basename option) list;
+      share_root: (basename optional * basename option) list;
       etc     : (basename optional * basename option) list;
       doc     : (basename optional * basename option) list;
       man     : (basename optional * basename option) list;
@@ -1120,6 +1121,7 @@ module X = struct
       stublibs = [];
       misc     = [];
       share    = [];
+      share_root = [];
       etc      = [];
       man      = [];
       doc      = [];
@@ -1132,6 +1134,7 @@ module X = struct
     let stublibs t = t.stublibs
     let misc t = t.misc
     let share t = t.share
+    let share_root t = t.share_root
     let etc t = t.etc
     let doc t = t.doc
     let man t =
@@ -1151,6 +1154,7 @@ module X = struct
     let s_toplevel = "toplevel"
     let s_stublibs = "stublibs"
     let s_share    = "share"
+    let s_share_root = "share_root"
     let s_etc      = "etc"
     let s_doc      = "doc"
     let s_man      = "man"
@@ -1163,6 +1167,7 @@ module X = struct
       s_stublibs;
       s_misc;
       s_share;
+      s_share_root;
       s_etc;
       s_doc;
       s_man;
@@ -1206,6 +1211,7 @@ module X = struct
           Variable (s_toplevel, mk      t.toplevel);
           Variable (s_stublibs, mk      t.stublibs);
           Variable (s_share   , mk      t.share);
+          Variable (s_share_root, mk    t.share_root);
           Variable (s_etc     , mk      t.etc);
           Variable (s_doc     , mk      t.doc);
           Variable (s_man     , mk      t.man);
@@ -1237,10 +1243,11 @@ module X = struct
       let toplevel = mk s_toplevel in
       let stublibs = mk s_stublibs in
       let share    = mk s_share    in
+      let share_root = mk s_share_root in
       let etc      = mk s_etc      in
       let doc      = mk s_doc      in
       let man      = mk s_man      in
-      { lib; bin; sbin; misc; toplevel; stublibs; share; etc; doc; man }
+      { lib; bin; sbin; misc; toplevel; stublibs; share; share_root; etc; doc; man }
 
   end
 

--- a/src/core/opamFile.mli
+++ b/src/core/opamFile.mli
@@ -346,8 +346,11 @@ module Dot_install: sig
   (** C bindings *)
   val stublibs: t -> (basename optional * basename option) list
 
-  (** List of shared files *)
+  (** List of architecture-independent files *)
   val share: t -> (basename optional * basename option) list
+
+  (** List of files under the more general share prefix *)
+  val share_root: t -> (basename optional * basename option) list
 
   (** List of etc files *)
   val etc: t -> (basename optional * basename option) list

--- a/src/scripts/opam_installer.ml
+++ b/src/scripts/opam_installer.ml
@@ -128,6 +128,8 @@ let iter_install f instfile options =
       instdir D.stublibs, instf S.stublibs, true;
       instdir D.man_dir, instf S.man, false;
       instdir D.share options.pkgname, instf S.share, false;
+      instdir (fun t s _ -> D.share_dir t s) options.pkgname,
+      instf S.share_root, false;
       instdir D.etc options.pkgname, instf S.etc, false;
       instdir D.doc options.pkgname, instf S.doc, false; ]
 


### PR DESCRIPTION
Needed for installing eg. editor modes in PFX/emacs/site-lisp ; hacks using '../' wheren't pretty
