### PR TITLE
Rsync backend: allow remotes

### DIFF
--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -92,14 +92,16 @@ let edit t name =
   if opam = orig_opam then None else
   let () = match pin with
     | Local dir ->
-      let src_opam =
-        OpamFilename.OP.(
-          if OpamFilename.exists_dir (dir / "opam") then dir / "opam" // "opam"
-          else dir // "opam")
-       in
-       if OpamState.confirm "Save the new opam file back to %S ?"
-           (OpamFilename.to_string src_opam) then
-         OpamFilename.copy ~src:file ~dst:src_opam
+      if OpamFilename.exists_dir dir then
+        let src_opam =
+          OpamFilename.OP.(
+            if OpamFilename.exists_dir (dir / "opam")
+            then dir / "opam" // "opam"
+            else dir // "opam")
+        in
+        if OpamState.confirm "Save the new opam file back to %S ?"
+            (OpamFilename.to_string src_opam) then
+          OpamFilename.copy ~src:file ~dst:src_opam
     | Version _ | Git _ | Darcs _ | Hg _ -> ()
   in
   match installed_nv with

--- a/src/core/opamMisc.ml
+++ b/src/core/opamMisc.ml
@@ -423,7 +423,8 @@ let sub_at n s =
 (** To use when catching default exceptions: ensures we don't catch fatal errors
     like C-c *)
 let fatal e = match e with
-  | Sys.Break | Assert_failure _ | Match_failure _ -> raise e
+  | Sys.Break -> prerr_newline (); raise e
+  | Assert_failure _ | Match_failure _ -> raise e
   | _ -> ()
 
 let register_backtrace, get_backtrace =

--- a/src/core/opamTypesBase.ml
+++ b/src/core/opamTypesBase.ml
@@ -42,6 +42,7 @@ let parse_url (s,c) =
     | "git" -> `git
     | "darcs" -> `darcs
     | "hg" -> `hg
+    | "rsync" | "ssh" | "scp" | "sftp" -> `local
     | p -> raise (Invalid_argument (Printf.sprintf "Unsupported protocol %s" p))
   in
   let suffix =
@@ -53,8 +54,12 @@ let parse_url (s,c) =
   | "hg" ->(s,c), `hg
   | _ ->
     match Re_str.bounded_split (Re_str.regexp_string "://") s 2 with
-    | ["file"; address] -> (address,c), `local
-    | [proto; _] -> (s,c), url_kind_of_string proto
+    | ["file"|"rsync"|"ssh"|"scp"|"sftp"; address] ->
+      (* strip the leading xx:// *)
+      (address,c), `local
+    | [proto; _] ->
+      (* keep the leading xx:// *)
+      (s,c), url_kind_of_string proto
     | [address] ->
       let dir = OpamFilename.Dir.of_string address in
       if OpamFilename.exists_dir OpamFilename.OP.(dir / ".git")


### PR DESCRIPTION
this should allow all ssh remotes permitted by rsync. Still dubbed 'local'
backend in the code, and needs testing

use e.g. `user@host:dir/to/project/`. Don't forget the trailing slash.
