### PR TITLE
Extend 'opam config' interface

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1012,7 +1012,8 @@ let config =
     ["exec"]    , `exec    , ["[--] COMMAND"; "[ARG]..."],
     "Execute $(i,COMMAND) with the correct environment variables. \
      This command can be used to cross-compile between switches using \
-     $(b,opam config exec --switch=SWITCH -- COMMAND ARG1 ... ARGn)";
+     $(b,opam config exec --switch=SWITCH -- COMMAND ARG1 ... ARGn). \
+     Opam expansion takes place in command and args.";
     ["var"]     , `var     , ["VAR"],
     "Return the value associated with variable $(i,VAR). Package variables can \
      be accessed with the syntax $(i,pkg:var).";
@@ -1020,6 +1021,15 @@ let config =
     "Without argument, prints a documented list of all available variables. With \
      $(i,PACKAGE), lists all the variables available for these packages. Use \
      $(i,-) to include global configuration variables for this switch.";
+    ["set"]     , `set     , ["VAR";"VALUE"],
+    "Set the given global opam variable for the current switch. Warning: \
+     changing a configured path will not move any files! This command does \
+     not perform any variable expansion.";
+    ["unset"]   , `unset     , ["VAR"],
+    "Unset the given global opam variable for the current switch. Warning: \
+     unsetting built-in configuration variables can cause problems!";
+    ["expand"]  , `expand  , ["STRING"],
+    "Expand variable interpolations in the given string";
     ["subst"]   , `subst   , ["FILE..."],
     "Substitute variables in the given files. The strings $(i,%{var}%) are \
      replaced by the value of variable $(i,var) (see $(b,var)).";
@@ -1119,6 +1129,12 @@ let config =
     | Some `list, params ->
       (try `Ok (Client.CONFIG.list (List.map OpamPackage.Name.of_string params))
        with Failure msg -> `Error (false, msg))
+    | Some `set, [var; value] ->
+      `Ok (Client.CONFIG.set (OpamVariable.Full.of_string var) (Some value))
+    | Some `unset, [var] ->
+      `Ok (Client.CONFIG.set (OpamVariable.Full.of_string var) None)
+    | Some `expand, [str] ->
+      `Ok (Client.CONFIG.expand str)
     | Some `var, [var] ->
       (try `Ok (Client.CONFIG.variable (OpamVariable.Full.of_string var))
        with Failure msg -> `Error (false, msg))

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1867,6 +1867,12 @@ module SafeAPI = struct
     let list names =
       read_lock (fun () -> API.CONFIG.list names)
 
+    let set var value =
+      switch_lock (fun () -> API.CONFIG.set var value)
+
+    let expand str =
+      read_lock (fun () -> API.CONFIG.expand str)
+
     let variable var =
       read_lock (fun () -> API.CONFIG.variable var)
 

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -85,6 +85,12 @@ module API: sig
     (** Display variables and their contents. *)
     val list: name list -> unit
 
+    (** Sets or unsets a global switch variable *)
+    val set: full_variable -> string option -> unit
+
+    (** Prints the variable expansion of the given string *)
+    val expand: string -> unit
+
     (** Display a given variable content. *)
     val variable: full_variable -> unit
 

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -34,11 +34,17 @@ val variable:  full_variable -> unit
 (** Substitute files *)
 val subst: basename list -> unit
 
+(** Prints expansion of variables in string *)
+val expand: string -> unit
+
+(** Sets or unsets switch config variables *)
+val set: full_variable -> string option -> unit
+
 (** Update the global and user configuration to use OPAM. *)
 val setup: user_config option -> global_config option -> unit
 
 (** Display the global and user configuration for OPAM. *)
 val setup_list: shell -> filename -> unit
 
-(** Execute a command in a subshell *)
+(** Execute a command in a subshell, after variable expansion *)
 val exec: inplace_path:bool -> string list -> unit

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -2192,6 +2192,12 @@ module X = struct
       try Some (List.assoc s t)
       with Not_found -> None
 
+    let set t k v =
+      let t = List.remove_assoc k t in
+      match v with
+      | Some v -> (k,v) :: t
+      | None -> t
+
   end
 
   module Comp = struct

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -479,6 +479,10 @@ module Dot_config: sig
   (** Lists all the bindings in the file *)
   val bindings: t -> (variable * variable_contents) list
 
+  (** Sets the given variable, overriding any previous definition.
+      With [None], unsets the variable*)
+  val set: t -> variable -> variable_contents option -> t
+
 end
 
 (** {2 Repository files} *)


### PR DESCRIPTION
- new commands 'set' and 'unset' for custom switch variables
- 'exec' now expands variables in command and arguments
- new command 'expand' to simply opam-evaluate a string