### PR TITLE
Correct PATH changes handling

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -263,7 +263,7 @@ let string_of_commands commands =
     "Nothing to do."
 
 let compilation_env t opam =
-  let env0 = OpamState.get_full_env ~opam t in
+  let env0 = OpamState.get_full_env ~opam ~force_path:true t in
   let env1 = [
     ("OPAM_PACKAGE_NAME", OpamPackage.Name.to_string (OpamFile.OPAM.name opam));
     ("OPAM_PACKAGE_VERSION", OpamPackage.Version.to_string (OpamFile.OPAM.version opam))

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1022,7 +1022,7 @@ let config =
           list_doc all_doc
           user_doc ocamlinit_doc profile_doc dot_profile_doc
           global_doc no_complete_doc no_eval_doc)
-    | Some `exec, (_::_ as c) -> `Ok (Client.CONFIG.exec c)
+    | Some `exec, (_::_ as c) -> `Ok (Client.CONFIG.exec ~inplace_path c)
     | Some `list, params ->
       (try `Ok (Client.CONFIG.list (List.map OpamPackage.Name.of_string params))
        with Failure msg -> `Error (false, msg))

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1643,8 +1643,8 @@ module SafeAPI = struct
     let setup_list shell dot_profile =
       read_lock (fun () -> API.CONFIG.setup_list shell dot_profile)
 
-    let exec command =
-      read_lock (fun () -> API.CONFIG.exec command)
+    let exec ~inplace_path command =
+      read_lock (fun () -> API.CONFIG.exec ~inplace_path command)
 
     let list names =
       read_lock (fun () -> API.CONFIG.list names)

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -79,7 +79,7 @@ module API: sig
     val setup_list: shell -> filename -> unit
 
     (** Execute a command in a subshell with the right environment variables. *)
-    val exec: string list -> unit
+    val exec: inplace_path:bool -> string list -> unit
 
     (** Display variables and their contents. *)
     val list: name list -> unit

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -196,7 +196,7 @@ let setup_list shell dot_profile =
   let t = OpamState.load_state "config-setup-list" in
   OpamState.display_setup t shell dot_profile
 
-let exec command =
+let exec ~inplace_path command =
   log "config-exex command=%S" (String.concat " " command);
   let t = OpamState.load_state "config-exec" in
   let cmd, args =
@@ -204,7 +204,7 @@ let exec command =
     | []        -> OpamSystem.internal_error "Empty command"
     | h::_ as l -> h, Array.of_list l in
   let env =
-    let env = OpamState.get_full_env t in
+    let env = OpamState.get_full_env ~force_path:(not inplace_path) t in
     let env = List.rev_map (fun (k,v) -> k^"="^v) env in
     Array.of_list env in
   raise (OpamGlobals.Exec (cmd, args, env))

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -40,4 +40,4 @@ val setup: user_config option -> global_config option -> unit
 val setup_list: shell -> filename -> unit
 
 (** Execute a command in a subshell *)
-val exec: string list -> unit
+val exec: inplace_path:bool -> string list -> unit

--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -1851,9 +1851,9 @@ let get_opam_env ~force_path t =
     | `Env _   -> { t with switch = OpamFile.Config.switch t.config } in
   add_to_env t [] (env_updates ~opamswitch:true ~force_path t)
 
-let get_full_env ?opam t =
+let get_full_env ~force_path ?opam t =
   let env0 = OpamMisc.env () in
-  add_to_env t ?opam env0 (env_updates ~opamswitch:true t)
+  add_to_env t ?opam env0 (env_updates ~opamswitch:true ~force_path t)
 
 let mem_pattern_in_string ~pattern ~string =
   let pattern = Re.compile (Re.str pattern) in

--- a/src/client/opamState.mli
+++ b/src/client/opamState.mli
@@ -102,8 +102,9 @@ val universe: state -> user_action -> universe
 
 (** {2 Environment} *)
 
-(** Get the current environment. *)
-val get_full_env: ?opam:OpamFile.OPAM.t -> state -> env
+(** Get the current environment with OPAM specific additions. If [force_path],
+    the PATH is modified to ensure opam dirs are leading. *)
+val get_full_env: force_path:bool -> ?opam:OpamFile.OPAM.t -> state -> env
 
 (** Get only environment modified by OPAM. If [force_path], the PATH is modified
     to ensure opam dirs are leading. *)


### PR DESCRIPTION
Internally prepend to PATH; respect --inplace-path for 'opam config exec'

Closes #1749; thanks !
