### PR TITLE
Sync local `opam` file with opam-repository

### DIFF
--- a/opam
+++ b/opam
@@ -2,13 +2,19 @@ opam-version: "1.2"
 name: "opam-lib"
 version: "1.3.0~dev"
 maintainer: "opam-devel@lists.ocaml.org"
+homepage:     "https://opam.ocaml.org/"
+dev-repo:     "https://github.com/ocaml/opam.git"
+bug-reports:  "https://github.com/ocaml/opam/issues"
 authors: [
-  "Thomas Gazagnaire <thomas@gazagnaire.org>"
-  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+   "Anil Madhavapeddy   <anil@recoil.org>"
+   "Fabrice Le Fessant  <Fabrice.Le_fessant@inria.fr>"
+   "Frederic Tuong      <tuong@users.gforge.inria.fr>"
+   "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+   "Guillem Rieu        <guillem.rieu@ocamlpro.com>"
+   "Vincent Bernardoff  <vb@luminar.eu.org>"
+   "Roberto Di Cosmo    <roberto@dicosmo.org>"
 ]
-homepage: "https://opam.ocaml.org"
-bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
 build: [
   ["./configure"]
   [make]
@@ -17,9 +23,9 @@ build: [
 depends: [
   "ocamlgraph"
   "cmdliner"
-  "dose" {>= "3.2.2+opam"}
+  "dose" {>= "3.2.2+opam" & < "4"}
   "cudf"
   "re" {>= "1.2.0"}
-  "ocamlfind"
+  "ocamlfind" {build}
   "jsonm"
 ]


### PR DESCRIPTION
This fixes compilation of a direct `opam pin add opam-lib --dev`
command, which currently picks up dose4