### PR TITLE
Opam name version

### DIFF
--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -21,7 +21,6 @@ let log fmt = OpamConsole.log "CUDF" fmt
 let slog = OpamConsole.slog
 
 (* custom cudf field labels *)
-let s_source = "opam-name"
 let s_source_number = "opam-version"
 let s_reinstall = "reinstall"
 let s_installed_root = "installed-root"
@@ -29,7 +28,7 @@ let s_pinned = "pinned"
 let s_version_lag = "version-lag"
 
 let cudf2opam cpkg =
-  let sname = Cudf.lookup_package_property cpkg s_source in
+  let sname = Common.CudfAdd.decode cpkg.Cudf.package in
   let name = OpamPackage.Name.of_string sname in
   let sver = Cudf.lookup_package_property cpkg s_source_number in
   let version = OpamPackage.Version.of_string sver in
@@ -411,7 +410,6 @@ let is_pinned = check s_pinned
 
 let default_preamble =
   let l = [
-    (s_source,         `String None) ;
     (s_source_number,  `String None);
     (s_reinstall,      `Bool (Some false));
     (s_installed_root, `Bool (Some false));

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -21,7 +21,7 @@ let log fmt = OpamConsole.log "CUDF" fmt
 let slog = OpamConsole.slog
 
 (* custom cudf field labels *)
-let s_source_number = "opam-version"
+let s_source_number = "number"
 let s_reinstall = "reinstall"
 let s_installed_root = "installed-root"
 let s_pinned = "pinned"
@@ -29,8 +29,8 @@ let s_version_lag = "version-lag"
 
 let cudf2opam cpkg =
   let sname = Common.CudfAdd.decode cpkg.Cudf.package in
+  let sver = Common.CudfAdd.string_of_version cpkg in
   let name = OpamPackage.Name.of_string sname in
-  let sver = Cudf.lookup_package_property cpkg s_source_number in
   let version = OpamPackage.Version.of_string sver in
   OpamPackage.create name version
 

--- a/src/solver/opamCudf.mli
+++ b/src/solver/opamCudf.mli
@@ -146,7 +146,6 @@ val remove_all_uninstalled_versions_but: Cudf.universe ->
 
 (** Cudf labels for package fields in the cudf format
     (use for the field Cudf.pkg_extra and with Cudf.lookup_package_property) *)
-val s_source: string         (** the original OPAM package name (as string) *)
 val s_source_number: string  (** the original OPAM package version (as string) *)
 val s_reinstall: string      (** a package to be reinstalled (a bool) *)
 val s_installed_root: string (** true if this package belongs to the roots

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -183,7 +183,6 @@ let opam2cudf universe ?(depopts=false) ~build version_map package =
   in
   let extras =
     let e = [
-      OpamCudf.s_source, `String (OpamPackage.Name.to_string name);
       OpamCudf.s_source_number, `String (OpamPackage.Version.to_string version);
     ] in
     let e = if installed && reinstall


### PR DESCRIPTION
The first patch remove opam-name that is redundant as opam package is encoded in the cudf package name, and change opam-version to number that is the field used in dose to encode the string representation of a version.