### PR TITLE
Add option -h to tar when building index.tar.gz

### DIFF
--- a/src/repositories/opamHTTP.ml
+++ b/src/repositories/opamHTTP.ml
@@ -265,7 +265,7 @@ let make_index_tar_gz repo_root =
     let dirs = [ "version"; "compilers"; "packages"; "repo" ] in
     match List.filter Sys.file_exists dirs with
     | [] -> ()
-    | d  -> OpamSystem.command ("tar" :: "czf" :: "index.tar.gz" :: d)
+    | d  -> OpamSystem.command ("tar" :: "czhf" :: "index.tar.gz" :: d)
   )
 
 let register () =


### PR DESCRIPTION
If the repository being packed up contains symbolic links, tar
does not follow them unless you pass to it the -h flag.
From the manpage of tar:

       -h, --dereference
           follow symlinks; archive and dump the files they point to

Symlinks pointing outside the repository are dangling if you don't
follow them.  Without the -h flag, opam admin make fails to produce
a usable index in a scenario where the files could be correctly served
by an HTTP server.  For example one could have

  /var/www/allrepos/repo1/packages/p/p.1
  /var/www/allrepos/repo1/index.tar.gz
  /var/www/allrepos/repo2/packages/p/p.1 -> ../../../repo1/packages/p/p.1
  /var/www/allrepos/repo2/index.tar.gz

This is useful if repo2 is a subset of repo1, and use symlinks to avoid
duplication, e.g. imagine allrepos being maintained under git.