### PR TITLE
opam config exec now does not set OPAMSWITCH unless --switch or OPAMSWITCH

### DIFF
--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -220,8 +220,9 @@ let exec ~inplace_path command =
     with
     | []        -> OpamSystem.internal_error "Empty command"
     | h::_ as l -> h, Array.of_list l in
+  let opamswitch = OpamStateConfig.(!r.switch_from <> `Default) in
   let env =
     OpamTypesBase.env_array
-      (OpamState.get_full_env ~force_path:(not inplace_path) t)
+      (OpamState.get_full_env ~opamswitch ~force_path:(not inplace_path) t)
   in
   raise (OpamStd.Sys.Exec (cmd, args, env))

--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -373,7 +373,9 @@ let config =
     "Execute $(i,COMMAND) with the correct environment variables. \
      This command can be used to cross-compile between switches using \
      $(b,opam config exec --switch=SWITCH -- COMMAND ARG1 ... ARGn). \
-     Opam expansion takes place in command and args.";
+     Opam expansion takes place in command and args. If no switch is \
+     present on the command line or in the OPAMSWITCH environment \
+     variable, OPAMSWITCH is not set in $(i,COMMAND)'s environment.";
     "var", `var, ["VAR"],
     "Return the value associated with variable $(i,VAR). Package variables can \
      be accessed with the syntax $(i,pkg:var).";

--- a/src/state/opamState.ml
+++ b/src/state/opamState.ml
@@ -2143,9 +2143,9 @@ let get_opam_env ~force_path t =
   let opamswitch = OpamStateConfig.(!r.switch_from <> `Default) in
   add_to_env t [] (env_updates ~opamswitch ~force_path t)
 
-let get_full_env ~force_path t =
+let get_full_env ?(opamswitch=true) ~force_path t =
   let env0 = List.map (fun (v,va) -> v,va,None) (OpamStd.Env.list ()) in
-  add_to_env t env0 (env_updates ~opamswitch:true ~force_path t)
+  add_to_env t env0 (env_updates ~opamswitch ~force_path t)
 
 let mem_pattern_in_string ~pattern ~string =
   let pattern = Re.compile (Re.str pattern) in

--- a/src/state/opamState.mli
+++ b/src/state/opamState.mli
@@ -129,8 +129,9 @@ val universe: state -> user_action -> universe
 (** {2 Environment} *)
 
 (** Get the current environment with OPAM specific additions. If [force_path],
-    the PATH is modified to ensure opam dirs are leading. *)
-val get_full_env: force_path:bool -> state -> env
+    the PATH is modified to ensure opam dirs are leading. If [opamswitch],
+    the OPAMSWITCH environment variable is included (default true). *)
+val get_full_env: ?opamswitch:bool -> force_path:bool -> state -> env
 
 (** Get only environment modified by OPAM. If [force_path], the PATH is modified
     to ensure opam dirs are leading. *)


### PR DESCRIPTION
Previously, `opam config exec` would always set the `OPAMSWITCH` environment variable. This causes issues when running processes like shells with `opam config exec -- bash` or similar because the shell's environment is not precisely the same as the parent process's environment. In partiular, the absence of `OPAMSWITCH` was not preserved and therefore the use of interactive opam commands was more unwieldy.

Using `opam config exec` to spawn a shell is a common technique when scripting with opam in order to avoid needing to run a separate command to set up the environment in a subshell. See <http://lists.ocaml.org/pipermail/opam-devel/2016-February/001393.html>.