### PR TITLE
Return a non-zero exit code if `opam init --comp=xxx` is invalid

### DIFF
--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -2280,7 +2280,7 @@ let install_compiler t ~quiet switch compiler =
     OpamGlobals.msg "Cannot find %s: %s is not a valid compiler name.\n"
       (OpamFilename.to_string comp_f)
       (OpamCompiler.to_string compiler);
-    OpamGlobals.exit 0;
+    OpamGlobals.exit 1;
   );
 
   let switch_dir = OpamPath.Switch.root t.root switch in


### PR DESCRIPTION
I noticed this while having an invalid compiler in a Dockerfile, and it continued the script despite not being initialized.  A non-zero error code would signal that OPAM has not actually initialized.
