### PR TITLE
Better behaviour with 'opam pin edit'

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1518,16 +1518,15 @@ module API = struct
       OpamGlobals.msg "\n";
       let empty_opam = OpamState.has_empty_opam t nv in
       let needs_reinstall2 =
-        if empty_opam then
-          OpamState.add_pinned_overlay ~template:true t name;
         if edit || empty_opam then
-          OpamPinCommand.edit t name
+          try OpamPinCommand.edit t name
+          with Not_found ->
+            (OpamGlobals.error "No valid metadata available.";
+             ignore (unpin name);
+             OpamGlobals.exit 1)
         else None
       in
-      let skip_action =
-        (* Unedited, empty opam *)
-        needs_reinstall2 = None && empty_opam in
-      if action && not skip_action then
+      if action then
         let t = OpamState.load_state "pin-reinstall-2" in
         if not (OpamPackage.has_name t.installed name) ||
            needs_reinstall <> None ||

--- a/src/client/opamPinCommand.mli
+++ b/src/client/opamPinCommand.mli
@@ -23,7 +23,9 @@ open OpamTypes
 val pin: name -> pin_option -> bool option
 
 (** Let the user edit a pinned package's opam file.
-    Returns [Some is_same_version] if the package should be rebuilt *)
+    Returns [Some is_same_version] if the package should be rebuilt.
+    raises [Not_found] if no valid opam file is available and the user didn't
+    succeed in producing one. *)
 val edit: OpamState.state -> name -> bool option
 
 (** Unpin a package. Returns true if the package should be rebuilt *)

--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -480,7 +480,9 @@ let remove_metadata t packages =
 (* Returns [opam, descr_file, files_dir]. We don't consider [url] since
    this is for pinned packages. if [root], don't look for a subdir [opam]
    to find [files] and [descr]. *)
-let local_opam ?(root=false) ?(version_override=true) nv dir =
+let local_opam
+    ?(root=false) ?(version_override=true) ?copy_invalid_to
+    nv dir =
   let has_dir d = if OpamFilename.exists_dir d then Some d else None in
   let has_file f = if OpamFilename.exists f then Some f else None in
   let opam_dir, descr, files_dir =
@@ -504,9 +506,14 @@ let local_opam ?(root=false) ?(version_override=true) nv dir =
         else Some opam
       with e ->
         OpamMisc.fatal e;
-        OpamGlobals.error "opam file for %s contains errors, ignoring"
-          (OpamPackage.to_string nv);
-        None
+        match copy_invalid_to with
+        | Some dst ->
+          OpamGlobals.warning
+            "Errors in opam file from %s source, \
+             ignored (fix with 'opam pin edit')"
+            (OpamPackage.to_string nv);
+          OpamFilename.copy ~src:local_opam ~dst; None
+        | None -> None
   in
   opam, descr, files_dir
 
@@ -2465,7 +2472,11 @@ let update_dev_package t nv =
     (* Do the update *)
     let result = fetch () in
     let new_meta = (* New version from the source *)
-      hash_meta @@ local_opam ~version_override:false nv srcdir
+      hash_meta @@
+      local_opam
+        ~version_override:false
+        ~copy_invalid_to:(OpamPath.Switch.Overlay.tmp_opam t.root t.switch name)
+        nv srcdir
     in
     let user_meta, old_meta, repo_meta =
       if OpamFilename.exists (srcdir // "opam") then
@@ -2510,6 +2521,8 @@ let update_dev_package t nv =
         (OpamGlobals.msg "Installing new package description for %s from %s\n"
            (OpamPackage.to_string nv)
            (Filename.concat (string_of_address remote_url) "opam");
+         OpamFilename.remove
+           (OpamPath.Switch.Overlay.tmp_opam t.root t.switch name);
          install_meta srcdir user_meta new_meta)
       else if
         OpamGlobals.msg

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -281,7 +281,7 @@ let switch_cont ~quiet ~warning switch =
     OpamState.check_base_packages t
 
 let switch ~quiet ~warning switch =
-  (snd (switch_cont ~quiet ~warning switch)) () 
+  (snd (switch_cont ~quiet ~warning switch)) ()
 
 (* Remove from [set] all the packages whose names appear in
    [filter]. *)

--- a/src/core/opamPath.ml
+++ b/src/core/opamPath.ml
@@ -168,6 +168,8 @@ module Switch = struct
 
     let opam t a n = package t a n // "opam"
 
+    let tmp_opam t a n = package t a n // "opam_"
+
     let url t a n = package t a n // "url"
 
     let descr t a n = package t a n // "descr"

--- a/src/core/opamPath.mli
+++ b/src/core/opamPath.mli
@@ -234,6 +234,10 @@ module Switch: sig
         $opam/$switch/cache/$name.$version/opam} *)
     val opam: t -> switch -> name -> filename
 
+    (** OPAM temp overlay (for user editing): {i
+        $opam/$switch/cache/$name.$version/opam_} *)
+    val tmp_opam: t -> switch -> name -> filename
+
     (** URL overlay: {i
         $opam/$switch/overlay/$name.$version/url} *)
     val url: t -> switch -> name -> filename


### PR DESCRIPTION
Edit from a temp file rather than the real one, import file from source even
if it has errors (to let the user fix them), keep the file formatting as-is
when opam has no modifications to make

Fixes  #1613 (partially) Closes  #1650
