### PR TITLE
Better resolution of local-switches

### DIFF
--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -253,10 +253,10 @@ let getchdir s =
   p
 
 let normalize s =
-  getchdir (getchdir s)
+  try getchdir (getchdir s) with File_not_found _ -> s
 
 let real_path p =
-  if Filename.is_relative p then
+  (* if Filename.is_relative p then *)
     match (try Some (Sys.is_directory p) with Sys_error _ -> None) with
     | None ->
       let rec resolve dir =
@@ -265,14 +265,18 @@ let real_path p =
         if dir = parent then dir
         else Filename.concat (resolve parent) (Filename.basename dir)
       in
-      resolve (Filename.concat (Sys.getcwd ()) p)
+      let p =
+        if Filename.is_relative p then Filename.concat (Sys.getcwd ()) p
+        else p
+      in
+      resolve p
     | Some true -> normalize p
     | Some false ->
       let dir = normalize (Filename.dirname p) in
       match Filename.basename p with
       | "." -> dir
       | base -> dir / base
-  else p
+  (* else p *)
 
 type command = string list
 

--- a/src/format/opamSwitch.ml
+++ b/src/format/opamSwitch.ml
@@ -15,7 +15,7 @@ let unset = of_string "#unset#"
 
 let not_installed s =
   OpamConsole.error_and_exit
-    "The selected compiler switch %s is not installed. Please choose a \
+    "The selected switch %s is not installed. Please choose a \
      different one using the 'opam switch' command."
     (to_string s)
 

--- a/src/format/opamSwitch.ml
+++ b/src/format/opamSwitch.ml
@@ -30,7 +30,12 @@ let of_string s =
   else s
 
 let of_dirname d =
-  OpamFilename.Dir.to_string d
+  let s = OpamFilename.Dir.to_string d in
+  try
+    let swdir = Filename.concat s external_dirname in
+    let r = OpamSystem.real_path Filename.(concat s (Unix.readlink swdir)) in
+    if Filename.basename r = external_dirname then Filename.dirname r else s
+  with Unix.Unix_error _ -> s
 
 let get_root root s =
   if is_external s

--- a/src/format/opamSwitch.mli
+++ b/src/format/opamSwitch.mli
@@ -32,5 +32,7 @@ val get_root: OpamFilename.Dir.t -> t -> OpamFilename.Dir.t
     switches ("_opam") *)
 val external_dirname: string
 
-(** Returns an external switch handle from a directory name *)
+(** Returns an external switch handle from a directory name. Resolves to the
+    destination if [external_dirname] at the given dir is a symlink to another
+    [external_dirname]. *)
 val of_dirname: OpamFilename.Dir.t -> t

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -165,7 +165,7 @@ let get_current_switch_from_cwd root =
   let open OpamStd.Option.Op in
   OpamFilename.find_in_parents
     (fun d ->
-       OpamSwitch.of_dirname d |>
+       OpamSwitch.of_string (OpamFilename.Dir.to_string d) |>
        OpamPath.Switch.switch_config root |>
        OpamFile.Switch_config.read_opt |> function
        | None -> false

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -77,7 +77,8 @@ let load lock_kind gt rt switch =
   let chrono = OpamConsole.timer () in
   log "LOAD-SWITCH-STATE";
 
-  if not (List.mem switch (OpamFile.Config.installed_switches gt.config)) then
+  if not (OpamSwitch.is_external switch) &&
+     not (List.mem switch (OpamFile.Config.installed_switches gt.config)) then
     (log "The switch %a does not appear to be installed according to %a"
        (slog OpamSwitch.to_string) switch
        (slog @@ OpamFile.to_string @* OpamPath.config) gt.root;


### PR DESCRIPTION
resolve _opam symlinks, so that they can be used to share a local switch between projects without problems

also small fixes for unregistered switch selection, and dirname normalisation