### PR TITLE
Change wording to reflect the command used

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1065,7 +1065,7 @@ let config =
        | _ -> bad_subcommand "config" commands command params)
     | Some `report, [] -> (
       let print label fmt = Printf.printf ("# %-15s "^^fmt^^"\n") label in
-      Printf.printf "# OPAM status report\n";
+      Printf.printf "# OPAM config report\n";
       print "opam-version" "%s " (OpamVersion.to_string (OpamVersion.full ()));
       print "self-upgrade" "%s"
         (if OpamGlobals.is_self_upgrade


### PR DESCRIPTION
This should help to reduce any confusion in remebering what
the command is that generates this output.

Fixes #2127