### PR TITLE
Cleanup uses of Re

### DIFF
--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -405,9 +405,18 @@ module OpamString = struct
 
   let split s c =
     Re_str.split (Re_str.regexp (Printf.sprintf "[%c]+" c)) s
+  (* Unavailable in re 1.2.0 {[
+       Re.(split (compile (rep1 (char c))) s
+     ]} *)
 
   let split_delim s c =
     Re_str.split_delim (Re_str.regexp (Printf.sprintf "[%c]" c)) s
+  (* Unavailable in re 1.2.0 {[
+       let s = if String.length s <> 0
+         then Printf.sprintf "%c%s%c" c s c
+         else s in
+       Re.(split (compile (rep1 (char c))) s)
+     ]} *)
 
   let fold_left f acc s =
     let acc = ref acc in


### PR DESCRIPTION
why use an unreadable DSL passed as strings when you can use OCaml ?