### PR TITLE
Better default criteria

### DIFF
--- a/src/core/opamGlobals.ml
+++ b/src/core/opamGlobals.ml
@@ -85,7 +85,7 @@ let solver_timeout =
   with Not_found | Failure _ -> 5.
 
 let default_preferences = (* "-removed,-notuptodate,-count(down),-new,-changed" *)
-  "-removed,-changed,-notuptodate"
+  "-removed,-count(up),-count(down),-notuptodate,-new"
 let default_upgrade_preferences = (* "-removed,-notuptodate,-count(down),-new,-changed" *)
   "-removed,-notuptodate,-changed"
 


### PR DESCRIPTION
The previous criteria minimised all changes before minimising notuptodate,
this only minimises up and down-grades (i.e. all changes but new packages).
This still avoids the 'upgrading unrelated packages' problem, while avoiding
the new problem
'not installing latest version because it has more dependances' (it manifests 
itself with 'opam install ocp-build' which would give prehistoric 0.1 because 
it didn't have any dependency).

Is this compatible with the currently deployed versions of aspcud though ?

Note: we'll still prefer the more specific '-notuptodate(requested),-changes'
when it becomes available, which avoids the mentionned problems but
prioritises installing the last versions of the packages you asked for.
