### PR TITLE
Also, install opam-lib when pinned. Fix #1547.

### DIFF
--- a/opam
+++ b/opam
@@ -13,6 +13,7 @@ build: [
   [make "opam"]
   ["sh" "-c" "echo %{version}% > \"%{root}%/opam.version\""]
   ["install" "--backup" "-m" "755" "src/opam" "%{root}%/opam"]
+  [make "libinstall"]
 ]
 remove: ["rm" "-f" "%{root}%/opam" "%{root}%/opam.version"]
 depends: [


### PR DESCRIPTION
I don't really know what to do about the switch restrictions but I had to edit those as well to run with `4.01.0+fp`.
