### PR TITLE
Don't preserve attributes in copy_dir

### DIFF
--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -96,7 +96,7 @@ let copy_dir ~src ~dst =
   if exists_dir dst then
     OpamSystem.internal_error
       "Cannot create %s as the directory already exists." (Dir.to_string dst);
-  OpamSystem.command [ "cp"; "-pPR"; Dir.to_string src; Dir.to_string dst ]
+  OpamSystem.command [ "cp"; "-PR"; Dir.to_string src; Dir.to_string dst ]
 
 let link_dir ~src ~dst =
   if exists_dir dst then


### PR DESCRIPTION
this isn't really needed (where important, we use 'install' instead), and 
causes problems on some filesystems (NFS...).

besides, it's consistent with OpamFilename.copy. Closes #1073
