### PR TITLE
Restore OpamSolver.installable

### DIFF
--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -347,7 +347,7 @@ let installable universe =
   log "trim";
   let simple_universe =
     load_cudf_universe universe universe.u_available ~build:true in
-  let trimed_universe = (* Algo.Depsolver.trim *) simple_universe in
+  let trimed_universe = Algo.Depsolver.trim simple_universe in
   Cudf.fold_packages
     (fun universe pkg -> OpamPackage.Set.add (OpamCudf.cudf2opam pkg) universe)
     OpamPackage.Set.empty


### PR DESCRIPTION
It was removed for release as a safeguard against a crash in Dose; I need it 
for opam-ci, and will test it again