### PR TITLE
Set OPAM_COLUMNS to force the formatting line length

### DIFF
--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -504,7 +504,9 @@ module OpamSys = struct
   let tty_out = Unix.isatty Unix.stdout
 
   let default_columns =
-    try int_of_string (Sys.getenv "COLUMNS") with _ -> 80
+    try int_of_string (Env.get "COLUMNS") with
+    | Not_found
+    | Failure _ -> 80
 
   let get_terminal_columns () =
     try (* terminfo *)

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -503,7 +503,8 @@ module OpamSys = struct
 
   let tty_out = Unix.isatty Unix.stdout
 
-  let default_columns = 80
+  let default_columns =
+    try int_of_string (Sys.getenv "COLUMNS") with _ -> 80
 
   let get_terminal_columns () =
     try (* terminfo *)
@@ -518,9 +519,6 @@ module OpamSys = struct
              | _ -> failwith "stty")
       with
         Unix.Unix_error _ | Sys_error _ | Failure _  | End_of_file | Not_found ->
-        try (* shell envvar *)
-          int_of_string (Env.get "COLUMNS")
-        with Not_found | Failure _ ->
           default_columns
 
   let terminal_columns =


### PR DESCRIPTION
Useful to be able to parse the output of `opam lint`: setting a high-value will print each warning/error on a different line, by preventing the formatter from adding line breaks.
