### PR TITLE
Add the `opam var` command

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -715,7 +715,7 @@ let global_options =
        interactive questions and overrides the $(b,\\$OPAMDEBUG) variable."
   in
   let json_flag =
-    mk_opt ["json"] "FILENAME"
+    mk_opt ~section ["json"] "FILENAME"
       "Save the results of the OPAM run in a computer-readable file. If the \
        filename contains the character `%', it will be replaced by an index \
        that doesn't overwrite an existing file. Similar to setting the \

--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -1061,6 +1061,36 @@ let config =
   ),
   term_info "config" ~doc ~man
 
+(* VAR *)
+let var_doc = "Prints the value associated with a given variable"
+let var =
+  let doc = var_doc in
+  let man = [
+    `S "DESCRIPTION";
+    `P "With a $(i,VAR) argument, prints the value associated with $(i,VAR). \
+        Without argument, lists the opam variables currently defined. This \
+        command is a shortcut to `opam config var` and `opam config list`.";
+  ] in
+  let varname =
+    Arg.(value & pos 0 (some string) None & info ~docv:"VAR" [])
+  in
+  let print_var global_options var =
+    apply_global_options global_options;
+    match var with
+    | None ->
+      OpamGlobalState.with_ `Lock_none @@ fun gt ->
+      (try `Ok (OpamConfigCommand.list gt [])
+       with Failure msg -> `Error (false, msg))
+    | Some v ->
+      OpamGlobalState.with_ `Lock_none @@ fun gt ->
+      (try `Ok (OpamConfigCommand.variable gt (OpamVariable.Full.of_string v))
+       with Failure msg -> `Error (false, msg))
+  in
+  Term.ret (
+    Term.(pure print_var $global_options $varname)
+  ),
+  term_info "var" ~doc ~man
+
 (* INSTALL *)
 let install_doc = "Install a list of packages."
 let install =
@@ -2339,6 +2369,7 @@ let commands = [
   reinstall;
   update; upgrade;
   config;
+  var;
   repository; make_command_alias repository "remote";
   switch;
   pin (); make_command_alias (pin ~unpin_only:true ()) ~options:" remove" "unpin";


### PR DESCRIPTION
mostly an alias for `opam config var`, although lists the defined
variables without a VAR argument