### PR TITLE
make cold: Fix order of PATH variable 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,6 @@ fastclean: rmartefacts
 
 cold:
 	./shell/bootstrap-ocaml.sh
-	env PATH=$$PATH:`pwd`/bootstrap/ocaml/bin ./configure $(CONFIGURE_ARGS)
-	env PATH=$$PATH:`pwd`/bootstrap/ocaml/bin $(MAKE) lib-ext
-	env PATH=$$PATH:`pwd`/bootstrap/ocaml/bin $(MAKE)
+	env PATH=`pwd`/bootstrap/ocaml/bin:$$PATH ./configure $(CONFIGURE_ARGS)
+	env PATH=`pwd`/bootstrap/ocaml/bin:$$PATH $(MAKE) lib-ext
+	env PATH=`pwd`/bootstrap/ocaml/bin:$$PATH $(MAKE)


### PR DESCRIPTION
so that local OCaml overrides any previously installed one (such as 3.11.x that is too old in CentOS 6)

Same fix needs to go into master, but this 1.2 one unblocks container builds for Travis CI