### PR TITLE
OpamFile: make 'permissive mode' the default without strict or debug

### DIFF
--- a/src/core/opamFile.ml
+++ b/src/core/opamFile.ml
@@ -118,8 +118,12 @@ module X = struct
         already_warned := true;
         false
 
+    (* Prints warnings or fails in strict mode; returns true if permissive mode
+       is enabled *)
     let check ?allow_major ?(versioned=true) =
       fun f fields ->
+        if not !OpamGlobals.strict && not !OpamGlobals.debug then true
+        else
         let f_opam_version =
           if List.mem s_opam_version fields then
             OpamFormat.assoc_option f.file_contents s_opam_version
@@ -149,15 +153,16 @@ module X = struct
             List.partition (fun x -> List.mem x fields) invalids
           in
           if too_many <> [] then
-            OpamGlobals.warning "duplicate fields in %s: %s"
+            OpamGlobals.warning "In %s:\n  duplicate fields %s"
               f.file_name
               (OpamMisc.string_of_list (fun x -> x) too_many);
           let is_, s_ =
             if List.length invalids <= 1 then "is an", "" else "are", "s" in
           if invalids <> [] then
-            OpamGlobals.warning "%s %s unknown field%s in %s."
+            OpamGlobals.warning "In %s:\n  %s %s unknown field%s."
+              f.file_name
               (OpamMisc.pretty_list invalids)
-              is_ s_ f.file_name;
+              is_ s_;
           if !OpamGlobals.strict then
             OpamGlobals.error_and_exit "Strict mode: bad fields in %s"
               f.file_name;
@@ -486,7 +491,7 @@ module X = struct
                 map,
               i+1
             | s ->
-              OpamGlobals.error "At %s:%d: skipped invalid line %S"
+              OpamGlobals.error "At %s:%d:\n  skipped invalid line %S"
                 (OpamFilename.prettify filename) i (String.concat " " s);
               map, i+1
           ) (empty,1) lines in
@@ -1268,7 +1273,12 @@ module X = struct
 
     let of_syntax ?(permissive=false) ?(conservative=false) f nv =
       let safe default f x y z =
-        try f x y z with OpamFormat.Bad_format _ when permissive -> default
+        try f x y z with
+        | OpamFormat.Bad_format _ as bf
+          when not conservative && not !OpamGlobals.strict ->
+          if not permissive then
+            OpamGlobals.warning "%s" (OpamFormat.string_of_bad_format bf);
+          default
       in
       let assoc_option x y z = safe None OpamFormat.assoc_option x y z in
       let assoc_list x y z = safe [] OpamFormat.assoc_list x y z in
@@ -1302,7 +1312,7 @@ module X = struct
                   (function Depflag_Unknown _ -> false | _ -> true) flags in
               if not permissive && known_flags <> flags then
                 OpamGlobals.warning
-                  "At %s: Unknown flags %s ignored for dependency %s"
+                  "At %s:\n  Unknown flags %s ignored for dependency %s"
                   (string_of_pos pos)
                   (OpamMisc.pretty_list (OpamMisc.filter_map (function
                        | Depflag_Unknown s -> Some s
@@ -1400,7 +1410,7 @@ module X = struct
               allflags in
           if not permissive && known_flags <> allflags then
             OpamGlobals.warning
-              "At %s: Unknown package flags %s ignored"
+              "At %s:\n  Unknown package flags %s ignored"
               (string_of_pos (OpamFormat.value_pos v))
               (OpamMisc.pretty_list (OpamMisc.filter_map (function
                    | Pkgflag_Unknown s -> Some s
@@ -2353,13 +2363,6 @@ module Make (F : F) = struct
     write_files := filename :: !write_files;
     log "Wrote %s in %.3fs" filename (chrono ())
 
-  let string_of_backtrace_list = function
-    | [] | _ when not (Printexc.backtrace_status ()) -> ""
-    | btl -> List.fold_left (fun s bts ->
-        let bt_lines = OpamMisc.split bts '\n' in
-        "\n  Backtrace:\n    "^(String.concat "\n    " bt_lines)^s
-      ) "" btl
-
   let read f =
     let filename = OpamFilename.prettify f in
     read_files := filename :: !read_files;
@@ -2381,13 +2384,7 @@ module Make (F : F) = struct
         else raise e (* Message already printed *)
       | e ->
         OpamMisc.fatal e;
-        let pos,msg,btl = match e with
-          | OpamFormat.Bad_format (Some pos, btl, msg) -> pos, ":\n  "^msg, btl
-          | OpamFormat.Bad_format (None, btl, msg) -> (f,-1,-1), ":\n  "^msg, btl
-          | _ -> (f,-1,-1),"",[] in
-        let e = OpamFormat.add_pos pos e in
-        OpamGlobals.error "At %s%s%s"
-          (string_of_pos pos) msg (string_of_backtrace_list btl);
+        OpamGlobals.error "%s" (OpamFormat.string_of_bad_format ~file:f e);
         if !OpamGlobals.strict then OpamGlobals.exit 66
         else raise e
 
@@ -2405,14 +2402,8 @@ module Make (F : F) = struct
 
   let read_from_channel ic =
     try F.of_channel dummy_file ic with
-    | OpamFormat.Bad_format (Some pos, btl, msg) as e ->
-      OpamGlobals.error "At %s: %s%s"
-        (string_of_pos pos) msg (string_of_backtrace_list btl);
-      if !OpamGlobals.strict then
-        OpamGlobals.error_and_exit "Strict mode: aborting"
-      else raise e
-    | OpamFormat.Bad_format (None, btl, msg) as e ->
-      OpamGlobals.error "Input error: %s%s" msg (string_of_backtrace_list btl);
+    | OpamFormat.Bad_format _ as e ->
+      OpamGlobals.error "%s" (OpamFormat.string_of_bad_format e);
       if !OpamGlobals.strict then
         OpamGlobals.error_and_exit "Strict mode: aborting"
       else raise e

--- a/src/core/opamFormat.mli
+++ b/src/core/opamFormat.mli
@@ -45,6 +45,8 @@ exception Bad_format of pos option * string list * string
 (** Raise [Bad_format]. *)
 val bad_format: ?pos:pos -> ('a, unit, string, 'b) format4 -> 'a
 
+val string_of_bad_format: ?file:filename -> exn -> string
+
 (** Adds a position to a Bad_format exception if it doesn't have one yet *)
 val add_pos: pos -> exn -> exn
 


### PR DESCRIPTION
Ref #3944

This makes most file format errors pass silently -- in particular unknown
fields or idents. Some "typing" errors (eg string where an ident is expected)
will lead to the whole field being ignored ; lint will report an error 2 "bad
format" in that case.

Also normalises some messages