### PR TITLE
Cleanup, document and improve sub-command handling

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -161,7 +161,7 @@ let with_switch_backup command f =
       OpamFilename.remove file
     else
      Printf.eprintf "\nThe former state can be restored with \
-                     %s switch import -f %S\n%!"
+                     %s switch import %S\n%!"
        Sys.argv.(0) (OpamFilename.to_string file);
     raise err
 

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -77,7 +77,7 @@ module API: sig
     val setup_list: shell -> filename -> unit
 
     (** Execute a command in a subshell with the right environment variables. *)
-    val exec: string -> unit
+    val exec: string list -> unit
 
     (** Display variables and their contents. *)
     val list: name list -> unit

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -195,10 +195,10 @@ let setup_list shell dot_profile =
   OpamState.display_setup t shell dot_profile
 
 let exec command =
-  log "config-exex command=%s" command;
+  log "config-exex command=%S" (String.concat " " command);
   let t = OpamState.load_state "config-exec" in
   let cmd, args =
-    match OpamMisc.split command ' ' with
+    match command with
     | []        -> OpamSystem.internal_error "Empty command"
     | h::_ as l -> h, Array.of_list l in
   let env =

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -37,4 +37,4 @@ val setup: user_config option -> global_config option -> unit
 val setup_list: shell -> filename -> unit
 
 (** Execute a command in a subshell *)
-val exec: string -> unit
+val exec: string list -> unit

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -428,7 +428,7 @@ let with_backup command f =
       OpamFilename.remove file
     else
       Printf.eprintf "The former package state can be restored with \
-                      %s switch import -f %S\n"
+                      %s switch import %S\n"
         Sys.argv.(0) (OpamFilename.to_string file);
     raise err
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -244,10 +244,10 @@ switch-alias:
 	$(CHECK) -l switch-alias-1 P1.1 P2.1 P3.1~weird-version.test P4.2
 	$(OPAMBIN) remove P3.1~weird-version.test P4.2
 	$(CHECK) -l switch-alias-2 P1.1 P2.1
-	$(OPAMBIN) switch export -f $(TMP_DIR)/export
+	$(OPAMBIN) switch export $(TMP_DIR)/export
 	$(OPAMBIN) switch install test --alias-of system --no-base-packages
 	$(CHECK) -l switch-alias-3
-	$(OPAMBIN)	switch import -f $(TMP_DIR)/export
+	$(OPAMBIN)	switch import $(TMP_DIR)/export
 	$(CHECK) -l switch-alias-4 P1.1 P2.1
 	$(OPAMBIN) switch install test2 --alias-of 20
 	$(CHECK) -l switch-alias-5


### PR DESCRIPTION
Addresses #1458, #1462, generates better man-pages and error messages, and 
sanitises some commands.

There may be some small incompatibilites that could break scripts though:
- 'opam switch exec': passes args directly, no String.split: the command
  shouldn't be quoted anymore (enables correct escaping; use -- for command
  arguments)
- 'opam switch import|export': now have a _mandatory_ FILE argument. '-f' no
  longer accepted.
- 'opam pin': backwards compat hacks removed, 'none' and '-u' don't exist
  anymore. 'opam unpin` for 'opam pin remove' still allowed because it's
  convenient and quite innocuous
- 'opam pin PKG TARGET': shortcut to 'opam pin add' removed
- 'opam pin --edit PKG': now use 'opam pin edit'
- 'opam config -env': no longer accepted for 'opam config env'
- some meaningless arguments that could be ignored before are now errors
