### PR TITLE
Allow version references in the 'depends' and 'depopts' fields

### DIFF
--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -160,7 +160,8 @@ let expand gt str =
   log "config-expand";
   OpamSwitchState.with_ `Lock_none gt @@ fun st ->
   OpamConsole.msg "%s\n"
-    (OpamFilter.expand_string ~default:"" (OpamPackageVar.resolve st) str)
+    (OpamFilter.expand_string ~default:(fun _ -> "")
+       (OpamPackageVar.resolve st) str)
 
 let set var value =
   if not (OpamVariable.Full.is_global var) then
@@ -224,7 +225,7 @@ let exec gt ~inplace_path command =
   OpamSwitchState.with_ `Lock_none gt @@ fun st ->
   let cmd, args =
     match
-      List.map (OpamFilter.expand_string ~default:""
+      List.map (OpamFilter.expand_string ~default:(fun _ -> "")
                   (OpamPackageVar.resolve st)) command
     with
     | []        -> OpamSystem.internal_error "Empty command"

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -303,7 +303,7 @@ let version_color st nv =
   let is_available nv = (* Ignore unavailability due to pinning *)
     try
       OpamFilter.eval_to_bool ~default:false
-        (OpamPackageVar.resolve_switch_raw st.switch_global
+        (OpamPackageVar.resolve_switch_raw ~package:nv st.switch_global
            st.switch st.switch_config)
         (OpamFile.OPAM.available (OpamSwitchState.opam st nv))
     with Not_found -> false

--- a/src/client/opamListCommand.mli
+++ b/src/client/opamListCommand.mli
@@ -89,6 +89,7 @@ val default_list_format: output_format list
 (** Outputs a list of packages as a table according to the formatting options *)
 val display:
   'a switch_state ->
+  header:bool ->
   format:output_format list ->
   dependency_order:bool ->
   all_versions:bool ->

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -111,7 +111,9 @@ let copy_files st opam =
 let edit_raw name temp_file =
   let rec edit () =
     if OpamStd.Sys.tty_in then
-      (OpamConsole.msg "Press enter to start the editor... ";
+      (OpamConsole.msg "Press enter to start \"%s\" (this can be customised by \
+                        setting EDITOR or OPAMEDITOR)... "
+         (Filename.basename OpamClientConfig.(!r.editor));
        ignore (read_line ()));
     let edited_ok =
       try
@@ -167,6 +169,7 @@ let edit_raw name temp_file =
         else edit ()
     with e ->
       OpamStd.Exn.fatal e;
+      log "Editing error: %s" (Printexc.to_string e);
       if OpamConsole.confirm "Errors in %s, retry editing ?"
           (OpamFile.to_string temp_file)
       then edit ()

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -647,7 +647,8 @@ let rec flock_update
        OpamConsole.formatted_msg
          "Another process has locked %s, waiting (C-c to abort)... "
          file;
-       Unix.lockf fd (unix_lock_op ~dontblock:false flag) 0;
+       (try Unix.lockf fd (unix_lock_op ~dontblock:false flag) 0;
+        with Sys.Break as e -> OpamConsole.msg "\n"; raise e);
        OpamConsole.msg "lock acquired.\n");
     lock.kind <- (flag :> lock_flag)
   | _ -> assert false

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1937,21 +1937,21 @@ module OPAMSyntax = struct
     Pp.pp parse (fun x -> x)
 
   (* Doesn't handle package name encoded in directory name *)
-  let pp_raw_fields =
+  let pp_raw_fields ~strict =
     Pp.I.check_opam_version () -|
-    Pp.I.check_fields ~name:"opam-file" ~allow_extensions:true
+    Pp.I.check_fields ~name:"opam-file" ~allow_extensions:true ~strict
       ~sections fields -|
     Pp.I.partition_fields is_ext_field -| Pp.map_pair
       (Pp.I.items -|
        OpamStd.String.Map.(Pp.pp (fun ~pos:_ -> of_list) bindings))
-      (Pp.I.fields ~name:"opam-file" ~empty ~sections fields -|
+      (Pp.I.fields ~name:"opam-file" ~empty ~sections ~strict fields -|
        handle_flags_in_tags -|
        handle_deprecated_available) -|
     Pp.pp
       (fun ~pos:_ (extensions, t) -> with_extensions extensions t)
       (fun t -> extensions t, t)
 
-  let pp_raw = Pp.I.map_file @@ pp_raw_fields
+  let pp_raw = Pp.I.map_file @@ pp_raw_fields ~strict:false
 
   let pp =
     pp_raw -|
@@ -2306,7 +2306,7 @@ module SwitchExportSyntax = struct
           Pp.map_pair
             (Pp.map_option
                (Pp.of_module "package-name" (module OpamPackage.Name)))
-            OPAMSyntax.pp_raw_fields -|
+            (OPAMSyntax.pp_raw_fields ~strict:false) -|
           Pp.pp
             (fun ~pos:_ (name, opam) ->
                match name with

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1771,12 +1771,12 @@ module OPAMSyntax = struct
         (Pp.V.map_list ~depth:1 Pp.V.string);
 
       "depends", no_cleanup Pp.ppacc with_depends depends
-        (Pp.V.package_formula `Conj Pp.V.filtered_constraints);
+        (Pp.V.package_formula `Conj Pp.V.(filtered_constraints ext_version));
       "depopts", with_cleanup cleanup_depopts Pp.ppacc with_depopts depopts
-        (Pp.V.package_formula `Disj Pp.V.filtered_constraints);
+        (Pp.V.package_formula `Disj Pp.V.(filtered_constraints ext_version));
       "conflicts", with_cleanup cleanup_conflicts
         Pp.ppacc with_conflicts conflicts
-        (Pp.V.package_formula `Disj Pp.V.constraints);
+        (Pp.V.package_formula `Disj (Pp.V.constraints Pp.V.version));
       "available", no_cleanup Pp.ppacc with_available available
         (Pp.V.list_depth 1 -| Pp.V.list -| Pp.V.filter);
       "flags", with_cleanup cleanup_flags Pp.ppacc add_flags flags
@@ -2450,7 +2450,7 @@ module CompSyntax = struct
         (Pp.V.map_list ~depth:1 Pp.V.command);
 
       "packages", Pp.ppacc with_packages packages
-        (Pp.V.package_formula `Conj Pp.V.constraints);
+        (Pp.V.package_formula `Conj (Pp.V.constraints Pp.V.version));
       "env", Pp.ppacc with_env env
         (Pp.V.map_list ~depth:2 Pp.V.env_binding);
       "preinstalled", Pp.ppacc_opt with_preinstalled
@@ -2546,7 +2546,10 @@ module CompSyntax = struct
     let nofilter x = x, (None: filter option) in
     let depends =
       OpamFormula.map (fun (n, formula) ->
-          Atom (n, (OpamFormula.map (fun a -> Atom (Constraint a)) formula)))
+          let cstr (op, v) =
+            Atom (Constraint (op, FString (OpamPackage.Version.to_string v)))
+          in
+          Atom (n, (OpamFormula.map cstr formula)))
         comp.packages
     in
     let url =

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -486,7 +486,7 @@ module OPAM: sig
   val sections: (t, opamfile_item list) OpamFormat.Pp.I.fields_def
 
   (** Doesn't handle package name encoded in directory name *)
-  val pp_raw_fields: (opamfile_item list, t) OpamFormat.Pp.t
+  val pp_raw_fields: strict:bool -> (opamfile_item list, t) OpamFormat.Pp.t
 
   (** Returns the raw print-AST contents of the file *)
   val contents: ?filename:'a typed_file -> t -> opamfile

--- a/src/format/opamFilter.ml
+++ b/src/format/opamFilter.ml
@@ -354,7 +354,9 @@ let filter_constraints ?default env filtered_constraint =
     (function
       | Filter flt ->
         if eval_to_bool ?default env flt then `True else `False
-      | Constraint c -> `Formula (Atom c))
+      | Constraint (relop, v) ->
+        let v = OpamPackage.Version.of_string (eval_to_string env v) in
+        `Formula (Atom (relop, v)))
     filtered_constraint
 
 let partial_filter_constraints env filtered_constraint =
@@ -386,9 +388,12 @@ let partial_filter_formula env ff =
 let string_of_filtered_formula =
   let string_of_constraint =
     OpamFormula.string_of_formula (function
-        | Constraint (op,v) ->
-          Printf.sprintf "%s %s"
-            (string_of_relop op) (OpamPackage.Version.to_string v)
+        | Constraint (op, FString s) ->
+          Printf.sprintf "%s \"%s\"" (string_of_relop op) s
+        | Constraint (op, (FIdent _ as v)) ->
+          Printf.sprintf "%s %s" (string_of_relop op) (to_string v)
+        | Constraint (op, v) ->
+          Printf.sprintf "%s (%s)" (string_of_relop op) (to_string v)
         | Filter f -> to_string f)
   in
   OpamFormula.string_of_formula (function

--- a/src/format/opamFilter.mli
+++ b/src/format/opamFilter.mli
@@ -55,9 +55,10 @@ type env = full_variable -> variable_contents option
     names and optional string converter *)
 type fident = name list * variable * (string * string) option
 
-(** Rewrites string interpolations within a string. Without [default],
-    preserves undefined expansions as is *)
-val expand_string: ?default:string -> env -> string -> string
+(** Rewrites string interpolations within a string. [default] is applied to the
+    fident string (e.g. what's between [%{] and [}%]) when the expansion is
+    undefined. If unspecified, this raises [Failure]. *)
+val expand_string: ?default:(string -> string) -> env -> string -> string
 
 (** Returns the (beginning, end) offsets and substrings of any unclosed [%{]
     expansions *)

--- a/src/format/opamFormat.ml
+++ b/src/format/opamFormat.ml
@@ -283,7 +283,8 @@ module Pp = struct
             match exn with
             | None ->
               OpamConsole.warning "%s"
-                (string_of_bad_format (Bad_format (pos, s)))
+                (string_of_bad_format (Bad_format (pos, s)));
+              assert false
             | Some e ->
               OpamConsole.warning "%s" (string_of_bad_format e))
       fmt
@@ -787,11 +788,24 @@ module Pp = struct
       in
       pp ~name:"filtered-constraints" parse_cs print_cs
 
+    let version =
+      string -| of_module "version" (module OpamPackage.Version)
+
+    let ext_version =
+      pp ~name:"version-expr"
+        (fun ~pos:_ -> function
+           | String (_,s) -> FString s
+           | Ident (_,s) -> FIdent (filter_ident_of_string s)
+           | _ -> unexpected ())
+        (function
+          | FString s -> String (pos_null, s)
+          | FIdent id -> Ident (pos_null, string_of_filter_ident id)
+          | _ -> assert false)
+
     let package_atom constraints =
       map_option
         (string -| of_module "pkg-name" (module OpamPackage.Name))
-        (constraints
-           (string -| of_module "pkg-version" (module OpamPackage.Version)))
+        constraints
 
     let package_formula kind constraints =
       let split, join = match kind with

--- a/src/format/opamFormat.mli
+++ b/src/format/opamFormat.mli
@@ -281,15 +281,24 @@ module Pp : sig
       (value, 'version) t ->
       (value list, 'version filter_or_constraint OpamFormula.formula) t
 
-    val package_atom :
-      ((value, version) t -> (value list, 'a) t) -> (value, name * 'a) t
+    (** Package versions *)
+    val version: (value, version) t
+
+    (** Package versions as filters, as they may appear in dependency (may be an
+        expanded string or an ident) *)
+    val ext_version: (value, filter) t
+
+      (** Returns an atom parser ("package" {>= "version"}) from a constraint
+          and a version parser*)
+    val package_atom:
+      (value list, 'a) t -> (value, name * 'a) t
 
     (** Takes a parser for constraints. Lists without operator will be
         understood as conjunctions or disjunctions depending on the first
         argument. *)
     val package_formula :
       [< `Conj | `Disj ] ->
-      ((value, version) t -> (value list, 'a) t) ->
+      (value list, 'a) t ->
       (value, (name * 'a) OpamFormula.formula) t
 
     (** Environment variable updates syntax *)

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -196,7 +196,7 @@ type 'a filter_or_constraint =
   | Constraint of (relop * 'a)
 
 type filtered_formula =
-  (name * version filter_or_constraint OpamFormula.formula) OpamFormula.formula
+  (name * filter filter_or_constraint OpamFormula.formula) OpamFormula.formula
 
 (** {2 Solver} *)
 

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -97,7 +97,9 @@ let compute_updates st =
     OpamPackage.Set.fold (fun nv acc ->
         let opam = OpamSwitchState.opam st nv in
         List.map (fun (name,op,str,cmt) ->
-            let s = OpamFilter.expand_string ~default:"" (fenv ~opam) str in
+            let s =
+              OpamFilter.expand_string ~default:(fun _ -> "") (fenv ~opam) str
+            in
             name, op, s, cmt)
           (OpamFile.OPAM.env opam)
         @ acc)
@@ -309,7 +311,7 @@ let string_of_update st shell updates =
     | `fish -> fish
     | `csh -> csh in
   let aux (ident, symbol, string, comment) =
-    let string = OpamFilter.expand_string ~default:"" fenv string in
+    let string = OpamFilter.expand_string ~default:(fun _ -> "") fenv string in
     let key, value = match symbol with
       | Eq  -> ident, string
       | PlusEq | ColonEq -> ident, Printf.sprintf "%s:$%s" string ident

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -107,7 +107,7 @@ let lint t =
     [t.available] @
     OpamFormula.fold_left (fun acc (_, f) ->
         OpamFormula.fold_left (fun acc -> function
-            | Constraint _ -> acc
+            | Constraint (_,f) -> f :: acc
             | Filter f -> f :: acc)
           acc f)
       [] (OpamFormula.ands [t.depends; t.depopts]) @

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -369,7 +369,7 @@ let lint_gen reader filename =
         in
         try
           Some (Pp.parse ~pos:(pos_file (OpamFile.filename filename))
-                  pp_raw_fields good_items),
+                  (pp_raw_fields ~strict:true) good_items),
           warnings
         with
         | OpamFormat.Bad_format bf -> None, warnings @ [warn_of_bad_format bf]

--- a/src/state/opamPackageVar.mli
+++ b/src/state/opamPackageVar.mli
@@ -37,8 +37,12 @@ val predefined_depends_variables: full_variable list
 (** Resolves globally available variables only *)
 val resolve_global: 'a global_state -> full_variable -> variable_contents option
 
-(** Resolves global variables within the context of a switch *)
-val resolve_switch: 'a switch_state -> full_variable -> variable_contents option
+(** Resolves global variables within the context of a switch. If a package is
+    specified, "name" and "version" as taken to exclusively resolve to the
+    current package name and version. *)
+val resolve_switch:
+  ?package:package ->
+  'a switch_state -> full_variable -> variable_contents option
 
 (** Resolves filter variables, including global, switch and package variables ;
     a map of locally defined variables can be supplied, as well as the opam file
@@ -52,6 +56,7 @@ val resolve:
 (** Like [resolve_switch], but takes more specific parameters so that it can be
     used before the switch state is fully loaded *)
 val resolve_switch_raw:
+  ?package:package ->
   'a global_state -> switch -> OpamFile.Dot_config.t -> full_variable ->
   variable_contents option
 

--- a/src/state/opamSolution.ml
+++ b/src/state/opamSolution.ml
@@ -42,8 +42,9 @@ let post_message ?(failed=false) st action =
     let messages =
       let filter_env = OpamPackageVar.resolve ~opam ~local:local_variables st in
       OpamStd.List.filter_map (fun (message,filter) ->
-          if OpamFilter.opt_eval_to_bool filter_env filter
-          then Some (OpamFilter.expand_string ~default:"" filter_env message)
+          if OpamFilter.opt_eval_to_bool filter_env filter then
+            Some (OpamFilter.expand_string ~default:(fun _ -> "")
+                    filter_env message)
           else None)
         messages
     in


### PR DESCRIPTION
Define 'name' and 'version' in switch scope in opam files, and allow
references.

This makes it possible e.g. for a package to depend on another one at the
same version.

    depends: "bar" { = version }
