### PR TITLE
Workaround git 2 issue with fetching remote hashes

### DIFF
--- a/src/repositories/opamGit.ml
+++ b/src/repositories/opamGit.ml
@@ -63,7 +63,14 @@ module Git = struct
         );
         let branch = OpamMisc.Option.default "HEAD" (snd repo.repo_address) in
         let refspec = Printf.sprintf "+%s:%s" branch remote_ref in
-        OpamSystem.command [ "git" ; "fetch" ; "-q"; "origin"; refspec ]
+        (try
+           OpamSystem.command [ "git" ; "fetch" ; "-q"; "origin"; refspec ]
+         with OpamSystem.Process_error _ ->
+           (* fallback to trying to fetch all (workaround, git 2.1 fails with
+              'fetch HASH' when HASH isn't available locally already) *)
+           OpamSystem.commands
+             [ [ "git" ; "fetch" ; "-q"; "origin" ];
+               [ "git" ; "fetch" ; "-q"; "origin"; refspec ] ])
       )
 
   let revision repo =


### PR DESCRIPTION
sub-optimal, as it will access the network twice, but it should be more
robust, and well, it's a workaround...
Closes #1847
