### PR TITLE
Pass the expected checksum to the OPAMFETCH program

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -225,7 +225,8 @@ let help_sections = [
   `P "$(i,OPAMEXTERNALSOLVER) see option `--solver'.";
   `P "$(i,OPAMFETCH) specifies how to download files: either `wget', `curl' or \
       a custom command where variables $(b,%{url}%), $(b,%{out}%), \
-      $(b,%{retries}%) and $(b,%{compress}%) will be replaced. Overrides the \
+      $(b,%{retries}%), $(b,%{compress}%) and $(b,%{checksum}%) will \
+      be replaced. Overrides the \
       'download-command' value from the main config file.";
   `P "$(i,OPAMJOBS) sets the maximum number of parallel workers to run.";
   `P "$(i,OPAMLOCKRETRIES) sets the number of tries after which OPAM gives up \

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1287,7 +1287,8 @@ module API = struct
            check_external_dep "wget" ||
            (match !OpamGlobals.download_tool with
             | Some (`Custom f) ->
-              (match f ~url:"" ~out:"-" ~retry:1 ~compress:false with
+              (match f ~url:"" ~out:"-" ~retry:1 ~checksum:"" ~compress:false
+               with
                | cmd::_ -> check_external_dep cmd
                | [] -> false)
             | _ -> false);

--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -1546,7 +1546,7 @@ let load_config root =
     | None -> OpamFile.Config.dl_tool config
   in
   let dl_command cmd =
-    fun ~url ~out ~retry ~compress ->
+    fun ~url ~out ~retry ?(checksum="") ~compress ->
       OpamFilter.single_command (fun v ->
           if not (is_global_conf v) then None else
           match OpamVariable.to_string (OpamVariable.Full.variable v) with
@@ -1554,6 +1554,7 @@ let load_config root =
           | "out" -> Some (S out)
           | "retry" -> Some (S (string_of_int retry))
           | "compress" -> Some (B compress)
+          | "checksum" -> Some (S checksum)
           | _ -> None)
         cmd
   in

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -300,16 +300,16 @@ let remove_suffix suffix filename =
   let filename = to_string filename in
   OpamMisc.remove_suffix ~suffix filename
 
-let download ~overwrite ?compress filename dirname =
+let download ~overwrite ?compress ?checksum filename dirname =
   mkdir dirname;
   let dst = to_string (create dirname (basename filename)) in
-  OpamSystem.download ~overwrite ?compress
+  OpamSystem.download ~overwrite ?compress ?checksum
     ~filename:(to_string filename) ~dst
   @@+ fun file -> Done (of_string file)
 
-let download_as ~overwrite ?(compress=false) filename dest =
+let download_as ~overwrite ?(compress=false) ?checksum filename dest =
   mkdir (dirname dest);
-  OpamSystem.download ~overwrite ~compress
+  OpamSystem.download ~overwrite ~compress ?checksum
     ~filename:(to_string filename) ~dst:(to_string dest)
   @@+ fun file ->
   assert (file = to_string dest);

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -204,11 +204,13 @@ val remove_suffix: Base.t -> t -> string
     of the downloaded file if the download is successful.
     Compress activates http content compression if supported. May break
     on gzipped files, only use for text files *)
-val download: overwrite:bool -> ?compress:bool -> t -> Dir.t -> t OpamProcess.job
+val download: overwrite:bool -> ?compress:bool -> ?checksum:string ->
+  t -> Dir.t -> t OpamProcess.job
 
 (** same as [download], but with a specified destination filename instead of a
     directory *)
-val download_as: overwrite:bool -> ?compress:bool -> t -> t -> unit OpamProcess.job
+val download_as: overwrite:bool -> ?compress:bool -> ?checksum:string ->
+  t -> t -> unit OpamProcess.job
 
 (** Apply a patch to a directory *)
 val patch: t -> Dir.t -> unit

--- a/src/core/opamGlobals.ml
+++ b/src/core/opamGlobals.ml
@@ -196,7 +196,8 @@ type download_tool = [
   | `Wget
   | `Curl
   | `Custom of
-      url:string -> out:string -> retry:int -> compress:bool -> string list
+      url:string -> out:string -> retry:int -> ?checksum:string ->
+      compress:bool -> string list
 ]
 let download_tool = ref None
 

--- a/src/core/opamGlobals.mli
+++ b/src/core/opamGlobals.mli
@@ -84,7 +84,8 @@ type download_tool = [
   | `Wget
   | `Curl
   | `Custom of
-      url:string -> out:string -> retry:int -> compress:bool -> string list
+      url:string -> out:string -> retry:int -> ?checksum:string ->
+      compress:bool -> string list
 ]
 
 val download_tool_env: string option ref

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -214,7 +214,7 @@ val funlock: lock -> unit
 (** {2 Misc} *)
 
 (** download compiler sources *)
-val download: overwrite:bool -> ?compress:bool ->
+val download: overwrite:bool -> ?compress:bool -> ?checksum:string ->
   filename:string -> dst:string -> string OpamProcess.job
 
 (** Apply a patch file in the current directory. *)

--- a/src/repositories/opamHTTP.ml
+++ b/src/repositories/opamHTTP.ml
@@ -221,7 +221,7 @@ module B = struct
     else
     OpamProcess.Job.catch
       (fun e -> OpamMisc.fatal e; Done (Not_available remote_url)) @@
-    OpamFilename.download ~overwrite:true filename dirname
+    OpamFilename.download ~overwrite:true ?checksum filename dirname
     @@+ fun local_file ->
     if OpamRepository.check_digest local_file checksum then
       (OpamGlobals.msg "[%s] %s downloaded\n"


### PR DESCRIPTION
I use a script to do caching on OPAM's download requests (to avoid pounding the servers, to work around overzealous firewalls, and to isolate myself from server failures and removed files). Unfortunately, the caching gets in the way when the contents of a file changes at the same URL.

In most cases, `opam` already knows about it because the checksum is updated in the package repository. This PR makes `opam` pass the checksum to the OPAMFETCH command (as `%{checksum}%`) which allows me to index my cache by checksums and avoid all problems with different files versions at the same URL.
