### PR TITLE
More tweaks to opam-admin findlib

### DIFF
--- a/src/tools/opam_findlib.ml
+++ b/src/tools/opam_findlib.ml
@@ -156,8 +156,9 @@ let process args =
     let orphans =
       StringSet.diff (installed_findlibs ()) (declared_findlibs repo packages)
     in
-    let orphans = StringSet.elements orphans in
-    OpamGlobals.msg "%s\n" (String.concat "\n" orphans)
+    match StringSet.elements orphans with
+    | []      -> ()
+    | orphans -> OpamGlobals.msg "%s\n" (String.concat "\n" orphans)
   else if args.infer || args.opam_pkgs <> [] || args.findlib_pkgs <> [] then
   let regexps =
     List.map (fun pattern ->


### PR DESCRIPTION
the --install option will only try to install the packages if the findlib file
is empty. That will save lots of useless reinstallations.
