### PR TITLE
Only update opam version of ~/.opam/config to 1.2

### DIFF
--- a/META.in
+++ b/META.in
@@ -29,12 +29,12 @@ package "state" (
   version = "@PACKAGE_VERSION@"
   archive(byte) = "opam-state.cma"
   archive(native) = "opam-state.cmxa"
-  requires = "opam-lib, opam-lib.format, opam-lib.solver, opam-lib.repository, cmdliner"
+  requires = "re.glob, opam-lib, opam-lib.format, opam-lib.solver, opam-lib.repository, cmdliner"
 )
 
 package "client" (
   version = "@PACKAGE_VERSION@"
   archive(byte) = "opam-client.cma"
   archive(native) = "opam-client.cmxa"
-  requires = "cmdliner, re.glob, opam-lib, opam-lib.format, opam-lib.solver, opam-lib.repository, opam-lib.state"
+  requires = "cmdliner, opam-lib, opam-lib.format, opam-lib.solver, opam-lib.repository, opam-lib.state"
 )

--- a/admin-scripts/Makefile
+++ b/admin-scripts/Makefile
@@ -5,5 +5,5 @@
 
 couverture: couverture.ml
 	sed 's/^#.*//' $< >couverture-tmp.ml
-	ocamlfind ocamlopt -package opam-lib.state -linkpkg ../src/tools/opam_admin_top.ml couverture-tmp.ml -o $@
+	ocamlfind ocamlopt -package re.glob,opam-lib.state -linkpkg ../src/tools/opam_admin_top.ml couverture-tmp.ml -o $@
 	rm couverture-tmp.ml

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -806,7 +806,7 @@ module X = struct
 
     let with_repositories t repositories = { t with repositories }
     let with_switch t switch = { t with switch }
-    let with_current_opam_version t = { t with opam_version = OpamVersion.current_nopatch }
+    let with_opam_version t opam_version = { t with opam_version }
     let with_criteria t solver_criteria = { t with solver_criteria }
     let with_solver t solver = { t with solver }
 

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -71,8 +71,8 @@ module Config: sig
   (** Repository updates *)
   val with_repositories: t -> repository_name list -> t
 
-  (** Update opam-version to the current one *)
-  val with_current_opam_version: t -> t
+  (** Update opam-version *)
+  val with_opam_version: t -> OpamVersion.t -> t
 
   val with_criteria: t -> (solver_criteria * string) list -> t
 

--- a/src/state/opamState.ml
+++ b/src/state/opamState.ml
@@ -1204,12 +1204,15 @@ let load_config root =
         (OpamFilename.Dir.to_string (OpamStateConfig.(!r.root_dir)));
     (* opam has been updated, so refresh the configuration file and
        clean-up the cache. *)
-    if OpamVersion.compare config_version (OpamVersion.of_string "1.2") < 0 then
+    let v1_2 = OpamVersion.of_string "1.2" in
+    if OpamVersion.compare config_version v1_2 < 0 then
+      let config = OpamFile.Config.with_opam_version config v1_2 in
       !upgrade_to_1_2_hook ();
-    let config = OpamFile.Config.with_current_opam_version config in
-    OpamStateConfig.write root config;
-    Cache.remove ();
-    config
+      OpamStateConfig.write root config;
+      Cache.remove ();
+      config
+    else
+      config
   ) else
     config
 


### PR DESCRIPTION
since there is no format changes yet, and opam 1.2 later chokes on the
1.3-advertised file, this was annoying