### PR TITLE
opam_installer.sh: fix wget emulation by cURL.

### DIFF
--- a/shell/opam_installer.sh
+++ b/shell/opam_installer.sh
@@ -27,16 +27,32 @@ EOF
     exit 1
 }
 
+#
+#       Report an error and exit
+#
+PROGNAME=$0
+error() {
+    echo -n "`basename $PROGNAME`: " >&2
+    for s in "$@"; do echo $s; done
+    exit 1
+}
+
+
 TMP=${TMPDIR:-/tmp}
 
+dlerror () {
+    error "Couldn't download $url" \
+        "There may not yet be a binary release for your architecture or OS, sorry."
+}
+
 getopam() {
-    url="$1"
-    opamfile="$2"
+    opamfile=$2
+    url=$1/$opamfile
 
     if which wget >/dev/null; then
-        wget -q -O "$TMP/$opamfile" "$url/$opamfile"
+        wget -q -O "$TMP/$opamfile" "$url" || dlerror
     else
-        curl -s -L -o "$TMP/$opamfile" "$url/$opamfile"
+        curl -s -L -o "$TMP/$opamfile" "$url" || dlerror
     fi
 }
 


### PR DESCRIPTION
`curl -O` (aka `--remote-name`) always saves the file into the current directory and thus the `-o $TMP/$opamfile` part was ignored.

I prefer calling `curl` explicitly to using it to emulate `wget` (trying to be too smart is not a good engineering.)

`error()` is useless as long as `set -e` is in effect.
