### PR TITLE
Fix to build OPAM on NetBSD without any installed libraries.

### DIFF
--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -55,8 +55,8 @@ archives: $(SRC_EXTS:=.download)
 	mkdir -p tmp
 	cd tmp && tar xf$(if $(patsubst %.tar.gz,,$(URL_$*)),j,z) ../$(notdir $(URL_$*))
 	rm -rf $*
-	mv tmp/* $*
-	rmdir tmp
+	@for ii in tmp/*; do if [ -d $${ii} ]; then mv $${ii} $*; fi; done; \
+	rm -rf tmp
 	@if [ -d patches/$* ]; then \
           cd $* && \
 	  for p in ../patches/$*/*.patch; do \


### PR DESCRIPTION
Under NetBSD, un-tar'ing a project's archive may result in an extra file getting created. NetBSD's `tar` recognizes GNU `tar` archives but places extra information in a file outside the directory tree that gets extracted. The extra file breaks the `Makefile` command that tries to move the archive's tree out of `tmp`.

This patch replaces the `mv` command with a slightly more complicated command that only moves directories out of the `tmp` directory. Because we may be leaving a file in `tmp`, the `rmdir` command is replaced with a `rm -rf` command.

This commit allows me to build OPAM on NetBSD with no libraries installed in the base system.