### PR TITLE
add back pef/opam export functions

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -7,8 +7,7 @@ version = @PACKAGE_VERSION@
 FETCH = @fetch@
 HAS_PACKAGES = @hasalldeps@
 USE_BYTE := $(if $(subst no,,@OCAMLOPT@),,true)
-
-PACKS = @OCAML_PKG_unix@ @OCAML_PKG_extlib@ @OCAML_PKG_re@ @OCAML_PKG_re_str@ @OCAML_PKG_re_pcre@ @OCAML_PKG_re_glob@ @OCAML_PKG_cmdliner@ @OCAML_PKG_ocamlgraph@ @OCAML_PKG_cudf@ @OCAML_PKG_dose3_common@ @OCAML_PKG_dose3_algo@ @OCAML_PKG_jsonm@
+PACKS = @OCAML_PKG_unix@ @OCAML_PKG_extlib@ @OCAML_PKG_re@ @OCAML_PKG_re_str@ @OCAML_PKG_re_pcre@ @OCAML_PKG_re_glob@ @OCAML_PKG_cmdliner@ @OCAML_PKG_ocamlgraph@ @OCAML_PKG_cudf@ @OCAML_PKG_dose3@ @OCAML_PKG_jsonm@
 
 OCAMLFIND = @OCAMLFIND@
 OCAML = @OCAML@

--- a/configure
+++ b/configure
@@ -587,8 +587,7 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 hasalldeps
 OCAML_PKG_jsonm
-OCAML_PKG_dose3_algo
-OCAML_PKG_dose3_common
+OCAML_PKG_dose3
 OCAML_PKG_cudf
 OCAML_PKG_ocamlgraph
 OCAML_PKG_cmdliner
@@ -4386,17 +4385,17 @@ $as_echo "not found" >&6; }
 
 
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for OCaml findlib package dose3.common" >&5
-$as_echo_n "checking for OCaml findlib package dose3.common... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for OCaml findlib package dose3" >&5
+$as_echo_n "checking for OCaml findlib package dose3... " >&6; }
 
   unset found
   unset pkg
   found=no
-  for pkg in dose3.common dose.common ; do
+  for pkg in dose3  ; do
     if $OCAMLFIND query $pkg >/dev/null 2>/dev/null; then
       { $as_echo "$as_me:${as_lineno-$LINENO}: result: found" >&5
 $as_echo "found" >&6; }
-      OCAML_PKG_dose3_common=$pkg
+      OCAML_PKG_dose3=$pkg
       found=yes
       break
     fi
@@ -4404,31 +4403,7 @@ $as_echo "found" >&6; }
   if test "$found" = "no" ; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
 $as_echo "not found" >&6; }
-    OCAML_PKG_dose3_common=no
-  fi
-
-
-
-
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for OCaml findlib package dose3.algo" >&5
-$as_echo_n "checking for OCaml findlib package dose3.algo... " >&6; }
-
-  unset found
-  unset pkg
-  found=no
-  for pkg in dose3.algo dose.algo ; do
-    if $OCAMLFIND query $pkg >/dev/null 2>/dev/null; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: found" >&5
-$as_echo "found" >&6; }
-      OCAML_PKG_dose3_algo=$pkg
-      found=yes
-      break
-    fi
-  done
-  if test "$found" = "no" ; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
-$as_echo "not found" >&6; }
-    OCAML_PKG_dose3_algo=no
+    OCAML_PKG_dose3=no
   fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -64,8 +64,7 @@ AC_CHECK_OCAML_PKG([re.glob])
 AC_CHECK_OCAML_PKG([cmdliner])
 AC_CHECK_OCAML_PKG([ocamlgraph])
 AC_CHECK_OCAML_PKG([cudf])
-AC_CHECK_OCAML_PKG(dose3.common,dose.common)
-AC_CHECK_OCAML_PKG(dose3.algo,dose.algo)
+AC_CHECK_OCAML_PKG([dose3])
 AC_CHECK_OCAML_PKG([jsonm])
 
 dnl echo

--- a/src/Makefile
+++ b/src/Makefile
@@ -35,7 +35,7 @@ endif
 
 ifneq ($(HAS_LIBEXT),)
   EXT_INCDIRS = ../src_ext/lib
-  LIBS = unix extlib re cmdliner graph cudf dose_common dose_algo uutf jsonm
+  LIBS = unix extlib re cmdliner graph cudf dose_common dose_algo dose_opam dose_versioning uutf jsonm
 else
   ifeq ($(HAS_PACKAGES),)
     $(error Dependencies missing. Either run 'make lib-ext' or install them and re-run './configure')
@@ -206,7 +206,8 @@ SRC_state = \
   opamSwitchAction.ml \
   opamUpdate.ml \
   opamAction.ml \
-  opamSolution.ml
+  opamSolution.ml \
+  opamPef.ml
 
 define PROJ_state
   SOURCES = $(call addmli,state,$(SRC_state))

--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -527,17 +527,13 @@ let config =
     | Some `subst, (_::_ as files) ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
       `Ok (OpamConfigCommand.subst gt (List.map OpamFilename.Base.of_string files))
-    | Some `pef, _params ->
-      failwith "!X todo"
-(*
-      let opam_state = OpamSwitchState.load_full_compat "config-universe"
-          (OpamStateConfig.get_switch ()) in
-      let dump oc = OpamState.dump_state opam_state oc in
+    | Some `pef, params ->
+      OpamGlobalState.with_ `Lock_none @@ fun gt ->
+      let dump oc = OpamPef.dump gt oc in
       (match params with
        | [] -> `Ok (dump stdout)
        | [file] -> let oc = open_out file in dump oc; close_out oc; `Ok ()
        | _ -> bad_subcommand commands ("config", command, params))
-*)
     | Some `cudf, params ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
       OpamSwitchState.with_ `Lock_none gt @@ fun opam_state ->

--- a/src/solver/solver.ocp
+++ b/src/solver/solver.ocp
@@ -9,8 +9,7 @@ begin library "opam-solver"
   ]
 
   requires = [
-    "dose3.common"
-    "dose3.algo"
+    "dose3"
     "opam-core"
     "opam-format"
   ]

--- a/src/state/opamPef.ml
+++ b/src/state/opamPef.ml
@@ -1,0 +1,301 @@
+open OpamTypes
+open OpamStd.Op
+open OpamPackage.Set.Op
+  
+let log fmt = OpamConsole.log "PEF" fmt
+let slog = OpamConsole.slog
+    
+open OpamStateTypes
+
+let string_of_atom = function
+  |(n,None,[]) -> OpamPackage.Name.to_string n
+  |(n,None,fl) -> 
+      Printf.sprintf "%s <%s>"
+        (OpamPackage.Name.to_string n)
+        (String.concat "," fl)
+  |(n,Some (op,v),[]) ->
+      Printf.sprintf "%s (%s %s)"
+        (OpamPackage.Name.to_string n)
+        (OpamFormula.string_of_relop op) 
+        (OpamPackage.Version.to_string v)
+  |(n,Some (op,v),fl) ->
+      Printf.sprintf "%s (%s %s) <%s>"
+        (OpamPackage.Name.to_string n)
+        (OpamFormula.string_of_relop op)
+        (OpamPackage.Version.to_string v)
+        (String.concat "," fl)
+
+let string_of_cnf string_of_atom cnf =
+  let string_of_clause c =
+    Printf.sprintf "%s" (OpamStd.List.concat_map " | " string_of_atom (List.rev c)) in
+  Printf.sprintf "%s" (OpamStd.List.concat_map " , " string_of_clause (List.rev cnf))
+
+let string_of_conjunction string_of_atom c =
+  Printf.sprintf "%s" (OpamStd.List.concat_map " , " string_of_atom (List.rev c))
+
+(* true if the opam package is available on the given switch *)
+let available_filter gt opam switch =
+  let switch_config = OpamSwitchState.load_switch_config gt switch in
+  let switch_global = (gt :> unlocked global_state) in
+  OpamFilter.eval_to_bool ~default:false
+  (OpamPackageVar.resolve_switch_raw
+     switch_global switch switch_config)
+  (OpamFile.OPAM.available opam)
+
+let pef_package ?(orphans=OpamPackage.Set.empty) switches gt =
+  (* could be done all at once *)
+  let all_opams =
+    List.fold_left (fun acc switch ->
+      OpamSwitchState.with_ `Lock_none gt ~switch @@ fun st ->
+	  (* The same package in two switches ? *)
+	  OpamPackage.Map.union (fun a _ -> a) st.opams acc
+    ) OpamPackage.Map.empty switches
+  in
+  let all_pinned =
+    List.fold_left (fun acc switch ->
+      OpamSwitchState.with_ `Lock_none gt ~switch @@ fun st ->
+	  OpamSwitch.Map.add switch st.pinned acc
+    ) OpamSwitch.Map.empty switches
+  in
+  let all_installed = 
+    List.fold_left (fun acc switch ->
+      OpamSwitchState.with_ `Lock_none gt ~switch @@ fun st ->
+	  OpamSwitch.Map.add switch st.installed acc
+    ) OpamSwitch.Map.empty switches
+  in
+  let all_reinstall = 
+    List.fold_left (fun acc switch ->
+      OpamSwitchState.with_ `Lock_none gt ~switch @@ fun st ->
+	  OpamSwitch.Map.add switch st.reinstall acc
+    ) OpamSwitch.Map.empty switches
+  in
+  let all_compiler_packages = 
+    List.fold_left (fun acc switch ->
+      OpamSwitchState.with_ `Lock_none gt ~switch @@ fun st ->
+	  OpamSwitch.Map.add switch st.compiler_packages acc
+    ) OpamSwitch.Map.empty switches
+  in
+
+  let depends   = OpamPackage.Map.map OpamFile.OPAM.depends all_opams in
+  let depopts   = OpamPackage.Map.map OpamFile.OPAM.depopts all_opams in
+  let conflicts = OpamPackage.Map.map OpamFile.OPAM.conflicts all_opams in
+  let maintainers = OpamPackage.Map.map OpamFile.OPAM.maintainer all_opams in
+  let to_dnf t =
+    let rec and_formula acc = function
+	| Atom c -> (c::acc)
+	| And(x,y) -> and_formula (and_formula acc y) x
+	| Empty | Block _ | Or _ -> assert false
+    in
+    let rec aux acc = function
+	| Empty   -> acc
+	| Block _ -> assert false
+      | (Atom _ | And _) as t -> (and_formula [] t)::acc
+	| Or(x,y) -> aux (aux acc y) x
+    in
+    aux [] (OpamFormula.dnf_of_formula t)
+  in
+  let to_cnf t =
+    let rec or_formula acc = function
+	| Atom c -> (c::acc)
+      | Or(x,y) -> or_formula ((or_formula acc y)) x
+	| Empty | Block _ | And _ -> assert false
+    in
+    let rec aux acc = function
+	| Empty    -> acc
+	| Block _  -> assert false
+      | (Atom _ | Or _ ) as t -> (or_formula [] t)::acc
+      | And(x,y) -> aux (aux acc y) x
+    in
+    aux [] (OpamFormula.cnf_of_formula t)
+  in
+  let formula_of_filtered f =
+    let aux n f =
+      let dnf_l =
+        to_dnf (
+          OpamFormula.map (function
+            |Constraint c -> Atom (Some c,None)
+            |Filter flt -> Atom (None,Some (OpamFilter.to_string flt))
+          ) f
+        )
+      in
+      OpamFormula.ands (
+        List.map (fun l ->
+          let flt =
+            List.fold_left (fun acc -> function
+              |(None,Some fl) -> fl::acc
+              |_ -> acc
+            ) [] l
+          in
+          OpamFormula.ors (
+            OpamStd.List.filter_map (function
+              |(None,Some f) when List.length l > 1 -> (
+                (* Group constraints of the form ocamlfind <build>,ocamlfind (>= 1.3.1) <build> 
+                 * into ocamlfind (>= 1.3.1) <build> *)
+                (*
+                Printf.eprintf "-> %s\n" (string_of_atom (n,None,[f]));
+                Printf.eprintf "%s\n" (String.concat "," (List.map (function (c,_) -> string_of_atom (n,c,flt)) l));
+                *)
+                None 
+              )
+              |(c,_) -> Some (Atom (c,flt))
+            ) l
+          )
+        ) dnf_l
+      )
+    in
+    List.rev (
+      to_cnf (
+        OpamFormula.map (fun (n,c) ->
+          match aux n c with
+          |Empty | Block _ -> (
+            (*
+              Printf.eprintf "xxx-> %s\n" (string_of_atom (n,None,[]));
+            *)
+              Atom (n,None,[])
+          )
+          |ff -> OpamFormula.map (fun (cs,s) -> Atom (n,cs,s)) ff
+        ) f
+      )
+    )
+  in
+  let aux switches gt package =
+    let opam =  OpamPackage.Map.find package all_opams in
+    let available =
+      match List.filter (available_filter gt opam) switches with
+      |[] -> None
+      |l -> Some("switch",(String.concat ", " (List.map OpamSwitch.to_string l)))
+    in
+    match available with
+    |None -> None
+    |Some _ -> 
+      let name = Some("package",(OpamPackage.name_to_string package)) in
+      let version = Some("version",(OpamPackage.version_to_string package)) in
+      let maintainer =
+        try
+          let m = OpamPackage.Map.find package maintainers in
+          Some("maintainer",(string_of_conjunction (fun a -> a) m))
+        with Not_found -> None
+      in
+      let depends =
+        try
+          let d = OpamPackage.Map.find package depends in
+          let dd = formula_of_filtered d in
+          Some ("depends", string_of_cnf string_of_atom dd)
+        with Not_found -> None
+      in
+      let depopts =
+        try
+          let d = OpamPackage.Map.find package depopts in
+          let dd = formula_of_filtered d in
+          Some ("depopts", string_of_cnf string_of_atom dd)
+        with Not_found -> None
+      in
+      let conflicts =
+        try
+          let c = OpamPackage.Map.find package conflicts in
+          let n = OpamPackage.name package in
+          let cc = (n,None)::(OpamFormula.to_disjunction c) in
+          Some("conflicts", string_of_conjunction OpamFormula.string_of_atom cc)
+        with Not_found -> None
+      in
+      let pinned =
+        let l =
+          List.fold_left (fun acc switch ->
+            let pinned = OpamSwitch.Map.find switch all_pinned in
+            if OpamPackage.Set.mem package pinned then
+              (OpamSwitch.to_string switch) :: acc
+            else acc
+          ) [] switches
+        in
+        match l with
+        |[] -> None
+        |l -> Some("pinned",String.concat ", " l)
+      in
+      let installed =
+        let l =
+          List.fold_left (fun acc switch ->
+            let installed = OpamSwitch.Map.find switch all_installed in
+            if OpamPackage.Set.mem package installed then
+              (OpamSwitch.to_string switch) :: acc
+            else acc
+          ) [] switches
+        in
+        match l with
+        |[] -> None
+        |l -> Some("installed",String.concat ", " l)
+      in
+      let reinstall =
+        let l =
+          List.fold_left (fun acc switch ->
+            let reinstall = OpamSwitch.Map.find switch all_reinstall in
+            if OpamPackage.Set.mem package reinstall then
+              (OpamSwitch.to_string switch) :: acc
+            else acc
+          ) [] switches
+        in
+        match l with
+        |[] -> None
+        |l -> Some("reinstall",String.concat ", " l)
+      in
+      let base =
+        let l =
+          List.fold_left (fun acc switch ->
+            let compiler_packages = OpamSwitch.Map.find switch all_compiler_packages in
+            if OpamPackage.Set.mem package compiler_packages then
+              (OpamSwitch.to_string switch) :: acc
+            else acc
+          ) [] switches
+        in
+        match l with
+        |[] -> None
+        |l -> Some("base",String.concat ", " l)
+      in
+      Some (
+        List.fold_left (fun acc -> function
+          |None -> acc
+          |Some (k,v) -> (k,(Common.Format822.dummy_loc,v))::acc
+        ) [] [name;version;maintainer;available;installed;pinned;base;depends;depopts;conflicts;reinstall]
+      )
+  in
+  let s =
+    List.fold_left (fun acc switch ->
+      OpamSwitchState.with_ `Lock_none gt ~switch @@ fun st ->
+        OpamPackage.Set.union (st.packages ++ st.installed) acc
+    ) orphans switches
+  in
+  OpamPackage.Set.fold (fun p l ->
+    match aux switches gt p with
+    |None -> l
+    |Some par -> par::l
+  ) s []
+;;
+
+let dump gt oc =
+  let switches = OpamFile.Config.installed_switches gt.config in
+  List.iter (fun par ->
+    List.iter (fun (k,(_,v)) -> Printf.fprintf oc "%s: %s\n" k v) (List.rev par);
+    Printf.fprintf oc "\n"
+  ) (pef_package switches gt)
+
+let pef_packagelist ?(profiles=[]) switches st =
+  let switch = OpamSwitch.to_string st.switch in
+  let options = (switch,List.map OpamSwitch.to_string switches,profiles) in
+  (* parse_string here is wrong ... It should parse the list XXX *)
+  let extras = [("reinstall",Some (Pef.Packages.parse_s Pef.Packages.parse_string))] in 
+  List.fold_left (fun acc par ->
+    match Opam.Packages.parse_package_stanza options ~extras par with
+    |Some pkg -> pkg::acc
+    |None -> acc
+  ) [] (pef_package switches st.switch_global)
+
+let pef_packageuniv ?(orphans=OpamPackage.Set.empty) ?(profiles=[]) switches st =
+  let switch = OpamSwitch.to_string st.switch in
+  let options = (switch,List.map OpamSwitch.to_string switches,profiles) in
+  let extras = [("reinstall",Some (Pef.Packages.parse_s Pef.Packages.parse_string))] in 
+  let h = Hashtbl.create 1024 in
+  List.iter (fun par ->
+    match Opam.Packages.parse_package_stanza options ~extras par with
+    |Some pkg -> Hashtbl.add h (pkg#name,pkg#version) pkg
+    |None -> ()
+  ) (pef_package ~orphans switches st.switch_global);
+  h

--- a/src/state/opamPef.mli
+++ b/src/state/opamPef.mli
@@ -1,0 +1,20 @@
+
+open OpamTypes
+open OpamStateTypes
+
+(** dump the pef universe *)
+val dump : unlocked global_state -> out_channel -> unit
+
+(** transform an opam univese into a list of 822 stanzas *)
+val pef_package : ?orphans:package_set -> OpamTypes.switch list ->
+  unlocked global_state -> Common.Format822.doc
+
+(** transform a list of 822 stanzas into a list of dose3/opam packages *)
+val pef_packagelist: ?profiles: string list -> 
+  OpamTypes.switch list -> unlocked switch_state -> Opam.Packages.package list
+
+(** transform a list of 822 stanzas into a hashtable of dose3/opam packages 
+    indexed by their (name,version) *)
+val pef_packageuniv: ?orphans: package_set -> ?profiles: string list -> 
+  OpamTypes.switch list  -> unlocked switch_state -> 
+    (Pef.Packages_types.name * Pef.Packages_types.version, Opam.Packages.package) Hashtbl.t

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -37,6 +37,7 @@ val with_:
   [< unlocked ] global_state ->
   ('a switch_state -> 'b) -> 'b
 
+val load_switch_config: 'a global_state -> switch -> OpamFile.Dot_config.t
 (** Creates a virtual state with all package available and nothing installed.
     Useful for querying and simulating actions when no switch is yet
     configured *)


### PR DESCRIPTION
Fix "opam config pef-universe" .

We add a new module opamPef.ml to export the opam universe to the pef/opam form of dose3.
I've also added a couple more of functions that are going to be used later to replace the 
opam -> cudf routines . 

Since the pef/opam format of dose3 needs two new modules dose3.versioning and dose3.opam, I've added all dose modules at onces in the Makefile / configure script.

This functionality is needed to the opam weather running at http://ows.irill.org