### PR TITLE
Improve default preferences to get the latest versions for new dependencies

### DIFF
--- a/src/core/opamGlobals.ml
+++ b/src/core/opamGlobals.ml
@@ -103,7 +103,7 @@ let solver_timeout =
 type solver_criteria = [ `Default | `Upgrade | `Fixup ]
 
 let default_preferences = function
-  | `Default -> "-count(removed),-notuptodate(request),-count(down),-count(changed),-notuptodate(solution)"
+  | `Default -> "-count(removed),-notuptodate(request),-count(down),-notuptodate(changed),-count(changed),-notuptodate(solution)"
   | `Upgrade -> "-count(down),-count(removed),-notuptodate(solution),-count(new)"
   | `Fixup -> "-count(changed),-notuptodate(solution)"
 


### PR DESCRIPTION
The -notuptodate(changed) should take care of getting the latest version of new dependencies brought in when installing a package.
Not the final solution to find the best compromise at an install, but getting close.
