### PR TITLE
Separate build and install steps

### DIFF
--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -101,8 +101,8 @@ let edit t name =
       match warnings with
       | [] -> Some opam
       | ws ->
-        OpamConsole.warning "The opam file didn't pass validation:\n%s\n"
-          (OpamFile.OPAM.warns_to_string ws);
+        OpamConsole.warning "The opam file didn't pass validation:";
+        OpamConsole.errmsg "%s\n" (OpamFile.OPAM.warns_to_string ws);
         if OpamConsole.confirm "Continue anyway ('no' will reedit) ?"
         then Some opam
         else edit ()

--- a/src/core/opamParallel.ml
+++ b/src/core/opamParallel.ml
@@ -141,6 +141,7 @@ module Make (G : G) = struct
             S.filter
               (fun n ->
                  List.for_all (fun n -> M.mem n results) (G.pred g n) &&
+                 not (M.mem n results) &&
                  S.is_empty (mutual_exclusion_set n %% map_keys running))
               (S.of_list (G.succ g n) ++ mutual_exclusion_set n)
           in

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -194,19 +194,40 @@ type repository = {
 
 (** {2 Solver} *)
 
-(** The solver answers a list of actions to perform *)
-type 'a action =
+(** Used internally when computing sequences of actions *)
+type 'a atomic_action = [
+  | `Remove of 'a
+  | `Install of 'a
+]
 
-  (** The package must be installed. The package could have been
-      present or not, but if present, it is another version than the
-      proposed solution. *)
-  | To_change of 'a option * 'a
+(** Used to compact the atomic actions and display to the user in a more
+    meaningful way *)
+type 'a highlevel_action = [
+  | 'a atomic_action
+  | `Upgrade of 'a * 'a
+  | `Downgrade of 'a * 'a
+  | `Reinstall of 'a
+]
 
-  (** The package must be deleted. *)
-  | To_delete of 'a
+(** Sub-type of [highlevel_action] corresponding to an installed package that
+    changed state or version *)
+type 'a change_action = [
+  | `Install of 'a
+  | `Upgrade of 'a * 'a
+  | `Downgrade of 'a * 'a
+]
 
-  (** The package is already installed, but it must be recompiled. *)
-  | To_recompile of 'a
+(** Used when applying solutions, separates build from install *)
+type 'a concrete_action = [
+  | 'a atomic_action
+  | `Build of 'a
+]
+
+type 'a action = [
+  | 'a atomic_action
+  | 'a highlevel_action
+  | 'a concrete_action
+]
 
 (** The possible causes of an action. *)
 type 'a cause =

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -204,17 +204,15 @@ type 'a atomic_action = [
     meaningful way *)
 type 'a highlevel_action = [
   | 'a atomic_action
-  | `Upgrade of 'a * 'a
-  | `Downgrade of 'a * 'a
+  | `Change of [ `Up | `Down ] * 'a * 'a
   | `Reinstall of 'a
 ]
 
 (** Sub-type of [highlevel_action] corresponding to an installed package that
     changed state or version *)
-type 'a change_action = [
+type 'a inst_action = [
   | `Install of 'a
-  | `Upgrade of 'a * 'a
-  | `Downgrade of 'a * 'a
+  | `Change of 'a * 'a * [ `Up | `Down ]
 ]
 
 (** Used when applying solutions, separates build from install *)

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -252,11 +252,11 @@ let filter_deps ~build ~test ~doc =
 
 let action_contents = function
   | `Remove p | `Install p | `Reinstall p | `Build p -> p
-  | `Upgrade (_,p) | `Downgrade (_,p) -> p
+  | `Change (_,_,p) -> p
 
 let full_action_contents = function
   | `Remove p | `Install p | `Reinstall p | `Build p -> [p]
-  | `Upgrade (p1,p2) | `Downgrade (p1,p2) -> [p1; p2]
+  | `Change (_,p1,p2) -> [p1; p2]
 
 let map_atomic_action f = function
   | `Remove p -> `Remove (f p)
@@ -264,8 +264,7 @@ let map_atomic_action f = function
 
 let map_highlevel_action f = function
   | #atomic_action as a -> map_atomic_action f a
-  | `Upgrade (p1, p2) -> `Upgrade (f p1, f p2)
-  | `Downgrade (p1,p2) -> `Downgrade (f p1, f p2)
+  | `Change (direction, p1, p2) -> `Change (direction, f p1, f p2)
   | `Reinstall p -> `Reinstall (f p)
 
 let map_concrete_action f = function

--- a/src/format/opamTypesBase.mli
+++ b/src/format/opamTypesBase.mli
@@ -57,6 +57,11 @@ val repository_kind_of_string: string -> repository_kind
 (** Extract a package from a package action. *)
 val action_contents: 'a action -> 'a
 
+val map_atomic_action: ('a -> 'b) -> 'a atomic_action -> 'b atomic_action
+val map_highlevel_action: ('a -> 'b) -> 'a highlevel_action -> 'b highlevel_action
+val map_concrete_action: ('a -> 'b) -> 'a concrete_action -> 'b concrete_action
+val map_action: ('a -> 'b) -> 'a action -> 'b action
+
 (** Extract a packages from a package action. This returns all concerned
     packages, including the old version for an up/down-grade. *)
 val full_action_contents: 'a action -> 'a list

--- a/src/format/opamTypesBase.mli
+++ b/src/format/opamTypesBase.mli
@@ -55,7 +55,7 @@ val string_of_repository_kind: repository_kind -> string
 val repository_kind_of_string: string -> repository_kind
 
 (** Extract a package from a package action. *)
-val action_contents: 'a action -> 'a
+val action_contents: [< 'a action ] -> 'a
 
 val map_atomic_action: ('a -> 'b) -> 'a atomic_action -> 'b atomic_action
 val map_highlevel_action: ('a -> 'b) -> 'a highlevel_action -> 'b highlevel_action

--- a/src/solver/opamActionGraph.mli
+++ b/src/solver/opamActionGraph.mli
@@ -20,7 +20,8 @@ module type ACTION = sig
   type package
   module Pkg: GenericPackage with type t = package
   include OpamParallel.VERTEX with type t = package action
-  val to_aligned_strings: t list -> string list
+  val to_string: [< t ] -> string
+  val to_aligned_strings: [< t ] list -> string list
 end
 
 module MakeAction (P: GenericPackage) : ACTION with type package = P.t and type t = P.t OpamTypes.action
@@ -44,7 +45,7 @@ module Make (A: ACTION) : SIG with type package = A.package
 (** Some messages that may be used for displaying actions. Single utf8 chars if
     the corresponding option is set, otherwise words. *)
 val action_strings:
-  ?utf8:bool -> [ `inst | `rm | `up | `down | `reinst ] -> string
+  ?utf8:bool -> 'a highlevel_action -> string
 
 (** Colorise string according to the action *)
-val action_color: [ `inst | `rm | `up | `down | `reinst ] -> string -> string
+val action_color: 'a highlevel_action -> string -> string

--- a/src/solver/opamActionGraph.mli
+++ b/src/solver/opamActionGraph.mli
@@ -38,6 +38,9 @@ module type SIG = sig
 
       There is no guarantee however that the resulting graph is acyclic. *)
   val reduce: t -> t
+
+  (** Expand install actions, adding a build action preceding them. *)
+  val explicit: t -> t
 end
 
 module Make (A: ACTION) : SIG with type package = A.package

--- a/src/solver/opamActionGraph.mli
+++ b/src/solver/opamActionGraph.mli
@@ -30,11 +30,11 @@ module type SIG = sig
   type package
   include OpamParallel.GRAPH with type V.t = package OpamTypes.action
 
-  (** Reduces a graph of atomic actions (only removals and installs) by turning
-      removal+install to reinstalls or up/down-grades, best for display.
-      Dependency ordering won't be as accurate though, as there is no proper
-      ordering of (reinstall a, reinstall b) if b depends on a. The resulting
-      graph contains at most one action per package name.
+  (** Reduces a graph of atomic or concrete actions (only removals, installs and
+      builds) by turning removal+install to reinstalls or up/down-grades, best
+      for display. Dependency ordering won't be as accurate though, as there is
+      no proper ordering of (reinstall a, reinstall b) if b depends on a. The
+      resulting graph contains at most one action per package name.
 
       There is no guarantee however that the resulting graph is acyclic. *)
   val reduce: t -> t

--- a/src/solver/opamHeuristic.ml
+++ b/src/solver/opamHeuristic.ml
@@ -33,9 +33,9 @@ type 'a state_space = 'a array list
 let minimize_actions interesting_names actions =
   let interesting_names = OpamStd.String.Set.of_list interesting_names in
   List.filter (function
-    | To_change (_, p)
-    | To_recompile p -> OpamStd.String.Set.mem p.Cudf.package interesting_names
-    | To_delete _    -> true
+    | `Install p | `Upgrade (_, p) | `Downgrade (_, p) | `Recompile p ->
+      OpamStd.String.Set.mem p.Cudf.package interesting_names
+    | `Remove _ -> true
   ) actions
 
 (* A list of [n] zero. *)
@@ -232,7 +232,7 @@ let actions_of_state ~version_map universe request state =
     raise (Not_reachable c)
   | Success u   ->
     try
-      let diff = OpamCudf.Diff.diff universe u in
+      let diff = OpamCudf.diff universe u in
       let actions = OpamCudf.actions_of_diff diff in
       let actions = minimize_actions (List.map fst state) actions in
       actions

--- a/src/solver/opamHeuristic.ml
+++ b/src/solver/opamHeuristic.ml
@@ -33,7 +33,7 @@ type 'a state_space = 'a array list
 let minimize_actions interesting_names actions =
   let interesting_names = OpamStd.String.Set.of_list interesting_names in
   List.filter (function
-    | `Install p | `Upgrade (_, p) | `Downgrade (_, p) | `Recompile p ->
+    | `Install p | `Change (_, _, p) | `Recompile p ->
       OpamStd.String.Set.mem p.Cudf.package interesting_names
     | `Remove _ -> true
   ) actions

--- a/src/solver/opamHeuristic.mli
+++ b/src/solver/opamHeuristic.mli
@@ -55,7 +55,7 @@ val resolve:
   (Cudf.universe -> Cudf.universe) ->
   Cudf.universe ->
   Cudf_types.vpkg request ->
-  (Cudf.package action list, OpamCudf.conflict) result
+  (Cudf.package atomic_action list, OpamCudf.conflict) result
 
 (** {2 Internal API} *)
 
@@ -151,4 +151,4 @@ val state_of_request: ?verbose:bool  ->
 val actions_of_state:
   version_map:int OpamPackage.Map.t ->
   Cudf.universe ->
-  Cudf_types.vpkg request -> Cudf.package state -> Cudf.package action list
+  Cudf_types.vpkg request -> Cudf.package state -> Cudf.package atomic_action list

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -239,12 +239,6 @@ let string_of_request r =
     (to_string r.wish_remove)
     (to_string r.wish_upgrade)
 
-let map_action f = function
-  | To_change (Some x, y) -> To_change (Some (f x), f y)
-  | To_change (None, y)   -> To_change (None, f y)
-  | To_delete y           -> To_delete (f y)
-  | To_recompile y        -> To_recompile (f y)
-
 (* Unused ?
 let map_cause f = function
   | Upstream_changes -> Upstream_changes
@@ -296,7 +290,8 @@ let cycle_conflict ~version_map univ cycles =
   OpamCudf.cycle_conflict ~version_map univ
     (List.map
        (List.map
-          (fun a -> Action.to_string (map_action OpamCudf.cudf2opam a)))
+          (fun a ->
+             Action.to_string (map_action OpamCudf.cudf2opam a)))
        cycles)
 
 let resolve ?(verbose=true) universe ~orphans request =
@@ -408,21 +403,20 @@ let check_for_conflicts universe =
 let new_packages sol =
   OpamCudf.ActionGraph.fold_vertex (fun action packages ->
       match action with
-      | To_change (_,p) -> OpamPackage.Set.add (OpamCudf.cudf2opam p) packages
-      | To_recompile _ | To_delete _ -> packages
+      | `Install p | `Upgrade (_,p) | `Downgrade (_,p) ->
+        OpamPackage.Set.add (OpamCudf.cudf2opam p) packages
+      | `Reinstall _ | `Remove _ | `Build _ -> packages
   ) sol OpamPackage.Set.empty
 
 let stats sol =
   OpamCudf.ActionGraph.fold_vertex (fun action stats ->
       match action with
-      | To_change (None, _) -> {stats with s_install = stats.s_install+1}
-      | To_change (Some x, y) ->
-        let c = Common.CudfAdd.compare x y in
-        if c < 0 then {stats with s_upgrade = stats.s_upgrade+1} else
-        if c > 0 then {stats with s_downgrade = stats.s_downgrade+1} else
-          {stats with s_reinstall = stats.s_reinstall+1}
-      | To_recompile _ -> {stats with s_reinstall = stats.s_reinstall+1}
-      | To_delete _ -> {stats with s_remove = stats.s_remove+1})
+      | `Install _ -> {stats with s_install = stats.s_install+1}
+      | `Upgrade _ -> {stats with s_upgrade = stats.s_upgrade+1}
+      | `Downgrade _ -> {stats with s_downgrade = stats.s_downgrade+1}
+      | `Reinstall _ -> {stats with s_reinstall = stats.s_reinstall+1}
+      | `Remove _ -> {stats with s_remove = stats.s_remove+1}
+      | `Build _ -> stats)
     (OpamCudf.ActionGraph.reduce sol)
     { s_install=0; s_reinstall=0; s_upgrade=0; s_downgrade=0; s_remove=0 }
 
@@ -440,7 +434,7 @@ let string_of_stats stats =
       (fun a ->
          let s = OpamActionGraph.action_strings a in
          if utf then OpamActionGraph.action_color a s else s)
-      [`inst;`reinst;`up;`down;`rm]
+      [`Install ();`Reinstall ();`Upgrade ((),());`Downgrade ((),());`Remove ()]
   in
   let msgs = List.filter (fun (a,_) -> a <> 0) (List.combine stats titles) in
   if utf then
@@ -482,8 +476,9 @@ let print_solution ~messages ~rewrite ~requested t =
         let cause = string_of_cause cudf_name cause in
         let messages =
           match a with
-          | To_change(_,p) | To_recompile p -> messages (OpamCudf.cudf2opam p)
-          | To_delete _ -> []
+          | `Install p | `Upgrade (_,p) | `Downgrade (_,p) | `Reinstall p ->
+            messages (OpamCudf.cudf2opam p)
+          | `Remove _ | `Build _ -> []
         in
         action :: actions, (cause, messages) :: details
       ) t ([],[])
@@ -519,9 +514,10 @@ let filter_solution filter t =
     ) in
   OpamCudf.ActionGraph.iter_vertex
     (function
-      | To_delete nv as a when not (filter (OpamCudf.cudf2opam nv)) ->
+      | `Remove nv as a when not (filter (OpamCudf.cudf2opam nv)) ->
         rm OpamCudf.ActionGraph.iter_pred a
-      | To_change (_, nv) as a when not (filter (OpamCudf.cudf2opam nv)) ->
+      | (`Install nv | `Upgrade (_,nv) | `Downgrade (_,nv)) as a
+        when not (filter (OpamCudf.cudf2opam nv)) ->
         rm OpamCudf.ActionGraph.iter_succ a
       | _ -> ())
     t;

--- a/src/state/opamAction.ml
+++ b/src/state/opamAction.ml
@@ -479,12 +479,8 @@ let sources_needed t g =
       | `Remove nv ->
         if removal_needs_download t nv
         then OpamPackage.Set.add nv acc else acc
-      | `Install nv | `Reinstall nv | `Build nv ->
-        OpamPackage.Set.add nv acc
-      | `Upgrade (nv1, nv2) | `Downgrade (nv1, nv2) ->
-        let acc = OpamPackage.Set.add nv2 acc in
-        if removal_needs_download t nv1
-        then OpamPackage.Set.add nv1 acc else acc)
+      | `Install nv -> OpamPackage.Set.add nv acc
+      | _ -> assert false)
     g OpamPackage.Set.empty
 
 let remove_package t ~metadata ?keep_build ?silent nv =
@@ -493,21 +489,48 @@ let remove_package t ~metadata ?keep_build ?silent nv =
   else
     remove_package_aux t ~metadata ?keep_build ?silent nv
 
-(* Build and install a package.
-   Assumes the package has already been downloaded to its build dir.
+(* Compiles a package.
+   Assumes the package has already been downloaded to [source].
 *)
-let build_and_install_package_aux t ~metadata:save_meta source nv =
-  (* OpamConsole.header_msg "Installing %s" (OpamPackage.to_string nv); *)
-
+let build_package t source nv =
   extract_package t source nv;
-
   let opam = OpamState.opam t nv in
   let commands =
     OpamFile.OPAM.build opam @
-    (if OpamStateConfig.(!r.build_test) then OpamFile.OPAM.build_test opam else []) @
-    (if OpamStateConfig.(!r.build_doc) then OpamFile.OPAM.build_doc opam else []) @
-    OpamFile.OPAM.install opam
+    (if OpamStateConfig.(!r.build_test)
+     then OpamFile.OPAM.build_test opam else []) @
+    (if OpamStateConfig.(!r.build_doc)
+     then OpamFile.OPAM.build_doc opam else [])
   in
+  let commands = OpamFilter.commands (OpamState.filter_env ~opam t) commands in
+  let env = OpamFilename.env_of_list (compilation_env t opam) in
+  let name = OpamPackage.name_to_string nv in
+  let dir = OpamPath.Switch.build t.root t.switch nv in
+  let rec run_commands = function
+    | (cmd::args)::commands ->
+      let text = OpamProcess.make_command_text name ~args cmd in
+      let dir = OpamFilename.Dir.to_string dir in
+      OpamSystem.make_command ~env ~name ~dir ~text
+        ~verbose:(OpamConsole.verbose ()) ~check_existence:false
+        cmd args
+      @@> fun result ->
+      if OpamProcess.is_success result then
+        run_commands commands
+      else
+        (OpamConsole.error
+           "The compilation of %s failed at %S."
+           name (String.concat " " (cmd::args));
+         Done (Some (OpamSystem.Process_error result)))
+    | []::commands -> run_commands commands
+    | [] -> Done None
+  in
+  run_commands commands
+
+(* Assumes the package has already been compiled in its build dir.
+   Does not register the installation in the metadata ! *)
+let install_package t nv =
+  let opam = OpamState.opam t nv in
+  let commands = OpamFile.OPAM.install opam in
   let commands = OpamFilter.commands (OpamState.filter_env ~opam t) commands in
   let env = OpamFilename.env_of_list (compilation_env t opam) in
   let name = OpamPackage.name_to_string nv in
@@ -526,39 +549,26 @@ let build_and_install_package_aux t ~metadata:save_meta source nv =
         run_commands commands
       else (
         OpamConsole.error
-          "The compilation of %s failed at %S."
+          "The installation of %s failed at %S."
           name (String.concat " " (cmd::args));
         remove_package ~metadata:false t ~keep_build:true ~silent:true nv
         @@| fun () -> Some (OpamSystem.Process_error result)
       )
     | []::commands -> run_commands commands
-    | [] ->
-      try
-        install_package t nv;
-        if save_meta then (
-          let installed = OpamPackage.Set.add nv t.installed in
-          let installed_roots = OpamPackage.Set.add nv t.installed_roots in
-          let reinstall = OpamPackage.Set.remove nv t.reinstall in
-          let t = update_metadata t ~installed ~installed_roots ~reinstall in
-          OpamState.install_metadata t nv;
-        );
-        OpamConsole.msg "%s installed %s.%s\n"
-          (if not (OpamConsole.utf8 ()) then "->"
-           else OpamActionGraph.
-                  (action_color (`Install ()) (action_strings (`Install ()))))
-          (OpamConsole.colorise `bold name)
-          (OpamPackage.version_to_string nv);
-        Done None
-      with e ->
-        remove_package ~metadata:false t ~keep_build:true ~silent:true nv
-        @@| fun () -> OpamStd.Exn.fatal e; Some e
+    | [] -> Done None
   in
-  run_commands commands
-
-let build_and_install_package t ~metadata source nv =
-  if not OpamStateConfig.(!r.fake) then
-    build_and_install_package_aux t ~metadata source nv
-  else
-    (OpamConsole.msg "(simulation) Building and installing %s.\n"
-       (OpamPackage.to_string nv);
-     Done None)
+  run_commands commands @@+ function
+  | Some _ as err -> Done err
+  | None ->
+    try
+      install_package t nv;
+      OpamConsole.msg "%s installed %s.%s\n"
+        (if not (OpamConsole.utf8 ()) then "->"
+         else OpamActionGraph.
+                (action_color (`Install ()) (action_strings (`Install ()))))
+        (OpamConsole.colorise `bold name)
+        (OpamPackage.version_to_string nv);
+      Done None
+    with e ->
+      remove_package ~metadata:false t ~keep_build:true ~silent:true nv
+      @@| fun () -> OpamStd.Exn.fatal e; Some e

--- a/src/state/opamAction.mli
+++ b/src/state/opamAction.mli
@@ -27,10 +27,15 @@ val download_package: t -> package ->
 (** Extracts and patches the source of a package *)
 val extract_package: t -> generic_file option -> package -> unit
 
-(** Build and install a package from its downloaded source. Returns [None] on
-    success, [Some exn] on error. *)
-val build_and_install_package:
-  t -> metadata:bool -> generic_file option -> package -> exn option OpamProcess.job
+(** Build a package from its downloaded source. Returns [None] on success, [Some
+    exn] on error. *)
+val build_package:
+  t -> generic_file option -> package -> exn option OpamProcess.job
+
+(** Installs a compiled package from its build dir. Returns [None] on success,
+    [Some exn] on error. *)
+val install_package:
+  t -> package -> exn option OpamProcess.job
 
 (** Find out if the package source is needed for uninstall *)
 val removal_needs_download: t -> package -> bool
@@ -42,16 +47,8 @@ val remove_package: t -> metadata:bool -> ?keep_build:bool -> ?silent:bool -> pa
     they're not needed (even in other switches) *)
 val cleanup_package_artefacts: t -> package -> unit
 
-(*
-(** Remove all the packages from a solution. This includes the package to
-    delete, to upgrade and to recompile. Return the updated state and set of all
-    deleted packages. *)
-val remove_all_packages: t -> metadata:bool -> OpamSolver.solution
-  -> (t * package_set) * [ `Successful of unit | `Exception of exn ]
-*)
-
 (** Compute the set of packages which will need to be downloaded to apply a
-    solution *)
+    solution. Takes a graph of atomic actions. *)
 val sources_needed: t -> OpamSolver.ActionGraph.t -> package_set
 
 (** Update package metadata *)

--- a/src/state/opamSolution.ml
+++ b/src/state/opamSolution.ml
@@ -27,7 +27,7 @@ module PackageActionGraph = OpamSolver.ActionGraph
 let post_message ?(failed=false) state action =
   match action with
   | `Remove _ | `Reinstall _ | `Build _ -> ()
-  | `Install pkg | `Upgrade (_,pkg) | `Downgrade (_,pkg) ->
+  | `Install pkg | `Change (_,_,pkg) ->
     let opam = OpamState.opam state pkg in
     let messages = OpamFile.OPAM.post_messages opam in
     let local_variables = OpamVariable.Map.empty in
@@ -154,8 +154,8 @@ let display_error (n, error) =
     | e -> disp "%s" (Printexc.to_string e)
   in
   match n with
-  | `Upgrade (_, nv)   -> f "upgrading to" nv
-  | `Downgrade (_, nv) -> f "downgrading to" nv
+  | `Change (`Up, _, nv)   -> f "upgrading to" nv
+  | `Change (`Down, _, nv) -> f "downgrading to" nv
   | `Install nv        -> f "installing" nv
   | `Reinstall nv      -> f "recompiling" nv
   | `Remove nv         -> f "removing" nv
@@ -525,7 +525,7 @@ let simulate_new_state state t =
     OpamSolver.ActionGraph.Topological.fold
       (fun action installed ->
         match action with
-        | `Install p | `Upgrade (_,p) | `Downgrade (_,p) | `Reinstall p ->
+        | `Install p | `Change (_,_,p) | `Reinstall p ->
           OpamPackage.Set.add p installed
         | `Remove p ->
           OpamPackage.Set.remove p installed

--- a/src/state/opamSolution.ml
+++ b/src/state/opamSolution.ml
@@ -221,13 +221,6 @@ let print_variable_warnings t =
     variable_warnings := true;
   )
 
-(* Transient state (not flushed to disk) *)
-type state = {
-  mutable s_installed      : package_set;
-  mutable s_installed_roots: package_set;
-  mutable s_reinstall      : package_set;
-}
-
 let output_json_solution solution =
   let to_proceed =
     PackageActionGraph.Topological.fold (fun a acc ->
@@ -260,25 +253,13 @@ let output_json_actions action_errors =
     ) action_errors
 
 (* Process the atomic actions in a graph in parallel, respecting graph order,
-   and report to user *)
+   and report to user. Takes a graph of atomic actions *)
 let parallel_apply t action action_graph =
   log "parallel_apply";
 
   (* We keep an imperative state up-to-date and flush it to disk as soon
      as an operation terminates *)
-  let state = {
-    s_installed       = t.installed;
-    s_installed_roots = t.installed_roots;
-    s_reinstall       = t.reinstall;
-  } in
   let t_ref = ref t in
-  let update_state () =
-    let installed       = state.s_installed in
-    let installed_roots = state.s_installed_roots in
-    let reinstall       = state.s_reinstall in
-    t_ref :=
-      OpamAction.update_metadata t ~installed ~installed_roots ~reinstall
-  in
 
   let root_installs =
     let names = OpamPackage.names_of_packages t.installed_roots in
@@ -292,22 +273,26 @@ let parallel_apply t action action_graph =
   in
 
   let add_to_install nv =
-    state.s_installed <- OpamPackage.Set.add nv state.s_installed;
-    state.s_reinstall <- OpamPackage.Set.remove nv state.s_reinstall;
-    if OpamPackage.Name.Set.mem (OpamPackage.name nv) root_installs then
-      state.s_installed_roots <- OpamPackage.Set.add nv state.s_installed_roots;
-    update_state ();
-    if not OpamStateConfig.(!r.dryrun) then OpamState.install_metadata !t_ref nv
+    t_ref :=
+      OpamAction.update_metadata t
+        ~installed:(OpamPackage.Set.add nv !t_ref.installed)
+        ~reinstall:(OpamPackage.Set.remove nv !t_ref.reinstall)
+        ~installed_roots:
+          (if OpamPackage.Name.Set.mem (OpamPackage.name nv) root_installs
+           then OpamPackage.Set.add nv !t_ref.installed_roots
+           else !t_ref.installed_roots);
+    if not OpamStateConfig.(!r.dryrun) then
+      OpamState.install_metadata !t_ref nv
   in
 
-  let remove_from_install deleted =
-    let rm = OpamPackage.Set.remove deleted in
-    state.s_installed       <- rm state.s_installed;
-    state.s_installed_roots <- rm state.s_installed_roots;
-    state.s_reinstall       <- rm state.s_reinstall;
-    update_state () in
-
-  let cancelled_exn = Failure "cancelled" in
+  let remove_from_install nv =
+    let rm = OpamPackage.Set.remove nv in
+    t_ref :=
+      OpamAction.update_metadata t
+        ~installed:(rm !t_ref.installed)
+        ~installed_roots:(rm !t_ref.installed_roots)
+        ~reinstall:(rm !t_ref.reinstall);
+  in
 
   (* 1/ fetch needed package archives *)
 
@@ -356,62 +341,101 @@ let parallel_apply t action action_graph =
 
   (* the child job to run on each action *)
   let job ~pred action =
-    if not (List.for_all (fun (_,r) -> r = None) pred) then
-      Done (Some cancelled_exn)
-    else
-    let t = !t_ref in
-    let nv = action_contents action in
-    let source =
-      try Some (OpamPackage.Map.find nv package_sources)
-      with Not_found -> None in
-    match action with
-    | `Install nv | `Upgrade (_,nv) | `Downgrade (_,nv) | `Reinstall nv ->
-      (OpamAction.build_and_install_package ~metadata:false t source nv
-       @@+ function
-       | None ->  add_to_install nv; Done None
-       | Some exn -> Done (Some exn))
-    | `Build _ -> assert false (* TODO *)
-    | `Remove nv ->
-      if OpamAction.removal_needs_download t nv then
-        (try OpamAction.extract_package t source nv
-         with e -> OpamStd.Exn.fatal e);
-      OpamProcess.Job.catch (fun e -> OpamStd.Exn.fatal e; Done ())
-         (OpamAction.remove_package t ~metadata:false nv) @@| fun () ->
-      remove_from_install nv;
-      None
+    let installed_removed =
+      try
+        Some
+          (List.fold_left (fun (inst,rem) -> function
+               | _, `Successful (inst1, rem1) ->
+                 OpamPackage.Set.Op.(inst ++ inst1, rem ++ rem1)
+               | _, (`Exception _ | `Error _) ->
+                 raise Exit)
+              (OpamPackage.Set.empty, OpamPackage.Set.empty) pred)
+      with Exit -> None
+    in
+    match installed_removed with
+    | None -> Done (`Error `Aborted) (* prerequisite failed *)
+    | Some (installed, removed) ->
+      let t = (* Local state for this process, only prerequisites are visible *)
+        { t with installed =
+                   OpamPackage.Set.Op.(t.installed -- removed ++ installed) }
+      in
+      let nv = action_contents action in
+      let source =
+        try Some (OpamPackage.Map.find nv package_sources)
+        with Not_found -> None in
+      if OpamStateConfig.(!r.fake) then
+        match action with
+        | `Build _ -> Done (`Successful (installed, removed))
+        | `Install nv ->
+          OpamConsole.msg "Faking installation of %s"
+            (OpamPackage.to_string nv);
+          add_to_install nv;
+          Done (`Successful (OpamPackage.Set.add nv installed , removed))
+        | `Remove nv ->
+          remove_from_install nv;
+          Done (`Successful (installed, OpamPackage.Set.add nv removed))
+        | _ -> assert false
+      else
+      match action with
+      | `Build nv ->
+          (OpamAction.build_package t source nv @@+ function
+            | None -> Done (`Successful (installed, removed))
+            | Some exn -> Done (`Exception exn))
+      | `Install nv ->
+        (OpamAction.install_package t nv @@+ function
+          | None ->
+            add_to_install nv;
+            Done (`Successful (OpamPackage.Set.add nv installed, removed))
+          | Some exn ->
+            Done (`Exception exn))
+      | `Remove nv ->
+        if OpamAction.removal_needs_download t nv then
+          (try OpamAction.extract_package t source nv
+           with e -> OpamStd.Exn.fatal e);
+        OpamProcess.Job.catch (fun e -> OpamStd.Exn.fatal e; Done ())
+          (OpamAction.remove_package t ~metadata:false nv) @@| fun () ->
+        remove_from_install nv;
+        `Successful (installed, OpamPackage.Set.add nv removed)
+      | _ -> assert false
   in
 
   let action_results =
     OpamConsole.header_msg "Processing actions";
     try
+      let action_graph = (* Add build actions *)
+        PackageActionGraph.explicit action_graph
+      in
+      let _installs =
+        PackageActionGraph.fold_vertex
+          (fun a acc -> match a with `Install _ as i -> i::acc | _ -> acc)
+          action_graph []
+      in
       let results =
         PackageActionGraph.Parallel.map
           ~jobs:(OpamState.jobs t)
           ~command:job
           ~dry_run:OpamStateConfig.(!r.dryrun)
+          (* ~mutually_exclusive:[_installs] *)
           action_graph
       in
-      let successful, failed =
-        List.partition (fun (_,r) -> r = None) results
+      let success, failure, aborted =
+        List.fold_left (fun (success, failure, aborted) -> function
+            | a, `Successful _ -> a::success, failure, aborted
+            | a, `Exception e -> success, (a,e)::failure, aborted
+            | a, `Error `Aborted -> success, failure, a::aborted
+          ) ([], [], []) results
       in
-      match failed with
-      | [] -> `Successful ()
-      | _::_ ->
-        let failed =
-          List.map (function (act,Some e) -> act, e | _ -> assert false) failed
-        in
-        let cancelled, failed =
-          List.partition (fun (_,e) -> e = cancelled_exn) failed
-        in
-        let act r = List.map fst r in
-        List.iter display_error failed;
-        output_json_actions failed;
-        `Error (Error (act successful, act failed, act cancelled))
+      if failure = [] && aborted = [] then `Successful ()
+      else (
+        List.iter display_error failure;
+        output_json_actions failure;
+        `Error (Error (success, List.map fst failure, aborted))
+      )
     with
-    | PackageActionGraph.Parallel.Errors (successful, errors, remaining) ->
+    | PackageActionGraph.Parallel.Errors (success, errors, remaining) ->
       List.iter display_error errors;
       output_json_actions errors;
-      `Error (Error (successful, List.map fst errors, remaining))
+      `Error (Error (success, List.map fst errors, remaining))
     | e -> `Exception e
   in
   let t = !t_ref in
@@ -420,10 +444,10 @@ let parallel_apply t action action_graph =
 
   let cleanup_artefacts graph =
     PackageActionGraph.iter_vertex (function
-        | `Remove nv | `Upgrade (nv, _) | `Downgrade (nv, _)
-          when not (OpamState.is_pinned t (OpamPackage.name nv)) ->
+        | `Remove nv when not (OpamState.is_pinned t (OpamPackage.name nv)) ->
           OpamAction.cleanup_package_artefacts t nv (* no-op if reinstalled *)
-        | _ -> ())
+        | `Remove _ | `Install _ -> ()
+        | _ -> assert false)
       graph
   in
   match action_results with
@@ -454,7 +478,7 @@ let parallel_apply t action action_graph =
     | Error (successful, failed, remaining) ->
       let filter_graph g l =
         if l = [] then PackageActionGraph.create () else
-        let g = PackageActionGraph.copy g in
+        let g = PackageActionGraph.explicit g in
         PackageActionGraph.iter_vertex (fun v ->
             if not (List.mem v l) then PackageActionGraph.remove_vertex g v)
           g;

--- a/src/tools/opam_mk_repo.ml
+++ b/src/tools/opam_mk_repo.ml
@@ -219,8 +219,9 @@ let resolve_deps args index names =
   with
   | Success solution ->
     OpamSolver.ActionGraph.fold_vertex (fun act acc -> match act with
-        | To_change (_, p) -> OpamPackage.Set.add p acc
-        | _ -> acc)
+        | `Install p -> OpamPackage.Set.add p acc
+        | `Remove _ -> acc
+        | _ -> assert false)
       (OpamSolver.get_atomic_action_graph solution) OpamPackage.Set.empty
   | Conflicts cs ->
     OpamConsole.error_and_exit "%s"


### PR DESCRIPTION
This uses a new separate action `Build in the concrete action graph,
making use of the build/install separation in opam files.

As a consequence,
- install step is unparallelised, which will allow for easily tracking changes
- the verbose package flag only prints install instructions, not the build anymore (needs doc!)
- the install step could be made to have access to stdin and query the user