### PR TITLE
Delay removal of packages as much as possible.

### DIFF
--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -1642,10 +1642,7 @@ let source =
       match OpamProcess.Job.run (OpamAction.download_package t nv) with
       | `Error _ -> OpamConsole.error_and_exit "Download failed"
       | `Successful s ->
-        (try OpamAction.extract_package t s nv with Failure _ -> ());
-        move_dir
-          ~src:(OpamPath.Switch.build t.switch_global.root t.switch nv)
-          ~dst:dir;
+        (try OpamAction.extract_package t s nv dir with Failure _ -> ());
         OpamConsole.formatted_msg "Successfully extracted to %s\n"
           (Dir.to_string dir);
         if OpamPinned.find_opam_file_in_source nv.name dir = None

--- a/src/core/opamParallel.ml
+++ b/src/core/opamParallel.ml
@@ -265,6 +265,7 @@ module type GRAPH = sig
   module Parallel : SIG with type G.t = t
                          and type G.V.t = vertex
   module Dot : sig val output_graph : out_channel -> t -> unit end
+  val transitive_closure:  ?reflexive:bool -> t -> unit
 end
 
 module MakeGraph (X: VERTEX) = struct
@@ -292,6 +293,8 @@ module MakeGraph (X: VERTEX) = struct
     end)
   include PG
   include Graph.Oper.I (PG)
+  let transitive_closure ?reflexive g =
+    ignore (add_transitive_closure ?reflexive g)
 end
 
 (* Simple polymorphic implem on lists when we don't need full graphs.

--- a/src/core/opamParallel.mli
+++ b/src/core/opamParallel.mli
@@ -95,6 +95,7 @@ module type GRAPH = sig
   module Parallel : SIG with type G.t = t
                          and type G.V.t = vertex
   module Dot : sig val output_graph : out_channel -> t -> unit end
+  val transitive_closure:  ?reflexive:bool -> t -> unit
 end
 
 module MakeGraph (V: VERTEX) : GRAPH with type V.t = V.t

--- a/src/solver/opamActionGraph.ml
+++ b/src/solver/opamActionGraph.ml
@@ -130,6 +130,7 @@ module Make (A: ACTION) : SIG with type package = A.package = struct
   include OpamParallel.MakeGraph(A)
 
   module Map = OpamStd.Map.Make (A.Pkg)
+  module Set = OpamStd.Set.Make (A.Pkg)
 
   (* Turn concrete actions (only install, remove and build) to higher-level
      actions (install, remove, up/downgrade, recompile). Builds are removed when
@@ -180,16 +181,59 @@ module Make (A: ACTION) : SIG with type package = A.package = struct
       ) !reduced;
     g
 
+  let get_dependent_base_package g =
+    let closed_g = copy g in
+    transitive_closure closed_g;
+    let base_packages =
+      fold_vertex (fun a acc ->
+          match a with
+          | `Build p ->
+            if pred g a = [] then Set.add p acc else acc
+          | _ -> acc) g Set.empty
+    in
+    let dependent_base_packages =
+      fold_vertex (fun a acc ->
+          match a with
+          | `Install p | `Reinstall p | `Change (_,_,p) ->
+            let preds =
+              List.filter
+                (function
+                  | `Build p -> Set.mem p base_packages
+                  | _ -> false)
+                (pred closed_g a) in
+            OpamStd.String.Map.add (A.Pkg.name_to_string p) preds acc
+          | _ -> acc) g OpamStd.String.Map.empty in
+    function p ->
+    match
+      OpamStd.String.Map.find_opt
+        (A.Pkg.name_to_string p)
+        dependent_base_packages
+    with
+    | None -> []
+    | Some pred -> pred
+
   let explicit g0 =
     let g = copy g0 in
+    let same_name p1 p2 = A.Pkg.(name_to_string p1 = name_to_string p2) in
     iter_vertex (fun a ->
         match a with
         | `Install p | `Reinstall p | `Change (_,_,p) ->
           let b = `Build p in
-          iter_pred (fun pred -> remove_edge g pred a; add_edge g pred b) g a;
+          iter_pred (function
+              | `Remove p1 when same_name p p1 -> ()
+              | pred -> remove_edge g pred a; add_edge g pred b)
+            g0 a;
           add_edge g b a
         | `Remove _ -> ()
         | `Build _ -> assert false)
       g0;
+    let get_dependent_base_package = get_dependent_base_package g in
+    iter_vertex (function
+        | `Remove p as a ->
+          List.iter
+            (fun b -> add_edge g b a)
+            (get_dependent_base_package p)
+        | `Install _ | `Reinstall _ | `Change _ | `Build _ -> ())
+      g;
     g
 end

--- a/src/solver/opamActionGraph.mli
+++ b/src/solver/opamActionGraph.mli
@@ -36,16 +36,18 @@ module type SIG = sig
       There is no guarantee however that the resulting graph is acyclic. *)
   val reduce: t -> t
 
-  (** Expand install actions, adding a build action preceding them. *)
-  val explicit: t -> t
-end
+  (** Expand install actions, adding a build action preceding them.
+      The argument [noop_remove] is a function that should return `true`
+      for package where the `remove` action is known not to modify the
+      filesystem (such as `conf-*` package). *)
+  val explicit: ?noop_remove:(package -> bool) -> t -> t end
 
 module Make (A: ACTION) : SIG with type package = A.package
 
 (** Some messages that may be used for displaying actions. Single utf8 chars if
     the corresponding option is set, otherwise words. *)
 val action_strings:
-  ?utf8:bool -> [ 'a highlevel_action | `Build of 'a ] -> string
+  ?utf8:bool -> 'a action -> string
 
 (** Colorise string according to the action *)
-val action_color:  [ 'a highlevel_action | `Build of 'a ] -> string -> string
+val action_color: 'a action -> string -> string

--- a/src/solver/opamActionGraph.mli
+++ b/src/solver/opamActionGraph.mli
@@ -45,7 +45,7 @@ module Make (A: ACTION) : SIG with type package = A.package
 (** Some messages that may be used for displaying actions. Single utf8 chars if
     the corresponding option is set, otherwise words. *)
 val action_strings:
-  ?utf8:bool -> 'a highlevel_action -> string
+  ?utf8:bool -> [ 'a highlevel_action | `Build of 'a ] -> string
 
 (** Colorise string according to the action *)
-val action_color: 'a highlevel_action -> string -> string
+val action_color:  [ 'a highlevel_action | `Build of 'a ] -> string -> string

--- a/src/state/opamAction.ml
+++ b/src/state/opamAction.ml
@@ -596,13 +596,14 @@ let build_package t source nv =
          Done (Some (OpamSystem.Process_error result)))
     | []::commands -> run_commands commands
     | [] ->
-      OpamConsole.msg "%s compiled  %s.%s\n"
+      if commands <> [] then
+        OpamConsole.msg "%s compiled  %s.%s\n"
           (if not (OpamConsole.utf8 ()) then "->"
            else OpamActionGraph.
                   (action_color (`Build ()) (action_strings (`Build ()))))
           (OpamConsole.colorise `bold name)
           (OpamPackage.version_to_string nv);
-        Done None
+      Done None
   in
   run_commands commands
 

--- a/src/state/opamAction.mli
+++ b/src/state/opamAction.mli
@@ -50,6 +50,10 @@ val remove_package:
   ?changes:OpamDirTrack.t -> ?force:bool ->
   package -> unit OpamProcess.job
 
+(** Returns [true] whenever [remove_package] is a no-op. *)
+val noop_remove_package:
+  rw switch_state -> package -> bool
+
 (** Removes auxiliary files related to a package, after checking that
     they're not needed (even in other switches) *)
 val cleanup_package_artefacts: rw switch_state -> package -> unit

--- a/src/state/opamAction.mli
+++ b/src/state/opamAction.mli
@@ -24,7 +24,7 @@ val download_package:
     downloaded [source] of the package [pkg]. See {!download_package}
     to download the sources. *)
 val extract_package:
-  rw switch_state -> generic_file option -> package -> unit
+  rw switch_state -> generic_file option -> package -> dirname -> unit
 
 (** [build_package t source pkg] builds the package [pkg] from its
     already downloaded [source]. Returns [None] on success, [Some exn]
@@ -46,7 +46,7 @@ val removal_needs_download: 'a switch_state -> package -> bool
     package's change file. if [force] is specified, remove files marked as added
     in [changes] even if the files have been modified since. *)
 val remove_package:
-  rw switch_state -> ?keep_build:bool -> ?silent:bool ->
+  rw switch_state -> ?silent:bool ->
   ?changes:OpamDirTrack.t -> ?force:bool ->
   package -> unit OpamProcess.job
 

--- a/src/state/opamPath.ml
+++ b/src/state/opamPath.ml
@@ -69,6 +69,10 @@ module Switch = struct
 
   let build t a nv = build_dir t a / OpamPackage.to_string nv
 
+  let remove_dir t a = meta t a / "remove"
+
+  let remove t a nv = remove_dir t a / OpamPackage.to_string nv
+
   let build_ocaml t a = build_dir t a / "ocaml"
 
   let build_install t a nv =

--- a/src/state/opamPath.mli
+++ b/src/state/opamPath.mli
@@ -86,6 +86,10 @@ module Switch: sig
       {i $meta/build/$packages} *)
   val build: t -> switch -> package -> dirname
 
+  (** Temporary folders used to decompress the corresponding archives, used only
+      for package removal {i $meta/remove/$packages} *)
+  val remove: t -> switch -> package -> dirname
+
   (** Temporary folders used to decompress and compile the OCaml
       compiler: {i $meta/build/ocaml} *)
   val build_ocaml: t -> switch -> dirname

--- a/src/state/opamSolution.ml
+++ b/src/state/opamSolution.ml
@@ -382,7 +382,9 @@ let parallel_apply t action action_graph =
   (* 2/ process the package actions (installations and removals) *)
 
   let action_graph = (* Add build actions *)
-    PackageActionGraph.explicit action_graph
+    let noop_remove nv =
+      OpamAction.noop_remove_package t nv in
+    PackageActionGraph.explicit ~noop_remove action_graph
   in
 
   let minimal_switch_state =

--- a/src/state/opamSolution.ml
+++ b/src/state/opamSolution.ml
@@ -446,7 +446,10 @@ let parallel_apply t action action_graph =
             Done (`Exception exn))
       | `Remove nv ->
         if OpamAction.removal_needs_download t nv then
-          (try OpamAction.extract_package t source nv
+          (try
+             let d = OpamPath.Switch.remove t.switch_global.root t.switch nv in
+             OpamFilename.rmdir d;
+             OpamAction.extract_package t source nv d
            with e -> OpamStd.Exn.fatal e);
         OpamProcess.Job.catch (fun e -> OpamStd.Exn.fatal e; Done ())
           (OpamAction.remove_package t nv) @@| fun () ->
@@ -524,6 +527,12 @@ let parallel_apply t action action_graph =
           when not (OpamPackage.has_name t.pinned nv.name) ->
           OpamAction.cleanup_package_artefacts t nv
           (* if reinstalled, only removes build dir *)
+        | `Install nv
+          when not (OpamPackage.has_name t.pinned nv.name) ->
+          let build_dir =
+            OpamPath.Switch.build t.switch_global.root t.switch nv in
+          if not OpamStateConfig.(!r.keep_build_dir) then
+            OpamFilename.rmdir build_dir
         | `Remove _ | `Install _ | `Build _ -> ()
         | _ -> assert false)
       graph

--- a/tests/packages/P5.opam
+++ b/tests/packages/P5.opam
@@ -5,8 +5,8 @@ version: "1"
 maintainer: "contact@ocamlpro.com"
 depends: [ "P1" ]
 depopts: [ "P2" ]
-build: [ [ "./build.sh" ]
-         [ "mkdir" "-p" "%{lib}%/p5" ]
-         [ "touch" "%{lib}%/p5/p2_present" ] {P2:installed}
-         [ "touch" "%{lib}%/p5/p2_absent" ] {!P2:installed} ]
+build: [ [ "./build.sh" ] ]
+install: [ [ "mkdir" "-p" "%{lib}%/p5" ]
+           [ "touch" "%{lib}%/p5/p2_present" ] {P2:installed}
+           [ "touch" "%{lib}%/p5/p2_absent" ] {!P2:installed} ]
 remove: [ "rm" "-rf" "%{lib}%/p5" ]


### PR DESCRIPTION
Now that OPAM is able to distinguish between the 'build' and 'install' rules, we want, when reinstalling a package, to build the new version before to remove the old one: whenever the new version fails to build, the old one is still installed and the opam repository is left untouched.

This is what this patch implements.

Unfortunatly, we might not apply this strategy with all packages. When a package A depends on a package B, for preserving the consistency of then .opam directory we still need to remove A before to remove B. Then, we can't wait for B to be built before to remove the old version. Still, we wait for A to be successfully built before to remove B.