### PR TITLE
keep opam's bin/ at the same place in the PATH list during a switch

### DIFF
--- a/src/core/opamMisc.ml
+++ b/src/core/opamMisc.ml
@@ -313,6 +313,19 @@ let reset_env_value ~prefix c v =
   let v = split_delim v c in
   List.filter (fun v -> not (starts_with ~prefix v)) v
 
+(* Split the list in two according to the first occurrence of the string
+   starting with the given prefix.
+*)
+let cut_env_value ~prefix c v =
+  let v = split_delim v c in
+  let rec aux before =
+    function
+      | [] -> [], List.rev before
+      | curr::after when starts_with ~prefix curr ->
+        before, after
+      | curr::after -> aux (curr::before) after
+  in aux [] v
+
 (* if rsync -arv return 4 lines, this means that no files have changed *)
 let rsync_trim = function
   | [] -> []

--- a/src/core/opamMisc.mli
+++ b/src/core/opamMisc.mli
@@ -189,6 +189,13 @@ val sub_at: int -> string -> string
 (** Remove from a c-separated list of string the one with the given prefix *)
 val reset_env_value: prefix:string -> char -> string -> string list
 
+(** split a c-separated list of string in two according to the first
+    occurrences of the string with the given [prefix]. The list of
+    elements occurring before is returned in reverse order. If there are
+    other elements with the same [prefix] they are kept in the second list.
+ *)
+val cut_env_value: prefix:string -> char -> string -> string list * string list
+
 (** if rsync -arv return 4 lines, this means that no files have changed *)
 val rsync_trim: string list -> string list
 


### PR DESCRIPTION
The proposed patch will keep the `bin/` directory corresponding to OPAM compiler's version at the same place in the `PATH` list when running `opam config env` after a switch. If no such directory was present in `PATH`, it is appended as the beginning of the list as is the case now. In the current setup, OPAM's `bin/` dir will be put in front of `PATH` regardless of its actual position, meaning that an `opam switch` may result in OPAM-managed executables inadvertently shadowing versions installed outside of OPAM.
