### PR TITLE
Fixed bug with git backend

### DIFF
--- a/src/repositories/opamGit.ml
+++ b/src/repositories/opamGit.ml
@@ -51,7 +51,8 @@ module Git = struct
             [ [ "git" ; "remote" ; "rm" ; "origin" ];
               [ "git" ; "remote" ; "add" ; "origin"; fst repo.repo_address ] ]
         );
-        OpamSystem.command [ "git" ; "fetch" ; "origin" ]
+        let branch = OpamMisc.Option.default "HEAD" (snd repo.repo_address) in
+        OpamSystem.command [ "git" ; "fetch" ; "origin"; branch ]
       )
 
   let revision repo =


### PR DESCRIPTION
fetch explicitely the remote HEAD when no branch is specified
(I was under the misconception that FETCH_HEAD was the remote HEAD, while it
is just the first alphabetical element of .git/FETCH_HEADS, which could get
you on a random branch. ugh.)
