### PR TITLE
patch to combine "remove -a --force"

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1331,6 +1331,11 @@ module API = struct
           (OpamSolver.reverse_dependencies
              ~depopts:false ~installed:true universe packages) in
       let to_keep =
+        if force then OpamPackage.Set.filter (fun p ->
+            let name = OpamPackage.Name.to_string (OpamPackage.name p) in
+            try
+              String.sub name 0 5 = "base-" && name <> "base-bytes"
+            with _ -> false) t.installed else
         (if autoremove then t.installed_roots else t.installed)
         -- to_remove -- full_orphans -- orphan_versions
       in


### PR DESCRIPTION
The current behavior of "opam remove -a" is to remove only packages that are not root packages. Sometimes, it is useful to "completely clean" a repository. We propose to use the combination of "-a" and "--force" to achieve this goal (combining "--force" with "-a" made no sense before as "--force" expects arguments while "-a" does not). When used together with this patch, these options will remove all packages from the switch, except "base-*" packages ("base-bytes" is removed, as it is not installed by ocaml itself).

Note that we use the heuristic that packages installed by ocaml starts with "base-", but it would be better to have another way to find them, as the example of "base-bytes" demonstrates.
