### PR TITLE
Fix Fish shell assignments on array env variables

### DIFF
--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -138,7 +138,9 @@ let print_sexp_env env =
 let print_fish_env env =
   List.iter (fun (k,v) ->
       match k with
-      | "PATH" | "MANPATH" ->
+      | "PATH" | "MANPATH" | "CDPATH" ->
+        (* This function assumes that `v` does not include any variable expansions
+         * and that the directory names are written in full. See the opamState.ml for details *)
         let v = OpamStd.String.split_delim v ':' in
         OpamConsole.msg "set -gx %s %s;\n" k
           (OpamStd.List.concat_map " " (Printf.sprintf "%S") v)

--- a/src/state/opamState.ml
+++ b/src/state/opamState.ml
@@ -1866,7 +1866,7 @@ let source t ~shell ?(interactive_only=false) f =
     | `csh ->
       Printf.sprintf "source %s >& /dev/null || true\n" (file f)
     | `fish ->
-      Printf.sprintf ". %s > /dev/null 2> /dev/null or true\n" (file f)
+      Printf.sprintf "source %s > /dev/null 2> /dev/null or true\n" (file f)
     | _ ->
       Printf.sprintf ". %s > /dev/null 2> /dev/null || true\n" (file f)
   in


### PR DESCRIPTION
* Correctly handle the case of the variable being unset
  - This fixes the "missing manpages" bug.

* Do not put quotes around array expansions:
    set -gx PATH  $PATH  "/blah"  # Good
    set -gx PATH "$PATH" "/blah"  # Bad

* Add logic for CDPATH, for future-proofing
  - It is the only other special array variable we have
    to potentially worry about.