### PR TITLE
Re-enabled read locks

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1405,6 +1405,9 @@ let switch_lock f =
 let global_lock f =
   OpamState.check (Global_lock f)
 
+let global_then_switch_lock f =
+  OpamState.check (Global_with_switch_cont_lock f)
+
 (** We protect each main functions with a lock depending on its access
     on some read/write data. *)
 
@@ -1490,11 +1493,11 @@ module SafeAPI = struct
   module SWITCH = struct
 
     let switch ~quiet ~warning name =
-      global_lock (fun () -> API.SWITCH.switch ~quiet ~warning name)
+      global_then_switch_lock (fun () -> API.SWITCH.switch_cont ~quiet ~warning name)
 
     let install ~quiet ~warning ~update_config switch ocaml_version =
-      global_lock (fun () ->
-        API.SWITCH.install ~quiet ~warning ~update_config switch ocaml_version)
+      global_then_switch_lock (fun () ->
+        API.SWITCH.install_cont ~quiet ~warning ~update_config switch ocaml_version)
 
     let import filename =
       switch_lock (fun () -> API.SWITCH.import filename)
@@ -1506,7 +1509,7 @@ module SafeAPI = struct
       global_lock (fun () -> API.SWITCH.remove switch)
 
     let reinstall switch =
-      global_lock (fun () -> API.SWITCH.reinstall switch)
+      switch_lock (fun () -> API.SWITCH.reinstall switch)
 
     let list ~print_short ~installed ~all =
       read_lock (fun () -> API.SWITCH.list ~print_short ~installed ~all)

--- a/src/client/opamSwitchCommand.mli
+++ b/src/client/opamSwitchCommand.mli
@@ -18,7 +18,13 @@
 
 open OpamTypes
 
-(** Install a new switch. *)
+(** Install a new switch. Returns a continuation that must be run to install the
+    packages, but only needs a switch lock. *)
+val install_cont:
+  quiet:bool -> warning:bool -> update_config:bool -> switch -> compiler ->
+  switch * (unit -> unit)
+
+(** Like [install_cont] but runs the continuation already *)
 val install:
   quiet:bool -> warning:bool -> update_config:bool -> switch -> compiler -> unit
 
@@ -31,7 +37,10 @@ val export: filename option -> unit
 (** Remove the given compiler switch. *)
 val remove: switch -> unit
 
-(** Switch to the given compiler switch. *)
+(** Switch to the given compiler switch. Returns a continuation like [install] *)
+val switch_cont: quiet:bool -> warning:bool -> switch -> switch * (unit -> unit)
+
+(** Like [switch_cont] but runs the continuation already. *)
 val switch: quiet:bool -> warning:bool -> switch -> unit
 
 (** Reinstall the given compiler switch. *)

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -508,10 +508,12 @@ let flock ?(read=false) file =
     with Unix.Unix_error (Unix.EAGAIN,_,_) ->
       if attempt > max_tries then
         OpamGlobals.error_and_exit
-          "Could not acquire %s lock to %S, aborting."
+          "Timeout trying to acquire %s lock to %S, \
+           is another opam process running ?"
           (if read then "read" else "write") file;
-      OpamGlobals.msg
-        "Another process has a write lock on %S. (attempt %d/%d)\n"
+      log
+        "Failed to %s-lock %S. (attempt %d/%d)"
+        (if read then "read" else "write")
         file attempt max_tries;
       Unix.sleep 1;
       loop (attempt + 1)

--- a/src/core/opamTypes.mli
+++ b/src/core/opamTypes.mli
@@ -388,6 +388,10 @@ type lock =
       a short time. *)
   | Switch_lock of (unit -> unit)
 
+  (** Call the function in a global lock, then relax to a switch
+      lock and call the function it returned *)
+  | Global_with_switch_cont_lock of (unit -> switch * (unit -> unit))
+
 (** A line in {i urls.tx} *)
 type file_attribute = OpamFilename.Attribute.t
 


### PR DESCRIPTION
The part that needed fixing for the tests was that some 'switch' commands were
keeping a global lock for package installs. They now properly relax to a
switch lock once the global operations are done, before getting to package 
installs

Closes #1302
