### PR TITLE
Add ./admin-script/extract-mini-repository

### DIFF
--- a/admin-scripts/compilers-to-packages.ml
+++ b/admin-scripts/compilers-to-packages.ml
@@ -96,7 +96,8 @@ iter_packages ~opam:(fun nv opam ->
       | None ->
         let available = OpamFile.OPAM.available opam in
         let rec aux = function
-          | FOp (FIdent ([],"ocaml-version",None), op, FString v) ->
+          | FOp (FIdent ([],var,None), op, FString v)
+            when OpamVariable.to_string var = "ocaml-version" ->
             Atom (op, OpamPackage.Version.of_string v)
           | FNot f ->
             OpamFormula.neg (fun (op,v) -> OpamFormula.neg_relop op, v)
@@ -108,13 +109,16 @@ iter_packages ~opam:(fun nv opam ->
         let ocaml_dep_formula = aux available in
         let rec aux =
           function
-          | FOp (FIdent ([],"ocaml-version",None), op, FString v) -> None
+          | FOp (FIdent ([],var,None), op, FString v)
+            when OpamVariable.to_string var = "ocaml-version" ->
+              None
           | FNot f -> OpamMisc.Option.map (fun f -> FNot f) (aux f)
           | FAnd (f1,f2) -> (match aux f1, aux f2 with
               | Some f1, Some f2 -> Some (FAnd (f1,f2))
               | None, f | f, None -> f)
           | FOr (f1,f2) -> (match aux f1, aux f2 with
               | Some f1, Some f2 -> Some (FOr (f1,f2))
+              | None, None -> None
               | None, f | f, None ->
                 OpamGlobals.error_and_exit "Unconvertible 'available' field in %s"
                   (OpamPackage.to_string nv))

--- a/admin-scripts/extract_mini_repository.sh
+++ b/admin-scripts/extract_mini_repository.sh
@@ -1,0 +1,143 @@
+#! /bin/sh
+
+set -e
+
+if [ $# = 0 ]; then
+   cat <<EOF
+
+This script is able to generate a minimalistic and self-contained
+opam-repository for a given set of packages and compiler versions.
+The resulting repository will be in './opam-mini-repository.tar.gz'
+
+Example:
+
+ ## Including only the latest compiler version:
+ $0 ocp-indent lwt
+
+ ## Including a specific version of OCaml or multiple versions.
+ $0 ocaml.4.02.1 ocaml.4.01.0 ocp-indent lwt
+
+Then, the resulting repository can be used to replace the default opam
+repository on computer without internet access and with only few spare
+disk space.
+
+  tar xf opam-mini-repository.tar.gz
+  opam init --root /tmp/opam default ./opam-mini-repository --comp 4.02.1
+
+EOF
+   exit 1
+fi
+
+DEFAULT_COMPILER=4.02.1
+OPAM_REPO=https://github.com/ocaml/opam-repository/archive/master.tar.gz
+REPO_DIR_NAME=opam-mini-repository
+
+EXE_PATH=$(readlink -f "$0")
+SOURCE_DIR=$(dirname "${EXE_PATH}")
+TARGET_DIR=$(pwd)
+WORK_DIR=$(mktemp -d)
+
+REQUEST=$*
+COMPILERS=
+
+for package in ${REQUEST}; do
+    case ${package} in
+        ocaml.*)
+            COMPILERS="${COMPILERS} ${package#ocaml.}"
+            ;;
+        *)
+            PACKAGES="${PACKAGES} ${package}"
+            ;;
+    esac
+done
+
+if [ -z "${COMPILERS}" ]; then
+    COMPILERS="${DEFAULT_COMPILER}"
+fi
+
+cleanup() {
+    rm -r "${WORK_DIR:?}"
+}
+
+trap cleanup EXIT
+
+## Fetch the opam-repository
+
+cd "${WORK_DIR}"
+wget ${OPAM_REPO}
+tar xf master.tar.gz
+mv opam-repository-master ${REPO_DIR_NAME}
+
+cd ${REPO_DIR_NAME}
+rm -rf "${WORK_DIR}/${REPO_DIR_NAME}/.git"
+
+## Remove the unrequired compilers version
+
+unrequired_compiler() {
+  for version in ${COMPILERS}; do
+      if [ ${version} = "$1" ]; then return 1; fi
+  done
+  return 0
+}
+
+for dir in compilers/*/*
+do
+    if unrequired_compiler "${dir##compilers/*/}"; then
+        rm -r "${dir}"
+    fi
+done
+
+# Remove empty directories in "compilers/"
+
+for dir in compilers/*
+do
+   rmdir "${dir}" 2> /dev/null || true
+done
+
+## Convert the required compilers as packages
+
+"${SOURCE_DIR}"/compilers-to-packages.ml
+
+## Fetch the packages and compilers archives
+
+for version in ${COMPILERS}; do
+    opam admin make --resolve --compiler ${version} ocaml.${version} ${PACKAGES}
+done
+
+## Remove the unrequired package "versions
+
+unrequired_version() {
+    case "$1" in
+        base-*)
+            return 1;;
+        *)
+            for version in archives/*
+            do
+                if [ "${version}" = "archives/$1+opam.tar.gz" ]; then return 1; fi
+            done
+    esac
+    return 0
+}
+
+for dir in packages/*/*
+do
+    if unrequired_version "${dir##packages/*/}"; then
+        rm -r "${dir}"
+    fi
+done
+
+# Remove empty directories in "packages/"
+
+for dir in packages/*
+do
+   rmdir "${dir}" 2> /dev/null || true
+done
+
+## Remove unrequired files
+
+rm -f .gitignore .travis-ci-install.sh .travis-ci.sh .travis.yml README.md
+
+## Build the archive
+
+cd "${WORK_DIR}"
+tar czf "${TARGET_DIR}/opam-mini-repository.tar.gz" ${REPO_DIR_NAME}


### PR DESCRIPTION
This script is able to generate a minimalistic and self-contained 
opam-repository for a given set of packages and compiler versions.
The resulting repository will be in './opam-mini-repository.tar.gz'.

```
## Including only the latest compiler version:
./extract-mini-repository ocp-indent lwt

## Including a specific version of OCaml or multiple versions.
./extract-mini-repository ocaml.4.02.1 ocaml.4.01.0 ocp-indent lwt
```

Then, the resulting repository can be used to replace the default opam
repository on computer without internet access and with only few spare
disk space.

```
tar xf opam-mini-repository.tar.gz
opam init --root /tmp/opam default ./opam-mini-repository --comp 4.02.1
```