### PR TITLE
Back out the optimisation to recompile only when archive checksum changs

### DIFF
--- a/src/core/opamRepository.ml
+++ b/src/core/opamRepository.ml
@@ -267,12 +267,7 @@ let package_state repo prefix nv all =
   let fs = match all with
     | `all       -> package_files repo prefix nv ~archive:true
     | `partial b -> package_important_files repo prefix nv ~archive:b in
-  let url = OpamPath.Repository.url repo prefix nv in
-  let l =
-    List.map (fun f ->
-        if f = url then url_checksum f
-        else OpamFilename.checksum f)
-      fs in
+  let l = List.map OpamFilename.checksum fs in
   List.flatten l
 
 (* Sort repositories by priority *)


### PR DESCRIPTION
The observable bug is that when I update the `url` file in a package to change
the `archive` source but not the checksum, this never propagates after an
`opam update`.  The reason is that the update is skipped due to the
optimisation that prevents recompilation of a package when the location
changes, but not the checksum.

Unfortunately, if using OPAM with a `local` remote, this makes it impossible
to fix a broken location without manually munging around in `~/.opam`.

Debugged with @samoht