### PR TITLE
Fix get git version

### DIFF
--- a/shell/get-git-id.ml
+++ b/shell/get-git-id.ml
@@ -34,11 +34,11 @@ let () =
   | None   -> version_none ()
   | Some s ->
     let reference =
-      try
+      try (* look for "ref: refs/heads/..." *)
         let c = String.rindex s ' ' in
 	let namedref = String.sub s (c+1) (String.length s -c-1) in
 	read (git namedref)
-      with Not_found ->
+      with Not_found -> (* detached state, .git/HEAD contains sha1 *)
         Some s in
     match reference with
     | None      -> version_none ()


### PR DESCRIPTION
Previous code only worked when at the tip of a branch, now it also handles detached HEAD states.
