### PR TITLE
Documentation refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,18 @@ The main documentation entry point to OPAM is the user manual,
 available using `opam --help`. To get help for a specific command, use
 `opam <command> --help`.
 
-#### Tutorials
+#### Guides and Tutorials
 
-A collection of tutorials are available online at <http://opam.ocaml.org>.
-These tutorials are automatically generated from the
-[wiki](https://github.com/ocaml/opam/wiki/_pages) and
-are also available in PDF format in the `doc/tutorials` directory.
+A collection of guides and tutorials is available
+[online](http://opam.ocaml.org/doc/Usage.html). They are generated from the
+files in [doc/pages](https://github.com/ocaml/opam/tree/master/doc/pages).
 
 #### API, Code Documentation and Developer Manual
 
 A more torough technical document describing OPAM and specifying the package
 description format is available in the
-[doc/dev-manual](https://raw.github.com/ocaml/opam/blob/doc/dev-manual/dev-manual.pdf).
-`make doc` will otherwise make the API documentation available under `doc/`.
+[developper manual](http://opam.ocaml.org/doc/manual/dev-manual.html). `make
+doc` will otherwise make the API documentation available under `doc/`.
 
 ## Community
 
@@ -87,16 +86,22 @@ that's not an option for you, you can use `git format-patch` and email TODO.
 
 The release cycle respects [Semantic Versioning](http://semver.org/).
 
-### Related repositories
+## Related repositories
 
-- [ocaml/opam-repository](https://github.com/ocaml/opam-repository) is the official repository for OPAM packages and compilers. A number of non-official repositories are also available on the interwebs, for instance on [Github](https://github.com/search?q=opam-repo&type=Repositories).
-- [opam2web](https://github.com/ocaml/opam2web) generates a collection of browsable HTML files for a given repository. It is used to generate http://opam.ocaml.org.
+- [ocaml/opam-repository](https://github.com/ocaml/opam-repository) is the
+  official repository for OPAM packages and compilers. A number of non-official
+  repositories are also available on the interwebs, for instance on
+  [Github](https://github.com/search?q=opam-repo&type=Repositories).
+- [opam2web](https://github.com/ocaml/opam2web) generates a collection of
+  browsable HTML files for a given repository. It is used to generate
+  http://opam.ocaml.org.
 - [opam-rt](https://github.com/ocaml/opam-rt) is the regression framework for OPAM.
-- [opamlot](https://github.com/ocamllabs/ocamlot) is the automated QA environment for OPAM. 
+- [opam-publish](https://github.com/AltGr/opam-publish) is a tool to facilitate
+  the creation, update and publication of OPAM packages.
 
 ## Copyright and license
 
-Copyright 2012-2014 OCamlPro  
+Copyright 2012-2014 OCamlPro
 Copyright 2012 INRIA
 
 All rights reserved. OPAM is distributed under the terms of

--- a/doc/pages/FAQ.md
+++ b/doc/pages/FAQ.md
@@ -1,21 +1,53 @@
 # OPAM FAQ
 
+> This FAQ is for general questions about OPAM and its usage. You may also be
+> interested in the more advanced [Tricks](Tricks.html) for specific use-cases
+> or advanced users.
+
+#### 🐫  What is OPAM for ?
+
+Easily installing, upgrading and managing your OCaml compiler(s), tools and
+libraries. It's made of a tool, the
+[OPAM package manager](https://github.com/ocaml/opam), and a
+community-maintained
+[package repository](https://github.com/ocaml/opam-repository).
+
+--
 
 #### 🐫  How to get, install and upgrade OPAM ?
 
 See the [install guide](Install.html).
 
+--
 
 #### 🐫  Where is the manual ?
 
 OPAM has git-like, hierarchical manpages. Try `opam --help` for a starting point.
 
-Get started with OPAM packages by reading the [Packaging Howto](Packaging.html).
+Or get started from the [Usage](Usage.html) guide.
 
-See the details on the file formats and more in the [Developper
-Guide](https://github.com/ocaml/opam/blob/latest/doc/dev-manual/dev-manual.pdf?raw=true)
-(pdf).
+If you want to know more about OPAM packages, see the [Packaging Howto](Packaging.html).
 
+Last but not least, the reference on the file formats and more is in the
+[Developper Guide](http://opam.ocaml.org/doc/manual/dev-manual.html).
+
+--
+
+#### 🐫  `opam init` gives me lots of errors about upgrading
+
+In case you can't or really don't want to switch to 1.2 for some reason, we
+still support OPAM 1.1 via a compatibility layer on the repository, but there
+may be glitches at `opam init`.
+
+For **OPAM 1.1**, you should initialise with:
+
+```
+opam init https://opam.ocaml.org/1.1
+```
+
+Or if your repository is already initialised, just run `opam update`.
+
+--
 
 #### 🐫  What changes does OPAM do to my filesystem ?
 
@@ -25,6 +57,7 @@ explicit options provided during `opam init`, only writes within `~/.opam` (and
 various internal data, a cache of downloaded archives, and your OCaml
 installations.
 
+--
 
 #### 🐫  Why does ``opam init`` need to add stuff to my init scripts / why is ``eval $(opam config env)`` needed ?
 
@@ -35,13 +68,14 @@ a few ocaml-related environment variables, and to prepend to your PATH variable.
 Of course, you may choose not to let OPAM change anything at `opam init`, and
 run `eval $(opam config env)` yourself whenever you will be needing it.
 
+--
 
 #### 🐫  What is a "switch" ?
 
-An ocaml installation and a set of installed packages within an OPAM
+An OCaml installation and a set of installed packages within an OPAM
 installation. This can be used to keep different OCaml versions side-by-side, or
 different sets of packages. See the [related
-section](Usage.html#opamswitch) in the Advanced usage manual and
+section](Usage.html#opamswitch) in the usage manual and
 `opam switch --help`. The "prefix" for a given installation is simply
 `~/.opam/<switch-name>`.
 
@@ -50,6 +84,7 @@ installation. In the former case, OPAM will need to recompile all packages when
 your system compiler changes. In the latter case, OCaml will be downloaded and
 compiled on creation of the switch.
 
+--
 
 #### 🐫  Can I work on different switches at the same time in different shells ?
 
@@ -62,6 +97,7 @@ opam config exec --switch <switch> -- <command>  # for one command
 
 This only affects the environment.
 
+--
 
 #### 🐫  Can I get a new switch with the same packages installed ?
 
@@ -78,17 +114,18 @@ OCaml version in your new switch. In that case, you'll need to remove them from
 the `file.export` file by hand (the format is straight-forward, one line per
 package).
 
+--
 
 #### 🐫  I installed a package by hand / used ``ocamlfind remove`` / fiddled with the installed packages and OPAM is out of sync. Help !
 
 Don't panic. OPAM assumes it's controlling what's below `~/.opam/<switch>`, but
 there are several ways you can recover:
-* `opam remove --force` will attempt to uninstall even if not registered as
-  installed. Then `opam install`
+* `opam remove --force` will run the uninstall instructions even if the package
+  is not registered as installed. Then retry `opam install`.
 * `opam reinstall` will try to remove an installed package, but go on to
   re-installing even if that fails.
 * If all else fails, you can re-install your current set of packages from
-  scratch using `opam switch reinstall`
+  scratch using `opam switch reinstall`.
 * You can force OPAM to register an installation or removal _without actually
   performing anything_ using `opam install|remove --fake`. This is not
   recommended though, as your manual install may not be exactly equivalent to
@@ -96,7 +133,10 @@ there are several ways you can recover:
   reinstallations or upgrades of the package. Don't complain if you mess up your
   installation using this! If you want to control how a package is installed or
   modify it, the right way is `opam pin`.
+* You shouldn't have to, but if you want to restart from scratch, just delete
+  `~/.opam` and get back to `opam init`
 
+--
 
 #### 🐫  What are the minimum requirements ?
 
@@ -104,6 +144,7 @@ there are several ways you can recover:
 problems with 512MB of RAM and no swap. Of course, software packages themselves
 may be more greedy.
 
+--
 
 #### 🐫  Some package fail during compilation, complaining about missing dependencies ("m4", "libgtk", etc.)
 
@@ -119,6 +160,7 @@ have no idea what the missing system package might be:
   tracker](https://github.com/ocaml/opam-repository/issues), to save the others
   the trouble of searching. Thanks.
 
+--
 
 #### 🐫  I have weird checksum errors: where do they come from ?
 
@@ -135,6 +177,7 @@ stale files. To clear your proxy cache, you can use `wget --no-cache
 
 As a last resort, you can bypass the checksum checks using `--no-checksums`.
 
+--
 
 #### 🐫  OPAM is prompting me to install or upgrade packages that I am not interested in, or doesn't install the latest version by default. Why ? What can I do ?
 
@@ -147,6 +190,7 @@ As a last resort, you can bypass the checksum checks using `--no-checksums`.
 * Another benefit of the external solvers is that they allow to be [quite
   expressive](Specifying_Solver_Preferences.html) on your expectations.
 
+--
 
 #### 🐫  Where do I report Bugs, Issues and Feature Requests?
 
@@ -164,6 +208,7 @@ mailing-list](http://lists.ocaml.org/listinfo/opam-devel).
 
 - You may also try IRC channel `#opam` on Freenode.
 
+--
 
 #### 🐫  How to link to libraries installed with OPAM ?
 
@@ -177,6 +222,7 @@ option `-I +dir` will make `dir` relative to `lib/ocaml`, and will only work for
 the libraries that ship with the compiler. Also, remember to add the dependency when
 you package your project !
 
+--
 
 #### 🐫  How does OPAM tell which version of a package is newer ?
 
@@ -195,6 +241,7 @@ from Debian:
 Here is an example of an ordered sequence: `~~`, `~`, `~beta2`, `~beta10`, `0.1`,
 `1.0~beta`, `1.0`, `1.0-test`, `1.0.1`, `1.0.10`, `dev`, `trunk`
 
+--
 
 #### 🐫  What does the `--jobs` option do ? It doesn't seem to enable parallel builds.
 

--- a/doc/pages/Packaging.md
+++ b/doc/pages/Packaging.md
@@ -19,9 +19,13 @@ $ opam pin remove <package>
 ```
 
 Publish to the OPAM repository:
-* Fork [https://github.com/ocaml/opam-repository]()
-* Add your `opam`, `descr` and `url` files to `packages/<pkgname>/<pkgname>.<version>`
-* File a [pull-request](https://github.com/ocaml/opam-repository/compare/)
+* Use the [opam-publish](https://github.com/AltGr/opam-publish#opam-publish)
+  tool (`opam install opam-publish`)
+* Or by hand:
+    - Fork [https://github.com/ocaml/opam-repository]()
+    - Add your `opam`, `descr` and `url` files to
+      `packages/<pkgname>/<pkgname>.<version>`
+    - File a [pull-request](https://github.com/ocaml/opam-repository/compare/)
 
 
 # Creating OPAM packages
@@ -41,6 +45,7 @@ to the opam file format.
 
 We'll be assuming that you have a working OPAM installation. If not, please
 first read the [install guide](Install.html).
+
 
 ### Get the source
 
@@ -70,6 +75,7 @@ $ opam pin add <project> . -n
 ```
 (`-n` tells OPAM to not try and install just yet, we'll get to it later)
 
+
 ### The "opam" file
 
 At this stage, OPAM will be looking for metadata for the package `<project>`, on
@@ -80,13 +86,14 @@ information we're interested in, only in a less normalised format.
 
 ```
 opam-version: "1.2"
-maintainer: "Name <email>"
-author: "Name <email>"
 name: "project"
 version: "0.1"
+maintainer: "Name <email>"
+author: "Name <email>"
 homepage: ""
 bug-reports: ""
 license: ""
+dev-repo: ""
 build: [
   ["./configure" "--prefix=%{prefix}%"]
   [make]
@@ -124,6 +131,7 @@ than a single element: `maintainer`, `author`, `homepage`, `bug-reports`,
 One you save and quit, OPAM will syntax-check and let you edit again in case of
 errors.
 
+
 ## Installing
 
 The best test is to let OPAM attempt to install your just created package. As
@@ -145,7 +153,7 @@ You can now check that everything is installed as expected. Do also check that
 If you need to change anything, simply do
 
 ```
-opam pin edit <project>
+$ opam pin edit <project>
 ```
 
 to get back to editing the `opam` file. Manually editing the `opam` file in
@@ -156,16 +164,38 @@ installed on your system, but that will be checked automatically by the
 continuous integration system when you attempt to publish your package to the
 OPAM repository, so don't worry.
 
+
 ## Getting a full OPAM package
 
 There are still two things missing for a complete package.
-* An appealing description. Put it in a simple utf-8 text file named `descr`.
-  Like for git commits, the first line is a short summary, and a longer text may
-  follow.
+* An appealing description.
 * An URL where OPAM may download the project source for the release. If your
   project is hosted on github, pushing `TAG` will automatically provide
-  https://github.com/me/project/archive/TAG.zip. This shoud be put in
-  an `url` file, with a format similar to that of `opam`:
+  https://github.com/me/project/archive/TAG.zip.
+
+[opam-publish](https://github.com/AltGr/opam-publish) is a tool that automates
+most of the steps to get a full package ready, reviewed and published. It's
+still to be considered beta quality, though, so you'll also find the full manual
+instructions here.
+
+### With opam-publish
+
+```
+$ opam install opam-publish
+$ opam-publish prepare <URL>
+```
+
+This'll provide you with a `<package>.<version>` directory, where you'll have to
+write a description within the `descr` file if your package is new. Check the
+files in that directory, it's the full contents of what will be included in the
+opam repository.
+
+### By hand
+
+* Write a cool description of your package within a simple utf-8 text file
+  `descr`. Like for git commits, the first line is a short summary, and a longer
+  text may follow.
+* Create a `url` file, with a format similar to that of `opam`:
 
     ```
     archive: "https://address/of/project.1.0.tar.gz"
@@ -175,9 +205,9 @@ There are still two things missing for a complete package.
   The checksum is a simple md5 of the archive, which you can obtain with:
 
     ```
-    curl -L "https://address/of/project.1.0.tar.gz" | md5sum
+    $ curl -L "https://address/of/project.1.0.tar.gz" | md5sum
     ```
-That's it !
+
 
 ## Publishing
 
@@ -186,6 +216,21 @@ mechanism. If you're not familiar with it, it is a fancy way to:
 * Make a patch to the OPAM repository
 * Propose this patch for review and integration. This will also trigger tests
   that your package installs successfully from scratch.
+
+### With opam-publish
+
+It's just:
+
+```
+opam-publish submit <package>.<version>
+```
+
+If all goes well, you'll be redirected to the github page that will track your
+pull-request (automated tests, discussion with the repository maintainers,
+etc.). You can re-run this command as needed if you want to update your package
+description.
+
+### By hand
 
 Here is how to do it from scratch:
 
@@ -300,4 +345,4 @@ into too much details, here are some of the most useful features:
     ```
 
 For more, see the
-[OPAM Developer's Manual](https://github.com/ocaml/opam/blob/latest/doc/dev-manual/dev-manual.pdf?raw=true)
+[OPAM Developer's Manual](http://opam.ocaml.org/doc/manual/dev-manual.html)

--- a/doc/pages/Tricks.md
+++ b/doc/pages/Tricks.md
@@ -1,0 +1,72 @@
+> The following are beyond the scope of the [FAQ](FAQ.html), but have been found
+> useful for specific use-cases or for advanced users.
+
+### Simulate actions from the current switch state (for debugging)
+
+- `opam upgrade --show-actions` (stop at the action summary dialog)
+- `opam upgrade --dry-run` (display only)
+- if you really want to try out the results:
+    * `opam switch export testing-state.export`
+    * `opam switch tmp-testing --alias-of system`
+    * `opam switch import testing-state.export --fake`
+    * try actions with `--fake` (registers them in OPAM, but doesn't actually
+      run the build/install commands)
+    * revert to normal: `opam switch <previous>; opam switch remove tmp-testing`
+- Experiment with the solver:
+    * `opam <request> --cudf=cudf-file`
+    * or `opam config cudf-universe >cudf-file-1.cudf`
+    * run e.g. aspcud with `aspcud cudf-file-1.cudf /dev/stdout CRITERIA`
+    * `admin-scripts/cudf-debug.ml cudf-file-1.cudf` may help with conflicts
+
+
+### Install in all switches
+
+Not supported natively at the moment, but it's being considered. Quick hack:
+```
+for switch in $(opam switch list -s -i); do
+  opam install --switch $switch PACKAGE
+done
+```
+You may want to add `--yes` if you're confident.
+
+
+### Update OPAM environment within emacs
+
+You may use the following snippet to define an `opam-env` function:
+
+```lisp
+(defun opam-env ()
+  (interactive nil)
+  (dolist (var (car (read-from-string (shell-command-to-string "opam config env --sexp"))))
+    (setenv (car var) (cadr var))))
+```
+
+You may want to run this at emacs startup if it doesn't inherit the proper shell
+environment.
+
+
+### Easily provide a set of packages for a group of users to install
+
+The easiest way is to create a package with your prerequisites as `depends` and
+have them pin that. A quick way to host the file is to use a
+[Gist](https://gist.github.com). Create one with minimal contents and listing
+your packages as dependencies -- the file name **has** to be `opam`:
+
+```
+opam-version: "1.2"
+name: "ocaml101"
+version: "0.1"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+depends: [ "menhir" { = "20140422" }
+           "merlin" { >= "2" }
+           "ocp-indent"
+           "ocp-index" ]
+```
+
+Save that and get the `HTTPS clone URL`. All that is needed then is to run:
+
+```shell
+$ opam pin add ocaml101 <HTTPS clone URL>
+```
+
+Furthermore, `opam update` will then pick up any modification you made to the gist.

--- a/doc/pages/index.menu
+++ b/doc/pages/index.menu
@@ -8,6 +8,7 @@ Install.md
 Usage.md
 
 FAQ.md
+Tricks.md
 Packaging.md
 Specifying_Solver_Preferences.md
 


### PR DESCRIPTION
Including:
- link to the html dev-manual
- promote opam-publish rather than the more complex instructions
- document workaround for OPAM 1.1 in the FAQ
- add the 'tricks' page
