### PR TITLE
Fix handling of SIGPIPE

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1345,7 +1345,7 @@ let run_external_command () =
 
 let run default commands =
   Sys.catch_break true;
-  let _ = Sys.signal Sys.sigpipe Sys.Signal_ignore in
+  let _ = Sys.signal Sys.sigpipe (Sys.Signal_handle (fun _ -> ())) in
   try
     if is_external_command () then run_external_command ();
     match Term.eval_choice ~catch:false default commands with


### PR DESCRIPTION
Do not ignore SIGPIPE beause that is inherited by child processes and it screws up shell scripts. Instead, install a handler that does nothing.

The package "pa_ovisitor" fails on my machine: it just loops, eating one core, because its build instructions include "yes no | omake <something>". When omake is done, the "yes" process ignores the SIGPIPE and just loops forever.
