### PR TITLE
Parsing of urls

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -592,8 +592,9 @@ let init =
     OpamFilename.mkdir global_options.root;
     apply_global_options global_options;
     apply_build_options build_options;
-    let repo_kind = guess_repository_kind repo_kind repo_address in
     let repo_priority = 0 in
+    let repo_address, repo_kind2 = parse_url repo_address in
+    let repo_kind = OpamMisc.Option.default repo_kind2 repo_kind in
     let repository = {
       repo_root = OpamPath.Repository.create (OpamPath.root ()) repo_name;
       repo_name; repo_kind; repo_address; repo_priority } in
@@ -1162,7 +1163,8 @@ let repository =
       | [name;address] ->
         let name = OpamRepositoryName.of_string name in
         let address = address_of_string address in
-        let kind = guess_repository_kind kind address in
+        let address, kind2 = parse_url address in
+        let kind = OpamMisc.Option.default kind2 kind in
         Client.REPOSITORY.add name kind address ~priority
       | _ -> error `toomany usage_add in
     let list = function

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -295,10 +295,7 @@ module API = struct
       let url = match OpamState.url t nv with
         | None   -> []
         | Some u ->
-          let kind =
-            match OpamFile.URL.kind u with
-            | None   -> "http"
-            | Some k -> string_of_repository_kind k in
+          let kind = string_of_repository_kind (OpamFile.URL.kind u) in
           let url = string_of_address (OpamFile.URL.url u) in
           let mirrors =
             OpamMisc.string_of_list string_of_address (OpamFile.URL.mirrors u) in

--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -307,12 +307,12 @@ let locally_pinned_package t n =
 
 let url_of_locally_pinned_package t n =
   let path, kind = locally_pinned_package t n in
-  OpamFile.URL.create (Some kind) path
+  OpamFile.URL.create kind path
 
 let repository_of_locally_pinned_package t n =
   let url = url_of_locally_pinned_package t n in
   let repo_address = OpamFile.URL.url url in
-  let repo_kind = guess_repository_kind (OpamFile.URL.kind url) repo_address in
+  let repo_kind = OpamFile.URL.kind url in
   let repo_root = OpamPath.Switch.dev_package t.root t.switch (OpamPackage.pinned n) in
   { repo_name     = OpamRepositoryName.of_string (OpamPackage.Name.to_string n);
     repo_priority = 0;
@@ -1126,7 +1126,7 @@ let is_dev_package t nv =
   match url t nv with
   | None     -> false
   | Some url ->
-    match guess_repository_kind (OpamFile.URL.kind url) (OpamFile.URL.url url) with
+    match OpamFile.URL.kind url with
     | `http  -> false
     | _      -> true
 
@@ -2165,7 +2165,7 @@ let install_compiler t ~quiet switch compiler =
               "No source for compiler %s"
               (OpamCompiler.to_string compiler) in
         let build_dir = OpamPath.Switch.build_ocaml t.root switch in
-        let kind = guess_repository_kind (OpamFile.Comp.kind comp) comp_src in
+        let kind = OpamFile.Comp.kind comp in
         if kind = `local
         && Sys.file_exists (fst comp_src)
         && Sys.is_directory (fst comp_src) then
@@ -2232,7 +2232,7 @@ let update_dev_package t nv =
   | Some url ->
     let remote_url = OpamFile.URL.url url in
     let mirrors = remote_url :: OpamFile.URL.mirrors url in
-    let kind = guess_repository_kind (OpamFile.URL.kind url) remote_url in
+    let kind = OpamFile.URL.kind url in
     let srcdir = dev_package t nv in
     let fetch () =
       log "updating %a:%a"
@@ -2398,7 +2398,7 @@ let download_upstream t nv dirname =
   | Some u ->
     let remote_url = OpamFile.URL.url u in
     let mirrors = remote_url :: OpamFile.URL.mirrors u in
-    let kind = guess_repository_kind (OpamFile.URL.kind u) remote_url in
+    let kind = OpamFile.URL.kind u in
     let checksum = OpamFile.URL.checksum u in
     match OpamRepository.pull_url kind nv dirname checksum mirrors with
     | Not_available u -> OpamGlobals.error_and_exit "%s is not available" u

--- a/src/core/opamFile.mli
+++ b/src/core/opamFile.mli
@@ -284,7 +284,7 @@ module Comp: sig
   val src: t -> address option
 
   (** Return the url kind *)
-  val kind: t -> repository_kind option
+  val kind: t -> repository_kind
 
   (** Return the list of patches to apply *)
   val patches: t -> filename list
@@ -489,7 +489,7 @@ module URL: sig
 
   include IO_FILE
 
-  val create: repository_kind option -> ?mirrors:address list -> address -> t
+  val create: repository_kind -> ?mirrors:address list -> address -> t
 
   (** URL address *)
   val url: t -> address
@@ -497,7 +497,7 @@ module URL: sig
   val mirrors: t -> address list
 
   (** Backend kind (could be curl/rsync/git/darcs/hg at the moment) *)
-  val kind: t -> repository_kind option
+  val kind: t -> repository_kind
 
   (** Archive checksum *)
   val checksum: t -> string option

--- a/src/core/opamRepository.ml
+++ b/src/core/opamRepository.ml
@@ -315,7 +315,7 @@ let make_archive ?(gener_digest=false) repo prefix nv =
       let checksum = OpamFile.URL.checksum url in
       let remote_url = OpamFile.URL.url url in
       let mirrors = remote_url :: OpamFile.URL.mirrors url in
-      let kind = guess_repository_kind (OpamFile.URL.kind url) remote_url in
+      let kind = OpamFile.URL.kind url in
       log "downloading %a:%a"
         (slog string_of_address) remote_url
         (slog string_of_repository_kind) kind;

--- a/src/core/opamTypesBase.mli
+++ b/src/core/opamTypesBase.mli
@@ -30,8 +30,10 @@ val string_of_address: address -> string
 (** Parse an address *)
 val address_of_string: string -> address
 
-(** Guess the repository kind *)
-val guess_repository_kind: repository_kind option -> address -> repository_kind
+(** Guess an address kind using url suffixes ([.git], etc.) and prefixes
+    ([http://], etc.). Defaults to `local. The returned address is a correct
+    path in case of [file://] *)
+val parse_url: address -> address * [`http|`local|`git|`darcs|`hg]
 
 (** Pretty-print repository kinds. *)
 val string_of_repository_kind: [`http|`local|`git|`darcs|`hg] -> string


### PR DESCRIPTION
Fixes one issue mentionned in #1285. This should handle git://, http:// etc.
prefixes correctly, as well as .git suffixes. There is still a heuristic that
defaults to a version pin if the target starts with a number and doesn't
contain slashes.
