### PR TITLE
Skip unneeded costly computation of transitive reduction

### DIFF
--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -84,9 +84,7 @@ module Graph = struct
   module Topo = Graph.Topological.Make (PG)
 
   let of_universe u =
-    let g = Algo.Defaultgraphs.PackageGraph.dependency_graph u in
-    PO.transitive_reduction g;
-    g
+    Algo.Defaultgraphs.PackageGraph.dependency_graph u
 
   let output g filename =
     let fd = open_out (filename ^ ".dot") in


### PR DESCRIPTION
Gives a huge speedup on some trivial requests (1.49s -> 0.67s on my example,
trying to install an already installed package)

Ref: #1363
