### PR TITLE
Allow <name>.opam in the source of packages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,7 @@
   correct OPAM path
 * ~/.opam/config doesn't refer to OPAM's patch-version anymore, to allow
   downgrading
+* Recognise <name>.opam files and directories when pinning a package to source
 * Lots of bug-fixes
 
 1.2.0

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -446,7 +446,7 @@ module API = struct
           OpamSystem.internal_error "opam file location for %s not found"
             (OpamPackage.to_string nv)
       in
-      if where then OpamGlobals.msg "%s\n" (OpamFilename.prettify (opam_f ()));
+      if where then OpamGlobals.msg "%s\n" (OpamFilename.to_string (opam_f ()));
 
       (* where does it come from (eg. which repository) *)
       let repository =

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -133,10 +133,8 @@ let edit t name =
       match dir with
       | Some dir when OpamFilename.exists_dir dir ->
         let src_opam =
-          OpamFilename.OP.(
-            if OpamFilename.exists_dir (dir / "opam")
-            then dir / "opam" // "opam"
-            else dir // "opam")
+          OpamMisc.Option.default OpamFilename.OP.(dir // "opam")
+            (OpamState.find_opam_file_in_source name dir)
         in
         if OpamGlobals.confirm "Save the new opam file back to %S ?"
             (OpamFilename.to_string src_opam) then
@@ -187,14 +185,16 @@ let pin name ?version pin_option =
       let no_changes = pin_option = current in
       if no_changes then
         OpamGlobals.note
-          "Package %s is already pinned to %s.\n\
+          "Package %s is already %s-pinned to %s.\n\
            This will erase any previous custom definition."
           (OpamPackage.Name.to_string name)
+          (string_of_pin_kind (kind_of_pin_option current))
           (string_of_pin_option current)
       else
         OpamGlobals.note
-          "%s is already pinned to %s."
+          "%s is currently %s-pinned to %s."
           (OpamPackage.Name.to_string name)
+          (string_of_pin_kind (kind_of_pin_option current))
           (string_of_pin_option current);
       if OpamGlobals.confirm "Proceed ?" then
         (OpamFilename.remove

--- a/src/client/opamState.mli
+++ b/src/client/opamState.mli
@@ -349,6 +349,9 @@ val update_pinned_package: state -> ?fixed_version:version -> name -> bool OpamP
 (** Check whether a package is a development package *)
 val is_dev_package: state -> package -> bool
 
+(** Looks up an 'opam' file for the given named package in a source directory *)
+val find_opam_file_in_source: name -> dirname -> filename option
+
 (** {2 Configuration files} *)
 
 (** Return the .config file for the given package *)

--- a/src/core/opamGlobals.ml
+++ b/src/core/opamGlobals.ml
@@ -475,7 +475,9 @@ let confirm ?(default=true) fmt =
   Printf.ksprintf (fun s ->
     try
       if !safe_mode then false else
-      let prompt () = msg "%s [%s] " s (if default then "Y/n" else "y/N") in
+      let prompt () =
+        formatted_msg "%s [%s] " s (if default then "Y/n" else "y/N")
+      in
       if !yes then (prompt (); msg "y\n"; true)
       else if !no then (prompt (); msg "n\n"; false)
       else if os () = Win32 then


### PR DESCRIPTION
Convenient when there are several packages compiled from the same repo