### PR TITLE
add support for displaying active switch in prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ config.status
 src/client/opamGitVersion.ml
 src/state/opamScript.ml
 src/core/opamVersion.ml
+src/core/opamScript.ml
 src/format/opamLexer.ml
 src/format/opamLineLexer.ml
 src/format/opamParser.ml

--- a/shell/opam_prompt.sh
+++ b/shell/opam_prompt.sh
@@ -19,7 +19,7 @@ __opam_ps1()
         ;;
     esac
 
-    local switch_name="$(opam switch show 2>/dev/null)"
+    local switch_name="$(opam switch show --safe 2>/dev/null)"
     if [ -z "$switch_name" ]; then
         return $exit
     fi

--- a/shell/opam_prompt.sh
+++ b/shell/opam_prompt.sh
@@ -1,0 +1,28 @@
+# This script allows you to see the active opam switch in your prompt. It
+# should be portable across all shells in common use.
+#
+# To enable, change your PS1 to call _opam_ps1 using command substitution. For
+# example, in bash:
+#
+#     PS1="$(__opam_ps1 "(%s)")\u@\h:\w\$ "
+#
+
+__opam_ps1()
+{
+    local exit=$?
+    local printf_format='(%s)'
+
+    case "$#" in
+        0|1)    printf_format="${1:-$printf_format}"
+        ;;
+        *)  return $exit
+        ;;
+    esac
+
+    local switch_name="$(opam switch show 2>/dev/null)"
+    if [ -z "$switch_name" ]; then
+        return $exit
+    fi
+    printf -- "$printf_format" "$switch_name"
+    return $exit
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -95,6 +95,7 @@ state/opamScript.ml: ../shell core/opamVersion.ml
 	ocaml ../shell/crunch.ml "complete"     < ../shell/opam_completion.sh > $@
 	ocaml ../shell/crunch.ml "complete_zsh" < ../shell/opam_completion_zsh.sh >> $@
 	ocaml ../shell/crunch.ml "switch_eval"  < ../shell/opam_switch_eval.sh >> $@
+	ocaml ../shell/crunch.ml "prompt"       < ../shell/opam_prompt.sh >> $@
 
 ifeq ($(OCAML_4_02),true)
   COMPATV = 4.02

--- a/src/state/opamScript.mli
+++ b/src/state/opamScript.mli
@@ -17,3 +17,4 @@
 val complete : string
 val complete_zsh : string
 val switch_eval : string
+val prompt : string


### PR DESCRIPTION
This pull request modifies the opam installation process put in place a shell function&mdash;namely `__opam_ps1`&mdash;that a user can use to display the currently active opam switch in his shell prompt.

Note that as is, the code does not actually modify the user's shell prompt. The user must explicitly modify a shell configuration file to utilize the function. To place the current opam switch at the beginning of the prompt, the user would defined `PS1` as follows:

```
PS1="$(__opam_ps1 "%s")\u@\h:\w\$"
```
This would result in the following prompt:

```
(system)user@host:~$
```

... where `system` indicates the default system switch is active. If another switch is selected, that part of the prompt would change appropriately.