### PR TITLE
Parse version constraints even with groupings in the middle. Fix #1180.

### DIFF
--- a/src/core/opamFormat.ml
+++ b/src/core/opamFormat.ml
@@ -330,10 +330,14 @@ let rec parse_constraints t =
   match t with
   | []                                            -> Empty
   | (Symbol r) :: (String v) :: []                -> Atom (relop r, version v)
-  | (Symbol r) :: (String v) :: (Symbol "&") :: t -> And (Atom (relop r, version v),
-                                                          parse_constraints t)
-  | (Symbol r) :: (String v) :: (Symbol "|") :: t -> Or (Atom (relop r, version v),
-                                                         parse_constraints t)
+  | (Symbol r) :: (String v) :: (Symbol "&") :: t ->
+    And (Atom (relop r, version v), parse_constraints t)
+  | (Symbol r) :: (String v) :: (Symbol "|") :: t ->
+    Or (Atom (relop r, version v),  parse_constraints t)
+  | (Group g) :: (Symbol "&") :: t                ->
+    And (Block (parse_constraints g), parse_constraints t)
+  | (Group g) :: (Symbol "|") :: t                ->
+    Or (Block (parse_constraints g), parse_constraints t)
   | [Group g]                                     -> Block (parse_constraints g)
   | x -> bad_format "Expecting a list of constraints, got %s" (kinds x)
 


### PR DESCRIPTION
I don't believe any other portion of code should rely on a particular formula structure and so this change is all that is required to parse expressions like `(>= "2.0.0" & < "3.0.0") | (>= "4.0.0" & < "5.0.0")`.
