### PR TITLE
Fix ocamlgraph in src_ext

### DIFF
--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -12,8 +12,8 @@ DOSEMD5  = e98ff720fcc3873def46c85c6a980a1b
 CMDLINER    = cmdliner-0.9.3
 CMDLINERMD5 = d63dd3b03966d65fc242246859c831c7
 
-GRAPH    = ocamlgraph-1.8.4
-GRAPHMD5 = ddbd90b536606934953ac834c072ead5
+GRAPH    = ocamlgraph-1.8.3
+GRAPHMD5 = ad2dc42f74c77dae9302c40cf2b5ff86
 
 RE       = ocaml-re-1.2.0
 REMD5    = 5cbfc137683ef2b0e91f931577f2e673


### PR DESCRIPTION
Restored pointer to real upstream sources of ocamlgraph in src_ext
Moved version to 1.8.3. Release 1.8.4 includes the graphml output moved there from dose, and will need to wait till the next dose release.
