### PR TITLE
add new export format for opam compatible with dose-distcheck

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -947,6 +947,8 @@ let config =
     "Prints a summary of your setup, useful for bug-reports.";
     ["cudf-universe"], `cudf, ["[FILE]"],
     "Outputs the current available package universe in CUDF format.";
+    ["pef-universe"], `pef, ["[FILE]"],
+    "Outputs the current available package universe in PEF format.";
   ] in
   let man = [
     `S "DESCRIPTION";
@@ -1042,13 +1044,17 @@ let config =
        with Failure msg -> `Error (false, msg))
     | Some `subst, (_::_ as files) ->
       `Ok (Client.CONFIG.subst (List.map OpamFilename.Base.of_string files))
-    | Some `cudf, params ->
+    | Some `pef, params ->
       let opam_state = OpamState.load_state "config-universe" in
       let dump oc = OpamState.dump_state opam_state oc in 
-      (*
+      (match params with
+       | [] -> `Ok (dump stdout)
+       | [file] -> let oc = open_out file in dump oc; close_out oc; `Ok ()
+       | _ -> bad_subcommand "config" commands command params)
+    | Some `cudf, params ->
+      let opam_state = OpamState.load_state "config-universe" in
       let opam_univ = OpamState.universe opam_state Depends in
       let dump oc = OpamSolver.dump_universe opam_univ oc in
-      *)
       (match params with
        | [] -> `Ok (dump stdout)
        | [file] -> let oc = open_out file in dump oc; close_out oc; `Ok ()

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1044,8 +1044,11 @@ let config =
       `Ok (Client.CONFIG.subst (List.map OpamFilename.Base.of_string files))
     | Some `cudf, params ->
       let opam_state = OpamState.load_state "config-universe" in
+      let dump oc = OpamState.dump_state opam_state oc in 
+      (*
       let opam_univ = OpamState.universe opam_state Depends in
       let dump oc = OpamSolver.dump_universe opam_univ oc in
+      *)
       (match params with
        | [] -> `Ok (dump stdout)
        | [file] -> let oc = open_out file in dump oc; close_out oc; `Ok ()

--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -1185,7 +1185,8 @@ let dump_state t oc =
 
     (try
       let c = OpamPackage.Map.find package conflicts in
-      match OpamFormula.to_conjunction c with
+      let n = OpamPackage.name package in
+      match (n,None)::(OpamFormula.to_conjunction c) with
       |[] -> ()
       |cc -> Printf.fprintf oc "conflicts: %s\n"
               (string_of_conjunction OpamFormula.string_of_atom cc);

--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -1125,6 +1125,69 @@ let universe t action =
     u_base      = base;
   }
 
+let string_of_cnf string_of_atom cnf =
+  let string_of_clause c =
+    Printf.sprintf "%s" (OpamMisc.sconcat_map " | " string_of_atom (List.rev c)) in
+  Printf.sprintf "%s" (OpamMisc.sconcat_map " , " string_of_clause (List.rev cnf))
+
+let string_of_conjunction string_of_atom c =
+  Printf.sprintf "%s" (OpamMisc.sconcat_map " , " string_of_atom (List.rev c))
+
+let dump_state t oc =
+  let opams = (* Read overlays of pinned packages *)
+    OpamPackage.Name.Map.fold (fun name pin map ->
+        let v = version_of_pin t name pin in
+        let overlay = OpamPath.Switch.Overlay.opam t.root t.switch name in
+        if OpamFilename.exists overlay then
+          OpamPackage.Map.add
+            (OpamPackage.create name v) (OpamFile.OPAM.read overlay) map
+        else map)
+      t.pinned t.opams
+  in
+  let depends   = OpamPackage.Map.map OpamFile.OPAM.depends opams in
+  let depopts   = OpamPackage.Map.map OpamFile.OPAM.depopts opams in
+  let conflicts = OpamPackage.Map.map OpamFile.OPAM.conflicts opams in
+  let maintainers = OpamPackage.Map.map OpamFile.OPAM.maintainer opams in
+  let base = base_packages t in
+
+  let aux package =
+    Printf.fprintf oc "package: %s\n" (OpamPackage.name_to_string package);
+    Printf.fprintf oc "version: %s\n" (OpamPackage.version_to_string package);
+    begin try
+      let m = OpamPackage.Map.find package maintainers in
+      Printf.fprintf oc "maintainer: %s\n" (string_of_conjunction (fun a -> a) m);
+    with Not_found -> () end;
+    if OpamPackage.Set.mem package base then
+      Printf.fprintf oc "base: true\n";
+
+    begin try
+      let d = OpamPackage.Map.find package depends in
+      let formula = (OpamFormula.formula_of_extended ~filter:(fun _ -> true) d) in
+      match OpamFormula.to_cnf formula with
+      |[] -> ()
+      |[[]] -> ()
+      |dd -> Printf.fprintf oc "depends: %s\n" (string_of_cnf OpamFormula.string_of_atom dd)
+    with Not_found -> () end;
+
+    begin try
+      let d = OpamPackage.Map.find package depopts in
+      let formula = (OpamFormula.formula_of_extended ~filter:(fun _ -> true) d) in
+      match OpamFormula.to_cnf formula with
+      |[] -> ()
+      |[[]] -> ()
+      |dd -> Printf.fprintf oc "reccomends: %s\n" (string_of_cnf OpamFormula.string_of_atom dd)
+    with Not_found -> () end;
+
+    begin try
+      let c = OpamPackage.Map.find package conflicts in
+      match OpamFormula.to_conjunction c with
+      |[] -> ()
+      |cc -> Printf.fprintf oc "conflicts: %s\n" (string_of_conjunction OpamFormula.string_of_atom cc);
+    with Not_found -> () end;
+    Printf.fprintf oc "\n";
+  in
+  OpamPackage.Set.iter aux (Lazy.force t.available_packages)
+
 let installed_versions t name =
   OpamSwitch.Map.fold (fun switch _ map ->
     let installed =

--- a/src/client/opamState.mli
+++ b/src/client/opamState.mli
@@ -88,6 +88,8 @@ type state = Types.t
     site. *)
 val load_state: ?save_cache:bool -> string -> state
 
+val dump_state: state -> out_channel -> unit
+
 (** Rebuild the state cache. *)
 val rebuild_state_cache: unit -> unit
 


### PR DESCRIPTION
This set of patches add an alternative format dump for opam (PEF : package export format). It is meant to be the new interface between the dose tools and opam to perform repository analysis. It is also needed for the new version of ows.irill.org, the upcoming new version of the opam weather service. This format is different from cudf as versions are strings and not integers. In the future I plan to add more fields to the export format.

Ex:

   package: cohttp
   version: 0.9.14
   maintainer: anil@recoil.org
   depends: fieldslib (>= 109.20.00) , cstruct (>= 1.0.1) , ounit , uri (< 1.5.0) , uri (>= 1.3.8) , re , ocamlfind
   reccomends: lwt | async
   conflicts: mirage-tcpip-xen (< 0.9.5) , mirage-tcpip-unix (< 0.9.5) , lwt (>= 2.4.7) , lwt (< 2.4.3) , async (> 109.53.02) , async (< 109.15.00)
