### PR TITLE
Save version_map in cudf file as comments

### DIFF
--- a/src/solver/opamCudf.mli
+++ b/src/solver/opamCudf.mli
@@ -77,12 +77,14 @@ val reverse_dependencies: Cudf.universe -> Cudf.package list -> Cudf.package lis
     [explain] is set to [false] *)
 val check_request:
   ?explain:bool ->
+  version_map:int OpamPackage.Map.t ->
   Cudf.universe ->
   Cudf_types.vpkg request ->
   (Cudf.universe, Algo.Diagnostic.reason list) result
 
 (** Compute the final universe state using the external solver. *)
 val get_final_universe:
+  version_map:int OpamPackage.Map.t ->
   Cudf.universe ->
   Cudf_types.vpkg request ->
   (Cudf.universe, Algo.Diagnostic.reason list) result
@@ -102,10 +104,11 @@ val solution_of_actions:
   solution
 
 (** Resolve a CUDF request. The result is either a conflict explaining
-    the error, or a resulting universe. 
+    the error, or a resulting universe.
     [~extern] specifies wether the external solver should be used *)
 val resolve:
   extern:bool ->
+  version_map:int OpamPackage.Map.t ->
   Cudf.universe ->
   Cudf_types.vpkg request ->
   (Cudf.universe, Algo.Diagnostic.reason list) result

--- a/src/solver/opamHeuristic.mli
+++ b/src/solver/opamHeuristic.mli
@@ -51,6 +51,7 @@ open OpamTypes
 (** Optimized resolution *)
 val resolve:
   ?verbose:bool ->
+  version_map:int OpamPackage.Map.t ->
   (Cudf.universe -> Cudf.universe) ->
   Cudf.universe ->
   Cudf_types.vpkg request ->
@@ -138,12 +139,16 @@ val explore: ?verbose:bool ->
     to explore is. Once the state-space is computed using
     [state_space], it calls [explore] (which will use [brute_force])
     to get an approximate solution to the request. *)
-val state_of_request: ?verbose:bool
-  -> Cudf.universe -> Cudf_types.vpkg request -> Cudf.package state option
+val state_of_request: ?verbose:bool  ->
+  version_map:int OpamPackage.Map.t ->
+  Cudf.universe ->
+  Cudf_types.vpkg request -> Cudf.package state option
 
 (** Convert a state into a series of action (withour the full closure
     of reinstallations). Raise [Not_reachable] is the state is not
     reachable. This function is called once we get a consistent state
     to build a solution than we can propose to the user. *)
-val actions_of_state: Cudf.universe -> (Cudf.universe -> Cudf.universe) ->
+val actions_of_state:
+  version_map:int OpamPackage.Map.t ->
+  Cudf.universe -> (Cudf.universe -> Cudf.universe) ->
   Cudf_types.vpkg request -> Cudf.package state -> Cudf.package action list

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -91,7 +91,7 @@ let cudf_versions_map universe packages =
 let name_to_cudf name =
   Common.CudfAdd.encode (OpamPackage.Name.to_string name)
 
-let atom2cudf universe version_map (name,cstr) =
+let atom2cudf universe (version_map : int OpamPackage.Map.t) (name,cstr) =
   name_to_cudf name, match cstr with
   | None -> None
   | Some (op,v) ->
@@ -312,12 +312,12 @@ let resolve ?(verbose=true) universe ~requested request =
     if OpamCudf.external_solver_available ()
     then
       try
-        let resp = OpamCudf.resolve ~extern:true u req in
+        let resp = OpamCudf.resolve ~extern:true ~version_map u req in
         OpamCudf.to_actions add_orphan_packages u resp
       with Failure "opamSolver" ->
         OpamGlobals.error_and_exit
           "Please retry with option --use-internal-solver"
-    else OpamHeuristic.resolve ~verbose add_orphan_packages u req in
+    else OpamHeuristic.resolve ~verbose ~version_map add_orphan_packages u req in
   match resolve simple_universe cudf_request with
   | Conflicts c     -> Conflicts (fun () ->
       OpamCudf.string_of_reasons cudf2opam simple_universe universe (c ()))


### PR DESCRIPTION
The "opam-version" field is not enough, as there is no way to recover the correct version for missing packages. So now, opam adds "#v2v:PACKAGE:VERSIONNUM=VERSIONSTRING" lines at the end of file. 

This would make "opam-version" useless, unless some other tools are using this field ?
