### PR TITLE
Check checksum format during parsing

### DIFF
--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -152,6 +152,9 @@ let to_string t =
 let digest t =
   Digest.to_hex (Digest.file (to_string t))
 
+let valid_digest t =
+  try Digest.from_hex t; true with Invalid_argument _ -> false
+
 let touch t =
   OpamSystem.write (to_string t) ""
 

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -152,8 +152,10 @@ let to_string t =
 let digest t =
   Digest.to_hex (Digest.file (to_string t))
 
-let valid_digest t =
-  try Digest.from_hex t; true with Invalid_argument _ -> false
+let digest_regex = Re.(compile (repn xdigit 32 (Some 32)))
+
+let valid_digest s =
+  OpamStd.String.exact_match digest_regex s
 
 let touch t =
   OpamSystem.write (to_string t) ""

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -206,6 +206,9 @@ val patch: t -> Dir.t -> unit
 (** Compute the MD5 digest of a file *)
 val digest: t -> string
 
+(** Check whether an MD5 digest is correctly formatted *)
+val valid_digest: string -> bool
+
 (** Compute the MD5 digest a file. Return the empty list if the file
     does not exist. *)
 val checksum: t -> string list

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -377,7 +377,11 @@ module X = struct
         OpamFormat.assoc_list s.file_contents s_mirrors
           (OpamFormat.parse_list (OpamFormat.parse_string @> address_of_string)) in
       let checksum =
-        OpamFormat.assoc_option s.file_contents s_checksum OpamFormat.parse_string in
+        match OpamFormat.assoc_option s.file_contents s_checksum OpamFormat.parse_string
+        with Some s when not (OpamFilename.valid_digest s) ->
+          OpamFormat.bad_format "%s is not a valid checksum" s
+           | s -> s
+      in
       let url, kind =
         match url_and_kind ~src ~archive ~http ~git ~darcs ~hg ~local
         with Some x -> x | None -> OpamFormat.bad_format "URL is missing" in


### PR DESCRIPTION
We recently had a url file with an invalid checksum (with an extra character) sneak through:

http://opam.ocaml.org/builds/20ff97ad14c79484d876c1200ba5e83dd7ca46ae/logs/local-ubuntu-14.04-ocaml-4.02.1/raw/sawja.html

This PR adds checksum validity checking during parsing so that errors can be caught earlier and reported more clearly.
