### PR TITLE
(transient) workaround Dose stack-overflow

### DIFF
--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -324,7 +324,7 @@ let installable universe =
   log "trim";
   let simple_universe =
     load_cudf_universe universe universe.u_available in
-  let trimed_universe = Algo.Depsolver.trim simple_universe in
+  let trimed_universe = (* Algo.Depsolver.trim *) simple_universe in
   Cudf.fold_packages
     (fun universe pkg -> OpamPackage.Set.add (OpamCudf.cudf2opam pkg) universe)
     OpamPackage.Set.empty


### PR DESCRIPTION
Doesn't cause trouble yet on opam-repo, but I managed to get a stack overflow
at this call with my experimental compilers-to-packages repo (that adds lots
of direct dependencies to "ocaml")

Better workaround it before it bites us, until the issue is fixed. Upstream
bug:
https://gforge.inria.fr/tracker/index.php?func=detail&aid=18453&group_id=4395&atid=13808