### PR TITLE
Cache environment updates in a separate file.

### DIFF
--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -61,6 +61,8 @@ let max_print = 100
 
 module OpamList = struct
 
+  let cons x xs = x :: xs
+
   let concat_map ?(left="") ?(right="") ?nil sep f =
     function
     | [] -> (match nil with Some s -> s | None -> left^right)

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -142,6 +142,8 @@ end
 
 module List : sig
 
+  val cons: 'a -> 'a list -> 'a list
+
   (** Convert list items to string and concat. [sconcat_map sep f x] is equivalent
       to String.concat sep (List.map f x) but tail-rec. *)
   val concat_map:

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -437,6 +437,34 @@ module Pinned_legacy = LineFile(struct
 
   end)
 
+
+(** Cached environment updates (<switch>/environment) *)
+
+module Environment = LineFile(struct
+
+    let internal = "environment"
+
+    type t = env_update list
+
+    let empty = []
+
+    let pp =
+      Pp.lines_set ~empty:[] ~add:OpamStd.List.cons ~fold:List.fold_right @@
+      Pp.identity ^+
+      Pp.of_pair "env_update_op"
+        (env_update_op_of_string, string_of_env_update_op) ^+
+      Pp.identity ^+
+      Pp.opt Pp.singleton
+
+    let pp =
+       pp -|
+       Pp.map_list
+         (Pp.pp
+           (fun ~pos:_ (a, (b, (c, d))) -> (a, b, c, d))
+           (fun (a, b, c, d) -> (a, (b, (c, d)))))
+
+  end)
+
 (** (2) Part of the public repository format *)
 
 (** repository index files ("urls.txt"): table

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -386,6 +386,9 @@ end
     migrate from 1.2 repository, and for reinstall) *)
 module PkgList: IO_FILE with type t = package_set
 
+(** Cached environment updates (<switch>/environment) *)
+module Environment: IO_FILE with type t = env_update list
+
 (** Compiler version [$opam/compilers/] *)
 module Comp: sig
 

--- a/src/state/opamPath.ml
+++ b/src/state/opamPath.ml
@@ -125,6 +125,8 @@ module Switch = struct
 
   let dev_package t a name = dev_packages_dir t a / OpamPackage.Name.to_string name
 
+  let environment t a = root t a // "environment"
+
   module Default = struct
 
     (** Visible files that can be redirected using

--- a/src/state/opamPath.mli
+++ b/src/state/opamPath.mli
@@ -165,6 +165,9 @@ module Switch: sig
       $opam/$switch/packages.dev/$name.$version/} *)
   val dev_package: t -> switch -> name -> dirname
 
+  (** Cached environment updates. *)
+  val environment: t -> switch -> filename
+
   (** Locations for the visible part of the installation *)
 
   (** Default config *)

--- a/src/state/opamState.mli
+++ b/src/state/opamState.mli
@@ -177,6 +177,8 @@ val update_init_scripts: state -> global:(global_config option) -> unit
 val global_variable_names: (string * string) list
 val package_variable_names: (string * string) list
 
+val compute_env_updates: state -> env_update list
+
 (** Check for user-defined variable overwrite. *)
 val get_env_var: full_variable -> variable_contents option
 


### PR DESCRIPTION
The environment updates are cached in <root>/<switch>/environment.
It is updated whenever the <root>/<switch>/state is updated.

This might be used by external tools (e.g. opam-manager) to read the
environment updates without having to depend on `OpamState`. This might
also permit to add a "costly topological sort" when computing the
environment updates.