### PR TITLE
Add global `wrap-build/install/remove-commands:` fields

### DIFF
--- a/shell/wrap-build.sh
+++ b/shell/wrap-build.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+exec unshare -Umnr /bin/sh -se "$@" <<EOF
+mount --bind ~ ~ # ro
+mount --bind . . # rw
+mount -o remount,ro,bind ~
+cd . # Sans ça $PWD ne pointe pas sur le nouveau mount!
+exec "\$@"
+EOF

--- a/shell/wrap-install.sh
+++ b/shell/wrap-install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -e
+exec unshare -Umnr /bin/sh -se "$@" <<EOF
+mount --bind ~ ~ # ro
+mount --bind "$OPAM_SWITCH_PREFIX" "$OPAM_SWITCH_PREFIX" # rw
+mount --bind "$OPAM_SWITCH_PREFIX/.opam-switch" "$OPAM_SWITCH_PREFIX/.opam-switch" # ro
+mount --bind . . # rw: many packages need to write to their build dir on install, if just to update some logs
+mount -o remount,ro,bind "$OPAM_SWITCH_PREFIX/.opam-switch"
+mount -o remount,ro,bind ~
+cd . # required
+exec "\$@"
+EOF

--- a/shell/wrap-remove.sh
+++ b/shell/wrap-remove.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+exec unshare -Umnr /bin/sh -se "$@" <<EOF
+mount --bind ~ ~ # ro
+mount --bind "$OPAM_SWITCH_PREFIX" "$OPAM_SWITCH_PREFIX" # rw
+mount --bind "$OPAM_SWITCH_PREFIX/.opam-switch" "$OPAM_SWITCH_PREFIX/.opam-switch" # ro
+mount -o remount,ro,bind "$OPAM_SWITCH_PREFIX/.opam-switch"
+mount -o remount,ro,bind ~
+cd .
+exec "\$@"
+EOF

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -859,6 +859,9 @@ module ConfigSyntax = struct
     dl_jobs : int;
     solver_criteria : (solver_criteria * string) list;
     solver : arg list option;
+    wrap_build : arg list;
+    wrap_install : arg list;
+    wrap_remove : arg list;
   }
 
   let opam_version t = t.opam_version
@@ -873,6 +876,9 @@ module ConfigSyntax = struct
     try Some (List.assoc kind t.solver_criteria)
     with Not_found -> None
   let solver t = t.solver
+  let wrap_build t = t.wrap_build
+  let wrap_install t = t.wrap_install
+  let wrap_remove t = t.wrap_remove
 
   let with_opam_version opam_version t = { t with opam_version }
   let with_repositories repositories t = { t with repositories }
@@ -888,6 +894,9 @@ module ConfigSyntax = struct
     { t with solver_criteria =
                (kind,criterion)::List.remove_assoc kind t.solver_criteria }
   let with_solver solver t = { t with solver = Some solver }
+  let with_wrap_build wrap_build t = { t with wrap_build }
+  let with_wrap_install wrap_install t = { t with wrap_install }
+  let with_wrap_remove wrap_remove t = { t with wrap_remove }
 
   let create installed_switches switch repositories
       ?(criteria=[]) ?solver jobs ?download_tool dl_jobs =
@@ -895,7 +904,8 @@ module ConfigSyntax = struct
       repositories ;
       installed_switches; switch;
       jobs; dl_tool = download_tool; dl_jobs;
-      solver_criteria = criteria; solver }
+      solver_criteria = criteria; solver;
+      wrap_build = []; wrap_install = []; wrap_remove = []; }
 
   let empty = {
     opam_version = OpamVersion.current_nopatch;
@@ -907,6 +917,9 @@ module ConfigSyntax = struct
     dl_jobs = 1;
     solver_criteria = [];
     solver = None;
+    wrap_build = [];
+    wrap_install = [];
+    wrap_remove = [];
   }
 
   let fields =
@@ -951,6 +964,15 @@ module ConfigSyntax = struct
         Pp.V.string;
       "solver", Pp.ppacc_opt
         with_solver solver
+        (Pp.V.map_list ~depth:1 Pp.V.arg);
+      "wrap-build-commands", Pp.ppacc
+        with_wrap_build wrap_build
+        (Pp.V.map_list ~depth:1 Pp.V.arg);
+      "wrap-install-commands", Pp.ppacc
+        with_wrap_install wrap_install
+        (Pp.V.map_list ~depth:1 Pp.V.arg);
+      "wrap-remove-commands", Pp.ppacc
+        with_wrap_remove wrap_remove
         (Pp.V.map_list ~depth:1 Pp.V.arg);
 
       (* deprecated fields *)

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -98,6 +98,10 @@ module Config: sig
 
   val with_solver: arg list -> t -> t
 
+  val with_wrap_build: arg list -> t -> t
+  val with_wrap_install: arg list -> t -> t
+  val with_wrap_remove: arg list -> t -> t
+
   (** Return the OPAM version *)
   val opam_version: t  -> opam_version
 
@@ -120,6 +124,10 @@ module Config: sig
   val criteria: t -> (solver_criteria * string) list
 
   val solver: t -> arg list option
+
+  val wrap_build: t -> arg list
+  val wrap_install: t -> arg list
+  val wrap_remove: t -> arg list
 
 end
 

--- a/src/format/opamFormat.ml
+++ b/src/format/opamFormat.ml
@@ -1028,12 +1028,12 @@ module Pp = struct
         match extra_fields with
         | [] -> items
         | (pos,_) :: _  ->
-          warn ~pos ?strict "Unexpected or duplicate fields or sections%s:%s"
+          warn ~pos ?strict "Unexpected or duplicate fields or sections%s:\n%s"
             in_name
             (OpamStd.Format.itemize
                (fun (pos,k) ->
                   Printf.sprintf "'%s:' at %s" k (string_of_pos pos))
-               extra_fields);
+               (List.rev extra_fields));
           valid_fields
       in
       let print items =


### PR DESCRIPTION
These are defined in ~/.opam/config and allow to wrap all command
invocation; this is primarily intended for testing purposes at the moment,
and the fields can only be set by hand.

The wrappers are resolved in the scope of the command that is run (package
variables are available). One intended usage is to restrict read/write
access of the commands on the testing frameworks (so that e.g. a package
that tries to install during its build phase will fail).

I use it for example with a shell script build wrapper:
```
exec unshare -Umnr /bin/sh -se "$@" <<EOF
mount --bind ~ ~
mount --bind . .
mount -o remount,ro,bind ~
cd . # required to update to the mount
exec "\$@"
EOF
```

that prevents writing to everywhere but . (i.e. the build dir), as well as network access.