### PR TITLE
Let opam run its updated version from opamroot

### DIFF
--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -230,6 +230,11 @@ let is_symlink src =
   with Unix.Unix_error _ ->
     OpamSystem.internal_error "%s does not exist." (to_string src)
 
+let is_exec file =
+  try OpamSystem.is_exec (to_string file)
+  with Unix.Unix_error _ ->
+    OpamSystem.internal_error "%s does not exist." (to_string file)
+
 let starts_with dirname filename =
   OpamMisc.starts_with ~prefix:(Dir.to_string dirname) (to_string filename)
 

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -156,6 +156,9 @@ val readlink: t -> t
 (** Is a symlink ? *)
 val is_symlink: t -> bool
 
+(** Is an executable ? *)
+val is_exec: t -> bool
+
 (** Copy a file *)
 val copy: src:t -> dst:t -> unit
 

--- a/src/core/opamGlobals.ml
+++ b/src/core/opamGlobals.ml
@@ -51,6 +51,13 @@ let do_not_copy_files = check "DONOTCOPYFILES"
 let sync_archives    = check "SYNCARCHIVES"
 let compat_mode_1_0  = check "COMPATMODE_1_0"
 let use_external_solver = ref (not !(check "NOASPCUD"))
+let no_self_upgrade  = check "NOSELFUPGRADE"
+
+(* Value set when opam calls itself *)
+let self_upgrade_bootstrapping_value = "bootstrapping"
+let is_self_upgrade =
+  try OpamMisc.getenv "OPAMNOSELFUPGRADE" = self_upgrade_bootstrapping_value
+  with Not_found -> false
 
 let curl_command = try Some (OpamMisc.getenv "OPAMCURL") with Not_found -> None
 

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -355,6 +355,11 @@ let copy src dst =
   mkdir (Filename.dirname dst);
   command ["cp"; src; dst ]
 
+let is_exec file =
+  let stat = Unix.stat file in
+  stat.Unix.st_kind = Unix.S_REG &&
+  stat.Unix.st_perm land 0o111 <> 0
+
 let install ?exec src dst =
   if Sys.is_directory src then
     internal_error "Cannot install %s: it is a directory." src;
@@ -363,7 +368,7 @@ let install ?exec src dst =
   mkdir (Filename.dirname dst);
   let exec = match exec with
     | Some e -> e
-    | None -> (Unix.stat src).Unix.st_perm land 0o100 <> 0 in
+    | None -> is_exec src in
   command
     ("install" :: "-m" :: (if exec then "0755" else "0644") ::
      [ src; dst ])

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -42,6 +42,10 @@ val copy: string -> string -> unit
     permissions of the original file to decide). *)
 val install: ?exec:bool -> string -> string -> unit
 
+(** Checks if a file is an executable (regular file with execution
+    permission) *)
+val is_exec: string -> bool
+
 (** [link src dst] links [src] to [dst]. Remove [dst] if it is a file,
     not a directory. *)
 val link: string -> string -> unit


### PR DESCRIPTION
this is not much but can be enough to open the gates for self-updating later
on.

I successfully tried it with a simple OPAM package that installs just
its exe to <opamroot>/opam
