### PR TITLE
Backport #2444 to 1.2.x

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -962,7 +962,10 @@ let config =
     ["exec"]    , `exec    , ["[--] COMMAND"; "[ARG]..."],
     "Execute $(i,COMMAND) with the correct environment variables. \
      This command can be used to cross-compile between switches using \
-     $(b,opam config exec --switch=SWITCH -- COMMAND ARG1 ... ARGn)";
+     $(b,opam config exec --switch=SWITCH -- COMMAND ARG1 ... ARGn). \
+     If no switch is present on the command line or in the OPAMSWITCH \
+     environment variable, OPAMSWITCH is not set in $(i,COMMAND)'s \
+     environment.";
     ["var"]     , `var     , ["VAR"],
     "Return the value associated with variable $(i,VAR). Package variables can \
      be accessed with the syntax $(i,pkg:var).";

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -217,8 +217,10 @@ let exec ~inplace_path command =
     match command with
     | []        -> OpamSystem.internal_error "Empty command"
     | h::_ as l -> h, Array.of_list l in
+  let opamswitch = !OpamGlobals.switch <> `Not_set in
   let env =
-    let env = OpamState.get_full_env ~force_path:(not inplace_path) t in
+    let env =
+      OpamState.get_full_env ~opamswitch ~force_path:(not inplace_path) t in
     let env = List.rev_map (fun (k,v) -> k^"="^v) env in
     Array.of_list env in
   raise (OpamGlobals.Exec (cmd, args, env))

--- a/src/client/opamState.ml
+++ b/src/client/opamState.ml
@@ -2070,9 +2070,9 @@ let get_opam_env ~force_path t =
   let opamswitch = !OpamGlobals.switch <> `Not_set in
   add_to_env t [] (env_updates ~opamswitch ~force_path t)
 
-let get_full_env ~force_path ?opam t =
+let get_full_env ?(opamswitch=true) ~force_path ?opam t =
   let env0 = OpamMisc.env () in
-  add_to_env t ?opam env0 (env_updates ~opamswitch:true ~force_path t)
+  add_to_env t ?opam env0 (env_updates ~opamswitch ~force_path t)
 
 let mem_pattern_in_string ~pattern ~string =
   let pattern = Re.compile (Re.str pattern) in

--- a/src/client/opamState.mli
+++ b/src/client/opamState.mli
@@ -105,8 +105,9 @@ val universe: state -> user_action -> universe
 (** {2 Environment} *)
 
 (** Get the current environment with OPAM specific additions. If [force_path],
-    the PATH is modified to ensure opam dirs are leading. *)
-val get_full_env: force_path:bool -> ?opam:OpamFile.OPAM.t -> state -> env
+    the PATH is modified to ensure opam dirs are leading. If [opamswitch],
+    the OPAMSWITCH environment variable is included (default true). *)
+val get_full_env: ?opamswitch:bool -> force_path:bool -> ?opam:OpamFile.OPAM.t -> state -> env
 
 (** Get only environment modified by OPAM. If [force_path], the PATH is modified
     to ensure opam dirs are leading. *)


### PR DESCRIPTION
Previously, `opam config exec` would always set the `OPAMSWITCH` environment variable. This causes issues when running processes like shells with `opam config exec -- bash` or similar because the shell's environment is not precisely the same as the parent process's environment. In partiular, the absence of `OPAMSWITCH` was not preserved and therefore the use of interactive opam commands was more unwieldy.

(cherry picked from commit a19c1384177c6080f21516e674929cabbcf34565 submitted as #2444)