### PR TITLE
Expand env values earlier

### DIFF
--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -141,7 +141,9 @@ let edit t name =
     in
     match installed_nv with
     | None -> None
-    | Some nv -> Some (OpamPackage.version nv = OpamFile.OPAM.version new_opam)
+    | Some nv ->
+      OpamState.write_switch_state t;
+      Some (OpamPackage.version nv = OpamFile.OPAM.version new_opam)
 (* unused ?
 let update_set set old cur save =
   if OpamPackage.Set.mem old set then


### PR DESCRIPTION
The ~switch/environment files are thus now fully expanded. Note that if you used the latest
version that may temporarily break your opam root (if you ended up with variables in the file).
Simply remove the file to fix.