### PR TITLE
Experiment: don't remove extra parens when printing opam files

### DIFF
--- a/src/format/opamFormat.ml
+++ b/src/format/opamFormat.ml
@@ -137,9 +137,7 @@ module V = struct
       (fun ~pos:_ -> function
          | Option (_,k,l) -> k, l
          | k -> k, [])
-      (function
-        | (v, []) -> v
-        | (v, l) -> Option (pos_null, v, l))
+      (function (v, l) -> Option (pos_null, v, l))
 
   let map_group pp1 = group -| map_list ~posf:value_pos pp1
 
@@ -161,7 +159,7 @@ module V = struct
     in
     pp
       (fun ~pos:_ v -> wrap (expected_depth - depth v) v)
-      (fun v -> lift expected_depth v)
+      (fun v -> v (*lift expected_depth v*))
 
   let map_list ?(depth=0) pp1 =
     list_depth depth -|

--- a/src/format/opamPrinter.ml
+++ b/src/format/opamPrinter.ml
@@ -52,6 +52,7 @@ let rec format_value fmt = function
   | List (_, l) ->
     Format.fprintf fmt "@[<hv>[@;<0 2>@[<hv>%a@]@,]@]" format_values l
   | Group (_,g)     -> Format.fprintf fmt "@[<hv>(%a)@]" format_values g
+  | Option(_,v,[])  -> Format.fprintf fmt "%a" format_value v
   | Option(_,v,l)   -> Format.fprintf fmt "@[<hov 2>%a@ {@[<hv>%a@]}@]"
                          format_value v format_values l
   | Env_binding (_,id,op,v) ->


### PR DESCRIPTION
More verbose, but might be more consistent. Probably desirable if we want to switch format, e.g. to sexps.

Example diff on `lambda-term`:

``` diff
17,21c17,21
< maintainer: "jeremie@dimino.org"
< authors: "Jérémie Dimino"
< license: "BSD3"
< homepage: "https://github.com/diml/lambda-term"
< bug-reports: "https://github.com/diml/lambda-term/issues"

---
> maintainer: ["jeremie@dimino.org"]
> authors: ["Jérémie Dimino"]
> license: ["BSD3"]
> homepage: ["https://github.com/diml/lambda-term"]
> bug-reports: ["https://github.com/diml/lambda-term/issues"]
30c30
< flags: light-uninstall

---
> flags: [light-uninstall]
35,37c35,37
< build-doc: ["ocaml" "setup.ml" "-doc"]
< install: ["ocaml" "setup.ml" "-install"]
< remove: ["ocamlfind" "remove" "lambda-term"]

---
> build-doc: [["ocaml" "setup.ml" "-doc"]]
> install: [["ocaml" "setup.ml" "-install"]]
> remove: [["ocamlfind" "remove" "lambda-term"]]
```
