### PR TITLE
escape path properly for cygwin after "make cold"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,6 @@ fastclean: rmartefacts
 
 cold:
 	./shell/bootstrap-ocaml.sh
-	env PATH=$$PATH:`pwd`/bootstrap/ocaml/bin ./configure $(CONFIGURE_ARGS)
-	env PATH=$$PATH:`pwd`/bootstrap/ocaml/bin $(MAKE) lib-ext
-	env PATH=$$PATH:`pwd`/bootstrap/ocaml/bin $(MAKE)
+	env PATH="$$PATH:`pwd`/bootstrap/ocaml/bin" ./configure $(CONFIGURE_ARGS)
+	env PATH="$$PATH:`pwd`/bootstrap/ocaml/bin" $(MAKE) lib-ext
+	env PATH="$$PATH:`pwd`/bootstrap/ocaml/bin" $(MAKE)


### PR DESCRIPTION
Cygwin paths have spaces in them typically, so path expressions need to be surrounded by quotes.