### PR TITLE
Show more accurate `opam config setup` instructions.

### DIFF
--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -2189,7 +2189,7 @@ let update_setup_interactive t shell dot_profile =
        OPAM manually (instructions will be displayed) or launch the automatic setup\n\
        later by running:\n\
       \n\
-       \   `opam config setup -a`.\n\
+       \   opam config setup -a\n\
        \n\
       \n\
        Do you want OPAM to modify %s and ~/.ocamlinit?\n\


### PR DESCRIPTION
The backtick is confusing since it's actually necessary
to specify with `opam config env`
