### PR TITLE
Pin import fixes

### DIFF
--- a/src/client/opamState.mli
+++ b/src/client/opamState.mli
@@ -375,8 +375,8 @@ val url_of_locally_pinned_package: state -> name -> OpamFile.URL.t
 (** {2 Overlays} *)
 
 (** Add overlay files for a pinned package. If no definition is found
-    use a minimal OPAM file unless [template] is set to [true] *)
-val add_pinned_overlay: ?template:bool -> state -> name -> unit
+    use a minimal OPAM file unless [template] is set to [true]. *)
+val add_pinned_overlay: ?template:bool -> ?version:version -> state -> name -> unit
 
 (** Remove all overlay files *)
 val remove_overlay: state -> name -> unit


### PR DESCRIPTION
- Corrected version of imported pinned packages
- Do not revert pinning state once we get to the install phase
- Correctly re-import pins during `pin reinstall` (behave as
  export-cleanup-reinstall compiler-reload state-import)

Closes #1387
