### PR TITLE
Simple opam file checks and validation

### DIFF
--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -80,7 +80,15 @@ let edit t name =
       | _, None ->
         OpamGlobals.error "The \"version\" field is mandatory";
         failwith "missing field"
-      | _ -> Some opam
+      | _ ->
+        match OpamFile.OPAM.validate opam with
+        | [] -> Some opam
+        | warns ->
+          OpamGlobals.warning "The opam file didn't pass validation:\n  - %s\n"
+            (String.concat "\n  - " warns);
+          if OpamGlobals.confirm "Continue anyway ('no' will reedit) ?"
+          then Some opam
+          else edit ()
     with e ->
       OpamMisc.fatal e;
       if OpamGlobals.confirm "Errors in %s, retry editing ?"

--- a/src/core/opamFile.mli
+++ b/src/core/opamFile.mli
@@ -107,6 +107,10 @@ module OPAM: sig
   (** Create an OPAM package template filled with common options *)
   val template: package -> t
 
+  (** Runs several sanity checks on the opam file; returns a list of
+      warnings *)
+  val validate: t -> string list
+
   (** Get OPAM version. *)
   val opam_version: t -> opam_version
 

--- a/src/core/opamVersion.ml.in
+++ b/src/core/opamVersion.ml.in
@@ -50,11 +50,14 @@ let major v =
     of_string (String.sub v 0 i)
   with Not_found -> v
 
-let current_nopatch =
+let nopatch v =
   try
-    let i = String.rindex current_raw '.' in
-    of_string (String.sub current_raw 0 i)
-  with Not_found -> current
+    let i = String.index v '.' in
+    let i = String.index_from v (i+1) '.' in
+    (String.sub v 0 i)
+  with Not_found -> v
+
+let current_nopatch = nopatch current_raw
 
 let message () =
   Printf.printf "\n\

--- a/src/core/opamVersion.mli
+++ b/src/core/opamVersion.mli
@@ -24,6 +24,9 @@ val current: t
 (** Extracts the major version *)
 val major: t -> t
 
+(** Major+minor version, strips the patch version *)
+val nopatch: t -> t
+
 (** The current OPAM version, truncated (only MAJOR.MINOR) *)
 val current_nopatch: t
 


### PR DESCRIPTION
Not sure where best to bind this in the interface (currently only `opam pin edit`):
- new `opam lint <opam file>` command ?
- opam-admin (I made sure any existing package will get warnings, don't worry)
- external tool ?
- opam-publish (surely !)
