### PR TITLE
make cold: add a `CONFIGURE_ARGS` variable to the bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,6 @@ fastclean:
 
 cold:
 	./shell/bootstrap-ocaml.sh
-	env PATH=$$PATH:`pwd`/bootstrap/ocaml/bin ./configure
+	env PATH=$$PATH:`pwd`/bootstrap/ocaml/bin ./configure $(CONFIGURE_ARGS)
 	env PATH=$$PATH:`pwd`/bootstrap/ocaml/bin $(MAKE) lib-ext
 	env PATH=$$PATH:`pwd`/bootstrap/ocaml/bin $(MAKE)


### PR DESCRIPTION
This must be done here since the `configure` phase cannot be done
before the compiler bootstrap (since it fails as there's no compiler
installed).
