### PR TITLE
git backend: make sure to fetch tags

### DIFF
--- a/src/repositories/opamGit.ml
+++ b/src/repositories/opamGit.ml
@@ -52,7 +52,8 @@ module Git = struct
               [ "git" ; "remote" ; "add" ; "origin"; fst repo.repo_address ] ]
         );
         let branch = OpamMisc.Option.default "HEAD" (snd repo.repo_address) in
-        OpamSystem.command [ "git" ; "fetch" ; "origin"; branch ]
+        let refspec = Printf.sprintf "+%s:FETCH_HEAD" branch in
+        OpamSystem.command [ "git" ; "fetch" ; "origin"; refspec ]
       )
 
   let revision repo =


### PR DESCRIPTION
Git requires an explicit local refspec to do so ; alright...
