### PR TITLE
Fix and test the 'setenv:' field

### DIFF
--- a/doc/modules
+++ b/doc/modules
@@ -13,7 +13,8 @@ src
 │   ├── opamProcess.ml                  Process and job handling, with logs, termination status, etc.
 │   ├── opamSystem.ml                   Bindings of lots of filesystem and system operations
 │   ├── opamFilename.ml                 Higher level file and directory name manipulation AND file operations, wrappers on OpamSystem using the filename type
-│   └── opamParallel.ml                 Parallel execution of jobs following a directed graph
+│   ├── opamParallel.ml                 Parallel execution of jobs following a directed graph
+│   └── opamUrl.ml                      URL parsing and printing, with support for our different backends
 │
 ├── format                              Definition of OPAM datastructures and its file interface
 │   │   [ opam-format lib ]
@@ -70,16 +71,16 @@ src
 │
 ├── client                              Everything related to the OPAM state, installation and front-end
 │   │   [ opam-client lib ]
-│   ├── opamClientConfig.ml             Configuration options for this lib (record, global reference, setter, initialisation)
+│   ├── opamClientConfig.ml             Configuration options for this lib (record, global reference, setter, initialisation), plus helper for global setup
 │   ├── opamConfigCommand.ml            Functions for the "opam config" subcommand
 │   ├── opamPinCommand.ml               Functions for the "opam pin" subcommand
 │   ├── opamRepositoryCommand.ml        Functions for the "opam repository" subcommand
 │   ├── opamSwitchCommand.ml            Functions for the "opam switch" subcommand
 │   ├── opamClient.ml                   High-level execution of user-facing functions like "upgrade", and wrappers around the *Command modules
-│   │   [ opam exe ]
 │   ├── opamGitVersion.mli              (generated) Current git version of OPAM
-│   ├── opamArg.ml                      Command-line argument parser (opam exec only)
-│   └── opamMain.ml                     Main
+│   ├── opamArg.ml                      Command-line argument parsers and helpers
+│   │   [ opam exe ]
+│   └── opamMain.ml                     Main, including cmdliner command handling
 │
 └── tools
     │   [ opam-admin tool ]
@@ -92,6 +93,6 @@ src
     ├── opam_admin.ml                   Source of the opam-admin tool, main
     │   [ other stand-alone tools ]
     ├── opam_admin_top.ml               Tiny library for admin-scripts, included in opam-admin.top
-    ├── opam_check.ml                   Tiny tool used in internal checks
+    ├── opam_check.ml                   Tiny tool used in internal checks ("make tests")
     ├── opam_installer.ml               Handles OPAM's ".install" files
     └── opamlfind.ml                    Experimental ocamlfind wrapper tool

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -140,7 +140,7 @@ let print_fish_env env =
 
 let env ~csh ~sexp ~fish ~inplace_path =
   log "config-env";
-  let t = OpamState.load_env_state "config-env"
+  let t = OpamState.load_state "config-env"
       OpamStateConfig.(!r.current_switch) in
   let env = OpamState.get_opam_env ~force_path:(not inplace_path) t in
   if sexp then

--- a/src/core/opamConsole.mli
+++ b/src/core/opamConsole.mli
@@ -78,7 +78,7 @@ val header_error :
 
 (** Display a dynamic status line to stdout, that will be erased on next output.
     The message should not be wider than screen nor contain newlines. *)
-val status_line : ('a, out_channel, unit, unit, unit, unit) format6 -> 'a
+val status_line : ('a, unit, string, unit) format4 -> 'a
 
 (** Ask the user to press Y/y/N/n to continue (returns a boolean).
     Defaults to true (yes) if unspecified *)

--- a/src/core/opamParallel.ml
+++ b/src/core/opamParallel.ml
@@ -149,11 +149,6 @@ module Make (G : G) = struct
         | Run (cmd, cont) ->
           log "Next task in job %a: %a" (slog (string_of_int @* V.hash)) n
             (slog OpamProcess.string_of_command) cmd;
-          if OpamProcess.is_verbose_command cmd ||
-             not (OpamConsole.disp_status_line ()) then
-            OpamStd.Option.iter
-              (OpamConsole.msg "%s Command started\n")
-              (OpamProcess.text_of_command cmd);
           let p =
             if dry_run then OpamProcess.dry_run_background cmd
             else OpamProcess.run_background cmd

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1436,7 +1436,7 @@ module OPAMSyntax = struct
         (Pp.V.map_list ~depth:1 @@
          Pp.V.ident -|
          Pp.of_pair "package-flag" (pkg_flag_of_string, string_of_pkg_flag));
-      "setenv", no_cleanup Pp.ppacc with_build_env build_env
+      "setenv", no_cleanup Pp.ppacc with_env env
         (Pp.V.map_list ~depth:2 Pp.V.env_binding);
 
       "build", no_cleanup Pp.ppacc with_build build

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -224,11 +224,13 @@ endif
 
 upgrade:
 	$(CHECK) -l upgrade-1 P1.1 P2.1 P3.1~weird-version.test P4.1
+	eval `$(OPAMBIN) config env`; [ "X$$P1" = "Xversion1" ]
 	$(OPAMBIN) upgrade
 ifeq ($(REPOKIND), git)
 	$(CHECK) -l upgrade-2 P1.1 P2.1 P3.1~weird-version.test P4.3
 else
 	$(CHECK) -l upgrade-2 P1.2 P2.1 P3.1~weird-version.test P4.3
+	eval `$(OPAMBIN) config env`; [ "X$$P1" = "Xversion2" ]
 endif
 
 downgrade:

--- a/tests/packages/P1-1.opam
+++ b/tests/packages/P1-1.opam
@@ -43,3 +43,5 @@ post-messages: [ "Thanks SO MUCH for installing this humble package"
                  "Nooo, something went wrong, this makes me feel sooo sad..." {failure} ]
 
 bug-reports: "TEST.com"
+
+setenv: [P1 = "version1"]

--- a/tests/packages/P1-1/build.sh
+++ b/tests/packages/P1-1/build.sh
@@ -1,3 +1,8 @@
 #! /bin/sh -eu
 
+if [ -n "${P1:-}" ]; then
+    echo "P1 ('$P1') should not be set yet" >&2
+    exit 12
+fi
+
 ocamlbuild p1.cma p1.cmxa

--- a/tests/packages/P1-2.opam
+++ b/tests/packages/P1-2.opam
@@ -6,3 +6,4 @@ maintainer: "contact@ocamlpro.com"
 substs:     [ "P1.config" ]
 libraries:  [ "p1" ]
 build: [ "./build.sh" ]
+setenv: [P1 = "version2"]

--- a/tests/packages/P1-2/build.sh
+++ b/tests/packages/P1-2/build.sh
@@ -1,3 +1,8 @@
 #! /bin/sh -eu
 
+if [ -n "${P1:-}" ]; then
+    echo "P1 ('$P1') should not be set yet" >&2
+    exit 12
+fi
+
 ocamlbuild p1.cma p1.cmxa

--- a/tests/packages/P4/build.sh
+++ b/tests/packages/P4/build.sh
@@ -1,5 +1,17 @@
 #! /bin/sh -e
 
+if [ $OPAM_PACKAGE_VERSION -eq 2 ]; then
+    if [ "X${P1:-}" != "Xversion1" ]; then
+        echo "P1 not set to version1 while P1.1 should be installed" >&2
+        exit 12
+    fi
+else
+    if [ -z "X${P1:-}" ]; then
+        echo "P1 not set while P1 should be installed" >&2
+        exit 12
+    fi
+fi
+
 echo "Building P4 with ${OPAM}"
 LIBDIR="`${OPAM} config var lib`"
 COMP="-I ${LIBDIR}/P1 -I ${LIBDIR}/P2 -I ${LIBDIR}/P3"


### PR DESCRIPTION
It requires 'opam config env' to load the full switch state currently.
But I'm counting on @OCamlPro-Henry's PR to fix that !