### PR TITLE
Broken URL to OPAM repository

### DIFF
--- a/doc/pages/Packaging.md
+++ b/doc/pages/Packaging.md
@@ -22,7 +22,7 @@ Publish to the OPAM repository:
 * Use the [opam-publish](https://github.com/OCamlPro/opam-publish#opam-publish)
   tool (`opam install opam-publish`)
 * Or by hand:
-    - Fork [https://github.com/ocaml/opam-repository]()
+    - Fork https://github.com/ocaml/opam-repository
     - Add your `opam`, `descr` and `url` files to
       `packages/<pkgname>/<pkgname>.<version>`
     - File a [pull-request](https://github.com/ocaml/opam-repository/compare/)


### PR DESCRIPTION
The URL was displayed as https://github.com/ocaml/opam-repository but pointed to http://opam.ocaml.org/doc/Packaging.html