### PR TITLE
Update basic guide to recommend ocaml 4.02.3 instead of 4.02.1

### DIFF
--- a/doc/pages/Usage.md
+++ b/doc/pages/Usage.md
@@ -21,8 +21,8 @@ details.
 ```
 # ** Get started **
 opam init            # Initialize ~/.opam using an already installed OCaml
-opam init --comp 4.02.1
-                     # Initialize with a freshly compiled OCaml 4.02.1
+opam init --comp 4.02.3
+                     # Initialize with a freshly compiled OCaml 4.02.3
 
 # ** Lookup **
 opam list -a         # List all available packages


### PR DESCRIPTION
The current basic usage guide uses ocaml 4.02.1. It is confusing for newcomers as you can see [here](http://irclog.whitequark.org/ocaml/2016-04-02#1459592018-1459592392;).