### PR TITLE
Add base-camlp4 to the preinstalled packages of the system compiler if available

### DIFF
--- a/src/client/opamState.mli
+++ b/src/client/opamState.mli
@@ -263,7 +263,7 @@ val find_packages_by_name: state -> name -> package_set option
 val installed_map: state -> version name_map
 
 (** Return the base packages *)
-val base_packages: name list
+val base_packages: name list Lazy.t
 
 (** Return all the collection of installed packages, for all the
     available packages *)

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -557,6 +557,18 @@ let system_ocamlc_where = system [ "ocamlc"; "-where" ]
 
 let system_ocamlc_version = system [ "ocamlc"; "-version" ]
 
+let system_camlp4_available = lazy (
+  let version = Lazy.force (system [ "camlp4"; "-version" ]) in
+  let where = Lazy.force (system [ "camlp4"; "-where" ]) in
+  let ocamlc_where = Lazy.force system_ocamlc_where in
+  let ocamlc_version = Lazy.force system_ocamlc_version in
+  match version, where, ocamlc_version, ocamlc_where with
+  | Some version, Some where, Some ocamlc_version, Some ocamlc_where ->
+    version = ocamlc_version &&
+    where = Filename.concat ocamlc_where "camlp4"
+  | _ -> false
+)
+
 let download_command =
   let retry = string_of_int OpamGlobals.download_retry in
   let wget ~compress:_ src =

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -113,6 +113,10 @@ val system_ocamlc_where: string option Lazy.t
 (** Return the version of the system compiler *)
 val system_ocamlc_version: string option Lazy.t
 
+(** Returns true if caml4, camlp4o and camlp4r are available for the
+    system compiler *)
+val system_camlp4_available: bool Lazy.t
+
 (** [directories_with_links dir] returns the directories in the directory [dir].
     Links pointing to directory are also returned. *)
 val directories_with_links: string -> string list


### PR DESCRIPTION
This is related to https://github.com/ocaml/opam-repository/pull/1641
