### PR TITLE
Add an opam file to ease pinning `opam-lib`

### DIFF
--- a/opam
+++ b/opam
@@ -1,0 +1,16 @@
+opam-version: "1.1"
+name: "opam-lib"
+maintainer: "opam-devel@lists.ocaml.org"
+homepage: "https://github.com/ocaml/opam"
+build: [
+  ["./configure"]
+  [make]
+]
+depends: [
+  "ocamlgraph"
+  "cmdliner"
+  "dose" {= "3.2.2+opam"}
+  "cudf"
+  "re" {>= "1.2.0"}
+  "ocamlfind"
+]


### PR DESCRIPTION
This allows to use `opam pin add opam-lib https://github.com/samoht/opam.git` to install `opam-lib`
