### PR TITLE
Fix update bug introduced in fef5f0704f59459dad119dbb30f63e92babc6d1f

### DIFF
--- a/doc/pages/FAQ.md
+++ b/doc/pages/FAQ.md
@@ -301,3 +301,15 @@ If for some reason you want the old behaviour, use one of:
 * an address of the form `vc-controlled-dir#branch`, typically `#master`
 * on Git you can use `#HEAD` to always get to the currently checked out branch
   (which used to be the default, and still is for remote gits)
+
+---
+
+#### 🐫  OPAM wants to do reinstallations after update. Can I skip them ?
+
+OPAM registers the need to recompile packages when they had meaningful changes
+in the repository, to guarantee consistency and allow to propagate fixes to
+already installed packages ; the official repository maintainers generally don't
+abuse this. There is no built-in command to reset them, in purpose, but removing
+the file `~/.opam/<switch>/reinstall` is enough to make OPAM forget about them.
+It's quite safe, but don't report issues if you did and your system is not up to
+date, obviously.

--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -183,7 +183,7 @@ let package_state_one t all nv =
     | `all ->
       OpamFilename.checksum opam
       @ OpamFilename.checksum descr
-      @ OpamRepository.url_checksum url
+      @ OpamFilename.checksum url
       @ OpamFilename.checksum_dir files
       @ OpamFilename.checksum archive
     | `partial true ->

--- a/src/core/opamRepository.ml
+++ b/src/core/opamRepository.ml
@@ -267,7 +267,12 @@ let package_state repo prefix nv all =
   let fs = match all with
     | `all       -> package_files repo prefix nv ~archive:true
     | `partial b -> package_important_files repo prefix nv ~archive:b in
-  let l = List.map OpamFilename.checksum fs in
+  let url = OpamPath.Repository.url repo prefix nv in
+  let l =
+    List.map (fun f ->
+        if all <> `all && f = url then url_checksum f
+        else OpamFilename.checksum f)
+      fs in
   List.flatten l
 
 (* Sort repositories by priority *)

--- a/src/core/opamRepository.mli
+++ b/src/core/opamRepository.mli
@@ -62,15 +62,19 @@ val compiler_index: repository repository_name_map -> (repository_name * string 
 
 (** {2 State} *)
 
-(** Get the meaningful checksum off an url file *)
+(** Get the package archive checksum off an url file *)
 val url_checksum: OpamFilename.t -> checksums
 
 (** Get all the package files *)
 val package_files: repository -> string option -> package -> archive:bool ->
   filename list
 
-(** Compute a package state (ie. a list of checksums). *)
-val package_state: repository -> string option -> package -> [`all|`partial of bool]
+(** Compute a package state (ie. a list of checksums). If [`partial archive],
+    only the checksum of the archive within the url file (instead of the file
+    itself), of the files/ subdirectory, and of the archive if set are
+    returned. *)
+val package_state: repository -> string option -> package ->
+  [`all|`partial of bool]
   -> checksums
 
 (** Get all the compiler files *)


### PR DESCRIPTION
OPAM would reinstall all packages after each update :( The 'package states'
are not well defined, and the interface between OpamRepository and OpamState 
for that purpose is very fragile (it relies in the same lists being computed,
in the same order, from two modules). But since this will go in 1.3, there is
no point in rewriting it now.