### PR TITLE
Store pinning info in opam switch exports

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -147,7 +147,7 @@ let with_switch_backup command f =
   let t = OpamState.load_state command in
   let file = OpamPath.Switch.backup t.root t.switch in
   OpamFilename.mkdir (OpamPath.Switch.backup_dir t.root t.switch);
-  OpamFile.Export.write file (t.installed, t.installed_roots);
+  OpamFile.Export.write file (t.installed, t.installed_roots, t.pinned);
   try
     f t;
     OpamFilename.remove file (* We might want to keep it even if successful ? *)

--- a/src/core/opamFile.ml
+++ b/src/core/opamFile.ml
@@ -362,40 +362,72 @@ module X = struct
 
     let internal = "export"
 
-    type t = package_set * package_set
+    type t = package_set * package_set * pin_option OpamPackage.Name.Map.t
 
-    let empty = (OpamPackage.Set.empty, OpamPackage.Set.empty)
+    let empty = (OpamPackage.Set.empty, OpamPackage.Set.empty, OpamPackage.Name.Map.empty)
 
-    let of_channel _ ic =
+    let of_channel f ic =
       let lines = Lines.of_channel ic in
-      let installed = ref OpamPackage.Set.empty in
-      let roots = ref OpamPackage.Set.empty in
-      let add n v r =
-        let nv = OpamPackage.create (OpamPackage.Name.of_string n)
-            (OpamPackage.Version.of_string v) in
-        installed := OpamPackage.Set.add nv !installed;
-        if r then
-          roots := OpamPackage.Set.add nv !roots;
+      let state = function
+        | "root" -> `Root
+        | "noroot" | "installed" -> `Installed
+        | "uninstalled" -> `Uninstalled
+        | s ->
+          OpamGlobals.error_and_exit "Invalid installation status (col. 3) in %s: %S"
+            (OpamFilename.to_string f) s
       in
-      List.iter (function
-        | []        -> ()
-        | [n; v]    -> add n v true
-        | [n; v; r] -> add n v (r = "root")
-        | l         ->
-          OpamGlobals.error_and_exit
-            "  Invalid line: %s\nThis is not a valid file to import."
-            (String.concat " " l)
-      ) lines;
-      (!installed, !roots)
+      let add (installed,roots,pinned) n v state p =
+        let name = OpamPackage.Name.of_string n in
+        let nv = OpamPackage.create name (OpamPackage.Version.of_string v) in
+        let installed =
+          if state <> `Uninstalled then OpamPackage.Set.add nv installed
+          else installed in
+        let roots =
+          if state = `Root then OpamPackage.Set.add nv roots
+          else roots in
+        let pinned = match p with
+          | None -> pinned
+          | Some (kind,p) ->
+            OpamPackage.Name.Map.add name (pin_option_of_string ~kind p) pinned
+        in
+        installed, roots, pinned
+      in
+      List.fold_left (fun acc -> function
+          | []        -> acc
+          | [n; v]    -> add acc n v `Root None
+          | [n; v; r] -> add acc n v (state r) None
+          | [n; v; r; pk; p] ->
+            add acc n v (state r) (Some (pin_kind_of_string pk,p))
+          | l ->
+            OpamGlobals.error_and_exit "Invalid line in %s: %S"
+              (OpamFilename.to_string f)
+              (String.concat " " l)
+        )
+        (OpamPackage.Set.empty, OpamPackage.Set.empty, OpamPackage.Name.Map.empty)
+        lines
 
-    let to_string _ (installed, roots) =
+    let to_string _ (installed, roots, pinned) =
       let buf = Buffer.create 1024 in
+      let print_pin pin =
+        Printf.sprintf "\t%s\t%s"
+          (string_of_pin_kind (kind_of_pin_option pin))
+          (string_of_pin_option pin) in
       OpamPackage.Set.iter (fun nv ->
-        Printf.bprintf buf "%s %s %s\n"
-          (OpamPackage.Name.to_string (OpamPackage.name nv))
-          (OpamPackage.Version.to_string (OpamPackage.version nv))
-          (if OpamPackage.Set.mem nv roots then "root" else "noroot")
-      ) installed;
+          let name = OpamPackage.name nv in
+          Printf.bprintf buf "%s\t%s\t%s%s\n"
+            (OpamPackage.Name.to_string (OpamPackage.name nv))
+            (OpamPackage.Version.to_string (OpamPackage.version nv))
+            (if OpamPackage.Set.mem nv roots then "root" else "installed")
+            (try print_pin (OpamPackage.Name.Map.find name pinned)
+             with Not_found -> "")
+        ) installed;
+      let installed_names = OpamPackage.names_of_packages installed in
+      OpamPackage.Name.Map.iter (fun name pin ->
+          if not (OpamPackage.Name.Set.mem name installed_names) then
+            Printf.bprintf buf "%s\t--\tuninstalled\t%s\n"
+              (OpamPackage.Name.to_string name)
+              (print_pin pin)
+        ) pinned;
       Buffer.contents buf
 
   end

--- a/src/core/opamFile.mli
+++ b/src/core/opamFile.mli
@@ -250,7 +250,8 @@ module Aliases: IO_FILE with type t = compiler switch_map
 
 (** Import/export file. This difference with [installed] is that we
     are explicit about root packages. *)
-module Export: IO_FILE with type t = package_set * package_set
+module Export: IO_FILE with type t =
+  package_set * package_set * pin_option OpamPackage.Name.Map.t
 
 (** List of installed packages: [$opam/$oversion/installed] *)
 module Installed: IO_FILE with type t = package_set


### PR DESCRIPTION
Fixes  #1265, #1387

Note however that any manually edited overlay (`pin edit`) can't be kept
through export / import at the moment: metadata will be reset to that of
the package source or the repository.
