### PR TITLE
Minor simplification in OpamState.

### DIFF
--- a/src/state/opamAction.ml
+++ b/src/state/opamAction.ml
@@ -289,7 +289,7 @@ let compilation_env t opam =
      OpamPackage.Version.to_string (OpamFile.OPAM.version opam),
      None)
   ] @ env0 in
-  OpamState.add_to_env t env1 (OpamFile.OPAM.build_env opam)
+  OpamState.add_to_env ~root:t.root env1 (OpamFile.OPAM.build_env opam)
 
 let update_switch_state ?installed ?installed_roots ?reinstall ?pinned t =
   let open OpamStd.Option.Op in

--- a/src/state/opamState.mli
+++ b/src/state/opamState.mli
@@ -137,7 +137,7 @@ val get_full_env: force_path:bool -> state -> env
 val get_opam_env: force_path:bool -> state -> env
 
 (** Update an environment. *)
-val add_to_env: state -> env -> env_update list -> env
+val add_to_env: root:OpamFilename.Dir.t -> env -> env_update list -> env
 
 (** Check if the shell environment is in sync with the current OPAM switch *)
 val up_to_date_env: state -> bool


### PR DESCRIPTION
Useful for `opam-manager`. This allows to reuse `update_env` without
building a fake `OpamState.t`.