### PR TITLE
Optimise computation of orphan packages

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -567,10 +567,11 @@ module API = struct
     let orphans = match changes with
       | None -> orphans
       | Some ch ->
+        if OpamPackage.Set.is_empty orphans then orphans else
         let recompile_cone =
           OpamPackage.Set.of_list @@
           OpamSolver.reverse_dependencies
-            ~depopts:true ~installed:false ~unavailable:true
+            ~depopts:true ~installed:true ~unavailable:true
             universe ch
         in
         orphans %% recompile_cone


### PR DESCRIPTION
Computing the reverse dependency cone even when unnecessary, and on all uninstalled packages,
was taking a fair amount of time on my lower-end machine.
