### PR TITLE
Fix bug in ~/.opam format upgrade

### DIFF
--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -361,7 +361,7 @@ module Format_upgrade = struct
         let meta_dir =  switch_dir / ".opam-switch" in
         let installed =
           (OpamFile.SwitchSelections.safe_read
-             (OpamFile.make (switch_dir // "switch-state")))
+             (OpamFile.make (meta_dir // "switch-state")))
           .sel_installed
         in
         OpamFilename.mkdir (meta_dir / "packages");


### PR DESCRIPTION
that caused installed package definitions (including compiler defs
generated in a previous step) to be lost.

@Drup: sorry!