### PR TITLE
Assume patches apply with '-p1'

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -667,12 +667,13 @@ files.
   `"org:foo"` tag is reserved for packages officially distributed by
   organization ``foo''.
 
-- <a id="opamfield-patches">`patches: [ <string> { <filter> } ... ]`</a>:
-  a list of files relative to the project source root (often added through the
-  `files/` metadata subdirectory). The listed patch files will be applied
-  sequentially to the source as with the `patch` command. Variable interpolation
-  is available, so you can specify `patches: [ "file" ]` to have the patch
-  processed from `file.in`.
+- <a id="opamfield-patches">`patches: [ <string> { <filter> } ... ]`</a>: a list
+  of files relative to the project source root (often added through the `files/`
+  metadata subdirectory). The listed patch files will be applied sequentially to
+  the source as with the `patch` command, stripping one level of leading
+  directories (`-p1`) -- which is what version control systems generally use .
+  Variable interpolation is available, so you can specify `patches: [ "file" ]`
+  to have the patch processed from `file.in`.
 
     Patches may be applied conditionally by adding _filters_.
 

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -212,8 +212,9 @@ val remove_prefix_dir: Dir.t -> Dir.t -> string
 (** Remove a suffix from a filename *)
 val remove_suffix: Base.t -> t -> string
 
-(** Apply a patch in a directory. Returns [true] on success *)
-val patch: t -> Dir.t -> bool OpamProcess.job
+(** Apply a patch in a directory. Returns [None] on success, the process error
+    otherwise *)
+val patch: t -> Dir.t -> exn option OpamProcess.job
 
 (** Create an empty file *)
 val touch: t -> unit

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -234,9 +234,9 @@ val get_lock_flag: lock -> lock_flag
 
 (** {2 Misc} *)
 
-(** Apply a patch file in the current directory. Returns false if the patch
-    didn't apply *)
-val patch: dir:string -> string -> bool OpamProcess.job
+(** Apply a patch file in the current directory. Returns the error if the patch
+    didn't apply. *)
+val patch: dir:string -> string -> exn option OpamProcess.job
 
 (** Create a tempory file in {i ~/.opam/logs/<name>XXX} *)
 val temp_file: ?dir:string -> string -> string


### PR DESCRIPTION
Being stricter means we don't have to try the patch for all values of
'-p', with the portability problems that caused, and that we can get the error
reports when patches fail to apply.

Closes #2576, and follows some fixes on packages in the repo at 
https://github.com/ocaml/opam-repository/pull/7645