### PR TITLE
Fix Fish shell error in opamState.ml

### DIFF
--- a/src/state/opamState.ml
+++ b/src/state/opamState.ml
@@ -2002,7 +2002,7 @@ let source t ~shell ?(interactive_only=false) f =
     | `csh ->
       Printf.sprintf "source %s >& /dev/null || true\n" (file f)
     | `fish ->
-      Printf.sprintf "source %s > /dev/null 2> /dev/null or true\n" (file f)
+      Printf.sprintf "source %s > /dev/null 2> /dev/null; or true\n" (file f)
     | _ ->
       Printf.sprintf ". %s > /dev/null 2> /dev/null || true\n" (file f)
   in


### PR DESCRIPTION
In Fish, `or` is a command of its own, not a syntax element. So you need a semicolon before it to start a new command. Reference: [`fish` documentation: commands – `or`](http://fishshell.com/docs/current/commands.html#or)

This should be the last fix needed to solve https://github.com/ocaml/opam/issues/2255 – the other issues were fixed by 758c3912cd1661d116a3bca47e52c2881a95afd5 (use `source`) and c87a2802fe73e94599c1064afac72c45b7d534f6 (don’t quote array variables).