### PR TITLE
move "External solvers" documentation from Usage to Install (#2261)

### DIFF
--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -240,4 +240,7 @@ explicitly specify which external solver to use by using the `--solver
 `$OPAMEXTERNALSOLVER` environment variable.
 
 External solvers also allow to specify [fine-grained
-preferences](Specifying_Solver_Preferences.html).
+preferences](Specifying_Solver_Preferences.html). `aspcud`
+is currently recommended because it supports a richer language of
+[solver preferences](Specifying_Solver_Preferences.html#Yestherearedifferentversionsoftheuserpreferencelanguage)
+giving OPAM more control over the requested solution.

--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -3,9 +3,9 @@
 
 # How to install OPAM
 
-This page describes how to install and configure OPAM.
-For further help on how to use OPAM, either read
-`opam --help` or move on to the [Usage](Usage.html) guide.
+This page describes how to install and configure OPAM and [external
+solvers](#Externalsolvers). For further help on how to use OPAM,
+either read `opam --help` or move on to the [Usage](Usage.html) guide.
 
 ## Upgrading from a previous version
 
@@ -203,3 +203,41 @@ necessary pre-requisites installed to run ocamlbrew, and then run:
 ```
 curl -kL https://raw.github.com/hcarty/ocamlbrew/master/ocamlbrew-install | env OCAMLBREW_FLAGS="-r" bash
 ```
+
+# External Solvers
+
+Resolving package installations in the presence of dependencies and
+conflicts is known to be an [NP-complete
+problem](https://hal.archives-ouvertes.fr/file/index/docid/149566/filename/ase.pdf).
+Thankfully, a big effort has already been put into solving it very
+efficiently: OPAM relies on this effort and delegates the solving
+process to _external solvers_. OPAM integrates a simple solver, so it
+can used without any extra dependencies, but for best results you
+should have one of those solvers on your system:
+
+- aspcud (recommended)
+- packup
+- mccs (no built-in support at the moment, but may be used with the following
+  solver configuration string: `mccs -i %{input}% -o %{output}%
+  -lexagregate[%{criteria}%]`.)
+
+We recommend installing one through your packaging system whenever
+possible: this should already have been taken care of if you installed
+OPAM through your packaging system. If you have trouble installing an
+external solver and have reliable network connectivity,
+[Irill](http://www.irill.org/) kindly provides a ["Solver
+farm"](http://cudf-solvers.irill.org/) which can be used as a remote
+solver by OPAM.
+
+If you use the internal solver only, the following symptoms may be
+sign that you need an external solver: very bad upgrade proposals, or
+dependency solving becoming very slow.
+
+OPAM will detect the availability of `aspcud` or `packup` commands on
+your system and should switch to using them directly. You can
+explicitly specify which external solver to use by using the `--solver
+<foo>` command-line argument, or
+`$OPAMEXTERNALSOLVER` environment variable.
+
+External solvers also allow to specify [fine-grained
+preferences](Specifying_Solver_Preferences.html).

--- a/doc/pages/Usage.md
+++ b/doc/pages/Usage.md
@@ -46,40 +46,6 @@ you find a package there but not on your computer, either it has been recently
 added and you should simply run `opam update`, or it's not available on your
 system or OCaml version -- `opam install PACKAGE` will give you the reason.
 
-
-## Before you get started: "external solvers"
-
-Resolving package installations in the presence of dependencies and
-conflicts is known to be an [NP-complete
-problem](https://hal.archives-ouvertes.fr/file/index/docid/149566/filename/ase.pdf).
-Thankfully, a big effort has already been put into solving it very
-efficiently: OPAM relies on this effort and delegates the solving
-process to _external solvers_. OPAM integrates a simple solver, so it
-can used without any extra dependencies, but for best results you
-should have one of those solvers on your system:
-
-- aspcud (recommended)
-- packup
-- mccs (no built-in support at the moment, but may be used with the following
-  solver configuration string: `mccs -i %{input}% -o %{output}%
-  -lexagregate[%{criteria}%]`.)
-
-We recommend installing one through your packaging system whenever
-possible: this should already have been taken care of if you installed
-OPAM through your packaging system. If you have trouble installing an
-external solver and have reliable network connectivity,
-[Irill](http://www.irill.org/) kindly provides a ["Solver
-farm"](http://cudf-solvers.irill.org/) which can be used as a remote
-solver by OPAM.
-
-If you use the internal solver only, the following symptoms may be
-sign that you need an external solver: very bad upgrade proposals, or
-dependency solving becoming very slow.
-
-External solvers also allow to specify [fine-grained
-preferences](Specifying_Solver_Preferences.html).
-
-
 ## Details on commands
 
 ### opam init
@@ -117,11 +83,22 @@ opam install ocp-indent ocp-index.1.0.2
 opam install "ocamlfind>=1.4.0"
 ```
 
+If OPAM seems unable to fulfill very simple installation requests or
+propose non-sensical install plans, it may be due to limitations of
+its internal dependency solver; you should check that you have an
+[External dependency solver](Install.html#Externalsolvers) on your
+system.
+
 ### opam upgrade
 
 Will attempt to upgrade the installed packages to their newest versions. You
 should run it after `opam update`, and may use `opam pin` to prevent specific
 packages from being upgraded.
+
+If OPAM proposes non-sensical upgrade plans, it may be due to
+limitations of its internal dependency solver; you should check that
+you have an [External dependency solver](Install.html#Externalsolvers)
+on your system.
 
 ### opam switch
 


### PR DESCRIPTION
We also detail how to explicitly specify a specific solver, as
recommended by Hezekiah M. Carty.

I guessed the `#Externalsolvers` id; can someone confirm that this will be correct demangling at release time?

Also, it would be nice if there was a way to ask OPAM which solver it will use, for users to check that the solver-detection heuristics worked (and that the solver is correctly installed, etc.). Is such an option hidden somewhere?