### PR TITLE
OpamParallel: allow to specify mutually exclusive jobs

### DIFF
--- a/src/core/opamParallel.mli
+++ b/src/core/opamParallel.mli
@@ -59,6 +59,7 @@ module type SIG = sig
   val iter:
     jobs:int ->
     command:(pred:(G.V.t * 'a) list -> G.V.t -> 'a OpamProcess.job) ->
+    ?mutually_exclusive:(G.V.t list list) ->
     G.t ->
     unit
 
@@ -67,6 +68,7 @@ module type SIG = sig
   val map:
     jobs:int ->
     command:(pred:(G.V.t * 'a) list -> G.V.t -> 'a OpamProcess.job) ->
+    ?mutually_exclusive:(G.V.t list list) ->
     G.t ->
     (G.V.t * 'a) list
 


### PR DESCRIPTION
Not used at the moment but will come in very handy for better handling
of the 'install' field.