### PR TITLE
Don't compile lib-ext targets that cannot be compiled due to missing compiler #2119

### DIFF
--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -36,8 +36,8 @@ lib-ext: clone build copy
 	@
 
 build: clone
-	$(MAKE) -f $(OCAMLMAKEFILE) subprojs SUBTARGET=bcl
-	$(MAKE) -f $(OCAMLMAKEFILE) subprojs SUBTARGET=ncl
+	[ $(OCAMLC) = no ] || $(MAKE) -f $(OCAMLMAKEFILE) subprojs SUBTARGET=bcl
+	[ $(OCAMLOPT) = no ] || $(MAKE) -f $(OCAMLMAKEFILE) subprojs SUBTARGET=ncl
 
 all: bcl ncl
 


### PR DESCRIPTION
So don't compile native libraries without ocamlopt, and don't compile bytecode
libraries without ocamlc.

This addresses the issue #2119.

I first bumped into the issue when compiling without ocamlopt, but decided to add ocamlc support for sake of completeness and to make testing easier. The symptoms when compiling lib-ext without ocamlopt are:

    no -c -I extlib/ extlib/enum.ml
    /bin/sh: 5: no: not found
