### PR TITLE
Fix warnings on OCaml 4.03.0

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -1,4 +1,5 @@
 OCAMLVERSION = @OCAMLVERSION@
+OCAML_4_03 = @ocaml_4_03@
 OCAML_4_02 = @ocaml_4_02@
 datarootdir = @datarootdir@
 prefix = @prefix@

--- a/configure
+++ b/configure
@@ -604,6 +604,7 @@ OCAMLFIND
 OCAMLYACC
 OCAMLLEXDOTOPT
 OCAMLLEX
+ocaml_4_03
 ocaml_4_02
 AWK
 OCAMLBUILD
@@ -3715,6 +3716,43 @@ x$ax_compare_version_B" | sed 's/^ *//' | sort -r | sed "s/x${ax_compare_version
       fi
 
 ocaml_4_02="$ax_compare_version"
+
+
+
+
+  # Used to indicate true or false condition
+  ax_compare_version=false
+
+  # Convert the two version strings to be compared into a format that
+  # allows a simple string comparison.  The end result is that a version
+  # string of the form 1.12.5-r617 will be converted to the form
+  # 0001001200050617.  In other words, each number is zero padded to four
+  # digits, and non digits are removed.
+
+  ax_compare_version_A=`echo "$OCAMLVERSION" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
+                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/[^0-9]//g'`
+
+
+  ax_compare_version_B=`echo "4.03.0" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
+                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/[^0-9]//g'`
+
+
+    ax_compare_version=`echo "x$ax_compare_version_A
+x$ax_compare_version_B" | sed 's/^ *//' | sort -r | sed "s/x${ax_compare_version_A}/true/;s/x${ax_compare_version_B}/false/;1q"`
+
+
+
+    if test "$ax_compare_version" = "true" ; then
+    :
+      fi
+
+ocaml_4_03="$ax_compare_version"
 
 
   # checking for ocamllex

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,8 @@ AS_IF([test "x${enable_version_check}" != "xno"], [
 
 AX_COMPARE_VERSION([$OCAMLVERSION], [ge], [4.02.0])
 AC_SUBST(ocaml_4_02,"$ax_compare_version")
+AX_COMPARE_VERSION([$OCAMLVERSION], [ge], [4.03.0])
+AC_SUBST(ocaml_4_03,"$ax_compare_version")
 
 AC_PROG_OCAMLLEX
 AC_PROG_OCAMLYACC

--- a/src/Makefile
+++ b/src/Makefile
@@ -88,10 +88,14 @@ state/opamScript.ml: ../shell core/opamVersion.ml
 	ocaml ../shell/crunch.ml "complete_zsh" < ../shell/opam_completion_zsh.sh >> $@
 	ocaml ../shell/crunch.ml "prompt"       < ../shell/opam_prompt.sh >> $@
 
-ifeq ($(OCAML_4_02),true)
-  COMPATV = 4.02
+ifeq ($(OCAML_4_03),true)
+  COMPATV = 4.03
 else
-  COMPATV = 4.01
+  ifeq ($(OCAML_4_02),true)
+    COMPATV = 4.02
+  else
+    COMPATV = 4.01
+  endif
 endif
 
 core/opamCompat.%: core/opamCompat.%.$(COMPATV)

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -9,6 +9,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open OpamCompat
 open OpamTypes
 open OpamStateTypes
 open OpamStd.Op
@@ -307,7 +308,7 @@ let disp_header = function
   | Package -> "Package"
   | Synopsis | Synopsis_or_target -> "Synopsis"
   | Description -> "Description"
-  | Field s -> String.capitalize s
+  | Field s -> String.capitalize_ascii s
   | Installed_version -> "Installed"
   | Pinning_target -> "Pin"
   | Raw -> "Metadata"

--- a/src/core/opamCompat.ml.4.01
+++ b/src/core/opamCompat.ml.4.01
@@ -19,6 +19,17 @@ module Bytes = struct
   external unsafe_of_string : string -> t = "%identity"
 end
 
+module String = struct
+  include String
+  let lowercase_ascii = lowercase
+  let capitalize_ascii = capitalize
+end
+
+module Char = struct
+  include Char
+  let lowercase_ascii = lowercase
+end
+
 module Buffer = struct
   include Buffer
   let add_subbytes = add_substring

--- a/src/core/opamCompat.ml.4.03
+++ b/src/core/opamCompat.ml.4.03
@@ -1,6 +1,6 @@
 (**************************************************************************)
 (*                                                                        *)
-(*    Copyright 2016 OCamlPro                                             *)
+(*    Copyright 2014 OCamlPro                                             *)
 (*                                                                        *)
 (*  All rights reserved. This file is distributed under the terms of the  *)
 (*  GNU Lesser General Public License version 2.1, with the special       *)
@@ -11,14 +11,5 @@
 module Bytes = Bytes
 module Buffer = Buffer
 module Filename = Filename
-
-module String = struct
-  include String
-  let lowercase_ascii = lowercase
-  let capitalize_ascii = capitalize
-end
-
-module Char = struct
-  include Char
-  let lowercase_ascii = lowercase
-end
+module String = String
+module Char = Char

--- a/src/core/opamCompat.mli.4.01
+++ b/src/core/opamCompat.mli.4.01
@@ -21,6 +21,17 @@ module Bytes : sig
   external unsafe_of_string : string -> t = "%identity"
 end
 
+module String : sig
+  include module type of String
+  val lowercase_ascii : string -> string
+  val capitalize_ascii : string -> string
+end
+
+module Char : sig
+  include module type of Char
+  val lowercase_ascii: char -> char
+end
+
 module Buffer : sig
   include module type of Buffer with type t = Buffer.t
   val add_subbytes : t -> Bytes.t -> int -> int -> unit

--- a/src/core/opamCompat.mli.4.02
+++ b/src/core/opamCompat.mli.4.02
@@ -13,3 +13,15 @@
 module Bytes = Bytes
 module Buffer = Buffer
 module Filename = Filename
+
+module String : sig
+  include module type of String
+  val lowercase_ascii : string -> string
+  val capitalize_ascii : string -> string
+end
+
+module Char : sig
+  include module type of Char
+  val lowercase_ascii: char -> char
+end
+

--- a/src/core/opamCompat.mli.4.03
+++ b/src/core/opamCompat.mli.4.03
@@ -8,17 +8,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Compatibility layer (Bytes, etc.) for different OCaml versions *)
+
 module Bytes = Bytes
 module Buffer = Buffer
 module Filename = Filename
-
-module String = struct
-  include String
-  let lowercase_ascii = lowercase
-  let capitalize_ascii = capitalize
-end
-
-module Char = struct
-  include Char
-  let lowercase_ascii = lowercase
-end
+module String = String
+module Char = Char

--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -262,7 +262,7 @@ let confirm ?(default=true) fmt =
       else if OpamStd.Sys.(not tty_out || os () = Win32 || os () = Cygwin) then
         let rec loop () =
           prompt ();
-          match String.lowercase (read_line ()) with
+          match String.lowercase_ascii (read_line ()) with
           | "y" | "yes" -> true
           | "n" | "no" -> false
           | "" -> default
@@ -276,7 +276,7 @@ let confirm ?(default=true) fmt =
         let ans =
           try
             if read stdin buf 0 1 = 0 then raise End_of_file
-            else Some (Char.lowercase (Bytes.get buf 0))
+            else Some (Char.lowercase_ascii (Bytes.get buf 0))
           with
           | Unix.Unix_error (Unix.EINTR,_,_) -> None
           | Unix.Unix_error _ -> raise End_of_file

--- a/src/core/opamDirTrack.ml
+++ b/src/core/opamDirTrack.ml
@@ -8,6 +8,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open OpamCompat
 open OpamStd.Op
 open OpamProcess.Job.Op
 
@@ -40,7 +41,7 @@ let string_of_change = function
 let to_string t =
   OpamStd.Format.itemize (fun (f, change) ->
       Printf.sprintf "%s of %s"
-        (String.capitalize (string_of_change change)) f)
+        (String.capitalize_ascii (string_of_change change)) f)
     (SM.bindings t)
 
 (** uid, gid, perm *)

--- a/src/core/opamHash.ml
+++ b/src/core/opamHash.ml
@@ -8,6 +8,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open OpamCompat
+
 type kind = [ `MD5 | `SHA256 | `SHA512 ]
 
 let default_kind = `MD5
@@ -25,7 +27,7 @@ let string_of_kind = function
   | `SHA256 -> "sha256"
   | `SHA512 -> "sha512"
 
-let kind_of_string s = match String.lowercase s with
+let kind_of_string s = match String.lowercase_ascii s with
   | "md5" -> `MD5
   | "sha256" -> `SHA256
   | "sha512" -> `SHA512
@@ -42,7 +44,7 @@ let len = function
 let valid kind = is_hex_str (len kind)
 
 let make kind s =
-  if valid kind s then kind, String.lowercase s
+  if valid kind s then kind, String.lowercase_ascii s
   else invalid_arg ("OpamHash.make_"^string_of_kind kind)
 
 let md5 = make `MD5
@@ -56,7 +58,7 @@ let of_string_opt s =
       | None -> `MD5, s
       | Some (skind, s) -> kind_of_string skind, s
     in
-    if valid kind s then Some (kind, String.lowercase s)
+    if valid kind s then Some (kind, String.lowercase_ascii s)
     else None
   with Invalid_argument _ -> None
 

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1048,7 +1048,7 @@ module Config = struct
       None
 
   let env_bool var =
-    env (fun s -> match String.lowercase s with
+    env (fun s -> match String.lowercase_ascii s with
         | "" | "0" | "no" | "false" -> false
         | "1" | "yes" | "true" -> true
         | _ -> failwith "env_bool")
@@ -1057,7 +1057,7 @@ module Config = struct
   let env_int var = env int_of_string var
 
   let env_level var =
-    env (fun s -> match String.lowercase s with
+    env (fun s -> match String.lowercase_ascii s with
         | "" | "no" | "false" -> 0
         | "yes" | "true" -> 1
         | s -> int_of_string s)
@@ -1070,7 +1070,7 @@ module Config = struct
     env float_of_string var
 
   let when_ext s =
-    match String.lowercase s with
+    match String.lowercase_ascii s with
     | "extended" -> `Extended
     | "always" -> `Always
     | "never" -> `Never

--- a/src/format/opamPackage.ml
+++ b/src/format/opamPackage.ml
@@ -9,6 +9,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open OpamCompat
 open OpamStd.Op
 
 let log fmt = OpamConsole.log "PACKAGE" fmt
@@ -66,7 +67,7 @@ module Name = struct
     x
 
   let compare n1 n2 =
-    match compare (String.lowercase n1) (String.lowercase n2) with
+    match compare (String.lowercase_ascii n1) (String.lowercase_ascii n2) with
     | 0 -> compare n1 n2
     | i -> i
 

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -254,7 +254,7 @@ type solver_result =
   | OK of package action list (** List of successful actions *)
   | Aborted
   | No_solution
-  | Error of package action list * package action list * package action list
+  | Partial_error of package action list * package action list * package action list
   (** List of successful actions, list of actions with errors,
       list of remaining undone actions *)
 

--- a/src/solver/opamCudf.mli
+++ b/src/solver/opamCudf.mli
@@ -101,6 +101,8 @@ val atomic_actions:
 val compute_root_causes: ActionGraph.t -> OpamPackage.Name.Set.t ->
   Cudf.package cause Map.t
 
+exception Solver_failure
+
 (** Resolve a CUDF request. The result is either a conflict holding
     an explanation of the error, or a resulting universe.
     [~extern] specifies whether the external solver should be used *)

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -369,7 +369,7 @@ let resolve ?(verbose=true) universe ~orphans request =
       try
         let resp = OpamCudf.resolve ~extern:true ~version_map u req in
         OpamCudf.to_actions add_orphan_packages u resp
-      with Failure "opamSolver" ->
+      with OpamCudf.Solver_failure ->
         OpamConsole.error_and_exit
           "External solver failure, please fix your installation and check \
            $OPAMROOT/config and variable $OPAMEXTERNALSOLVER.\n\


### PR DESCRIPTION
There is one left on matching `Sys_error "Broken pipe"` ; but not sure how to avoid it
(we do register a signal handler; but what may happen is that the signal is caught before the handler is registered, and we do get that exception)