### PR TITLE
Some improvements to `opam install`

### DIFF
--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -47,7 +47,8 @@ module API: sig
   (** Install the given list of packages. Second argument, if not None, specifies
       that given packages should be added or removed from the roots.
       Third argument installs all dependencies but not the packages themselves *)
-  val install: atom list -> bool option -> bool -> unit
+  val install:
+    atom list -> bool option -> deps_only:bool -> upgrade:bool -> unit
 
   (** Reinstall the given set of packages. *)
   val reinstall: atom list -> unit

--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -632,13 +632,18 @@ let install =
     Arg.(value & flag & info ["deps-only"]
            ~doc:"Install all its dependencies, but don't actually install the \
                  package.") in
-  let install global_options build_options add_to_roots deps_only atoms =
+  let upgrade =
+    Arg.(value & flag & info ["u";"upgrade"]
+           ~doc:"Upgrade the packages if already installed, rather than \
+                 ignoring them") in
+  let install
+      global_options build_options add_to_roots deps_only upgrade atoms =
     apply_global_options global_options;
     apply_build_options build_options;
-    Client.install atoms add_to_roots deps_only
+    Client.install atoms add_to_roots ~deps_only ~upgrade
   in
   Term.(pure install $global_options $build_options
-        $add_to_roots $deps_only $nonempty_atom_list),
+        $add_to_roots $deps_only $upgrade $nonempty_atom_list),
   term_info "install" ~doc ~man
 
 (* REMOVE *)
@@ -1453,7 +1458,7 @@ let check_and_run_external_commands () =
           (OpamRepositoryConfig.init ();
            OpamSolverConfig.init ();
            OpamClientConfig.init ();
-           Client.install [pkgname,None] None false;
+           Client.install [pkgname,None] None ~deps_only:false ~upgrade:false;
            OpamConsole.header_msg "Carrying on to \"%s\""
              (String.concat " " (Array.to_list Sys.argv));
            OpamConsole.msg "\n";

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -413,22 +413,22 @@ type 'a switch_map = 'a OpamSwitch.Map.t
 (** The different kinds of locks *)
 type lock =
 
+  | Read_lock of (unit -> unit)
   (** The function does not modify anything, but it needs the state
       not to change while it is running. *)
-  | Read_lock of (unit -> unit)
 
+  | Global_lock of (unit -> unit)
   (** Take the global lock, all subsequent calls to OPAM are
       blocked. *)
-  | Global_lock of (unit -> unit)
 
+  | Switch_lock of (unit -> switch) * (unit -> unit)
   (** Take a global read lock and a switch lock. The first function is
       called with the read lock, then the second function is called with
       the returned switch write-locked. *)
-  | Switch_lock of (unit -> switch) * (unit -> unit)
 
+  | Global_with_switch_cont_lock of (unit -> switch * (unit -> unit))
   (** Call the function in a global lock, then relax to a switch
       lock and call the function it returned *)
-  | Global_with_switch_cont_lock of (unit -> switch * (unit -> unit))
 
 (** A line in {i urls.tx} *)
 type file_attribute = OpamFilename.Attribute.t

--- a/src/format/opamTypesBase.mli
+++ b/src/format/opamTypesBase.mli
@@ -105,10 +105,15 @@ val pos_null: pos
 val string_of_pos: pos -> string
 
 val string_of_relop: relop -> string
+
 val relop_of_string: string -> relop (** Raises Invalid_argument*)
+
 val string_of_logop: logop -> string
+
 val logop_of_string: string -> logop (** Raises Invalid_argument*)
+
 val string_of_pfxop: pfxop -> string
+
 val pfxop_of_string: string -> pfxop (** Raises Invalid_argument*)
 
 (** Parses the data suitable for a filter.FIdent from a string. May

--- a/src/state/opamSolution.ml
+++ b/src/state/opamSolution.ml
@@ -76,7 +76,7 @@ let check_solution state = function
     OpamStd.Sys.exit 4
   | OK actions ->
     List.iter (post_message state) actions
-  | Nothing_to_do -> ()
+  | Nothing_to_do -> OpamConsole.msg "Nothing to do.\n"
   | Aborted     -> OpamStd.Sys.exit 0
 
 let sum stats =


### PR DESCRIPTION
* allow `-u` to upgrade if installed
* avoid error on `opam install foo --deps-only` when foo is unavailable