### PR TITLE
Fix `resolve_var` in `opam switch install`

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1356,7 +1356,7 @@ module API = struct
           OpamCompiler.Map.empty;
         OpamFile.Repo_config.write (OpamRepositoryPath.config repo) repo;
         OpamProcess.Job.run (OpamRepository.init repo);
-        OpamState.install_global_config root switch;
+        ignore (OpamState.install_global_config root switch);
 
         (* Init global dirs *)
         OpamFilename.mkdir (OpamPath.packages_dir root);

--- a/src/state/opamState.ml
+++ b/src/state/opamState.ml
@@ -1690,7 +1690,8 @@ let install_global_config root switch =
   let config = OpamFile.Dot_config.create vars in
   OpamFile.Dot_config.write
     (OpamPath.Switch.global_config root switch)
-    config
+    config;
+  config
 
 let fix_descriptions_hook =
   ref (fun ?save_cache:_ ?verbose:_ _ -> assert false)
@@ -1739,7 +1740,7 @@ let upgrade_to_1_1 () =
     (* fix the base config files *)
     let aliases = OpamFile.Aliases.safe_read (OpamPath.aliases root) in
     OpamSwitch.Map.iter (fun switch _ ->
-        install_global_config root switch
+        ignore (install_global_config root switch)
       ) aliases;
 
     OpamFilename.with_tmp_dir (fun tmp_dir ->
@@ -2543,7 +2544,7 @@ let install_compiler t ~quiet:_ switch compiler =
         OpamFilename.mkdir (OpamPath.Switch.Default.man_dir ~num t.root switch)
       ) ["1";"1M";"2";"3";"4";"5";"6";"7";"9"];
 
-    install_global_config t.root switch;
+    let switch_config = install_global_config t.root switch in
 
     let comp = OpamFile.Comp.read comp_f in
     if not (OpamFile.Comp.preinstalled comp) &&
@@ -2622,7 +2623,7 @@ let install_compiler t ~quiet:_ switch compiler =
           ; [OpamStateConfig.(Lazy.force !r.makecmd); "install" ]
           ]
         else
-        let t = { t with switch } in
+        let t = { t with switch; compiler; switch_config } in
         let env = resolve_variable t OpamVariable.Map.empty in
         OpamFilter.commands env (OpamFile.Comp.build comp)
       in

--- a/src/state/opamState.mli
+++ b/src/state/opamState.mli
@@ -213,7 +213,7 @@ val redirect: state -> repository -> (repository * filter option) option
 (** {2 Compilers} *)
 
 (** (Re-)install the configuration for a given root and switch *)
-val install_global_config: dirname -> switch -> unit
+val install_global_config: dirname -> switch -> OpamFile.Dot_config.t
 
 (** Install the given compiler *)
 val install_compiler: state -> quiet:bool -> switch -> compiler -> unit


### PR DESCRIPTION
Currently the variables are resolved by looking values in the current switch environment and not in the newly created switch. Then, the OCaml compiler is configured with a `-prefix` that corresponds to the current switch.

```
> opam switch install 4.02.2 --debug --verbose
[...]
00:00.083  STATE                   ROOT      : /home/henry/.opam
00:00.083  STATE                   SWITCH    : 4.02.1
[...]
00:00.223  STATE                   State switch-install-with-packages-1 loaded in 0.072s
00:00.223  STATE                   install_compiler switch=4.02.2 compiler=4.02.2
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/lib
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/lib/stublibs
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/lib/toplevel
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/build
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/bin
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/sbin
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/doc
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/man
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/install
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/config
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/man/man1
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/man/man1M
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/man/man2
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/man/man3
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/man/man4
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/man/man5
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/man/man6
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/man/man7
00:00.224  SYSTEM                  mkdir /home/henry/.opam/4.02.2/man/man9
00:00.224  STATE                   install_global_config switch=4.02.2
00:00.227  FILE(.config)           Wrote ~/.opam/4.02.2/config/global-config.config in 0.000s

=-=- Installing compiler 4.02.2 -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[...]
Now compiling OCaml. This may take a while, please bear with us...
Processing: [4.02.2: ./configure]
+ ./configure "-prefix" "/home/henry/.opam/4.02.1" "-with-debug-runtime" (CWD=/home/henry/.opam/4.02.2/build/ocaml)
```
