### PR TITLE
Fixed state-cache loading

### DIFF
--- a/src/core/opamVersion.ml.in
+++ b/src/core/opamVersion.ml.in
@@ -85,6 +85,6 @@ let full () =
     | Some v -> Printf.sprintf " (%s)" (to_string v) in
   Printf.sprintf "%s%s" (to_string current) git_version
 
-let magic =
+let magic () =
   let hash = Hashtbl.hash full in
-  Printf.sprintf "%08X" (hash mod (Int32.to_int Int32.max_int))
+  String.sub (Printf.sprintf "%08X" hash) 0 8

--- a/src/core/opamVersion.mli
+++ b/src/core/opamVersion.mli
@@ -39,8 +39,8 @@ val set_git: string -> unit
 (** The full version (current + git) *)
 val full: unit -> t
 
-(** Magic string *)
-val magic: string
+(** Magic string, always of length 8 *)
+val magic: unit -> string
 
 (** Display the version message *)
 val message: unit -> unit


### PR DESCRIPTION
Beta2 change caused it to be skipped, incurring a long load time at the first
run of OPAM after boot