### PR TITLE
CLI simplifications

### DIFF
--- a/src/client/opamRepositoryCommand.ml
+++ b/src/client/opamRepositoryCommand.ml
@@ -53,21 +53,19 @@ let update_repos_config rt repositories =
 let add rt name url =
   log "repository-add";
   let root = rt.repos_global.root in
-  (try
-     let r = OpamRepositoryName.Map.find name rt.repositories in
-     if r.repo_url = url then
-       (OpamConsole.note
-          "Repository %s is already configured to that URL. \
-           Maybe what you wanted was 'opam repository select' ?"
-          (OpamRepositoryName.to_string name);
-        OpamStd.Sys.exit 0)
-     else
-       OpamConsole.error_and_exit
-         "Repository %s is already set up and points to %s. Maybe you meant \
-          'opam repository set-url' or 'opam repository select' ?"
-         (OpamRepositoryName.to_string name)
-         (OpamUrl.to_string r.repo_url)
-   with Not_found -> ());
+  let repo_exists =
+    OpamStd.Option.of_Not_found
+      (OpamRepositoryName.Map.find name) rt.repositories
+  in
+  match repo_exists with
+  | Some r when r.repo_url = url -> rt
+  | Some r ->
+    OpamConsole.error_and_exit
+      "Repository %s is already set up and points to %s. Maybe you meant \
+       'opam repository set-url' ?"
+      (OpamRepositoryName.to_string name)
+      (OpamUrl.to_string r.repo_url)
+  | None ->
   let repo = { repo_name = name; repo_url = url;
                repo_root = OpamRepositoryPath.create root name;
                repo_priority = 0; }


### PR DESCRIPTION
* much simplified 'opam repo' command
* lifted 'var', 'env', 'exec' from 'opam config' to the toplevel (e.g. 'opam env' instead of 'opam config env')