### PR TITLE
Local switches

### DIFF
--- a/opam-devel.opam
+++ b/opam-devel.opam
@@ -13,7 +13,7 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam"
+dev-repo: "https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "opam-devel"]

--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -787,12 +787,12 @@ let config =
      setup --user) to setup the user ones. To modify both the global and user \
      configuration, use $(b,opam config setup --all).";
     "exec", `exec, ["[--] COMMAND"; "[ARG]..."],
-    "Execute $(i,COMMAND) with the correct environment variables. \
-     This command can be used to cross-compile between switches using \
-     $(b,opam config exec --switch=SWITCH -- COMMAND ARG1 ... ARGn). \
-     Opam expansion takes place in command and args. If no switch is \
-     present on the command line or in the OPAMSWITCH environment \
-     variable, OPAMSWITCH is not set in $(i,COMMAND)'s environment.";
+    "Execute $(i,COMMAND) with the correct environment variables. This command \
+     can be used to cross-compile between switches using $(b,opam config exec \
+     --switch=SWITCH -- COMMAND ARG1 ... ARGn). Opam expansion takes place in \
+     command and args. If no switch is present on the command line or in the \
+     $(i,OPAMSWITCH) environment variable, $(i,OPAMSWITCH) is not set in \
+     $(i,COMMAND)'s environment.";
     "var", `var, ["VAR"],
     "Return the value associated with variable $(i,VAR). Package variables can \
      be accessed with the syntax $(i,pkg:var).";
@@ -1479,11 +1479,11 @@ let switch_doc = "Manage multiple installation of compilers."
 let switch =
   let doc = switch_doc in
   let commands = [
-    "create", `install, ["SWITCH|DIR"; "[COMPILER]"],
-    "Create a new switch with the given name, and install the given compiler \
-     there. $(i,COMPILER), if omitted, defaults to $(i,SWITCH) unless \
-     $(b,--packages) or $(b,--empty) is specified. If a directory name is \
-     specified instead of a name, the switch will be created there.";
+    "create", `install, ["SWITCH"; "[COMPILER]"],
+    "Create a new switch, and install the given compiler there. $(i,SWITCH) \
+     can be a plain name, or a directory, absolute or relative. $(i,COMPILER), \
+     if omitted, defaults to $(i,SWITCH) unless $(b,--packages) or \
+     $(b,--empty) is specified.";
     "set", `set, ["SWITCH"],
     "Set the currently active switch, among the installed switches.";
     "remove", `remove, ["SWITCH"], "Remove the given switch from disk.";
@@ -1517,6 +1517,13 @@ let switch =
         switch set) to set the currently active switch. Without argument, \
         lists installed switches, with one switch argument, defaults to \
         $(b,set).";
+    `P ("Switch handles $(i,SWITCH) can be either a plain name, for switches \
+         that will be held inside $(i,~/.opam), or a directory name, which in \
+         that case is the directory where the switch prefix will be installed, as "
+        ^ OpamSwitch.external_dirname ^
+        ". Opam will automatically select a switch by that name found in the \
+         current directory or its parents, unless $(i,OPAMSWITCH) is set or \
+         $(b,--switch) is specified.");
     `P "$(b,opam switch set) sets the default switch globally, but it is also \
         possible to select a switch in a given shell session, using the \
         environment. For that, use $(i,eval `opam config env \

--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -1479,10 +1479,11 @@ let switch_doc = "Manage multiple installation of compilers."
 let switch =
   let doc = switch_doc in
   let commands = [
-    "create", `install, ["SWITCH"; "[COMPILER]"],
+    "create", `install, ["SWITCH|DIR"; "[COMPILER]"],
     "Create a new switch with the given name, and install the given compiler \
      there. $(i,COMPILER), if omitted, defaults to $(i,SWITCH) unless \
-     $(b,--packages) or $(b,--empty) is specified.";
+     $(b,--packages) or $(b,--empty) is specified. If a directory name is \
+     specified instead of a name, the switch will be created there.";
     "set", `set, ["SWITCH"],
     "Set the currently active switch, among the installed switches.";
     "remove", `remove, ["SWITCH"], "Remove the given switch from disk.";

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -209,6 +209,7 @@ let install_compiler_packages t atoms =
   t
 
 let install gt ?repos ~update_config ~packages switch =
+  let update_config = update_config && not (OpamSwitch.is_external switch) in
   let old_switch_opt = OpamFile.Config.switch gt.config in
   let comp_dir = OpamPath.Switch.root gt.root switch in
   if List.mem switch (OpamFile.Config.installed_switches gt.config) then

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -100,6 +100,19 @@ let list gt ~print_short =
           The current global system switch is %s."
          (OpamStd.Option.to_string ~none:"unset"
             (fun s -> OpamConsole.colorise `bold (OpamSwitch.to_string s)) sys))
+  | Some switch, `Default when OpamSwitch.is_external switch ->
+    OpamConsole.msg "\n";
+    OpamConsole.note
+      "Current switch has been selected based on the current directory.\n\
+       The current global system switch is %s."
+      (OpamStd.Option.to_string ~none:"unset"
+         (fun s -> OpamConsole.colorise `bold (OpamSwitch.to_string s))
+         (OpamFile.Config.switch gt.config));
+    if not (OpamEnv.is_up_to_date_switch gt.root switch) then
+      OpamConsole.warning
+        "The environment is not in sync with the current switch.\n\
+         You should run: %s"
+        (OpamEnv.eval_string gt (Some switch))
   | Some switch, `Default ->
     if not (OpamEnv.is_up_to_date_switch gt.root switch) then
       (OpamConsole.msg "\n";

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -278,6 +278,12 @@ let switch lock gt switch =
     in
     OpamEnv.check_and_print_env_warning st;
     st
+  else if OpamSwitch.is_external switch &&
+          OpamFilename.exists_dir (OpamSwitch.get_root gt.root switch) then
+      let rt = OpamRepositoryState.load `Lock_none gt in
+      let st = OpamSwitchState.load lock gt rt switch in
+      OpamEnv.check_and_print_env_warning st;
+      st
   else
     OpamConsole.error_and_exit "No switch %s is currently installed. \
                                 Installed switches are: %s"

--- a/src/client/opamSwitchCommand.mli
+++ b/src/client/opamSwitchCommand.mli
@@ -16,7 +16,8 @@ open OpamStateTypes
 
 (** Install a new switch, with the given packages set as compiler. The given
     [global_state] is unlocked as soon as possible, i.e. after registering the
-    existence of the new switch *)
+    existence of the new switch. [update_config] sets the switch as current
+    globally, unless it is external *)
 val install:
   rw global_state ->
   ?repos:repository_name list ->

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -326,6 +326,12 @@ let remove_suffix suffix filename =
   let filename = to_string filename in
   OpamStd.String.remove_suffix ~suffix filename
 
+let rec find_in_parents f dir =
+  if f dir then Some dir else
+  let parent = dirname_dir dir in
+  if parent = dir then None
+  else find_in_parents f parent
+
 let patch filename dirname =
   OpamSystem.patch ~dir:(Dir.to_string dirname) (to_string filename)
 

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -233,6 +233,10 @@ val touch: t -> unit
 (** Change file permissions *)
 val chmod: t -> int -> unit
 
+(** Returns the closest parent of a directory (including itself) for which the
+    predicate holds, if any *)
+val find_in_parents: (Dir.t -> bool) ->  Dir.t -> Dir.t option
+
 (** {2 Locking} *)
 
 (** See [OpamSystem.flock]. Prefer the higher level [with_flock] functions when

--- a/src/format/opamSwitch.ml
+++ b/src/format/opamSwitch.ml
@@ -19,12 +19,14 @@ let not_installed s =
      different one using the 'opam switch' command."
     (to_string s)
 
-let is_external s = OpamStd.String.contains ~sub:Filename.dir_sep s
+let is_external s =
+  OpamStd.String.starts_with ~prefix:"." s ||
+  OpamStd.String.contains ~sub:Filename.dir_sep s
 
 let of_string s =
   if is_external s then OpamFilename.Dir.(to_string (of_string s))
   else s
 
 let get_root root s =
-  if is_external s then OpamFilename.Dir.of_string s
+  if is_external s then OpamFilename.Op.(OpamFilename.Dir.of_string s / "_opam")
   else OpamFilename.Op.(root / s)

--- a/src/format/opamSwitch.ml
+++ b/src/format/opamSwitch.ml
@@ -18,3 +18,13 @@ let not_installed s =
     "The selected compiler switch %s is not installed. Please choose a \
      different one using the 'opam switch' command."
     (to_string s)
+
+let is_external s = OpamStd.String.contains ~sub:Filename.dir_sep s
+
+let of_string s =
+  if is_external s then OpamFilename.Dir.(to_string (of_string s))
+  else s
+
+let get_root root s =
+  if is_external s then OpamFilename.Dir.of_string s
+  else OpamFilename.Op.(root / s)

--- a/src/format/opamSwitch.ml
+++ b/src/format/opamSwitch.ml
@@ -23,10 +23,13 @@ let is_external s =
   OpamStd.String.starts_with ~prefix:"." s ||
   OpamStd.String.contains ~sub:Filename.dir_sep s
 
+let external_dirname = "_opam"
+
 let of_string s =
   if is_external s then OpamFilename.Dir.(to_string (of_string s))
   else s
 
 let get_root root s =
-  if is_external s then OpamFilename.Op.(OpamFilename.Dir.of_string s / "_opam")
+  if is_external s
+  then OpamFilename.Op.(OpamFilename.Dir.of_string s / external_dirname)
   else OpamFilename.Op.(root / s)

--- a/src/format/opamSwitch.mli
+++ b/src/format/opamSwitch.mli
@@ -18,3 +18,12 @@ val unset: t
 
 (** Display an error message when a switch is not installed. *)
 val not_installed: t -> 'a
+
+(** Determines wether this switch is internal (bound to a prefix within the opam
+    root) or living somewhere else, in which case its prefix dir is inferred
+    from its name using [get_root] *)
+val is_external: t -> bool
+
+(** Returns the root directory of the switch with the given name, assuming the
+    given opam root *)
+val get_root: OpamFilename.Dir.t -> t -> OpamFilename.Dir.t

--- a/src/format/opamSwitch.mli
+++ b/src/format/opamSwitch.mli
@@ -27,3 +27,7 @@ val is_external: t -> bool
 (** Returns the root directory of the switch with the given name, assuming the
     given opam root *)
 val get_root: OpamFilename.Dir.t -> t -> OpamFilename.Dir.t
+
+(** The relative dirname in which the opam switch prefix sits for external
+    switches ("_opam") *)
+val external_dirname: string

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -39,6 +39,13 @@ let load lock_kind =
      currently installed shell init scripts) *)
   let config_lock = OpamFilename.flock lock_kind (OpamPath.config_lock root) in
   let config = load_config global_lock root in
+  let switches =
+    List.filter
+      (fun sw -> not (OpamSwitch.is_external sw) ||
+                 OpamFilename.exists_dir (OpamSwitch.get_root root sw))
+      (OpamFile.Config.installed_switches config)
+  in
+  let config = OpamFile.Config.with_installed_switches switches config in
   let global_variables =
     List.fold_left (fun acc (v,value,doc) ->
         OpamVariable.Map.add v (lazy (Some value), doc) acc)

--- a/src/state/opamPath.ml
+++ b/src/state/opamPath.ml
@@ -60,7 +60,7 @@ let backup t = backup_dir t /- backup_file ()
 
 module Switch = struct
 
-  let root t a = t / OpamSwitch.to_string a
+  let root t a = OpamSwitch.get_root t a
 
   (** Internal files and dirs with static location *)
 

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -118,7 +118,20 @@ let initk k =
   let open OpamStd.Option.Op in
   let current_switch, switch_from =
     match env_string "SWITCH" with
-    | Some "" | None -> None, None
+    | Some "" | None ->
+      OpamFilename.(
+        match
+          find_in_parents
+            (fun d -> exists_dir
+                Op.(d / OpamSwitch.external_dirname /
+                    OpamPath.Switch.meta_dirname))
+            (cwd ())
+        with
+        | None -> None, None
+        | Some dir ->
+          Some (OpamSwitch.of_string (OpamFilename.Dir.to_string dir)),
+          Some `Default
+      )
     | Some s -> Some (OpamSwitch.of_string s), Some `Env
   in
   setk (setk (fun c -> r := c; k)) !r

--- a/src/state/opamSwitchAction.ml
+++ b/src/state/opamSwitchAction.ml
@@ -122,6 +122,12 @@ let add_to_reinstall st ~unpinned_only packages =
   { st with reinstall = st.reinstall ++ packages %% st.installed }
 
 let set_current_switch lock gt switch =
+  if OpamSwitch.is_external switch then
+    OpamConsole.error_and_exit
+      "Can not set external switch '%s' globally. To set it in the current \
+       shell use:\n %s"
+      (OpamSwitch.to_string switch)
+      (OpamEnv.eval_string gt (Some switch));
   let config = OpamFile.Config.with_switch switch gt.config in
   let gt = { gt with config } in
   OpamGlobalState.write gt;

--- a/src/state/opamSwitchAction.mli
+++ b/src/state/opamSwitchAction.mli
@@ -23,7 +23,8 @@ val create_empty_switch:
     Unless [OpamStateConfig.(!r.dryrun)] *)
 val write_selections: rw switch_state -> unit
 
-(** Updates the defined default switch and loads its state *)
+(** Updates the defined default switch and loads its state; fails and exits with
+    a message if the switch is external *)
 val set_current_switch:
   'a lock -> rw global_state -> switch -> 'a switch_state
 

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -87,6 +87,17 @@ let load lock_kind gt rt switch =
     OpamFilename.flock lock_kind (OpamPath.Switch.lock gt.root switch)
   in
   let switch_config = load_switch_config gt switch in
+  if OpamVersion.compare
+      (OpamVersion.nopatch (switch_config.OpamFile.Switch_config.opam_version))
+      (OpamVersion.nopatch OpamFormatUpgrade.latest_version)
+     <> 0 then
+    OpamConsole.error_and_exit
+      "Could not load opam switch %s: it reports version %s while %s was \
+       expected"
+      (OpamSwitch.to_string switch)
+      (OpamVersion.to_string
+         (switch_config.OpamFile.Switch_config.opam_version))
+      (OpamVersion.to_string OpamFormatUpgrade.latest_version);
   let { sel_installed = installed; sel_roots = installed_roots;
         sel_pinned = pinned; sel_compiler = compiler_packages; } =
     load_selections gt switch


### PR DESCRIPTION
This PR provides the possibility to use directories as switch handles,
which holds the switch contents below `_opam` at that path. The switch
is then automatically selected if opam is run from the given directory
or a descendent.

External switches are still registered globally in ~/.opam/config,
which allows listings, format upgrade, global repository settings
changes, etc. ; but the case where they aren't registered should be
handled nicely.