### PR TITLE
Always look in the environment for user-provided variable overides

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -141,6 +141,11 @@ let help_sections = [
       `opam config env --switch=SWITCH'.";
   `P "$(i,OPAMUTF8MSGS) use nice UTF8 characters in OPAM messages.";
   `P "$(i,OPAMVERBOSE) see option `--verbose'.";
+  `P "$(i,OPAMVAR_var) overrides the contents of the variable $(i,var)  when \
+      substituting `%{var}%` strings in `opam` files.";
+  `P "$(i,OPAMVAR_package_var) overrides the contents of the variable \
+      $(i,package:var) when substituting `%{package:var}%` strings in \
+      `opam` files.";
   `P "$(i,OPAMYES) see option `--yes'.";
 
   `S "FURTHER DOCUMENTATION";

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -274,12 +274,14 @@ let quick_lookup v =
 	OpamFile.Config.switch (OpamFile.Config.read config) in
     let config = OpamPath.Switch.config root switch OpamPackage.Name.global_config in
     let config = OpamFile.Dot_config.read config in
-
-    if OpamVariable.to_string var = "switch" then
-      Some (S (OpamSwitch.to_string switch))
-    else match OpamVariable.Full.section v with
-    | None   -> OpamFile.Dot_config.variable config var
-    | Some s -> OpamFile.Dot_config.Section.variable config s var
+    match OpamState.get_env_var v with
+    | Some _ as c -> c
+    | None ->
+      if OpamVariable.to_string var = "switch" then
+        Some (S (OpamSwitch.to_string switch))
+      else match OpamVariable.Full.section v with
+        | None   -> OpamFile.Dot_config.variable config var
+        | Some s -> OpamFile.Dot_config.Section.variable config s var
   ) else
     None
 

--- a/src/client/opamState.mli
+++ b/src/client/opamState.mli
@@ -151,6 +151,9 @@ val substitute_file: state -> ?opam:OpamFile.OPAM.t -> variable_map -> basename 
 val global_variable_names: string list
 val package_variable_names: string list
 
+(** Check for user-defined variable overwrite. *)
+val get_env_var: full_variable -> variable_contents option
+
 (** Evaluate a filter *)
 val eval_filter: state -> ?opam:OpamFile.OPAM.t -> variable_map -> filter option -> bool
 


### PR DESCRIPTION
This let us do:

```
export bin=/usr/local/bin && opam install foo
```
