### PR TITLE
For external plugin search, always do a full PATH search

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1983,7 +1983,7 @@ let check_and_run_external_commands () =
       && List.for_all (fun (_,info) -> Term.name info <> name) commands
     then
     (* No such command, check if there is a matching plugin *)
-    let command = opam ^ "-" ^ name in
+    let command = (Filename.basename opam) ^ "-" ^ name in
     let t = OpamState.load_env_state "plugins" in
     let env = OpamState.get_full_env ~force_path:false t in
     let env = Array.of_list (List.rev_map (fun (k,v) -> k^"="^v) env) in


### PR DESCRIPTION
This prevents different behaviour if the command is executed with
`opam` vs `/usr/bin/opam`.

This is a backport to the 1.2 branch, as the bug is fixed in
OPAM trunk already.  See #2317.