### PR TITLE
Fix off-by-one in state backup timestamp

### DIFF
--- a/src/state/opamPath.ml
+++ b/src/state/opamPath.ml
@@ -77,7 +77,7 @@ let backup_file =
   let file = lazy Unix.(
       let tm = gmtime (Unix.gettimeofday ()) in
       Printf.sprintf "state-%04d%02d%02d%02d%02d%02d.export"
-        (tm.tm_year+1900) tm.tm_mon tm.tm_mday tm.tm_hour tm.tm_min tm.tm_sec
+        (tm.tm_year+1900) (tm.tm_mon+1) tm.tm_mday tm.tm_hour tm.tm_min tm.tm_sec
     ) in
   fun () -> Lazy.force file
 


### PR DESCRIPTION
The `Unix.tm_mon` is a zero-based month and so should be incremented when using as a human-readable month.

```
$ opam install ...
...
The former state can be restored with opam switch import "/home/simonbe/.opam/4.02.2/backup/state-20160301102642.export"
$ date
Fri Apr  1 10:49:39 UTC 2016
```

The month should be 04, not 03. No, this is not an April fools commit :)

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>