### PR TITLE
Better printing of conflicts

### DIFF
--- a/src/core/opamFormula.ml
+++ b/src/core/opamFormula.ml
@@ -194,7 +194,7 @@ let to_string t =
   let string_of_pkg = function
     | n, Empty -> OpamPackage.Name.to_string n
     | n, c     ->
-      Printf.sprintf "(%s %s)"
+      Printf.sprintf "%s %s"
         (OpamPackage.Name.to_string n)
         (string_of_formula string_of_constraint c) in
   string_of_formula string_of_pkg t


### PR DESCRIPTION
some causes wouldn't be merged when they concerned the last step depending on
a non-existing package, eg:

```
opam install ackdo-reloaded.0.3 --switch 4.00.0 --show
```
