### PR TITLE
Strip packages conflicting with the compiler

### DIFF
--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -55,8 +55,8 @@ let utf8, utf8_extended =
 
 let timer () =
   if debug () then
-    let t = Sys.time () in
-    fun () -> Sys.time () -. t
+    let t = Unix.time () in
+    fun () -> Unix.time () -. t
   else
     fun () -> 0.
 

--- a/src/format/opamFormula.mli
+++ b/src/format/opamFormula.mli
@@ -42,7 +42,7 @@ val check: atom -> OpamPackage.t -> bool
 
 (** Return all packages satisfying the given atoms from a set (i.e. name
     matching at least one of the atoms, version matching all atoms with the
-    appropriate name)*)
+    appropriate name) *)
 val packages_of_atoms: OpamPackage.Set.t -> atom list -> OpamPackage.Set.t
 
 (** AND formulas *)

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -583,13 +583,18 @@ let call_external_solver ~version_map univ req =
   let cudf_request = to_cudf univ req in
   if Cudf.universe_size univ > 0 then
     let criteria = OpamSolverConfig.criteria req.criteria in
+    let chrono = OpamConsole.timer () in
     log "Calling external solver with criteria %s" criteria;
     ignore (dump_cudf_request ~version_map cudf_request
               criteria OpamSolverConfig.(!r.cudf_file));
     try
-      Algo.Depsolver.check_request_using
-        ~call_solver:(dose_solver_callback ~criteria)
-        ~criteria ~explain:true cudf_request
+      let r =
+        Algo.Depsolver.check_request_using
+          ~call_solver:(dose_solver_callback ~criteria)
+          ~criteria ~explain:true cudf_request
+      in
+      log "External solver call done in %.3f" (chrono ());
+      r
     with e ->
       OpamStd.Exn.fatal e;
       OpamConsole.warning "External solver failed:";

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -247,6 +247,7 @@ let load_cudf_universe ?depopts ~build
   log "Load cudf universe (depopts:%b, build:%b)"
     (OpamStd.Option.default false depopts)
     build;
+  let chrono = OpamConsole.timer () in
   let version_map = match version_map with
     | Some vm -> vm
     | None -> cudf_versions_map opam_universe opam_packages in
@@ -278,7 +279,7 @@ let load_cudf_universe ?depopts ~build
     with Cudf.Constraint_violation s ->
       OpamConsole.error_and_exit "Malformed CUDF universe (%s)" s
   in
-  log ~level:3 "Load cudf universe: done";
+  log ~level:3 "Load cudf universe: done in %.3fs" (chrono ());
   (* We can trim the universe here to get faster results, but we
      choose to keep it bigger to get more precise conflict messages. *)
   (* let universe = Algo.Depsolver.trim universe in *)

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -329,16 +329,6 @@ let cleanup_request universe (req:atom request) =
   let wish_install =
     List.filter (fun (n,_) -> not (List.mem_assoc n req.wish_upgrade))
       req.wish_install in
-  let wish_install = (* Always add compiler packages *)
-    OpamStd.List.filter_map (fun nv ->
-        let n = nv.name in
-        if List.mem_assoc n req.wish_install ||
-           List.mem_assoc n req.wish_upgrade
-        then None
-        else Some (n, Some (`Eq, nv.version)))
-      (OpamPackage.Set.elements universe.u_base)
-    @ wish_install
-  in
   let wish_upgrade =
     List.rev_map (fun (n,c as pkg) ->
         if c = None

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -318,6 +318,7 @@ let lint t =
            | (CString "make", _)::_, _ -> true
            | _ -> false
          ) all_commands);
+(*
     cond 40 `Warning
       "Field 'features' is still experimental and not yet to be used on \
        the official repo"
@@ -337,6 +338,7 @@ let lint t =
         instead for compatibility"
        ~detail:alpha_flags
        (alpha_flags <> []));
+*)
     (let undep_pkgs =
        List.fold_left
          (fun acc v ->


### PR DESCRIPTION
in fact stripping all conflicting compiler versions. Solver times back to normal

(we were already hinting to the solver that we wanted to keep the specific package versions,
so it could have done this optimisation itself, but it seems it didn't)