### PR TITLE
Enable curl compression on urls.txt

### DIFF
--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -286,16 +286,16 @@ let remove_suffix suffix filename =
   let filename = to_string filename in
   OpamMisc.remove_suffix ~suffix filename
 
-let download ~overwrite filename dirname =
+let download ~overwrite ?compress filename dirname =
   mkdir dirname;
   let dst = to_string (create dirname (basename filename)) in
-  let file = OpamSystem.download ~overwrite
+  let file = OpamSystem.download ~overwrite ?compress
       ~filename:(to_string filename) ~dst in
   of_string file
 
-let download_as ~overwrite filename dest =
+let download_as ~overwrite ?(compress=false) filename dest =
   mkdir (dirname dest);
-  let file = OpamSystem.download ~overwrite
+  let file = OpamSystem.download ~overwrite ~compress
       ~filename:(to_string filename) ~dst:(to_string dest) in
   assert (file = to_string dest);
   ()

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -189,12 +189,14 @@ val remove_prefix: Dir.t -> t -> string
 val remove_suffix: Base.t -> t -> string
 
 (** download a remote file in a given directory. Return the location
-    of the downloaded file if the download is successful.  *)
-val download: overwrite:bool -> t -> Dir.t -> t
+    of the downloaded file if the download is successful.
+    Compress activates http content compression if supported. May break
+    on gzipped files, only use for text files *)
+val download: overwrite:bool -> ?compress:bool -> t -> Dir.t -> t
 
 (** same as [download], but with a specified destination filename instead of a
     directory *)
-val download_as: overwrite:bool -> t -> t -> unit
+val download_as: overwrite:bool -> ?compress:bool -> t -> t -> unit
 
 (** iterate downloads until one is sucessful *)
 val download_iter: overwrite:bool -> t list -> Dir.t -> t

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -171,7 +171,8 @@ val funlock: string -> unit
 (** {2 Misc} *)
 
 (** download compiler sources *)
-val download: overwrite:bool -> filename:string -> dst:string -> string
+val download: overwrite:bool -> ?compress:bool ->
+  filename:string -> dst:string -> string
 
 (** Apply a patch file in the current directory. *)
 val patch: string -> unit

--- a/src/repositories/opamHTTP.ml
+++ b/src/repositories/opamHTTP.ml
@@ -64,7 +64,8 @@ let make_state ~download_index repo =
 	    (OpamRepositoryName.to_string repo.repo_name)
 	    (OpamFilename.to_string remote_index_file);
           let file =
-            OpamFilename.download ~overwrite:false remote_index_file repo.repo_root  in
+            OpamFilename.download ~compress:true ~overwrite:false
+              remote_index_file repo.repo_root in
           OpamFilename.remove local_index_file_save;
           file;
         with e ->


### PR DESCRIPTION
I had to enable it in nginx configuration as well. Gives a huge speedup for
update. We could enable it for wget as well, but then we need to gunzip by
hand
Ref: #1157
