### PR TITLE
Implement a printer that preserves (some) formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,9 @@ fastlink:
 	        $(foreach e,o cmo cmx cmxs cmi cmt cmti,$(wildcard _obuild/opam-$l/*.$e)))\
 	      src/$l/;)
 	@ln -sf ../_obuild/opam-admin.top/opam-admin.top.byte src/opam-admin.top
+	@ln -sf  $(addprefix ../../,\
+	      $(foreach e,o cmo cmx cmxs cmi cmt cmti,$(wildcard _obuild/opam-admin.top/*.$e)))\
+	      src/tools/;
 
 rmartefacts: ALWAYS
 	@rm -f $(addprefix src/, opam opam-admin opam-installer opam-check)

--- a/admin-scripts/compilers-to-packages.ml
+++ b/admin-scripts/compilers-to-packages.ml
@@ -1,6 +1,7 @@
 #!/usr/bin/env opam-admin.top
 
 #directory "+../opam-lib";;
+#directory "+../re";;
 
 (**************************************************************************)
 (*                                                                        *)
@@ -20,6 +21,59 @@
 open OpamTypes
 open OpamProcess.Job.Op
 open Opam_admin_top
+;;
+
+let vars_new_1_2 = [ "compiler"; "ocaml-native"; "ocaml-native-tools";
+                     "ocaml-native-dynlink"; "arch" ]
+
+let replace_vars_str = function
+  | "compiler" -> "ocaml:compiler"
+  | "preinstalled" -> "ocaml:preinstalled"
+  | "ocaml-version" -> "ocaml:version"
+  | "ocaml-native" -> "ocaml:native"
+  | "ocaml-native-tools" -> "ocaml:native-tools"
+  | "ocaml-native-dynlink" -> "ocaml:native-dynlink"
+  | v -> v
+
+let replace_vars v = OpamVariable.of_string (replace_vars_str (OpamVariable.to_string v))
+
+let filter_string =
+  let rex =
+    Re.(compile ( seq [
+        str "%{";
+        rep (seq [opt (char '%'); opt (char '}'); diff notnl (set "}%")]);
+        str "}%";
+      ]))
+  in
+  Re_pcre.substitute ~rex ~subst:(fun s ->
+      "%{" ^ replace_vars_str (String.sub s 2 (String.length s - 4)) ^ "}%")
+
+let rec map_filter = function
+  | FIdent ([],i,df) -> FIdent ([], replace_vars i, df)
+  | FString s -> FString (filter_string s)
+  | FBool _ | FIdent _ | FUndef as f -> f
+  | FOp (f1,op,f2) -> FOp (map_filter f1, op, map_filter f2)
+  | FAnd (f1,f2) -> FAnd (map_filter f1, map_filter f2)
+  | FOr (f1,f2) -> FOr (map_filter f1, map_filter f2)
+  | FNot f -> FNot (map_filter f)
+
+let filter_vars_optlist ol =
+  List.map (fun (x, filter) -> x, OpamStd.Option.Op.(filter >>| map_filter)) ol
+
+let filter_args sl =
+  List.map
+    (fun (s, filter) ->
+       (match s with
+        | CString s -> CString (filter_string s)
+        | CIdent i -> CIdent (replace_vars_str i)),
+       OpamStd.Option.Op.(filter >>| map_filter))
+    sl
+
+let filter_vars_commands ol =
+  List.map
+    (fun (args, filter) -> filter_args args,
+                           OpamStd.Option.Op.(filter >>| map_filter))
+    ol
 ;;
 
 iter_compilers_gen @@ fun c ~prefix ~comp ~descr ->
@@ -61,12 +115,13 @@ iter_compilers_gen @@ fun c ~prefix ~comp ~descr ->
     |> O.with_build @ build
     |> O.with_maintainer @ [ "contact@ocamlpro.com" ]
     |> O.with_patches @ List.map nofilter patches
+    |> O.with_env @ OpamFile.Comp.env comp
+    |> O.with_flags @ [Pkgflag_Compiler]
   in
   (match OpamFile.Comp.src comp with
    | None -> ()
    | Some address ->
-     let adr,kind = OpamTypesBase.parse_url address in
-     let url = OpamFile.URL.create kind adr in
+     let url = OpamFile.URL.create address in
      OpamFile.URL.write (OpamRepositoryPath.url repo prefix nv) url);
   OpamFile.OPAM.write (OpamRepositoryPath.opam repo prefix nv) opam;
   OpamStd.Option.iter
@@ -89,65 +144,36 @@ iter_compilers_gen @@ fun c ~prefix ~comp ~descr ->
   comp, `Keep
 ;;
 
+module OF = OpamFile.OPAM
+;;
+
 iter_packages ~opam:(fun nv opam ->
-    let ocaml_version = OpamFile.OPAM.ocaml_version opam in
-    let ocaml_version_formula, available =
-      match ocaml_version with
-      | None ->
-        let available = OpamFile.OPAM.available opam in
-        let rec aux = function
-          | FOp (FIdent ([],var,None), op, FString v)
-            when OpamVariable.to_string var = "ocaml-version" ->
-            Atom (op, OpamPackage.Version.of_string v)
-          | FNot f ->
-            OpamFormula.neg (fun (op,v) -> OpamFormula.neg_relop op, v)
-              (aux f)
-          | FAnd (f1,f2) -> OpamFormula.ands [aux f1; aux f2]
-          | FOr (f1,f2) -> OpamFormula.ors [aux f1; aux f2]
-          | _ -> Empty
-        in
-        let ocaml_dep_formula = aux available in
-        let rec aux =
-          function
-          | FOp (FIdent ([],var,None), op, FString v)
-            when OpamVariable.to_string var = "ocaml-version" ->
-              None
-          | FNot f -> OpamStd.Option.map (fun f -> FNot f) (aux f)
-          | FAnd (f1,f2) -> (match aux f1, aux f2 with
-              | Some f1, Some f2 -> Some (FAnd (f1,f2))
-              | None, f | f, None -> f)
-          | FOr (f1,f2) -> (match aux f1, aux f2 with
-              | Some f1, Some f2 -> Some (FOr (f1,f2))
-              | None, None -> None
-              | None, f | f, None ->
-                OpamConsole.error_and_exit "Unconvertible 'available' field in %s"
-                  (OpamPackage.to_string nv))
-          | f -> Some f
-        in
-        let rem_available =
-          OpamStd.Option.default (FBool true) (aux available)
-        in
-        ocaml_dep_formula, rem_available
-      | Some f ->
-        OpamFormula.map (fun (op,v) ->
-            Atom (op, OpamPackage.Version.of_string
-                    (OpamCompiler.Version.to_string v))
-          ) f,
-        OpamFile.OPAM.available opam
-    in
-    let depends = OpamFormula.(
-        And (Atom (OpamPackage.Name.of_string "ocaml",
-                   ([],ocaml_version_formula)),
-             OpamFile.OPAM.depends opam)
-      )
-    in
-    let opam = OpamFile.OPAM.with_ocaml_version opam None in
     if OpamPackage.name_to_string nv <> "ocaml" then
-      let opam = OpamFile.OPAM.with_depends opam depends in
-      let opam = OpamFile.OPAM.with_available opam available in
+      let available = map_filter (OF.available opam) in
+      let available =
+        match OF.ocaml_version opam with
+        | None -> available
+        | Some cstr ->
+          let filter = OpamFormula.
+          OpamFormula.ands [cstr; available]
+      in
+      let opam = OpamFile.OPAM.with_ocaml_version opam OpamFormula.Empty in
+      let opam = OF.with_available opam available in
+      let opam =
+        OF.with_build opam (filter_vars_commands (OF.build opam)) in
+      let opam =
+        OF.with_install opam (filter_vars_commands (OF.install opam)) in
+      let opam =
+        OF.with_features opam
+          (List.map (fun (a,b,f) -> a, b, map_filter f) (OF.features opam)) in
+      let opam = OF.with_opam_version opam (OpamVersion.of_string "1.3") in
+      let opam = OF.with_patches opam (filter_vars_optlist (OF.patches opam)) in
+      let opam = OF.with_libraries opam (filter_vars_optlist (OF.libraries opam)) in
+      let opam = OF.with_syntax opam (filter_vars_optlist (OF.syntax opam)) in
+      let opam = OF.with_messages opam (filter_vars_optlist (OF.messages opam)) in
+      let opam = OF.with_post_messages opam (filter_vars_optlist (OF.post_messages opam)) in
       opam
     else opam)
   ()
-  (* Warning : no conversion done on the _variable_ ocaml-version *)
 ;;
 

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -372,6 +372,10 @@ module OPAM: sig
   val with_descr_opt: t -> Descr.t option -> t
   val with_url: t -> URL.t -> t
   val with_url_opt: t -> URL.t option -> t
+
+  (** Prints to a string, while keeping the format of the original file as much as possible *)
+  val to_string_with_preserved_format: filename -> t -> string
+
 end
 
 (** Compiler aliases: [$opam/aliases] *)

--- a/src/state/opamAction.ml
+++ b/src/state/opamAction.ml
@@ -278,7 +278,7 @@ let string_of_commands commands =
 *)
 
 let compilation_env t opam =
-  let env0 = OpamState.get_full_env ~opam ~force_path:true t in
+  let env0 = OpamState.get_full_env ~force_path:true t in
   let env1 = [
     ("MAKEFLAGS", "", None);
     ("MAKELEVEL", "", None);
@@ -289,7 +289,7 @@ let compilation_env t opam =
      OpamPackage.Version.to_string (OpamFile.OPAM.version opam),
      None)
   ] @ env0 in
-  OpamState.add_to_env t ~opam env1 (OpamFile.OPAM.build_env opam)
+  OpamState.add_to_env t env1 (OpamFile.OPAM.build_env opam)
 
 let update_switch_state ?installed ?installed_roots ?reinstall ?pinned t =
   let open OpamStd.Option.Op in

--- a/src/state/opamState.ml
+++ b/src/state/opamState.ml
@@ -2016,7 +2016,7 @@ let source t ~shell ?(interactive_only=false) f =
       Printf.sprintf "if tty -s >/dev/null 2>&1; then\n  %sfi\n" s
   else s
 
-let expand_env t ?opam (env: env_update list) variables : env =
+let expand_env t (env: env_update list) : env =
   List.rev_map (fun (ident, op, string, comment) ->
     let prefix = OpamFilename.Dir.to_string t.root in
     let read_env () =
@@ -2051,13 +2051,12 @@ let expand_env t ?opam (env: env_update list) variables : env =
       ident, String.concat c (cons ~head:false string (read_env())), comment
   ) env
 
-let add_to_env t ?opam (env: env) ?(variables=OpamVariable.Map.empty)
-    (updates: env_update list) =
+let add_to_env t (env: env) (updates: env_update list) =
   let env =
     List.filter (fun (k,_,_) -> List.for_all (fun (u,_,_,_) -> u <> k) updates)
       env
   in
-  env @ expand_env t ?opam updates variables
+  env @ expand_env t updates
 
 let compute_env_updates t =
   (* Todo: put these back into their packages !
@@ -2145,9 +2144,9 @@ let get_opam_env ~force_path t =
   let opamswitch = OpamStateConfig.(!r.switch_from <> `Default) in
   add_to_env t [] (env_updates ~opamswitch ~force_path t)
 
-let get_full_env ~force_path ?opam t =
+let get_full_env ~force_path t =
   let env0 = List.map (fun (v,va) -> v,va,None) (OpamStd.Env.list ()) in
-  add_to_env t ?opam env0 (env_updates ~opamswitch:true ~force_path t)
+  add_to_env t env0 (env_updates ~opamswitch:true ~force_path t)
 
 let mem_pattern_in_string ~pattern ~string =
   let pattern = Re.compile (Re.str pattern) in

--- a/src/state/opamState.mli
+++ b/src/state/opamState.mli
@@ -130,16 +130,14 @@ val universe: state -> user_action -> universe
 
 (** Get the current environment with OPAM specific additions. If [force_path],
     the PATH is modified to ensure opam dirs are leading. *)
-val get_full_env: force_path:bool -> ?opam:OpamFile.OPAM.t -> state -> env
+val get_full_env: force_path:bool -> state -> env
 
 (** Get only environment modified by OPAM. If [force_path], the PATH is modified
     to ensure opam dirs are leading. *)
 val get_opam_env: force_path:bool -> state -> env
 
 (** Update an environment. *)
-val add_to_env: state -> ?opam:OpamFile.OPAM.t -> env ->
-  ?variables:(variable_contents option) OpamVariable.Map.t ->
-  env_update list -> env
+val add_to_env: state -> env -> env_update list -> env
 
 (** Check if the shell environment is in sync with the current OPAM switch *)
 val up_to_date_env: state -> bool

--- a/src/tools/opam_admin_top.ml
+++ b/src/tools/opam_admin_top.ml
@@ -87,7 +87,9 @@ let iter_packages_gen ?(quiet=false) f =
       let changed = ref false in
       let upd () = changed := true; incr changed_files in
       if opam <> opam2 then
-        (upd (); OpamFile.OPAM.write opam_file opam2);
+        (upd ();
+         let s = OpamFile.OPAM.to_string_with_preserved_format opam_file opam2 in
+         OpamFilename.write opam_file s);
       if descr <> descr2 then
         (upd (); wopt OpamFile.Descr.write descr_file descr2);
       if url <> url2 then


### PR DESCRIPTION
It reprints unchanged fields as they were in the original file.
The new function is bound in opam-admin.top so that it makes minimal modifications.

See
- https://github.com/ocaml/opam-repository/pull/5140 
- https://github.com/ocaml/opam-repository/pull/5176
- http://lists.ocaml.org/pipermail/opam-devel/2015-November/001266.html