### PR TITLE
use sysctl on FreeBSD to find the amount of online processors

### DIFF
--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -457,11 +457,13 @@ let install ?exec src dst =
 let cpu_count () =
   try
     let ans =
-      if OpamStd.Sys.os () = OpamStd.Sys.Win32 then
-        [OpamStd.Env.get "NUMBER_OF_PROCESSORS"]
-      else
-        read_command_output ~verbose:(verbose_for_base_commands ())
-          ["getconf"; "_NPROCESSORS_ONLN"]
+      let open OpamStd in
+      match Sys.os () with
+      | Sys.Win32 -> [Env.get "NUMBER_OF_PROCESSORS"]
+      | Sys.FreeBSD -> read_command_output ~verbose:(verbose_for_base_commands ())
+                         ["sysctl"; "-n"; "hw.ncpu"]
+      | _ -> read_command_output ~verbose:(verbose_for_base_commands ())
+               ["getconf"; "_NPROCESSORS_ONLN"]
     in
     int_of_string (List.hd ans)
   with Not_found | Process_error _ | Failure _ -> 1


### PR DESCRIPTION
as mentioned in #2180 `getconf _NPROCSSOR_ONLN` does not work on FreeBSD, but `sysctl -n hw.ncpu` does.