### PR TITLE
fix: remove call to awk in Makefile, replacing it by an ocaml script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ with-ocamlbuild: autogen
 	  find src/$$i -type f \( -not -name opamMain.ml \) \
 	                       \( -name \*.ml -or -name \*.mly -or -name \*.mll \)\
 	    | xargs -n 1 basename\
-	    | awk -F. "{ print (toupper(substr(\$$1,0,1)) substr(\$$1,2)) }"\
+	    | ocaml ./shell/modulename_of_mlfilename.ml\
 	    > src/$$i/opam-$$i.mllib &&\
 	  ocamlbuild $(OCAMLBUILD_FLAGS) opam-$$i.cma opam-$$i.cmxa;\
 	done;\

--- a/shell/modulename_of_mlfilename.ml
+++ b/shell/modulename_of_mlfilename.ml
@@ -1,0 +1,9 @@
+try
+  let x = input_char stdin in
+  print_char(Char.uppercase x);
+  while true do 
+    match input_char stdin with
+   | '.' -> raise End_of_file
+   | c -> print_char c
+  done
+with End_of_file -> print_newline()


### PR DESCRIPTION
because some old versions of awk are buggy
cf. https://github.com/ocaml/opam/issues/1247

modified:   Makefile
new file:   shell/modulename_of_mlfilename.ml
