### PR TITLE
'opam switch' interface cleanup (script-breaking changes)

### DIFF
--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -551,7 +551,7 @@ let guess_compiler_package ?repos rt name =
       with
       | Not_found ->
         OpamConsole.error_and_exit
-          "No compiler matching '%s' founf, use 'opam switch list-available' \
+          "No compiler matching '%s' found, use 'opam switch list-available' \
            to see what is available"
           name
       | Failure _ ->

--- a/src/tools/opam_format_upgrade.ml
+++ b/src/tools/opam_format_upgrade.ml
@@ -92,7 +92,7 @@ let system_conf_script =
   \    (Printf.eprintf\n\
   \       \"ERROR: The compiler found at %%s has version %%s,\\n\\\n\
   \        and this package requires %{_:version}%.\\n\\\n\
-  \        You should use e.g. 'opam switch %{_:name}%.%%s' \\\n\
+  \        You should use e.g. 'opam switch create %{_:name}%.%%s' \\\n\
   \        instead.\"\n\
   \       ocamlc Sys.ocaml_version Sys.ocaml_version;\n\
   \     exit 1)\n\

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -158,7 +158,7 @@ else
 	cp packages/P5.tar.gz $(OPAM_REPO)/archives/P5.1+opam.tar.gz
 endif
 	$(OPAMBIN) update
-	$(OPAMBIN) switch system --packages ocaml.system
+	$(OPAMBIN) switch create system --packages ocaml.system
 
 list:
 	$(OPAMBIN) list -A
@@ -263,11 +263,11 @@ switch-alias:
 	$(OPAMBIN) remove P3.1~weird-version.test P4.2
 	$(CHECK) -l switch-alias-2 ocaml.system P1.1 P2.1
 	$(OPAMBIN) switch export $(TMP_DIR)/export
-	$(OPAMBIN) switch install test --alias-of system
+	$(OPAMBIN) switch create test system
 	$(CHECK) -l switch-alias-3 ocaml.system
 	$(OPAMBIN)	switch import $(TMP_DIR)/export
 	$(CHECK) -l switch-alias-4 ocaml.system P1.1 P2.1
-	$(OPAMBIN) switch install test2 --alias-of 20
+	$(OPAMBIN) switch create test2 20
 	$(CHECK) -l switch-alias-5 ocaml.20
 	$(OPAMBIN) install P1
 	$(CHECK) -l switch-alias-6 ocaml.20 P1.1
@@ -277,7 +277,7 @@ switch-alias:
 
 switch-env-packages:
 	$(CHECK) -l switch-env-packages-1 ocaml.system P1.1 P2.1
-	$(OPAMBIN) switch 10+a+b --packages=ocaml.10+a+b,P1,P2,P3,P4
+	$(OPAMBIN) switch install 10+a+b --packages=ocaml.10+a+b,P1,P2,P3,P4
 	$(CHECK) -l switch-env-packages-2 ocaml.10+a+b P1.1 P2.1 P3.1~weird-version.test P4.3
 	./test-TEST.sh $(wildcard $(OPAM_ROOT)/10+a+b/build/P4.3/P4*.env) "1"
 


### PR DESCRIPTION
This will likely break some scripts.

'opam switch foo' or 'opam switch set foo' will NO LONGER try and install
'foo', it can now only switch to an existing switch

'opam switch create SWITCH [COMPILER]' is now preferred over 'opam switch
install'; '--alias-of' is no longer allowed or necessary, since the
positional argument is used instead; '--empty' and '--package' give the
full extent of possibilities.