### PR TITLE
Allow 'opam show --file', add '-' to read from stdin

### DIFF
--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -124,8 +124,14 @@ val url: url Arg.converter
 (** Filename converter *)
 val filename: filename Arg.converter
 
+(** Filename converter also accepting "-" for stdin/stdout *)
+val existing_filename_or_dash: filename option Arg.converter
+
 (** Dirnam converter *)
 val dirname: dirname Arg.converter
+
+val existing_filename_dirname_or_dash:
+  OpamFilename.generic_file option Arg.converter
 
 (** Package name converter *)
 val package_name: name Arg.converter

--- a/src/client/opamListCommand.mli
+++ b/src/client/opamListCommand.mli
@@ -113,3 +113,6 @@ val list:
 val info:
   'a global_state ->
   fields:string list -> raw_opam:bool -> where:bool -> atom list -> unit
+
+(** Prints the value of an opam field in a shortened way *)
+val mini_field_printer: value -> string

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1986,7 +1986,7 @@ module OPAMSyntax = struct
          | Some _, None, None -> t
          | None, Some _, Some _ -> t
          | None, _, _ ->
-           OpamConsole.warning
+           OpamConsole.log "FILE(opam)"
              "Outputting opam file %s with unspecified name or version"
              (OpamFilename.to_string filename);
            t

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -415,12 +415,20 @@ let lint_gen reader filename =
 
 let lint_file filename =
   let reader filename =
-    let ic = OpamFilename.open_in (OpamFile.filename filename) in
     try
-      let f = OpamFile.Syntax.of_channel filename ic in
-      close_in ic; f
-    with e -> close_in ic; raise e
+      let ic = OpamFilename.open_in (OpamFile.filename filename) in
+      try
+        let f = OpamFile.Syntax.of_channel filename ic in
+        close_in ic; f
+      with e -> close_in ic; raise e
+    with OpamSystem.File_not_found _ ->
+      OpamConsole.error_and_exit "File %s not found"
+        (OpamFile.to_string filename)
   in
+  lint_gen reader filename
+
+let lint_channel filename ic =
+  let reader filename = OpamFile.Syntax.of_channel filename ic in
   lint_gen reader filename
 
 let lint_string filename string =

--- a/src/state/opamFileTools.mli
+++ b/src/state/opamFileTools.mli
@@ -27,12 +27,16 @@ val template: package -> OpamFile.OPAM.t
     this specific warning/error. *)
 val lint: OpamFile.OPAM.t -> (int * [`Warning|`Error] * string) list
 
-(** Same as [validate], but operates on a file, which allows catching parse
+(** Same as [lint], but operates on a file, which allows catching parse
     errors too. You can specify an expected name and version *)
 val lint_file: OpamFile.OPAM.t OpamFile.typed_file ->
   (int * [`Warning|`Error] * string) list * OpamFile.OPAM.t option
 
-(** Like [validate_file], but takes the file contents as a string *)
+(** Same as [lint_file], but taking input from a channel *)
+val lint_channel: OpamFile.OPAM.t OpamFile.typed_file -> in_channel ->
+  (int * [`Warning|`Error] * string) list * OpamFile.OPAM.t option
+
+(** Like [lint_file], but takes the file contents as a string *)
 val lint_string: OpamFile.OPAM.t OpamFile.typed_file -> string ->
   (int * [`Warning|`Error] * string) list * OpamFile.OPAM.t option
 


### PR DESCRIPTION
Document the fact that this can now print any field, from 'opam show' or
from the package description if suffixed with ':' (which is the general
convention when referring to opam file fields).

`opam show --file - --field f` can be useful to third-party tool that want
to access opam metadata.