### PR TITLE
Add dose patch for clean exit on solver errors

### DIFF
--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -63,7 +63,7 @@ $(DOSE).tar.gz:
 
 dose.stamp: $(DOSE).tar.gz
 	tar xfz $(DOSE).tar.gz
-	cd $(DOSE) && patch -p1 < ../dose-mktemp.diff && patch -p1 < ../dose-quotecriteria.diff && patch -p1  < ../dose-pcre2re.diff && cd ..
+	cd $(DOSE) && patch -p1 < ../dose-mktemp.diff && patch -p1 < ../dose-quotecriteria.diff && patch -p1  < ../dose-pcre2re.diff && patch -p1  < ../dose-exceptions.diff && cd ..
 	rm -rf dose
 	mv $(DOSE) dose
 	@touch $@

--- a/src_ext/dose-exceptions.diff
+++ b/src_ext/dose-exceptions.diff
@@ -1,0 +1,32 @@
+diff --git a/common/cudfSolver.ml b/common/cudfSolver.ml
+index 9b71147..7197fa3 100644
+--- a/common/cudfSolver.ml
++++ b/common/cudfSolver.ml
+@@ -38,13 +38,6 @@ let rmtmpdir path =
+     ignore (Unix.system (Printf.sprintf "rm -rf %s" path))
+ ;;
+ 
+-let check_exit_status cmd = function
+-  |Unix.WEXITED 0   -> ()
+-  |Unix.WEXITED i   -> fatal "command '%s' failed with code %d" cmd i
+-  |Unix.WSIGNALED i -> fatal "command '%s' killed by signal %d" cmd i
+-  |Unix.WSTOPPED i  -> fatal "command '%s' stopped by signal %d" cmd i
+-;;
+-
+ let rec input_all_lines acc chan =
+   try input_all_lines ((input_line chan)::acc) chan
+   with End_of_file -> acc
+@@ -69,6 +62,13 @@ let fatal fmt =
+   ) fmt
+ ;;
+ 
++let check_exit_status cmd = function
++  |Unix.WEXITED 0   -> ()
++  |Unix.WEXITED i   -> fatal "command '%s' failed with code %d" cmd i
++  |Unix.WSIGNALED i -> fatal "command '%s' killed by signal %d" cmd i
++  |Unix.WSTOPPED i  -> fatal "command '%s' stopped by signal %d" cmd i
++;;
++
+ (** [execsolver] execute an external cudf solver.
+     exec_pat : execution string
+     cudf : a cudf document (preamble, universe, request)


### PR DESCRIPTION
Source:
https://gforge.inria.fr/plugins/scmgit/cgi-bin/gitweb.cgi?p=dose/dose.git;a=commit;h=3d9b403766e7741e84fb648dde7867dd6f869b38 
Closes #1202

When trying to reproduce by linking aspcud to /bin/false I got a worse problem though (full silent lock)
