### PR TITLE
Fix typo in documentation of dev-repo

### DIFF
--- a/doc/dev-manual/dev-manual.tex
+++ b/doc/dev-manual/dev-manual.tex
@@ -354,7 +354,7 @@ the following restrictions:
   related pages for the package.
 
 \item {\tt dev-repo} is the URL of the package's source repository, which may be
-  useful for developpers: not to be mistaken with the URL file, which points to
+  useful for developers: not to be mistaken with the URL file, which points to
   the specific packaged version. It is typically a version-control address, and
   follows the format allowed for {\tt TARGET} by {\tt opam pin add}. You can use
   an address of the form {\tt vcs+scheme://xxx} to specify the version control


### PR DESCRIPTION
Found by @toolslive in ocaml/opam-repository#4368.