### PR TITLE
Don't raise on command not found in build/remove scripts

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -367,7 +367,8 @@ let remove_package_aux t ~metadata ?(keep_build=false) ?(silent=false) nv =
               Some
                 (OpamSystem.make_command ?name:nameopt ~metadata ~text cmd args
                    ~env:(OpamFilename.env_of_list env)
-                   ~dir:(OpamFilename.Dir.to_string exec_dir)))
+                   ~dir:(OpamFilename.Dir.to_string exec_dir)
+                   ~check_existence:false))
           remove
       in
       OpamProcess.Job.of_list ~keep_going:true commands
@@ -529,7 +530,9 @@ let build_and_install_package_aux t ~metadata:save_meta source nv =
     | (cmd::args)::commands ->
       let text = OpamProcess.make_command_text name ~args cmd in
       let dir = OpamFilename.Dir.to_string dir in
-      OpamSystem.make_command ~env ~name ~metadata ~dir ~text cmd args
+      OpamSystem.make_command ~env ~name ~metadata ~dir ~text
+        ~check_existence:false
+        cmd args
       @@> fun result ->
       if OpamProcess.is_success result then
         run_commands commands

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -361,7 +361,9 @@ let log_file name = match name with
   | None   -> temp_file "log"
   | Some n -> temp_file ~dir:(Sys.getcwd ()) n
 
-let make_command ?verbose ?(env=default_env) ?name ?text ?metadata ?allow_stdin ?dir cmd args =
+let make_command
+    ?verbose ?(env=default_env) ?name ?text ?metadata ?allow_stdin ?dir ?(check_existence=true)
+    cmd args =
   let name = log_file name in
   let verbose =
     OpamMisc.Option.default (!OpamGlobals.debug || !OpamGlobals.verbose) verbose
@@ -369,7 +371,7 @@ let make_command ?verbose ?(env=default_env) ?name ?text ?metadata ?allow_stdin 
   (* Check that the command doesn't contain whitespaces *)
   if None <> try Some (String.index cmd ' ') with Not_found -> None then
     OpamGlobals.warning "Command %S contains 1 space" cmd;
-  if command_exists ~env ?dir cmd then
+  if not check_existence || command_exists ~env ?dir cmd then
     OpamProcess.command ~env ~name ?text ~verbose ?metadata ?allow_stdin ?dir
       cmd args
   else

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -137,10 +137,17 @@ val system_ocamlc_version: string option Lazy.t
     Links pointing to directory are also returned. *)
 val directories_with_links: string -> string list
 
-(** Make a comman suitable for OpamProcess.Job *)
+(** Make a comman suitable for OpamProcess.Job. if [verbose], is set,
+    command and output will be displayed (at command end for the
+    latter, if concurrent commands are running). [name] is used for
+    naming log files. [text] is what is displayed in the status line
+    for this command. May raise Command_not_found, unless
+    [check_existence] is set to false (in which case you can end up
+    with a process error instead) *)
 val make_command:
   ?verbose:bool -> ?env:string array -> ?name:string -> ?text:string ->
   ?metadata:(string * string) list -> ?allow_stdin:bool -> ?dir:string ->
+  ?check_existence:bool ->
   string -> string list -> OpamProcess.command
 
 (** OLD COMMAND API, DEPRECATED *)


### PR DESCRIPTION
i.e. let the command fail normally rather than raise an exception