### PR TITLE
Choose solver criteria depending on the action

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -91,8 +91,11 @@ let apply_global_options o =
     !OpamGlobals.use_external_solver && not o.use_internal_solver;
   OpamGlobals.cudf_file := o.cudf_file;
   OpamGlobals.no_self_upgrade := !OpamGlobals.no_self_upgrade || o.no_self_upgrade;
-  OpamGlobals.solver_preferences := match o.solver_preferences with None -> !OpamGlobals.solver_preferences | Some v -> v
-
+  match o.solver_preferences with
+  | None -> ()
+  | Some prefs ->
+    OpamGlobals.solver_preferences := prefs;
+    OpamGlobals.solver_upgrade_preferences := prefs
 
 (* Build options *)
 type build_options = {
@@ -483,7 +486,8 @@ let global_options =
         and takes precedence over it if both are specified. \
         For details on the supported language, see \
         $(i,  http://opam.ocaml.org/doc/Specifying_Solver_Preferences.html). \
-        The default value is "^OpamGlobals.default_preferences)
+        The default value is "^OpamGlobals.default_upgrade_preferences^
+       " for upgrades, and "^OpamGlobals.default_preferences^" otherwise.")
       Arg.(some string) None in
   let cudf_file =
     mk_opt ["cudf"] "FILENAME"

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -219,7 +219,8 @@ let install_packages ~packages switch compiler =
 	~requested:roots
         { wish_install = [];
           wish_remove  = [];
-          wish_upgrade = to_install } in
+          wish_upgrade = to_install;
+          criteria = !OpamGlobals.solver_preferences; } in
     begin try
         OpamSolution.check_solution t solution;
       with e ->
@@ -309,7 +310,8 @@ let import_t filename t =
       ~requested:(OpamPackage.names_of_packages imported)
       { wish_install = to_import @ to_keep;
         wish_remove  = [];
-        wish_upgrade = []; } in
+        wish_upgrade = [];
+        criteria = !OpamGlobals.solver_preferences; } in
   OpamSolution.check_solution t solution
 
 let export filename =

--- a/src/core/opamGlobals.ml
+++ b/src/core/opamGlobals.ml
@@ -85,11 +85,19 @@ let solver_timeout =
   with Not_found | Failure _ -> 5.
 
 let default_preferences = (* "-removed,-notuptodate,-count(down),-new,-changed" *)
+  "-removed,-changed,-notuptodate"
+let default_upgrade_preferences = (* "-removed,-notuptodate,-count(down),-new,-changed" *)
   "-removed,-notuptodate,-changed"
 
-let solver_preferences = ref(
-  try OpamMisc.strip (OpamMisc.getenv "OPAMCRITERIA")
-  with Not_found -> default_preferences)
+let solver_preferences, solver_upgrade_preferences  =
+  let get s = OpamMisc.strip (OpamMisc.getenv s) in
+  try
+    let prefs = get "OPAMCRITERIA" in
+    ref prefs, try ref (get "OPAMUPGRADECRITERIA") with Not_found -> ref prefs
+  with Not_found ->
+    ref default_preferences,
+    try ref (get "OPAMUPGRADECRITERIA")
+    with Not_found -> ref default_upgrade_preferences
 
 let default_external_solver = "aspcud"
 

--- a/src/core/opamTypes.ml
+++ b/src/core/opamTypes.ml
@@ -240,6 +240,7 @@ type ('a, 'b) result =
 
 (** Solver request *)
 type 'a request = {
+  criteria: string;
   wish_install: 'a conjunction;
   wish_remove : 'a conjunction;
   wish_upgrade: 'a conjunction;

--- a/src/scripts/opam_mk_repo.ml
+++ b/src/scripts/opam_mk_repo.ml
@@ -107,7 +107,8 @@ let resolve_deps index names =
     u_conflicts = OpamPackage.Map.map OpamFile.OPAM.conflicts opams;
     u_action = Install requested;
   } in
-  let request = { wish_install = atoms; wish_remove = []; wish_upgrade = [] } in
+  let request = { wish_install = atoms; wish_remove = []; wish_upgrade = [];
+                  criteria = !OpamGlobals.solver_preferences; } in
   match OpamSolver.resolve ~verbose:true universe ~requested request with
   | Success solution ->
     OpamSolver.ActionGraph.fold_vertex (fun act acc -> match act with

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -273,8 +273,9 @@ let solution cudf2opam cudf_solution =
 let map_request f r =
   let f = List.rev_map f in
   { wish_install = f r.wish_install;
-    wish_remove  = f r.wish_remove ;
-    wish_upgrade = f r.wish_upgrade }
+    wish_remove  = f r.wish_remove;
+    wish_upgrade = f r.wish_upgrade;
+    criteria = r.criteria }
 
 (* Remove duplicate packages *)
 (* Add upgrade constraints *)


### PR DESCRIPTION
This resolves the problem of unrelated packages installed on 'opam install' by
minimising the changes except on 'opam upgrade'. You may now specify 
OPAMUPGRADECRITERIA. OPAMCRITERIA and --criteria still change the criteria for
all actions.

Closes #1345
