### PR TITLE
Lint: allow missing name/version

### DIFF
--- a/src/core/opamFile.ml
+++ b/src/core/opamFile.ml
@@ -1423,10 +1423,12 @@ module X = struct
                 <> 0)
             "Field 'opam-version' doesn't match the current version, validation \
              may not be accurate";
+(*
           cond (t.name = None)
             "Missing field 'name' or directory in the form 'name.version'";
           cond (t.version = None)
             "Missing field 'version' or directory in the form 'name.version'";
+*)
           cond (t.maintainer = [""] || t.homepage = [""] || t.author = [""] ||
                 t.license = [""] || t.doc = [""] || t.tags = [""] ||
                 t.bug_reports = [""])


### PR DESCRIPTION
these may be specified from the context, so depending on where
the file lies checking them doesn't make sense.

Also, fixes bug where files without name or version couldn't
be written back.
Closes #1760
