### PR TITLE
Fix subtle mistake in request generation used for internal heuristics

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -958,10 +958,11 @@ module API = struct
             wish_remove  = OpamSolution.eq_atoms_of_packages unavailable;
             wish_upgrade = [] }
         else
-          { wish_install = OpamSolution.atoms_of_packages
-                (OpamPackage.Set.inter t.installed_roots (Lazy.force t.available_packages));
+	  let eqnames, neqnames = List.partition (function (_,Some(`Eq,_)) -> true | _ -> false) atoms in
+          { wish_install = eqnames @ (OpamSolution.atoms_of_packages
+                (OpamPackage.Set.inter t.installed_roots (Lazy.force t.available_packages)));
             wish_remove  = OpamSolution.eq_atoms_of_packages unavailable;
-            wish_upgrade = atoms }
+            wish_upgrade = neqnames }
       in
       let action =
         if add_to_roots = Some false || deps_only then


### PR DESCRIPTION
Removed from the upgrade section of the request packages with explicit equality constraints: they need to go in
the install part of the request.
