### PR TITLE
next: add local subcommand

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -219,6 +219,7 @@ opam-client.cma: opam-core.cma opam-format.cma opam-solver.cma opam-repository.c
 opam-client.cmxa: opam-core.cmxa opam-format.cmxa opam-solver.cmxa opam-repository.cmxa opam-state.cmxa ALWAYS
 
 SRC_client = \
+  opamLocalConfig.ml \
   opamClientConfig.ml \
   opamSwitchCommand.ml \
   opamConfigCommand.ml \

--- a/src/Makefile
+++ b/src/Makefile
@@ -227,6 +227,7 @@ SRC_client = \
   opamPinCommand.ml \
   opamListCommand.ml \
   opamClient.ml \
+  opamLocalCommand.ml \
   opamGitVersion.ml \
   opamArg.ml
 

--- a/src/client/opamClientConfig.ml
+++ b/src/client/opamClientConfig.ml
@@ -73,6 +73,7 @@ let search_files = ["findlib"]
 open OpamStd.Op
 
 let local_override () =
+  let open OpamStd.Option.Op in
   match
     OpamStateConfig.(!r.switch_from),
     OpamLocalConfig.(!r.local_file)
@@ -81,7 +82,7 @@ let local_override () =
     let current_switch = OpamFile.Local.switch opamlocal in
     OpamStateConfig.update
       ?current_switch
-      ?switch_from:(Option.map (fun _ -> `Local) current_switch)
+      ?switch_from:(current_switch >>| fun _ -> `Local)
       ()
   | _, _ -> ()
 

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -52,7 +52,7 @@ val opam_init:
   ?autoremove:bool ->
   ?editor:string ->
   ?current_switch:OpamSwitch.t ->
-  ?switch_from:[ `Command_line | `Default | `Env ] ->
+  ?switch_from:[ `Command_line | `Default | `Env | `Local ] ->
   ?jobs:int Lazy.t ->
   ?dl_jobs:int ->
   ?external_tags:string list ->

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -51,6 +51,8 @@ val opam_init:
   ?pin_kind_auto:bool ->
   ?autoremove:bool ->
   ?editor:string ->
+  ?sandbox_dir:OpamTypes.dirname option ->
+  ?local_file:OpamFile.Local.t option ->
   ?current_switch:OpamSwitch.t ->
   ?switch_from:[ `Command_line | `Default | `Env | `Local ] ->
   ?jobs:int Lazy.t ->

--- a/src/client/opamLocalCommand.ml
+++ b/src/client/opamLocalCommand.ml
@@ -34,7 +34,7 @@
 let create_cont t dir ~update_config ~packages switch =
   let dir =
     let pred dir = OpamFilename.(exists Op.(dir // ".opamlocal")) in
-    match OpamFile.locate_ancestor pred dir with
+    match OpamFilename.find_ancestor_dir pred dir with
     | Some _ ->
       OpamConsole.error "Already in a local sandbox.";
       OpamStd.Sys.exit 1

--- a/src/client/opamLocalCommand.mli
+++ b/src/client/opamLocalCommand.mli
@@ -31,48 +31,17 @@
     POSSIBILITY OF SUCH DAMAGE.
   ----------------------------------------------------------------------------*)
 
-type t = {
-  sandbox_dir : OpamTypes.dirname option;
-  local_file : OpamFile.Local.t option
-}
+open OpamTypes
+open OpamStateTypes
 
-type 'a options_fun =
-  ?sandbox_dir:OpamTypes.dirname option ->
-  ?local_file:OpamFile.Local.t option ->
-  'a
+val create_cont:
+  rw global_state -> dirname ->
+  update_config:bool -> packages:atom conjunction -> 
+  switch ->
+  switch * (unit -> unit)
 
-let default =
-  { sandbox_dir = None; local_file = None }
-
-let setk k t
-  ?sandbox_dir
-  ?local_file
-  =
-  let (+) x opt = match opt with Some x -> x | None -> x in
-  k {
-    sandbox_dir = t.sandbox_dir + sandbox_dir;
-    local_file = t.local_file + local_file;
-  }
-
-let set t = setk (fun x () -> x) t
-
-let r = ref default
-
-let update ?noop:_ = setk (fun cfg () -> r := cfg) !r
-
-let initk k =
-  let pred dir = OpamFilename.(exists Op.(dir // ".opamlocal")) in
-  let sandbox_dir = OpamFile.locate_ancestor pred (OpamFilename.cwd ()) in
-  let local_file =
-    match sandbox_dir with
-    | None -> None
-    | Some dir ->
-      let local_file = OpamFilename.Op.(dir // ".opamlocal") in
-      try Some OpamFile.(Local.read (make local_file))
-      with _ -> None
-  in
-  setk (setk (fun c -> r := c; k)) !r
-    ~sandbox_dir
-    ~local_file
-
-let init ?noop:_ = initk (fun () -> ())
+val create :
+  rw global_state -> dirname ->
+  update_config:bool -> packages:atom conjunction ->
+  switch ->
+  unit

--- a/src/client/opamLocalConfig.ml
+++ b/src/client/opamLocalConfig.ml
@@ -62,7 +62,7 @@ let update ?noop:_ = setk (fun cfg () -> r := cfg) !r
 
 let initk k =
   let pred dir = OpamFilename.(exists Op.(dir // ".opamlocal")) in
-  let sandbox_dir = OpamFile.locate_ancestor pred (OpamFilename.cwd ()) in
+  let sandbox_dir = OpamFilename.find_ancestor_dir pred (OpamFilename.cwd ()) in
   let local_file =
     match sandbox_dir with
     | None -> None

--- a/src/client/opamLocalConfig.ml
+++ b/src/client/opamLocalConfig.ml
@@ -1,0 +1,77 @@
+(*----------------------------------------------------------------------------
+    Copyright (c) 2016 Inhabited Type LLC <spiros@inhabitedtype.com
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of the author nor the names of his contributors
+       may be used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND ANY EXPRESS
+    OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+  ----------------------------------------------------------------------------*)
+
+type t = {
+  sandbox_dir : OpamTypes.dirname option;
+  local_file : OpamFile.Local.t option
+}
+
+type 'a options_fun =
+  ?sandbox_dir:OpamTypes.dirname option ->
+  ?local_file:OpamFile.Local.t option ->
+  'a
+
+let default =
+  { sandbox_dir = None; local_file = None }
+
+let setk k t
+  ?sandbox_dir
+  ?local_file
+  =
+  let (+) x opt = match opt with Some x -> x | None -> x in
+  k {
+    sandbox_dir = t.sandbox_dir + sandbox_dir;
+    local_file = t.local_file + local_file;
+  }
+
+let set t = setk (fun x () -> x) t
+
+let r = ref default
+
+let update ?noop:_ = setk (fun cfg () -> r := cfg) !r
+
+let initk k =
+  let sandbox_dir = OpamFile.Local.locate (OpamFilename.cwd ()) in
+  let local_file =
+    match sandbox_dir with
+    | None -> None
+    | Some dir ->
+      let local_file = OpamFilename.Op.(dir // ".opamlocal") in
+      try Some OpamFile.(Local.read (make local_file))
+      with _ -> None
+  in
+  setk (setk (fun c -> r := c; k)) !r
+    ~sandbox_dir
+    ~local_file
+
+let init ?noop:_ = initk (fun () -> ())

--- a/src/client/opamLocalConfig.ml
+++ b/src/client/opamLocalConfig.ml
@@ -69,7 +69,7 @@ let initk k =
     | Some dir ->
       let local_file = OpamFilename.Op.(dir // ".opamlocal") in
       try Some OpamFile.(Local.read (make local_file))
-      with _ -> None
+      with e -> OpamStd.Exn.fatal e; None
   in
   setk (setk (fun c -> r := c; k)) !r
     ~sandbox_dir

--- a/src/client/opamLocalConfig.mli
+++ b/src/client/opamLocalConfig.mli
@@ -1,0 +1,46 @@
+(*----------------------------------------------------------------------------
+    Copyright (c) 2016 Inhabited Type LLC <spiros@inhabitedtype.com
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of the author nor the names of his contributors
+       may be used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND ANY EXPRESS
+    OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+  ----------------------------------------------------------------------------*)
+
+type t = private {
+  sandbox_dir : OpamTypes.dirname option;
+  local_file : OpamFile.Local.t option
+}
+
+type 'a options_fun =
+  ?sandbox_dir:OpamTypes.dirname option ->
+  ?local_file:OpamFile.Local.t option ->
+  'a
+
+include OpamStd.Config.Sig
+  with type t := t
+   and type 'a options_fun := 'a options_fun

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -130,13 +130,17 @@ let list gt ~print_short ~installed ~all =
     OpamConsole.note
       "No switch is currently set, you should use 'opam switch <switch>' \
        to set an active switch"
-  | Some switch, `Env ->
+  | Some switch, ((`Env | `Local) as src) ->
     let sys = OpamFile.Config.switch gt.config in
     if sys <> Some switch then
+      let src = match src with
+        | `Env -> "OPAMSWITCH variable"
+        | `Local -> "local sandbox" in
       (OpamConsole.msg "\n";
        OpamConsole.note
-         "Current switch is set locally through the OPAMSWITCH variable.\n\
+         "Current switch is set locally through the %s.\n\
           The current global system switch is %s."
+         src
          (OpamStd.Option.to_string ~none:"unset"
             (fun s -> OpamConsole.colorise `bold (OpamSwitch.to_string s)) sys))
   | Some switch, `Default ->

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -123,6 +123,17 @@ let basename_dir dirname =
 let dirname_dir dirname =
   Dir.to_string (Filename.dirname (Dir.of_string dirname))
 
+let find_ancestor_dir pred dir =
+  let root = raw_dir "/" in
+  let rec loop dir =
+    if pred dir then Some dir
+    else if dir = root then None
+    else loop (dirname_dir dir)
+  in
+  if not (exists_dir dir)
+    then None
+    else loop dir
+
 let to_list_dir dir =
   let base d = Dir.of_string (Filename.basename (Dir.to_string d)) in
   let rec aux acc dir =

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -77,6 +77,9 @@ val dirname_dir: Dir.t -> Dir.t
 (** Return the deeper directory name *)
 val basename_dir: Dir.t -> Base.t
 
+(** Find an ancestor of the directory that satisfies the predicate. *)
+val find_ancestor_dir : (Dir.t -> bool) -> Dir.t -> Dir.t option
+
 (** Turn a full path into a list of directory names *)
 val to_list_dir: Dir.t -> Dir.t list
 

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1180,6 +1180,56 @@ module Dot_config = struct
   include SyntaxFile(Dot_configSyntax)
 end
 
+module Local = struct
+  type t = Dot_config.t
+
+  let empty = Dot_config.empty
+
+  let opam_switch = "OPAMSWITCH"
+
+  let create switch : t =
+    let open OpamVariable in
+    Dot_config.create [
+      of_string opam_switch, S (OpamSwitch.to_string switch) ]
+
+  let str key t =
+    match Dot_config.variable t (OpamVariable.of_string key) with
+    | Some (S value) -> Some value
+    | _              -> None
+
+  let switch t =
+    Option.map OpamSwitch.of_string (str opam_switch t)
+
+  let with_switch t switch =
+    let open OpamVariable in
+    Dot_config.set t (of_string opam_switch) (Some (S (OpamSwitch.to_string switch)))
+
+  let write filename t =
+    Dot_config.write filename t
+
+  let read filename =
+    Dot_config.read filename
+
+  let read_opt filename =
+    Dot_config.read_opt filename
+
+  let safe_read filename =
+    Dot_config.safe_read filename
+
+  let read_from_channel ?filename in_channel =
+    Dot_config.read_from_channel ?filename in_channel
+
+  let read_from_string ?filename string =
+    Dot_config.read_from_string ?filename string
+
+  let write_to_channel ?filename out_channel t =
+    Dot_config.write_to_channel ?filename out_channel t
+
+  let write_to_string ?filename t =
+    Dot_config.write_to_string ?filename t
+
+end
+
 (** (2) General, public repository format *)
 
 (** Public repository definition file (<repo>/repo) *)

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -2609,16 +2609,3 @@ module Comp = struct
   include CompSyntax
   include SyntaxFile(CompSyntax)
 end
-
-let locate_ancestor pred dir =
-  let open OpamFilename in
-  let root = raw_dir "/" in
-  let rec loop dir =
-    if pred dir then Some dir
-    else if dir = root then None
-    else loop (dirname_dir dir)
-  in
-  if not (exists_dir dir)
-    then None
-    else loop dir
-

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1198,7 +1198,7 @@ module Local = struct
     | _              -> None
 
   let switch t =
-    Option.map OpamSwitch.of_string (str opam_switch t)
+    OpamStd.Option.map OpamSwitch.of_string (str opam_switch t)
 
   let with_switch t switch =
     let open OpamVariable in

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -2559,3 +2559,16 @@ module Comp = struct
   include CompSyntax
   include SyntaxFile(CompSyntax)
 end
+
+let locate_ancestor pred dir =
+  let open OpamFilename in
+  let root = raw_dir "/" in
+  let rec loop dir =
+    if pred dir then Some dir
+    else if dir = root then None
+    else loop (dirname_dir dir)
+  in
+  if not (exists_dir dir)
+    then None
+    else loop dir
+

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -741,6 +741,8 @@ end
 
 (**/**)
 
+val locate_ancestor : (dirname -> bool) -> dirname -> dirname option
+
 module type SyntaxFileArg = sig
   val internal: string
   type t

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -671,6 +671,21 @@ module Dot_config: sig
 
 end
 
+(** .opamlocal files *)
+module Local: sig
+
+  include IO_FILE
+
+  (** Create a new .opamlocal *)
+  val create: OpamTypes.switch -> t
+
+  (** The switch associated with [t] *)
+  val switch: t -> OpamTypes.switch option
+
+  (** Set the switch of [t] *)
+  val with_switch : t -> OpamTypes.switch -> t
+end
+
 (** {2 Repository files} *)
 
 (** Association between package names and repositories *)

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -756,8 +756,6 @@ end
 
 (**/**)
 
-val locate_ancestor : (dirname -> bool) -> dirname -> dirname option
-
 module type SyntaxFileArg = sig
   val internal: string
   type t

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -121,16 +121,9 @@ let update ?noop:_ = setk (fun cfg () -> r := cfg) !r
 let initk k =
   let open OpamStd.Config in
   let open OpamStd.Option.Op in
-  let local =
-    let open OpamFile in
-    try Local.read (make (OpamFilename.of_string ".opamlocal"))
-    with _ -> Local.empty in
   let current_switch, switch_from =
     match env_string "SWITCH" with
-    | Some "" | None ->
-      (match OpamFile.Local.switch local with
-      | None -> None, None
-      | Some switch -> Some switch, Some `Local)
+    | Some "" | None -> None, None
     | Some s -> Some (OpamSwitch.of_string s), Some `Env
   in
   setk (setk (fun c -> r := c; k)) !r

--- a/src/state/opamStateConfig.mli
+++ b/src/state/opamStateConfig.mli
@@ -21,7 +21,7 @@ open OpamTypes
 type t = private {
   root_dir: OpamFilename.Dir.t;
   current_switch: OpamSwitch.t option;
-  switch_from: [ `Env | `Command_line | `Default ];
+  switch_from: [ `Env | `Command_line | `Default | `Local ];
   jobs: int Lazy.t;
   dl_jobs: int;
   external_tags: string list;
@@ -39,7 +39,7 @@ type t = private {
 type 'a options_fun =
   ?root_dir:OpamFilename.Dir.t ->
   ?current_switch:OpamSwitch.t ->
-  ?switch_from:[ `Env | `Command_line | `Default ] ->
+  ?switch_from:[ `Env | `Command_line | `Default | `Local ] ->
   ?jobs:(int Lazy.t) ->
   ?dl_jobs:int ->
   ?external_tags:string list ->


### PR DESCRIPTION
This pull request adds the `local` subcommand to OPAM for managing directory-local switches, often referred to as a "sandbox". When in such a directory, OPAM will use the switch associated with the directory when executing all commands. For example if the user's current active switch is `switch-1`, running `opam install <pgk>` would normally install `<pkg>` into `switch-1`. However, if the user is in a sandbox directory associated with `switch-2`, then running `opam install <pkg>` will install `<pkg>` in `switch-2`. Similarly, running `opam config env` within the sandbox will display the environment for `switch-2`, rather than `switch-1`.

The only `local` subcommand included in this command is `create`. This allows users to setup a directory as a sandbox, associating with it a switch. The `create` command takes the same arguments as `opam switch create` for configuring the initial state of the switch.

In the future, additional commands may be added below `opam local` in order to assist in the management of sandboxes.

This pull request targets the `next` branch of OPAM development.

As mentioned to @AltGr via email, this pull request intentionally does not include command-line documentation.
