### PR TITLE
Add automatic fallbacks using backup-urls

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+1.3.0
+* New field 'backup-urls' can be set to a list of URLs providing archive
+  mirroring by hash, in case a link to an archive is dead. Currently, such
+  a service is provided by "http://opam.ocamlpro.com/backup"
+
 1.2.2
 * Fixed wrong locks being taken during `switch reinstall` (#2051)
 * Fixed `config report` that wasn't displaying the external solver (#2059)

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -797,6 +797,7 @@ module ConfigSyntax = struct
     dl_jobs : int;
     solver_criteria : (solver_criteria * string) list;
     solver : arg list option;
+    backup_urls : string list;
   }
 
   let opam_version t = t.opam_version
@@ -804,6 +805,7 @@ module ConfigSyntax = struct
   let switch t = t.switch
   let jobs t = t.jobs
   let dl_tool t = t.dl_tool
+  let backup_urls t = t.backup_urls
   let dl_jobs t = t.dl_jobs
   let criteria t = t.solver_criteria
   let criterion kind t =
@@ -815,6 +817,7 @@ module ConfigSyntax = struct
   let with_repositories t repositories = { t with repositories }
   let with_switch t switch = { t with switch }
   let with_jobs t jobs = { t with jobs }
+  let with_backup_urls t backup_urls = { t with backup_urls }
   let with_dl_tool t dl_tool = { t with dl_tool = Some dl_tool }
   let with_dl_jobs t dl_jobs = { t with dl_jobs }
   let with_criteria t solver_criteria = { t with solver_criteria }
@@ -823,10 +826,13 @@ module ConfigSyntax = struct
                (kind,criterion)::List.remove_assoc kind t.solver_criteria }
   let with_solver t solver = { t with solver = Some solver }
 
+  let backup_url_ocamlpro = "http://opam.ocamlpro.com/backup"
+
   let create switch repositories ?(criteria=[]) ?solver jobs ?download_tool dl_jobs =
     { opam_version = OpamVersion.current;
       repositories ; switch ; jobs ; dl_tool = download_tool; dl_jobs ;
-      solver_criteria = criteria; solver }
+      solver_criteria = criteria; solver;
+      backup_urls = [backup_url_ocamlpro] }
 
   let empty = {
     opam_version = OpamVersion.current;
@@ -837,6 +843,7 @@ module ConfigSyntax = struct
     dl_jobs = 1;
     solver_criteria = [];
     solver = None;
+    backup_urls = [backup_url_ocamlpro];
   }
 
   let fields =
@@ -874,6 +881,9 @@ module ConfigSyntax = struct
       "solver-fixup-criteria", Pp.ppacc_opt
         (with_criterion `Fixup) (criterion `Fixup)
         Pp.V.string;
+      "backup-urls", Pp.ppacc
+        with_backup_urls backup_urls
+        (Pp.V.map_list ~depth:1 Pp.V.string);
       "solver", Pp.ppacc_opt
         with_solver solver
         (Pp.V.map_list ~depth:1 Pp.V.arg);

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -826,13 +826,11 @@ module ConfigSyntax = struct
                (kind,criterion)::List.remove_assoc kind t.solver_criteria }
   let with_solver t solver = { t with solver = Some solver }
 
-  let backup_url_ocamlpro = "http://opam.ocamlpro.com/backup"
-
   let create switch repositories ?(criteria=[]) ?solver jobs ?download_tool dl_jobs =
     { opam_version = OpamVersion.current;
       repositories ; switch ; jobs ; dl_tool = download_tool; dl_jobs ;
       solver_criteria = criteria; solver;
-      backup_urls = [backup_url_ocamlpro] }
+      backup_urls = [] }
 
   let empty = {
     opam_version = OpamVersion.current;
@@ -843,7 +841,7 @@ module ConfigSyntax = struct
     dl_jobs = 1;
     solver_criteria = [];
     solver = None;
-    backup_urls = [backup_url_ocamlpro];
+    backup_urls = [];
   }
 
   let fields =

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -92,6 +92,10 @@ module Config: sig
 
   val dl_tool: t -> arg list option
 
+ (* Field "backup-urls": a list of urls from which it is possible
+    to download by checksum, i.e. $URL/9/a/b/9ab48749e8201... *)
+  val backup_urls: t -> string list
+
   (** Return the number of download jobs *)
   val dl_jobs: t -> int
 

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -61,10 +61,12 @@ let pull_url package local_dirname checksum remote_url =
   let rec attempt = function
     | [] -> assert false
     | [url] -> pull url
-    | url::mirrors ->
+    | url:: (mirror :: _ as mirrors) ->
       pull url @@+ function
       | Not_available s ->
-        OpamConsole.warning "download of %s failed, trying mirror" s;
+        OpamConsole.warning "download of %s at %s failed, trying mirror %s"
+          (OpamPackage.to_string package) s
+          (OpamUrl.to_string mirror);
         attempt mirrors
       | r -> Done r
   in


### PR DESCRIPTION
This PR provides a solution to the problem of archives becoming unavailable (because the site is down, or because the compression algorithm changed). It is based on looking up archives, on failure, from a configuration parameter called `backup-urls`, that is initially initialized to OCamlPro's backup of archives (http://opam.ocamlpro.com/backup).

Initial configuration:
backup-urls: [ "http://opam.ocamlpro.com/backup" ]

Disabling the feature:
backup-urls: []
