### PR TITLE
Fix spurious reinstalls of pinned packages across switches

### DIFF
--- a/src/client/opamRepositoryCommand.ml
+++ b/src/client/opamRepositoryCommand.ml
@@ -404,7 +404,7 @@ let fix_package_descriptions t ~verbose =
   if verbose then print_updated_packages t updates;
 
   (* update $opam/$oversion/reinstall for all installed switches *)
-  OpamState.add_to_reinstall ~all:true t updates.changed;
+  OpamState.add_to_reinstall ~all_unpinned:true t updates.changed;
 
   updates
 

--- a/src/state/opamState.mli
+++ b/src/state/opamState.mli
@@ -351,11 +351,11 @@ val repository_of_package: state -> package -> repository option
 val repository_and_prefix_of_package:
   state -> package -> (repository * string option) option
 
-(** Add the given packages to the set of package to reinstall. If [all]
-    is set, this is done for ALL the switches (useful when a package
-    change upstream for instance). If not, only the reinstall state of the
-    current switch is changed. *)
-val add_to_reinstall: state -> all:bool -> package_set -> unit
+(** Add the given packages to the set of package to reinstall and save to disk.
+    If [all_unpinned] is set, this is done for all the switches where the
+    package is not pinned (useful when a package changed upstream for instance).
+    If not, only the reinstall state of the current switch is changed. *)
+val add_to_reinstall: state -> all_unpinned:bool -> package_set -> unit
 
 (** Return the files for a given package *)
 val copy_files: state -> package -> dirname -> unit


### PR DESCRIPTION
when a package was installed in a switch and pinned in another, 'opam update' didn't
propagate the reinstall information correctly