### PR TITLE
Fix incorrect contractions in messages.

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -133,7 +133,7 @@ three scopes:
    package's own OPAM file (when not shadowed by another variable), in which
    case the variables will relate to the version of the package being defined.
    Otherwise, the installed version is always used, and most variables will be
-   undefined when the package is'nt installed.
+   undefined when the package isn't installed.
 3. Some fields define their own local variables, like `success` in the field
    `post-messages`
 

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -86,7 +86,7 @@ let switch_to_updated_self debug opamroot =
        with e ->
          OpamMisc.fatal e;
          OpamGlobals.error
-           "Could'nt run the upgraded opam %s found at %s. \
+           "Couldn't run the upgraded opam %s found at %s. \
             Continuing with %s from the system."
            (OpamVersion.to_string update_version)
            updated_self_str

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -587,7 +587,7 @@ let check_cudf_version =
             log "Solver is aspcud > 1.9: using latest version criteria";
             `Latest
           | _ ->
-            log "Solver is'nt aspcud > 1.9, using compat criteria";
+            log "Solver isn't aspcud > 1.9, using compat criteria";
             `Compat
       with OpamSystem.Process_error _ ->
         log "Solver doesn't know about '-v': using compat criteria";

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -65,7 +65,7 @@ archives: $(SRC_EXTS:=.download)
         fi
 	@touch $@
 
-# OCamlMakefile doesn'nt include stand-alone mlis in the packs...
+# OCamlMakefile doesn't include stand-alone mlis in the packs...
 graph-workaround:
 	cp graph/src/sig.mli graph/src/sig.ml
 	cp graph/src/sig_pack.mli graph/src/sig_pack.ml


### PR DESCRIPTION
These patches don't affect the logic of opam or its build environment. It simply fixes some spelling mistakes in messages.