### PR TITLE
Fix warning 41

### DIFF
--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -2000,7 +2000,7 @@ module OPAM = struct
            (fun acc v ->
               match OpamVariable.Full.package v with
               | Some n when
-                  t.name = Some n &&
+                  t.name <> Some n &&
                   not (OpamPackage.Name.Set.mem n all_depends) ->
                 OpamPackage.Name.Set.add n acc
               | _ -> acc)


### PR DESCRIPTION
Witthout the fix, the comparison prints the warning only for packages which are using a reference to themselves (and obviously, their own name is not in the depends). Currently, it is only "bat"...