### PR TITLE
Removals last (don't merge yet!)

### DIFF
--- a/admin-scripts/split_install.ml
+++ b/admin-scripts/split_install.ml
@@ -1,0 +1,45 @@
+#!/usr/bin/env opam-admin.top
+
+#directory "+../opam-lib";;
+#directory "+../re";;
+open Opam_admin_top;;
+open OpamTypes;;
+
+iter_packages ~opam:(fun _ opam ->
+    let module O = OpamFile.OPAM in
+    if O.install opam <> [] then opam else
+      let rec rev_split_while acc cond = function
+        | [] -> acc, []
+        | x::r when cond x -> rev_split_while (x::acc) cond r
+        | l -> acc, List.rev l
+      in
+      let condition = function
+        | (CString "install",_)::_, _ -> true
+        | (CString "cp",_)::r, _ ->
+          (try
+             let dest =
+               match List.filter (function
+                   | CString s, _ -> not (OpamStd.String.starts_with ~prefix:"-" s)
+                   | CIdent _, _ -> true)
+                   (List.rev r)
+               with
+               | (d, _)::_ -> d
+               | _ -> raise Not_found
+             in
+             let dests = ["prefix";"bin";"sbin";"lib";"man";"doc";"share";"etc";
+                          "toplevel";"stublibs";"doc"] in
+             match dest with
+             | CIdent i -> List.mem i dests
+             | CString s ->
+               Re.(execp (compile (seq [alt (List.map str dests); str "}%"])) s)
+           with Not_found -> false)
+        | l, _ -> List.exists (fun (arg,_) -> arg =CString "install") l
+      in
+      let install, build =
+        rev_split_while [] condition (List.rev (O.build opam))
+      in
+      let opam = OpamFile.OPAM.with_build opam build in
+      let opam = OpamFile.OPAM.with_install opam install in
+      opam)
+  ()
+;;

--- a/src/solver/opamActionGraph.ml
+++ b/src/solver/opamActionGraph.ml
@@ -15,6 +15,7 @@
 (**************************************************************************)
 
 open OpamTypes
+open OpamStd.Op
 
 module type ACTION = sig
   type package
@@ -127,6 +128,7 @@ module type SIG = sig
   include OpamParallel.GRAPH with type V.t = package OpamTypes.action
   val reduce: t -> t
   val explicit: t -> t
+  val removals_last: t -> t
 end
 
 module Make (A: ACTION) : SIG with type package = A.package = struct
@@ -201,4 +203,33 @@ module Make (A: ACTION) : SIG with type package = A.package = struct
         | `Build _ -> assert false)
       g0;
     g
+
+  module Set = OpamStd.Set.Make (A)
+
+  (* Adds any unrelated, non-remove action as an antecedent of every remove
+     action, to be sure it's done as late as possible *)
+  let removals_last g0 =
+    let g = copy g0 in
+    let closure = transitive_closure g in
+    let nonremove_actions =
+      fold_vertex (fun a acc -> match a with
+          | `Remove _ -> acc
+          | a -> Set.add a acc)
+        g Set.empty
+    in
+    let rm_list l set =
+      List.fold_left (fun acc x -> Set.remove x acc) set l
+    in
+    iter_vertex (function
+        | `Remove _ as rm ->
+          let unrelated =
+            nonremove_actions
+            |> rm_list (pred closure rm)
+            |> rm_list (succ closure rm)
+          in
+          Set.iter (fun a -> add_edge g a rm) unrelated
+        | _ -> ())
+      g;
+    g
+
 end

--- a/src/solver/opamActionGraph.ml
+++ b/src/solver/opamActionGraph.ml
@@ -187,11 +187,15 @@ module Make (A: ACTION) : SIG with type package = A.package = struct
 
   let explicit g0 =
     let g = copy g0 in
+    let same_name p1 p2 = A.Pkg.(name_to_string p1 = name_to_string p2) in
     iter_vertex (fun a ->
         match a with
         | `Install p | `Reinstall p | `Change (_,_,p) ->
           let b = `Build p in
-          iter_pred (fun pred -> remove_edge g pred a; add_edge g pred b) g a;
+          iter_pred (function
+              | `Remove p1 when same_name p p1 -> ()
+              | pred -> remove_edge g pred a; add_edge g pred b)
+            g0 a;
           add_edge g b a
         | `Remove _ -> ()
         | `Build _ -> assert false)

--- a/src/solver/opamActionGraph.mli
+++ b/src/solver/opamActionGraph.mli
@@ -41,6 +41,11 @@ module type SIG = sig
 
   (** Expand install actions, adding a build action preceding them. *)
   val explicit: t -> t
+
+  (** To minimise the consequences of failures: adds edges to the graph to
+      ensure removals are done as late as possible. Since they're fast, the loss
+      in parallelism is negligible. *)
+  val removals_last: t -> t
 end
 
 module Make (A: ACTION) : SIG with type package = A.package

--- a/src/state/opamSolution.ml
+++ b/src/state/opamSolution.ml
@@ -387,6 +387,9 @@ let parallel_apply t action action_graph =
   let action_graph = (* Add build actions *)
     PackageActionGraph.explicit action_graph
   in
+  let action_graph = (* Delay removals to minimise consequences of failures *)
+    PackageActionGraph.removals_last action_graph
+  in
 
   let timings = Hashtbl.create 17 in
   (* the child job to run on each action *)
@@ -420,7 +423,7 @@ let parallel_apply t action action_graph =
         match action with
         | `Build _ -> Done (`Successful (installed, removed))
         | `Install nv ->
-          OpamConsole.msg "Faking installation of %s"
+          OpamConsole.msg "Faking installation of %s... "
             (OpamPackage.to_string nv);
           add_to_install nv;
           Done (`Successful (OpamPackage.Set.add nv installed , removed))

--- a/tests/packages/P5.opam
+++ b/tests/packages/P5.opam
@@ -5,8 +5,8 @@ version: "1"
 maintainer: "contact@ocamlpro.com"
 depends: [ "P1" ]
 depopts: [ "P2" ]
-build: [ [ "./build.sh" ]
-         [ "mkdir" "-p" "%{lib}%/p5" ]
+build: [ [ "./build.sh" ] ]
+install: [[ "mkdir" "-p" "%{lib}%/p5" ]
          [ "touch" "%{lib}%/p5/p2_present" ] {P2:installed}
          [ "touch" "%{lib}%/p5/p2_absent" ] {!P2:installed} ]
 remove: [ "rm" "-rf" "%{lib}%/p5" ]


### PR DESCRIPTION
In the action processing graph:
- remove the constraint to remove the previous version of a package before rebuilding
- add constraints to do the removals as late as possible, while keeping the constraint to always have a consistent installed package set.

This follows from a suggestion by @UnixJunkie at #2319 -- thanks!

WARNING: this assumes the "build" instructions from opam files don't do any installation, which is currently NOT the case on the opam-repository (as it used to be the standard behaviour).
A script is provided to help with the transition, but this shouldn't be merged until it can be applied on the repository!