### PR TITLE
Detect number of CPUs on init to enable parallelism

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1236,7 +1236,7 @@ module API = struct
         log "State isn't broken but upgrade fails: something might be wrong.";
         broken_state_message ~need_fixup:true cs
 
-  let init repo compiler ~jobs shell dot_profile update_config =
+  let init repo compiler shell dot_profile update_config =
     log "INIT %a" (slog OpamRepositoryBackend.to_string) repo;
     let root = OpamStateConfig.(!r.root_dir) in
     let config_f = OpamPath.config root in
@@ -1339,7 +1339,8 @@ module API = struct
 
         (* Create ~/.opam/config *)
         let config =
-          OpamFile.Config.create switch [repo.repo_name] jobs
+          OpamFile.Config.create switch [repo.repo_name]
+            OpamStateConfig.(Lazy.force default.jobs)
             OpamStateConfig.(default.dl_jobs)
         in
         OpamStateConfig.write root config;

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -23,7 +23,7 @@ module API: sig
 
   (** Initialize the client a consistent state. *)
   val init:
-    repository -> compiler -> jobs:int ->
+    repository -> compiler ->
     shell -> filename -> [`ask|`yes|`no] ->
     unit
 

--- a/src/client/opamClientConfig.ml
+++ b/src/client/opamClientConfig.ml
@@ -113,7 +113,7 @@ let load_defaults root_dir =
     OpamStateConfig.update
       ~current_switch:(OpamFile.Config.switch conf)
       ~switch_from:`Default
-      ~jobs:(OpamFile.Config.jobs conf)
+      ~jobs:(lazy (OpamFile.Config.jobs conf))
       ~dl_jobs:(OpamFile.Config.dl_jobs conf)
       ();
     true

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -454,6 +454,18 @@ let install ?exec src dst =
   command ("install" :: "-m" :: (if exec then "0755" else "0644") ::
      [ src; dst ])
 
+let cpu_count () =
+  try
+    let ans =
+      if OpamStd.Sys.os () = OpamStd.Sys.Win32 then
+        [OpamStd.Env.get "NUMBER_OF_PROCESSORS"]
+      else
+        read_command_output ~verbose:(verbose_for_base_commands ())
+          ["getconf"; "_NPROCESSORS_ONLN"]
+    in
+    int_of_string (List.hd ans)
+  with Not_found | Process_error _ | Failure _ -> 1
+
 module Tar = struct
 
   let extensions =

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -182,6 +182,9 @@ val extract_in: string -> string -> unit
     exist. *)
 val mkdir: string -> unit
 
+(** Get the number of active processors on the system *)
+val cpu_count: unit -> int
+
 (** {2 File locking function} *)
 
 type lock

--- a/src/state/opamState.ml
+++ b/src/state/opamState.ml
@@ -129,7 +129,7 @@ let dot_config t name =
 let is_package_installed t nv =
   OpamPackage.Set.mem nv t.installed
 
-let jobs _ = OpamStateConfig.(!r.jobs)
+let jobs _ = Lazy.force OpamStateConfig.(!r.jobs)
 
 let dl_jobs _ = OpamStateConfig.(!r.dl_jobs)
 

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -17,7 +17,7 @@ type t = {
   root_dir: OpamFilename.Dir.t;
   current_switch: OpamSwitch.t;
   switch_from: [ `Env | `Command_line | `Default ];
-  jobs: int;
+  jobs: int Lazy.t;
   dl_jobs: int;
   external_tags: string list;
   keep_build_dir: bool;
@@ -36,7 +36,7 @@ let default = {
     );
   current_switch = OpamSwitch.system;
   switch_from = `Default;
-  jobs = 1;
+  jobs = lazy (OpamSystem.cpu_count ());
   dl_jobs = 3;
   external_tags = [];
   keep_build_dir = false;
@@ -57,8 +57,8 @@ type 'a options_fun =
   ?root_dir:OpamFilename.Dir.t ->
   ?current_switch:OpamSwitch.t ->
   ?switch_from:[ `Env | `Command_line | `Default ] ->
-  ?jobs: int ->
-  ?dl_jobs: int ->
+  ?jobs:(int Lazy.t) ->
+  ?dl_jobs:int ->
   ?external_tags:string list ->
   ?keep_build_dir:bool ->
   ?no_base_packages:bool ->
@@ -123,7 +123,7 @@ let init ?noop:_ =
     ?root_dir:(env_string "ROOT" >>| OpamFilename.Dir.of_string)
     ?current_switch
     ?switch_from
-    ?jobs:(env_int "JOBS")
+    ?jobs:(env_int "JOBS" >>| fun s -> lazy s)
     ?dl_jobs:(env_int "DOWNLOADJOBS")
     ?keep_build_dir:(env_bool "KEEPBUILDDIR")
     ?no_base_packages:(env_bool "NOBASEPACKAGES")

--- a/src/state/opamStateConfig.mli
+++ b/src/state/opamStateConfig.mli
@@ -19,7 +19,7 @@ type t = private {
   root_dir: OpamFilename.Dir.t;
   current_switch: OpamSwitch.t;
   switch_from: [ `Env | `Command_line | `Default ];
-  jobs: int;
+  jobs: int Lazy.t;
   dl_jobs: int;
   external_tags: string list;
   keep_build_dir: bool;
@@ -36,8 +36,8 @@ type 'a options_fun =
   ?root_dir:OpamFilename.Dir.t ->
   ?current_switch:OpamSwitch.t ->
   ?switch_from:[ `Env | `Command_line | `Default ] ->
-  ?jobs: int ->
-  ?dl_jobs: int ->
+  ?jobs:(int Lazy.t) ->
+  ?dl_jobs:int ->
   ?external_tags:string list ->
   ?keep_build_dir:bool ->
   ?no_base_packages:bool ->


### PR DESCRIPTION
also fixes a duplicate --jobs option on 'opam init' Detection thanks to
@dbuenzli at http://stackoverflow.com/questions/16269393/how-to-get-the-number-of-cores-on-a-machine-with-ocaml