### PR TITLE
Don't print version numbers for pinned and dev packages until they're known

### DIFF
--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -2535,7 +2535,7 @@ let update_dev_package t nv =
       then
         (* No manual changes *)
         (OpamGlobals.msg "Installing new package description for %s from %s\n"
-           (OpamPackage.to_string nv)
+           (OpamPackage.name_to_string nv)
            (Filename.concat (string_of_address remote_url) "opam");
          OpamFilename.remove
            (OpamPath.Switch.Overlay.tmp_opam t.root t.switch name);

--- a/src/repositories/opamLocal.ml
+++ b/src/repositories/opamLocal.ml
@@ -120,13 +120,13 @@ module B = struct
     if OpamFilename.exists remote_filename then
     OpamGlobals.msg "[%s] Synchronizing with %s\n"
         (OpamGlobals.colorise `green
-           (OpamPackage.to_string package))
+           (OpamPackage.name_to_string package))
         (OpamFilename.to_string remote_filename);
     pull_file_quiet local_dirname remote_filename
 
   let pull_dir package local_dirname remote_dirname =
     OpamGlobals.msg "[%s] Synchronizing with %s\n"
-      (OpamGlobals.colorise `green (OpamPackage.to_string package))
+      (OpamGlobals.colorise `green (OpamPackage.name_to_string package))
       (OpamFilename.Dir.to_string remote_dirname);
     pull_dir_quiet local_dirname remote_dirname
 

--- a/src/repositories/opamVCS.ml
+++ b/src/repositories/opamVCS.ml
@@ -71,7 +71,7 @@ module Make (VCS: VCS) = struct
                     (OpamPackage.to_string package) in
     let repo = repo dirname remote_url in
     OpamGlobals.msg "[%s] Fetching %s\n"
-      (OpamGlobals.colorise `green (OpamPackage.to_string package))
+      (OpamGlobals.colorise `green (OpamPackage.name_to_string package))
       (string_of_address remote_url);
     download_dir (pull_repo repo)
 


### PR DESCRIPTION
ie not in the 'Updating metadata' and dl messages. They're of course still
there in the action messages. Closes #1704
