### PR TITLE
Set author and committer at git init

### DIFF
--- a/src/repositories/opamGit.ml
+++ b/src/repositories/opamGit.ml
@@ -25,8 +25,15 @@ module Git = struct
     OpamFilename.exists_dir (repo.repo_root / ".git")
 
   let init repo =
+    let env =
+      Array.append (Unix.environment ()) [|
+        "GIT_AUTHOR_NAME=Opam";
+        "GIT_AUTHOR_EMAIL=opam@ocaml.org";
+        "GIT_COMMITTER_NAME=Opam";
+        "GIT_COMMITTER_EMAIL=opam@ocaml.org"
+      |] in
     OpamFilename.in_dir repo.repo_root (fun () ->
-      OpamSystem.commands [
+      OpamSystem.commands ~env [
         [ "git" ; "init" ] ;
         [ "git" ; "remote" ; "add" ; "origin" ; fst repo.repo_address ] ;
         [ "git" ; "commit" ; "--allow-empty" ; "-m" ; "opam-git-init" ] ;


### PR DESCRIPTION
Fixes #1747
- we use init rather than clone to decouple init from update
- we need HEAD defined to be able to diff, etc, for that an init commit is
  needed
- anyway after that we'll reset to the master branch

this patch defines a bunch of env variables so that git doesn't complain.
