### PR TITLE
Properly treat conflicts as a disjunction

### DIFF
--- a/admin-scripts/depopts_to_conflicts.ml
+++ b/admin-scripts/depopts_to_conflicts.ml
@@ -60,9 +60,9 @@ iter_packages ~opam:(fun _ opam ->
           depopts [] in
       let conflicts = OpamFile.OPAM.conflicts opam in
       let add_conflicts =
-        let c = OpamFormula.to_conjunction conflicts in
+        let c = OpamFormula.to_disjunction conflicts in
         List.filter (fun f -> not (List.mem f c)) neg_depopts in
-      OpamFormula.ands (conflicts :: [OpamFormula.of_conjunction add_conflicts])
+      OpamFormula.ands (conflicts :: [OpamFormula.of_disjunction add_conflicts])
     in
     let opam = OpamFile.OPAM.with_depopts opam depopts in
     let opam = OpamFile.OPAM.with_conflicts opam conflicts in

--- a/admin-scripts/to_1_1.ml
+++ b/admin-scripts/to_1_1.ml
@@ -115,7 +115,7 @@ let to_1_1 _ opam =
   let opam =
     OF.with_conflicts opam
       (OpamFormula.map (fun (n, cstr) ->
-           OpamFormula.Atom (n, rewrite_constraint ~conj:true cstr))
+           OpamFormula.Atom (n, rewrite_constraint ~conj:false cstr))
           (OF.conflicts opam))
   in
   let opam = OF.with_available opam (filter_vars (OF.available opam) +! FBool true) in

--- a/opam
+++ b/opam
@@ -8,7 +8,7 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam"
+dev-repo: "https://github.com/ocaml/opam.git"
 build: [
   ["./configure"]
   [make]

--- a/src/format/opamFormat.mli
+++ b/src/format/opamFormat.mli
@@ -193,23 +193,29 @@ val parse_package_name : ?expected:name -> value -> name
 
 val parse_package_version : ?expected:version -> value -> version
 
-(** Parse package formula where AND are implicit: [x y -> x & y] *)
-val parse_formula : value -> formula
+(** Parser for version constraints in formulas *)
+val parse_constraints: value list -> OpamFormula.version_formula
 
-(** Build a formula where AND are implicit. *)
-val make_formula : formula -> value
+(** Parser for version constraints in formula with dependency flags *)
+val parse_ext_constraints:
+  value list -> package_dep_flag list * OpamFormula.version_formula
 
-(** Parse an AND formula where constraints are extended with leading keywords *)
-val parse_ext_formula : value -> ext_formula
+(** Builder for version constraints in formulas *)
+val make_constraints: OpamFormula.version_formula -> value list
 
-(** Make an AND formula where constraints are extended with leading keywords *)
-val make_ext_formula : ext_formula -> value
+(** Builder for version constraints in formula with dependency flags *)
+val make_ext_constraints:
+  package_dep_flag list * OpamFormula.version_formula -> value list
 
-(** Parse optional package formula where OR are implicit: [x y -> x | y] *)
-val parse_opt_formula : value -> ext_formula
+(** Parse package formula as a [`Conj]unction or [`Disj]unction, using the given
+    parser for constraints *)
+val parse_formula :
+  [`Conj | `Disj] -> (value list -> 'a) -> value -> (name * 'a) generic_formula
 
-(** Build a formula where OR are implicit. *)
-val make_opt_formula : ext_formula -> value
+(** Build a formula as a [`Conj]unction or [`Disj]unction, building constraints
+    with the given function *)
+val make_formula :
+  [`Conj | `Disj] -> ('a -> value list) -> (name * 'a) generic_formula -> value
 
 (** Parse compiler versions *)
 val parse_compiler_version: value -> compiler_version

--- a/src/format/opamFormula.ml
+++ b/src/format/opamFormula.ml
@@ -305,7 +305,8 @@ let to_conjunction t =
   match to_dnf t with
   | []  -> []
   | [x] -> x
-  | _   -> OpamConsole.error_and_exit "%s is not a valid conjunction" (to_string t)
+  | _   ->
+    failwith (Printf.sprintf "%s is not a valid conjunction" (to_string t))
 
 let ands l = List.fold_left make_and Empty l
 
@@ -321,7 +322,8 @@ let to_disjunction t =
   match to_cnf t with
   | []  -> []
   | [x] -> x
-  | _   -> OpamConsole.error_and_exit "%s is not a valid disjunction" (to_string t)
+  | _   ->
+    failwith (Printf.sprintf "%s is not a valid disjunction" (to_string t))
 
 let ors l = List.fold_left make_or Empty l
 

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -161,8 +161,9 @@ let opam2cudf universe ?(depopts=false) ~build version_map package =
   let conflicts =
     try OpamPackage.Map.find package universe.u_conflicts
     with Not_found -> Empty in
-  let conflicts = (* prevents install of multiple versions of the same pkg *)
-    (name, None)::OpamFormula.to_conjunction conflicts in
+  let conflicts =
+    (name, None) :: (* prevents install of multiple versions of the same pkg *)
+    OpamFormula.to_disjunction conflicts in
   let installed = OpamPackage.Set.mem package universe.u_installed in
   let base = OpamPackage.Set.mem package universe.u_base in
   let reinstall = match universe.u_action with


### PR DESCRIPTION
this has been bothering me for a while ; note that it is NOT a
backwards-compatible change, but files advertised as before 1.3 will be
handled silently. Just a few packages used it though.

A lint warning is provisionned, too, but inhibited for now (files < 1.3)

Closes #2246