### PR TITLE
Allow _tag_ `"flags:plugin"` instead of _flag_ `plugin`

### DIFF
--- a/doc/dev-manual/dev-manual.tex
+++ b/doc/dev-manual/dev-manual.tex
@@ -526,13 +526,17 @@ depends: [
   \item{\tt light-uninstall} the package's uninstall instructions don't require the
     package source. This is currently inferred when the only uninstall
     instructions have the form `ocamlfind remove...`, but making it explicit is
-    preferred (since OPAM 1.2.0).
+    preferred (since \OPAM\ 1.2.0).
   \item{\tt verbose} when this is present, the stdout of the package's build and
     install instructions will be printed to the user (since \OPAM\ 1.2.1).
   \item{\tt plugin} the package installs a program named \verb+opam-$NAME+. OPAM
     will hand over to it when run with subcommand \verb+$NAME+, automatically
-    installing it if necessary.
+    installing it if necessary (since \OPAM\ 1.2.2).
   \end{description}
+  Since some of those wheren't known in \OPAM\ 1.2.0, which will complain about
+  them, they shouldn't be used in the 1.2 branch. Using a {\tt flags:foo} {\em
+    tag} instead is thus allowed as a compatible way to activate flag {\tt foo}
+  on 1.2.x versions.
 
 \item {\tt features} is currently experimental and shouldn't be used on the main
   package repository. It allows to define custom variables that better document

--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -486,6 +486,11 @@ recommended to check the validity and quality of your `opam` files.
   the packages. The `"org:foo"` tag is reserved for packages officially
   distributed by organization ``foo''.
 
+  Tags in the form `"flags:<ident>"` can be used to pass meaningful `flags` to
+  OPAM: see the `flags:` field below. This is mostly intended for compatibility
+  with earlier releases in the 1.2 branch, which will complain about unknown
+  values in the `flags:` field.
+
 - `patches: [ <string> { <filter> } ... ]`: a list of files relative to the
   project source root (often added through the `files/` metadata subdirectory).
   The listed patch files will be applied sequentially to the source as with the
@@ -630,7 +635,9 @@ recommended to check the validity and quality of your `opam` files.
     - `verbose`: when this is present, the stdout of the package's build and
       install instructions will be printed to the user (since OPAM 1.2.1).
     - `plugin`: the package installs a program named `opam-<name>` and may be
-      auto-installed and run with `opam <name>` (since OPAM 1.2.2)
+      auto-installed and run with `opam <name>` (since OPAM 1.2.2 ; the use is
+      discouraged in the 1.2 branch for compatibility, use `tag: "flags:plugin"`
+      instead)
 
 - `features: [ <ident> <string> { <filter> } ... ]` (EXPERIMENTAL): this field
   is currently experimental and shouldn't be used on the main package

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -312,7 +312,7 @@ let removal_needs_download t nv =
       (OpamPackage.to_string nv);
     false
   | Some opam ->
-    if List.mem Pkgflag_LightUninstall (OpamFile.OPAM.flags opam) then true
+    if OpamFile.OPAM.has_flag Pkgflag_LightUninstall opam then true
     else
     let commands =
       OpamFilter.commands (OpamState.filter_env ~opam t)
@@ -533,7 +533,7 @@ let build_and_install_package_aux t ~metadata:save_meta source nv =
         ~verbose:!OpamGlobals.verbose ~check_existence:false
         cmd args
       @@> fun result ->
-      if List.mem Pkgflag_Verbose (OpamFile.OPAM.flags opam) then
+      if OpamFile.OPAM.has_flag Pkgflag_Verbose opam then
         List.iter (OpamGlobals.msg "%s\n") result.OpamProcess.r_stdout;
       if OpamProcess.is_success result then
         run_commands commands

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -805,7 +805,10 @@ let list =
        distribution, etc.). \
        Common tags include `debian', `x86', `osx', `homebrew', `source'... \
        Without $(i,TAGS), display the tags and all associated external \
-       dependencies."
+       dependencies. \
+       Rather than using this directly, you should probably head for the \
+       `depext' plugin, that can infer your system's tags and handle \
+       the system installations. Run `opam depext'."
       Arg.(some & list string) None in
   let list global_options print_short all installed
       installed_roots unavailable sort
@@ -1971,8 +1974,7 @@ let check_and_run_external_commands () =
         let candidates = Lazy.force t.available_packages in
         let nv = OpamPackage.max_version candidates pkgname in
         let opam = OpamPackage.Map.find nv t.opams in
-        if (List.mem Pkgflag_Plugin (OpamFile.OPAM.flags opam) ||
-            List.mem "flags:plugin" (OpamFile.OPAM.tags opam)) &&
+        if OpamFile.OPAM.has_flag Pkgflag_Plugin opam &&
            not (OpamState.is_name_installed t pkgname) &&
            OpamGlobals.confirm "OPAM plugin %s is not installed. \
                                 Install it on the current switch?"

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1970,8 +1970,9 @@ let check_and_run_external_commands () =
         let pkgname = OpamPackage.Name.of_string name in
         let candidates = Lazy.force t.available_packages in
         let nv = OpamPackage.max_version candidates pkgname in
-        let flags = OpamFile.OPAM.flags (OpamPackage.Map.find nv t.opams) in
-        if List.mem Pkgflag_Plugin flags &&
+        let opam = OpamPackage.Map.find nv t.opams in
+        if (List.mem Pkgflag_Plugin (OpamFile.OPAM.flags opam) ||
+            List.mem "flags:plugin" (OpamFile.OPAM.tags opam)) &&
            not (OpamState.is_name_installed t pkgname) &&
            OpamGlobals.confirm "OPAM plugin %s is not installed. \
                                 Install it on the current switch?"

--- a/src/core/opamFile.ml
+++ b/src/core/opamFile.ml
@@ -1154,6 +1154,10 @@ module X = struct
     let opam_version t = t.opam_version
     let bug_reports t = t.bug_reports
     let flags t = t.flags
+    let has_flag f t =
+      List.mem f t.flags ||
+      (* Allow in tags for compatibility *)
+      List.mem ("flags:"^OpamFormat.(parse_ident (make_flag f))) t.tags
     let dev_repo t = t.dev_repo
 
     let with_opam_version t opam_version = { t with opam_version }
@@ -1633,6 +1637,14 @@ module X = struct
           "Field 'features' is still experimental and not yet to be used on \
            the official repo"
           (t.features <> []);
+        cond 40 `Warning
+          "Package uses flags that aren't recognised by earlier versions in \
+           the 1.2 branch. At the moment, you should use a tag \"flags:foo\" \
+           instead for compatibility."
+          (List.exists (function
+               | Pkgflag_LightUninstall | Pkgflag_Unknown _ -> false
+               | _ -> true)
+              t.flags);
         cond 41 `Warning
           "Some packages are mentionned in package scripts of features, but \
            there is no dependency or depopt toward them"

--- a/src/core/opamFile.mli
+++ b/src/core/opamFile.mli
@@ -228,6 +228,10 @@ module OPAM: sig
   (** The package flags that are present for this package. *)
   val flags: t -> package_flag list
 
+  (** Check the package for the given flag. Allows flags specified through tags
+      for compatibility *)
+  val has_flag: package_flag -> t -> bool
+
   (** Sets the opam version *)
   val with_opam_version: t -> opam_version -> t
 


### PR DESCRIPTION
ref: ocaml/opam-repository/issues/3944