### PR TITLE
Avoid a 'Sys_error' with 'opam pin'

### DIFF
--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -2321,7 +2321,7 @@ let update_dev_package t nv =
         ["descr", `Digest (OpamFilename.digest d)]) @
       (match files_dir with None -> [] | Some files_dir ->
         List.map (fun f ->
-            OpamFilename.remove_prefix files_dir f,
+            OpamFilename.remove_prefix (OpamFilename.dirname_dir files_dir) f,
             `Digest (OpamFilename.digest f))
           (OpamFilename.rec_files files_dir))
     in


### PR DESCRIPTION
 When pinning to a local directory (or a git), if the source directory contains files in 'opam/files', opam may raise:

```
Sys_error(.../opam/files/ocsigenserver.install: No such file or directory)'
```

For instance:

```
$ opam pin ocsigenserver .
[...]
Fatal error:
Sys_error("/home/greg/.opam/4.01.0+ocsigen/packages.dev/ocsigenserver/opam/ocsigenserver.install: No such file or directory")
Backtrace:
  Raised by primitive operation at file "core/opamSystem.ml", line 366, characters 5-25
  Called from file "list.ml", line 73, characters 12-15
  Called from file "client/opamState.ml", line 2398, characters 9-47
  Called from file "client/opamClient.ml", line 1164, characters 13-48
  Called from file "client/opamClient.ml", line 152, characters 4-7
```
