### PR TITLE
AppVeyor: print opam config env at end of compilation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,4 +22,5 @@ install:
 build_script:
   - '%CYG_ROOT%/bin/bash -lc "cd \"$OLDPWD\" && env DJDIR="workaround" ./configure && make lib-ext && make && make install"'
   - '%CYG_ROOT%/bin/bash -lc "opam init -y -a"'
+  - '%CYG_ROOT%/bin/bash -lc "opam config env"'
   - '%CYG_ROOT%/bin/bash -lc "opam install -y -v ocamlfind"'


### PR DESCRIPTION
The environment variable OCAML_TOPLEVEL_PATH is not set under Cygwin, this change is a first step towards detecting what's wrong.
See https://github.com/ocaml/opam/issues/2362