### PR TITLE
Fix CAML_LD_LIBRARY_PATH when switching from system

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1284,11 +1284,10 @@ module API = struct
         let switch = OpamSwitch.of_string (OpamCompiler.to_string compiler) in
         let quiet = (compiler = OpamCompiler.system) in
         OpamState.install_compiler t ~quiet switch compiler;
-        OpamState.update_switch_config t switch;
+        let t = OpamState.update_switch_config t switch in
 
         (* Finally, load the complete state and install the compiler packages *)
         log "installing compiler packages";
-        let t = OpamState.load_state "init-3" in
         let compiler_packages = OpamState.get_compiler_packages t compiler in
         let compiler_names =
           OpamPackage.Name.Set.of_list (List.rev_map fst compiler_packages) in

--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -2501,7 +2501,9 @@ let install_compiler t ~quiet:_ switch compiler =
 let update_switch_config t switch =
   let config = OpamFile.Config.with_switch t.config switch in
   OpamFile.Config.write (OpamPath.config t.root) config;
-  update_init_scripts { t with switch }  ~global:None
+  let t = load_state "switch-config" in
+  update_init_scripts t ~global:None;
+  t
 
 (* Dev packages *)
 

--- a/src/client/opamState.mli
+++ b/src/client/opamState.mli
@@ -233,7 +233,7 @@ val install_global_config: dirname -> switch -> unit
 val install_compiler: state -> quiet:bool -> switch -> compiler -> unit
 
 (** Write the right compiler switch in ~/.opam/config *)
-val update_switch_config: state -> switch -> unit
+val update_switch_config: state -> switch -> state
 
 (** Get the packages associated with the given compiler *)
 val get_compiler_packages: state -> compiler -> atom list

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -176,8 +176,7 @@ let remove_t switch ?(confirm = true) t =
     OpamFilename.rmdir comp_dir
 
 let update_global_config t ~warning switch =
-  OpamState.update_switch_config t switch;
-  let t = OpamState.load_state "switch-update-config" in
+  let t = OpamState.update_switch_config t switch in
   if warning then
     OpamState.print_env_warning_at_switch t
 
@@ -271,18 +270,6 @@ let install_packages ~packages switch compiler =
           "Inconsistent set of base compiler packages: \
            %s needed but not included"
           OpamPackage.Name.Set.(to_string (diff to_install_names roots));
-(*
-      let pinned =
-        OpamPackage.Set.fold (fun pkg pins ->
-            OpamPackage.Name.Map.add
-              (OpamPackage.name pkg) (Version (OpamPackage.version pkg))
-              pins)
-          to_install_pkgs
-          OpamPackage.Name.Map.empty in
-      OpamFile.Pinned.write (OpamPath.Switch.pinned t.root t.switch) pinned;
-      let t = { t with pinned } in
-      OpamPackage.Name.Set.iter (OpamState.add_pinned_overlay t) to_install_names;
-*)
       let result =
         OpamSolution.apply ~ask:false t (Switch roots)
           ~requested:roots


### PR DESCRIPTION
Closes #1847, #1849.

Supersedes #1875 -- thanks @antegallya for helping out (your fix was ok but
didn't handle the new switch case, where the state given to the function
wasn't up-to-date enough; I wish all writing functions returned the modified
state but we're not there yet)
