### PR TITLE
Simplify the pinning system, remove "mixed", add "--working-dir"

### DIFF
--- a/shell/md5check.ml
+++ b/shell/md5check.ml
@@ -15,6 +15,7 @@ let () =
       \  expected: %s\n\
       \    actual: %s\n"
       file md5 md5_of_file;
-    Sys.remove file
+    Sys.remove file;
+    exit 1
   ) else
     Printf.printf "%s has the expected MD5.\n" file

--- a/src/client/opamAction.mli
+++ b/src/client/opamAction.mli
@@ -14,27 +14,26 @@
 open OpamTypes
 open OpamStateTypes
 
-(** [download t pkg] downloads the source of the package [pkg] into
-    the local cache. Returns the downloaded file or directory. *)
+(** [download t pkg] downloads the source of the package [pkg] into its locally
+    cached source dir. Returns [Some errmsg] on error, [None] on success.
+
+    This doesn't update dev packages that already have a locally cached
+    source. *)
 val download_package:
-  rw switch_state -> package ->
-  [ `Error of string | `Successful of generic_file option ] OpamProcess.job
+  rw switch_state -> package -> string option OpamProcess.job
 
-(** [extract_package t source pkg] extracts and patches the already
-    downloaded [source] of the package [pkg]. See {!download_package}
-    to download the sources. *)
-val extract_package:
-  rw switch_state -> generic_file option -> package -> dirname ->
-  exn option OpamProcess.job
+(** [prepare_package_source t pkg dir] updates the given source [dir] with the
+    extra downloads, overlays and patches from the package's metadata
+    applied. *)
+val prepare_package_source:
+  rw switch_state -> package -> dirname -> exn option OpamProcess.job
 
-(** [build_package t source build_dir pkg] builds the package [pkg] within
-    [build_dir].
-    If [source] is specified, it is first extracted or copied into [build_dir].
+(** [build_package t build_dir pkg] builds the package [pkg] within [build_dir].
     Returns [None] on success, [Some exn] on error.
-    See {!download_package} to download the source. *)
+    See {!download_package} and {!prepare_package_source} for the previous
+    steps. *)
 val build_package:
-  rw switch_state -> ?test:bool -> ?doc:bool ->
-  generic_file option -> dirname -> package ->
+  rw switch_state -> ?test:bool -> ?doc:bool -> dirname -> package ->
   exn option OpamProcess.job
 
 (** [install_package t pkg] installs an already built package. Returns

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -108,6 +108,7 @@ let apply_global_options o =
     (* ?dryrun:bool *)
     (* ?fake:bool *)
     (* ?makecmd:string Lazy.t *)
+    (* ?skip_dev_update:bool *)
     ?json_out:OpamStd.Option.Op.(o.json >>| function "" -> None | s -> Some s)
     (* - client options - *)
     (* ?print_stats:bool *)
@@ -136,17 +137,18 @@ type build_options = {
   show          : bool;
   dryrun        : bool;
   fake          : bool;
+  skip_update   : bool;
   external_tags : string list;
   jobs          : int option;
 }
 
 let create_build_options
     keep_build_dir reuse_build_dir inplace_build working_dir make no_checksums
-    req_checksums build_test build_doc show dryrun external_tags fake
-    jobs = {
+    req_checksums build_test build_doc show dryrun skip_update external_tags
+    fake jobs = {
   keep_build_dir; reuse_build_dir; inplace_build; working_dir; make;
   no_checksums; req_checksums; build_test; build_doc; show; dryrun;
-  external_tags; fake; jobs;
+  skip_update; external_tags; fake; jobs;
 }
 
 let apply_build_options b =
@@ -176,6 +178,7 @@ let apply_build_options b =
     ?working_dir:(flag b.working_dir)
     ?show:(flag b.show)
     ?fake:(flag b.fake)
+    ?skip_dev_update:(flag b.skip_update)
     ()
 
 let when_enum = [ "always", `Always; "never", `Never; "auto", `Auto ]
@@ -791,6 +794,12 @@ let build_options =
   let dryrun =
     mk_flag ["dry-run"]
       "Simulate the command, but don't actually perform any changes." in
+  let skip_update =
+    mk_flag ["skip-updates"]
+      "When running an install, upgrade or reinstall on source-pinned \
+       packages, they are normally updated from their origin first. This flag \
+       disables that behaviour and will keep them to their version in cache."
+  in
   let external_tags =
     mk_opt ["e";"external"] "TAGS"
       "Display the external packages associated to the given tags. \
@@ -805,4 +814,4 @@ let build_options =
   Term.(pure create_build_options
     $keep_build_dir $reuse_build_dir $inplace_build $working_dir $make
     $no_checksums $req_checksums $build_test $build_doc $show $dryrun
-    $external_tags $fake $jobs_flag)
+    $skip_update $external_tags $fake $jobs_flag)

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -127,6 +127,7 @@ type build_options = {
   keep_build_dir: bool;
   reuse_build_dir: bool;
   inplace_build : bool;
+  working_dir   : bool;
   make          : string option;
   no_checksums  : bool;
   req_checksums : bool;
@@ -140,10 +141,10 @@ type build_options = {
 }
 
 let create_build_options
-    keep_build_dir reuse_build_dir inplace_build make no_checksums
+    keep_build_dir reuse_build_dir inplace_build working_dir make no_checksums
     req_checksums build_test build_doc show dryrun external_tags fake
     jobs = {
-  keep_build_dir; reuse_build_dir; inplace_build; make;
+  keep_build_dir; reuse_build_dir; inplace_build; working_dir; make;
   no_checksums; req_checksums; build_test; build_doc; show; dryrun;
   external_tags; fake; jobs;
 }
@@ -172,6 +173,7 @@ let apply_build_options b =
     ?keep_build_dir:(flag b.keep_build_dir)
     ?reuse_build_dir:(flag b.reuse_build_dir)
     ?inplace_build:(flag b.inplace_build)
+    ?working_dir:(flag b.working_dir)
     ?show:(flag b.show)
     ?fake:(flag b.fake)
     ()
@@ -753,6 +755,14 @@ let build_options =
        affects packages that are explicitely listed on the command-line. \
        This is equivalent to setting $(b,\\$OPAMINPLACEBUILD) to \"true\"."
   in
+  let working_dir =
+    mk_flag ["working-dir"]
+      "Whenever updating packages that are bound to a local, \
+       version-controlled directory, update to the current working state of \
+       their source instead of the last commited state, or the ref they are \
+       pointing to. \
+       This only affects packages explicitely listed on the command-line."
+  in
   let no_checksums =
     mk_flag ["no-checksums"]
       "Do not verify the checksum of downloaded archives.\
@@ -793,6 +803,6 @@ let build_options =
        WARNING: This option is dangerous and likely to break your OPAM \
        environment. You probably want `--dry-run'. You've been warned." in
   Term.(pure create_build_options
-    $keep_build_dir $reuse_build_dir $inplace_build $make $no_checksums
-    $req_checksums $build_test $build_doc $show $dryrun $external_tags $fake
-    $jobs_flag)
+    $keep_build_dir $reuse_build_dir $inplace_build $working_dir $make
+    $no_checksums $req_checksums $build_test $build_doc $show $dryrun
+    $external_tags $fake $jobs_flag)

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -633,6 +633,7 @@ let slog = OpamConsole.slog
            fetch_cmd_user ||
            check_external_dep "curl" ||
            check_external_dep "wget";
+           "diff", check_external_dep "diff";
            "patch", check_external_dep "patch";
            "tar", check_external_dep "tar";
            "unzip", check_external_dep "unzip"]

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -510,6 +510,29 @@ let slog = OpamConsole.slog
            controlled upstream) and can't be updated individually. What you \
            want is probably to update your repositories: %s"
           (OpamPackage.Set.to_string nondev_packages);
+      let dirty_dev_packages, dev_packages =
+        if names <> [] then OpamPackage.Set.empty, dev_packages else
+          OpamPackage.Set.partition
+            (fun nv ->
+               let src_cache =
+                 OpamPath.Switch.dev_package st.switch_global.root st.switch
+                   nv.name
+               in
+               let cache_url =
+                 OpamUrl.of_string (OpamFilename.Dir.to_string src_cache)
+               in
+               match OpamSwitchState.primary_url st nv with
+               | Some { OpamUrl.backend = #OpamUrl.version_control as vc; _ } ->
+                 OpamProcess.Job.run @@
+                 OpamRepository.is_dirty { cache_url with OpamUrl.backend = vc }
+               | _ -> false)
+            dev_packages
+      in
+      OpamPackage.Set.iter (fun nv ->
+          OpamConsole.note "%s has previously been updated with --working-dir, \
+                            not resetting unless explicitely selected"
+            (OpamPackage.to_string nv))
+        dirty_dev_packages;
       dev_packages
     in
 

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -176,6 +176,7 @@ let slog = OpamConsole.slog
   (* Check atoms for pinned packages, and update them. Returns the state that
      may have been reloaded if there were changes *)
   let update_dev_packages_t atoms t =
+    let working_dir = OpamClientConfig.(!r.working_dir) in
     let to_update =
       List.fold_left (fun to_update (name,_) ->
           try
@@ -189,7 +190,12 @@ let slog = OpamConsole.slog
     if OpamPackage.Set.is_empty to_update then t else (
       OpamConsole.header_msg "Synchronising pinned packages";
       try
-        let _success, t, _pkgs = OpamUpdate.dev_packages t to_update in
+        let working_dir =
+          if working_dir then Some (OpamSwitchState.packages_of_atoms t atoms)
+          else None
+        in
+        let _success, t, _pkgs =
+          OpamUpdate.dev_packages t ?working_dir to_update in
         t
       with e ->
         OpamStd.Exn.fatal e;

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -176,6 +176,7 @@ let slog = OpamConsole.slog
   (* Check atoms for pinned packages, and update them. Returns the state that
      may have been reloaded if there were changes *)
   let update_dev_packages_t atoms t =
+    if OpamClientConfig.(!r.skip_dev_update) then t else
     let working_dir = OpamClientConfig.(!r.working_dir) in
     let to_update =
       List.fold_left (fun to_update (name,_) ->

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -196,9 +196,11 @@ let slog = OpamConsole.slog
         in
         let _success, t, _pkgs =
           OpamUpdate.dev_packages t ?working_dir to_update in
+        OpamConsole.msg "\n";
         t
       with e ->
         OpamStd.Exn.fatal e;
+        OpamConsole.msg "\n";
         t
     )
 

--- a/src/client/opamClientConfig.ml
+++ b/src/client/opamClientConfig.ml
@@ -17,6 +17,7 @@ type t = {
   keep_build_dir: bool;
   reuse_build_dir: bool;
   inplace_build: bool;
+  working_dir: bool;
   show: bool;
   fake: bool;
   json_out: string option;
@@ -31,6 +32,7 @@ let default = {
   keep_build_dir = false;
   reuse_build_dir = false;
   inplace_build = false;
+  working_dir = false;
   show = false;
   fake = false;
   json_out = None;
@@ -45,6 +47,7 @@ type 'a options_fun =
   ?keep_build_dir:bool ->
   ?reuse_build_dir:bool ->
   ?inplace_build:bool ->
+  ?working_dir:bool ->
   ?show:bool ->
   ?fake:bool ->
   ?json_out:string option ->
@@ -59,6 +62,7 @@ let setk k t
     ?keep_build_dir
     ?reuse_build_dir
     ?inplace_build
+    ?working_dir
     ?show
     ?fake
     ?json_out
@@ -73,6 +77,7 @@ let setk k t
     keep_build_dir = t.keep_build_dir + keep_build_dir;
     reuse_build_dir = t.reuse_build_dir + reuse_build_dir;
     inplace_build = t.inplace_build + inplace_build;
+    working_dir = t.working_dir + working_dir;
     show = t.show + show;
     fake = t.fake + fake;
     json_out = t.json_out + json_out;
@@ -99,6 +104,7 @@ let initk k =
     ?keep_build_dir:(env_bool "KEEPBUILDDIR")
     ?reuse_build_dir:(env_bool "REUSEBUILDDIR")
     ?inplace_build:(env_bool "INPLACEBUILD")
+    ?working_dir:(env_bool "WORKINGDIR")
     ?show:(env_bool "SHOW")
     ?fake:(env_bool "FAKE")
     ?json_out:(env_string "JSON" >>| function "" -> None | s -> Some s)

--- a/src/client/opamClientConfig.ml
+++ b/src/client/opamClientConfig.ml
@@ -20,6 +20,7 @@ type t = {
   working_dir: bool;
   show: bool;
   fake: bool;
+  skip_dev_update: bool;
   json_out: string option;
 }
 
@@ -35,6 +36,7 @@ let default = {
   working_dir = false;
   show = false;
   fake = false;
+  skip_dev_update = false;
   json_out = None;
 }
 
@@ -50,6 +52,7 @@ type 'a options_fun =
   ?working_dir:bool ->
   ?show:bool ->
   ?fake:bool ->
+  ?skip_dev_update:bool ->
   ?json_out:string option ->
   'a
 
@@ -65,6 +68,7 @@ let setk k t
     ?working_dir
     ?show
     ?fake
+    ?skip_dev_update
     ?json_out
   =
   let (+) x opt = match opt with Some x -> x | None -> x in
@@ -80,6 +84,7 @@ let setk k t
     working_dir = t.working_dir + working_dir;
     show = t.show + show;
     fake = t.fake + fake;
+    skip_dev_update = t.skip_dev_update + skip_dev_update;
     json_out = t.json_out + json_out;
   }
 
@@ -107,6 +112,7 @@ let initk k =
     ?working_dir:(env_bool "WORKINGDIR")
     ?show:(env_bool "SHOW")
     ?fake:(env_bool "FAKE")
+    ?skip_dev_update:(env_bool "SKIPUPDATE")
     ?json_out:(env_string "JSON" >>| function "" -> None | s -> Some s)
 
 let init ?noop:_ = initk (fun () -> ())

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -23,6 +23,7 @@ type t = private {
   working_dir: bool;
   show: bool;
   fake: bool;
+  skip_dev_update: bool;
   json_out: string option;
 }
 
@@ -39,6 +40,7 @@ type 'a options_fun =
   ?working_dir:bool ->
   ?show:bool ->
   ?fake:bool ->
+  ?skip_dev_update:bool ->
   ?json_out:string option ->
   'a
   (* constraint 'a = 'b -> 'c *)
@@ -69,6 +71,7 @@ val opam_init:
   ?working_dir:bool ->
   ?show:bool ->
   ?fake:bool ->
+  ?skip_dev_update:bool ->
   ?json_out:string option ->
   ?current_switch:OpamSwitch.t ->
   ?switch_from:[ `Command_line | `Default | `Env ] ->

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -20,6 +20,7 @@ type t = private {
   keep_build_dir: bool;
   reuse_build_dir: bool;
   inplace_build: bool;
+  working_dir: bool;
   show: bool;
   fake: bool;
   json_out: string option;
@@ -35,6 +36,7 @@ type 'a options_fun =
   ?keep_build_dir:bool ->
   ?reuse_build_dir:bool ->
   ?inplace_build:bool ->
+  ?working_dir:bool ->
   ?show:bool ->
   ?fake:bool ->
   ?json_out:string option ->
@@ -64,6 +66,7 @@ val opam_init:
   ?keep_build_dir:bool ->
   ?reuse_build_dir:bool ->
   ?inplace_build:bool ->
+  ?working_dir:bool ->
   ?show:bool ->
   ?fake:bool ->
   ?json_out:string option ->

--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -2483,6 +2483,16 @@ let lint =
   Term.(pure lint $global_options $files $package $normalise $short $warnings),
   term_info "lint" ~doc ~man
 
+(* CLEAN *)
+(* Todo:
+   global
+   - clear cache (+ old archives/ dir)
+   - clear logs
+   - find and clean unused repositories
+   for one/all switches:
+   - clear build dirs
+   - clean stale sources (of non-pinned packages)
+*)
 
 (* HELP *)
 let help =

--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -1983,10 +1983,7 @@ let pin ?(unpin_only=false) () =
      (and contents, if local) of $(i,TARGET), Use $(b,--kind) or an explicit \
      URL to disable that behaviour.\n\
      Pins to version control systems may target a specific branch or commit \
-     using $(b,#branch) e.g. $(b,git://host/me/pkg#testing). When they don't, \
-     in the special case of version-controlled pinning to a local path, OPAM \
-     will use \"mixed mode\": it will only use version-controlled files, but \
-     at their current, on-disk version.\n\
+     using $(b,#branch) e.g. $(b,git://host/me/pkg#testing).\n\
      If $(i,PACKAGE) is not a known package name, a new package by that name \
      will be locally created.\n\
      The package version may be specified by using the format \

--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -2105,7 +2105,7 @@ let pin ?(unpin_only=false) () =
     | `Source
         ({ OpamUrl.backend = #OpamUrl.version_control; hash = None; _ }
          as url) ->
-      (match OpamProcess.Job.run (OpamRepository.get_branch url) with
+      (match OpamProcess.Job.run (OpamRepository.current_branch url) with
        | Some b ->
          OpamConsole.note "Will pin to '%s' using %s"
            b (OpamUrl.string_of_backend url.OpamUrl.backend);

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -477,20 +477,6 @@ let source_pin st name ?version ?edit:(need_edit=false) ?(force=false) target_ur
       (OpamPackage.Name.to_string name)
       (string_of_pinned opam);
 
-    (match target_url with
-     | Some ({ OpamUrl.backend = #OpamUrl.version_control;
-               transport = "file";
-               hash = None;
-               path = _; } as url) ->
-       (match OpamUrl.local_dir url with
-        | Some dir ->
-          OpamConsole.note
-            "Pinning in mixed mode: OPAM will use tracked files in the current \
-             working tree from %s. If this is not what you want, pin to a \
-             given branch (e.g. %s#HEAD)"
-            (OpamFilename.Dir.to_string dir) (OpamUrl.to_string url)
-        | None -> ())
-     | _ -> ());
     st
 
 (* pure *)

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -46,11 +46,6 @@ type std_path =
   | Lib | Bin | Sbin | Share | Doc | Etc | Man
   | Toplevel | Stublibs
 
-(** Generalized file type *)
-type generic_file = OpamFilename.generic_file =
-  | D of dirname
-  | F of filename
-
 (** Download result *)
 type 'a download =
   | Up_to_date of 'a

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -13,18 +13,6 @@ open OpamTypes
 
 include OpamCompat
 
-let download_map fn = function
-  | Up_to_date f    -> Up_to_date (fn f)
-  | Result  f       -> Result (fn f)
-  | Not_available d -> Not_available d
-
-let download_dir = download_map (fun d -> D d)
-let download_file = download_map (fun f -> F f)
-let string_of_download = function
-  | Up_to_date _ -> "already up-to-date"
-  | Result _ -> "synchronized"
-  | Not_available _ -> OpamConsole.colorise `red "unavailable"
-
 let std_path_of_string = function
   | "prefix" -> Prefix
   | "lib" -> Lib
@@ -52,10 +40,6 @@ let string_of_std_path = function
 
 let all_std_paths =
   [ Prefix; Lib; Bin; Sbin; Share; Doc; Etc; Man; Toplevel; Stublibs ]
-
-let string_of_generic_file = function
-  | D d -> OpamFilename.Dir.to_string d
-  | F f -> OpamFilename.to_string f
 
 let string_of_shell = function
   | `fish -> "fish"

--- a/src/format/opamTypesBase.mli
+++ b/src/format/opamTypesBase.mli
@@ -17,20 +17,9 @@ open OpamTypes
 
 include module type of OpamCompat
 
-(** Upcast a downloaded directory. *)
-val download_dir: dirname download -> generic_file download
-
-(** Upcast a downloaded file. *)
-val download_file: filename download -> generic_file download
-
-(** Corresponding user message *)
-val string_of_download: _ download -> string
-
 val string_of_std_path: std_path -> string
 val std_path_of_string: string -> std_path
 val all_std_paths: std_path list
-
-val string_of_generic_file: generic_file -> string
 
 (** Extract a package from a package action. *)
 val action_contents: [< 'a action ] -> 'a

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -88,6 +88,8 @@ module B = struct
   let revision _ =
     Done None
 
+  let sync_dirty dir url = pull_url dir None url
+
 end
 
 (* Helper functions used by opam-admin *)

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -83,7 +83,7 @@ module B = struct
          Done (Not_available msg))
     @@ fun () ->
     OpamDownload.download ~overwrite:true ?checksum remote_url dirname
-    @@+ fun local_file -> Done (Result (F local_file))
+    @@+ fun local_file -> Done (Result (Some local_file))
 
   let revision _ =
     Done None

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -213,4 +213,6 @@ module B = struct
   let revision _ =
     Done None
 
+  let sync_dirty dir url = pull_url dir None url
+
 end

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -140,6 +140,7 @@ let validate_and_add_to_cache label url cache_dir file checksums =
      | _ -> ());
     true
 
+(* [cache_dir] used to add to cache only *)
 let pull_from_upstream
     label ?(working_dir=false) cache_dir destdir checksums url =
   let module B = (val url_backend url: OpamRepositoryBackend.S) in
@@ -152,22 +153,27 @@ let pull_from_upstream
   (if working_dir then B.sync_dirty destdir url
    else B.pull_url destdir cksum url)
   @@| function
-  | (Result (F file) | Up_to_date (F file)) as ret ->
+  | (Result (Some file) | Up_to_date (Some file)) as ret ->
     if validate_and_add_to_cache label url cache_dir file checksums then
-      (OpamConsole.msg "[%s] %s %s\n"
+      (OpamConsole.msg "[%s] %s from %s\n"
          (OpamConsole.colorise `green label)
-         (if url.OpamUrl.backend = `http then "downloaded from"
-          else "synchronised with")
+         (match ret with Up_to_date _ -> "no changes" | _ -> "downloaded")
          (OpamUrl.to_string url);
        ret)
     else
       Not_available "Checksum mismatch"
-  | Result (D dir) | Up_to_date (D dir) ->
-    if checksums = [] then Result (D dir) else
+  | (Result None | Up_to_date None) as ret ->
+    if checksums = [] then
+      (OpamConsole.msg "[%s] %s from %s\n"
+         (OpamConsole.colorise `green label)
+         (match ret with Up_to_date _ -> "no changes" | _ -> "synchronised")
+         (OpamUrl.to_string url);
+       Result None)
+    else
       (OpamConsole.error "%s: file checksum specified, but a directory was \
                           retrieved from %s"
          label (OpamUrl.to_string url);
-       OpamFilename.rmdir dir;
+       OpamFilename.rmdir destdir;
        Not_available "can't check directory checksum")
   | Not_available r -> Not_available r
 
@@ -184,8 +190,14 @@ let rec pull_from_mirrors label ?working_dir cache_dir destdir checksums = funct
       pull_from_mirrors label cache_dir destdir checksums mirrors
     | r -> Done r
 
-let pull_url label ?cache_dir ?(cache_urls=[]) ?(silent_hits=false) ?working_dir
+let pull_tree
+    label ?cache_dir ?(cache_urls=[]) ?working_dir
     local_dirname checksums remote_urls =
+  let extract_archive f =
+    OpamFilename.extract_job f local_dirname @@+ function
+    | None -> Done (Up_to_date ())
+    | Some e -> Done (Not_available (Printexc.to_string e))
+  in
   (match cache_dir with
    | Some cache_dir ->
      let text = OpamProcess.make_command_text label "dl" in
@@ -195,52 +207,37 @@ let pull_url label ?cache_dir ?(cache_urls=[]) ?(silent_hits=false) ?working_dir
      assert (cache_urls = []);
      Done (Not_available "no cache"))
   @@+ function
-  | Up_to_date (f, _) ->
-    if not silent_hits then
-      OpamConsole.msg "[%s] found in cache\n"
-        (OpamConsole.colorise `green label);
-    Done (Up_to_date (F f))
-  | Result (f, url) ->
+  | Up_to_date (archive, _) ->
+    OpamConsole.msg "[%s] found in cache\n"
+      (OpamConsole.colorise `green label);
+    extract_archive archive
+  | Result (archive, url) ->
     OpamConsole.msg "[%s] downloaded from %s\n"
       (OpamConsole.colorise `green label)
       (OpamUrl.to_string url);
-    Done (Result (F f))
+    extract_archive archive
   | Not_available _ ->
     if checksums = [] && OpamRepositoryConfig.(!r.force_checksums = Some true)
     then
       OpamConsole.error_and_exit
         "%s: Missing checksum, and `--require-checksums` was set."
         label;
-    pull_from_mirrors label ?working_dir
-      cache_dir local_dirname checksums remote_urls
+    pull_from_mirrors label ?working_dir cache_dir local_dirname checksums
+      remote_urls
+    @@+ function
+    | Up_to_date _ -> assert false
+    | Result (Some archive) ->
+      OpamFilename.with_tmp_dir_job @@ fun tmpdir ->
+      let tmp_archive = OpamFilename.(create tmpdir (basename archive)) in
+      OpamFilename.move ~src:archive ~dst:tmp_archive;
+      extract_archive tmp_archive
+    | Result None -> Done (Result ())
+    | Not_available _ as na -> Done na
 
 let revision dirname url =
   let kind = url.OpamUrl.backend in
   let module B = (val find_backend_by_kind kind: OpamRepositoryBackend.S) in
   B.revision dirname
-
-let pull_url_and_fix_digest label dirname checksums file url =
-  pull_url label dirname [] url @@+ function
-  | Not_available _
-  | Up_to_date _
-  | Result (D _) as r -> Done r
-  | Result (F f) as r ->
-    let fixed_checksums =
-      List.map (fun c ->
-          match OpamHash.mismatch (OpamFilename.to_string f) c with
-          | Some actual ->
-            OpamConsole.msg
-              "Fixing wrong checksum for %s: current value is %s, setting it \
-               to %s.\n"
-              label (OpamHash.to_string c) (OpamHash.to_string actual);
-            actual
-          | None -> c)
-        checksums
-    in
-    (if fixed_checksums <> checksums then
-       let u = OpamFile.URL.read file in
-       OpamFile.URL.write file (OpamFile.URL.with_checksum fixed_checksums u));
-    Done r
 
 let pull_file label ?cache_dir ?(cache_urls=[])  ?(silent_hits=false)
     file checksums remote_urls =
@@ -275,8 +272,8 @@ let pull_file label ?cache_dir ?(cache_urls=[])  ?(silent_hits=false)
         pull_from_mirrors label cache_dir tmpdir checksums remote_urls
         @@| function
         | Up_to_date _ -> assert false
-        | Result (F f) -> OpamFilename.move ~src:f ~dst:file; Result ()
-        | Result (D _) -> Not_available "is a directory"
+        | Result (Some f) -> OpamFilename.move ~src:f ~dst:file; Result ()
+        | Result None -> Not_available "is a directory"
         | Not_available _ as na -> na)
 
 let pull_file_to_cache label ~cache_dir ?(cache_urls=[]) checksums remote_urls =
@@ -294,8 +291,8 @@ let pull_file_to_cache label ~cache_dir ?(cache_urls=[]) checksums remote_urls =
         pull_from_mirrors label (Some cache_dir) tmpdir checksums remote_urls
         @@| function
         | Up_to_date _ -> assert false
-        | Result (F _) -> Result ()
-        | Result (D _) -> Not_available "is a directory"
+        | Result (Some _) -> Result ()
+        | Result None -> Not_available "is a directory"
         | Not_available _ as na -> na)
 
 let packages r =

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -406,7 +406,7 @@ let on_local_version_control url ~default f =
        f dir (find_vcs_backend backend))
   | #OpamUrl.backend -> default
 
-let get_branch url =
+let current_branch url =
   on_local_version_control url ~default:(Done None) @@
   fun dir (module VCS) -> VCS.current_branch dir
 

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -140,7 +140,8 @@ let validate_and_add_to_cache label url cache_dir file checksums =
      | _ -> ());
     true
 
-let pull_from_upstream label ?working_dir cache_dir destdir checksums url =
+let pull_from_upstream
+    label ?(working_dir=false) cache_dir destdir checksums url =
   let module B = (val url_backend url: OpamRepositoryBackend.S) in
   let cksum = match checksums with [] -> None | c::_ -> Some c in
   let text =
@@ -148,7 +149,8 @@ let pull_from_upstream label ?working_dir cache_dir destdir checksums url =
       (OpamUrl.string_of_backend url.OpamUrl.backend)
   in
   OpamProcess.Job.with_text text @@
-  B.pull_url destdir cksum url
+  (if working_dir then B.sync_dirty destdir url
+   else B.pull_url destdir cksum url)
   @@| function
   | (Result (F file) | Up_to_date (F file)) as ret ->
     if validate_and_add_to_cache label url cache_dir file checksums then

--- a/src/repository/opamRepository.mli
+++ b/src/repository/opamRepository.mli
@@ -38,7 +38,9 @@ val update: repository -> unit OpamProcess.job
     Not_available returned.
     The first argument, [label] is only for status message printing. *)
 val pull_url:
-  string -> ?cache_dir:dirname -> ?cache_urls:url list -> ?silent_hits:bool ->
+  string ->
+  ?cache_dir:dirname -> ?cache_urls:url list ->
+  ?silent_hits:bool -> ?working_dir:bool ->
   dirname -> OpamHash.t list -> url list ->
   generic_file download OpamProcess.job
 

--- a/src/repository/opamRepository.mli
+++ b/src/repository/opamRepository.mli
@@ -29,20 +29,15 @@ val init: dirname -> repository_name -> unit OpamProcess.job
     achieved. *)
 val update: repository -> unit OpamProcess.job
 
-(** Fetch an URL into a directory: if a single file, it will be put in that
-    directory, otherwise the given directory is synchronised with the remote
-    one. Several mirrors can be provided, in which case they will be tried in
-    order, in case of an error.
-    All provided hashes are checked in case of a single file; if the hash list
-    is non-empty, and a directory is obtained, an error message is printed and
-    Not_available returned.
-    The first argument, [label] is only for status message printing. *)
-val pull_url:
-  string ->
-  ?cache_dir:dirname -> ?cache_urls:url list ->
-  ?silent_hits:bool -> ?working_dir:bool ->
+(** Fetch an URL and put the resulting tree into the supplied directory. The URL
+    must either point to a tree (VCS, rsync) or to a known archive type. In case
+    of an archive, the cache is used and supplied the hashes verified, then the
+    archive uncompressed. In case of a version-controlled URL, it's checked out,
+    or synchronised directly if local and [working_dir] was set. *)
+val pull_tree:
+  string -> ?cache_dir:dirname -> ?cache_urls:url list -> ?working_dir:bool ->
   dirname -> OpamHash.t list -> url list ->
-  generic_file download OpamProcess.job
+  unit download OpamProcess.job
 
 (** Same as [pull_url], but for fetching a single file. *)
 val pull_file:
@@ -55,12 +50,6 @@ val pull_file:
 val pull_file_to_cache:
   string -> cache_dir:dirname -> ?cache_urls:url list ->
   OpamHash.t list -> url list -> unit download OpamProcess.job
-
-(** As [pull_url], but doesn't check hashes, and instead patches the given url
-    file to match the actual file hashes, as downloaded *)
-val pull_url_and_fix_digest:
-  string -> dirname -> OpamHash.t list -> OpamFile.URL.t OpamFile.t -> url list ->
-  generic_file download OpamProcess.job
 
 (** Get the optional revision associated to a backend (git hash, etc.). *)
 val revision: dirname -> url -> version option OpamProcess.job

--- a/src/repository/opamRepository.mli
+++ b/src/repository/opamRepository.mli
@@ -67,7 +67,7 @@ val revision: dirname -> url -> version option OpamProcess.job
 
 (** Get the version-control branch for that url. Only applicable for local,
     version controlled URLs. Returns [None] in other cases. *)
-val get_branch: url -> string option OpamProcess.job
+val current_branch: url -> string option OpamProcess.job
 
 (** Returns true if the url points to a local, version-controlled directory that
     has uncommitted changes *)

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -22,11 +22,11 @@ type update =
 module type S = sig
   val name: OpamUrl.backend
   val pull_url: dirname -> OpamHash.t option -> url ->
-    generic_file download OpamProcess.job
+    filename option download OpamProcess.job
   val fetch_repo_update:
     repository_name -> dirname -> url -> update OpamProcess.job
   val revision: dirname -> version option OpamProcess.job
-  val sync_dirty: dirname -> url -> generic_file download OpamProcess.job
+  val sync_dirty: dirname -> url -> filename option download OpamProcess.job
 end
 
 let compare r1 r2 = compare r1.repo_name r2.repo_name
@@ -58,7 +58,7 @@ let check_digest filename = function
        OpamConsole.error
          "Bad checksum for %s: expected %s\n\
          \                     got      %s\n\
-          Metadata might be out of date, in this case run `opam update`."
+          Metadata might be out of date, in this case use `opam update`."
          (OpamFilename.to_string filename)
          (OpamHash.to_string expected)
          (OpamHash.to_string bad_hash);

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -26,6 +26,7 @@ module type S = sig
   val fetch_repo_update:
     repository_name -> dirname -> url -> update OpamProcess.job
   val revision: dirname -> version option OpamProcess.job
+  val sync_dirty: dirname -> url -> generic_file download OpamProcess.job
 end
 
 let compare r1 r2 = compare r1.repo_name r2.repo_name

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -52,6 +52,11 @@ module type S = sig
       update the VCS commit information. *)
   val revision: dirname -> version option OpamProcess.job
 
+  (** Like [pull_url], except for locally-bound version control backends, where
+      it should get the latest, uncommited source. *)
+  val sync_dirty:
+    dirname -> url -> generic_file download OpamProcess.job
+
 end
 
 (** Pretty-print *)

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -32,13 +32,21 @@ module type S = sig
   val name: OpamUrl.backend
 
   (** [pull_url local_dir checksum remote_url] pulls the contents of
-      [remote_url] into [local_dir]. Can return either a file or a directory.
-      [checksum] is the optional expected checksum, and is here in case it is
-      useful for retrieval, but is not expected to be verified by this
-      function (and it doesn't apply to directories). *)
+      [remote_url] into [local_dir].
+
+      Two kinds of results are allowed:
+
+      - a single file was downloaded, in this case it is placed within
+        [local_dir] and returned as [Some filename]
+
+      - a directory was retrieved, in this case the contents of [local_dir] have
+        been synchronised with its own, and [None] is returned
+
+      [checksum] can be used for retrieval but is NOT checked by this
+      function. *)
   val pull_url:
     dirname -> OpamHash.t option -> url ->
-    generic_file download OpamProcess.job
+    filename option download OpamProcess.job
 
   (** [pull_repo_update] fetches the remote update from [url] to the local
       repository at [dirname], but does not apply it, allowing for further
@@ -55,7 +63,7 @@ module type S = sig
   (** Like [pull_url], except for locally-bound version control backends, where
       it should get the latest, uncommited source. *)
   val sync_dirty:
-    dirname -> url -> generic_file download OpamProcess.job
+    dirname -> url -> filename option download OpamProcess.job
 
 end
 

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -34,43 +34,6 @@ module Make (VCS: VCS) = struct
 
   let name = VCS.name
 
-  (* Local repos without a branch set actually use the rsync backend, but
-     limited to versionned files *)
-  let synched_repo repo_url = match repo_url with
-    | { OpamUrl.transport = "file"; hash = None; path = _; backend = _ } as url ->
-      OpamUrl.local_dir url
-    | _ -> None
-
-  let rsync repo_root repo_url dir =
-    VCS.versionned_files dir
-    @@+ fun files ->
-    let files =
-      List.map OpamFilename.(remove_prefix dir)
-        (OpamFilename.rec_files (VCS.vc_dir dir))
-      @ files
-    in
-    let stdout_file =
-      let f = OpamSystem.temp_file "rsync-files" in
-      let fd = open_out f in
-      List.iter (fun s -> output_string fd s; output_char fd '\n') files;
-      close_out fd;
-      f
-    in
-    (* Remove non-versionned files from destination *)
-    (* fixme: doesn't clean directories *)
-    let fset = OpamStd.String.Set.of_list files in
-    List.iter (fun f ->
-        let basename = OpamFilename.remove_prefix repo_root f in
-        if not (OpamStd.String.Set.mem basename fset)
-        then OpamFilename.remove f)
-      (OpamFilename.rec_files repo_root);
-    OpamLocal.rsync_dirs ~args:["--files-from"; stdout_file]
-      ~exclude_vcdirs:false
-      repo_url repo_root
-    @@+ fun dl ->
-    OpamSystem.remove stdout_file;
-    Done dl
-
   let fetch_repo_update repo_name repo_root repo_url =
     if VCS.exists repo_root then
       OpamProcess.Job.catch (fun e -> Done (OpamRepositoryBackend.Update_err e))
@@ -103,11 +66,6 @@ module Make (VCS: VCS) = struct
 
   let pull_url dirname checksum url =
     if checksum <> None then invalid_arg "VC pull_url doesn't allow checksums";
-    match synched_repo url with
-    | Some dir ->
-      rsync dirname url dir @@|
-      download_dir
-    | None ->
       OpamProcess.Job.catch
         (fun e ->
            OpamConsole.error "Could not synchronize %s from %S:\n%s"
@@ -133,5 +91,38 @@ module Make (VCS: VCS) = struct
   let revision repo_root =
     VCS.revision repo_root @@+ fun r ->
     Done (Some (OpamPackage.Version.of_string r))
+
+  let sync_dirty repo_root repo_url =
+    match OpamUrl.local_dir repo_url with
+    | None -> pull_url repo_root None repo_url
+    | Some dir ->
+      VCS.versionned_files dir
+      @@+ fun files ->
+      let files =
+        List.map OpamFilename.(remove_prefix dir)
+          (OpamFilename.rec_files (VCS.vc_dir dir))
+        @ files
+      in
+      let stdout_file =
+        let f = OpamSystem.temp_file "rsync-files" in
+        let fd = open_out f in
+        List.iter (fun s -> output_string fd s; output_char fd '\n') files;
+        close_out fd;
+        f
+      in
+      (* Remove non-versionned files from destination *)
+      (* fixme: doesn't clean directories *)
+      let fset = OpamStd.String.Set.of_list files in
+      List.iter (fun f ->
+          let basename = OpamFilename.remove_prefix repo_root f in
+          if not (OpamStd.String.Set.mem basename fset)
+          then OpamFilename.remove f)
+        (OpamFilename.rec_files repo_root);
+      OpamLocal.rsync_dirs ~args:["--files-from"; stdout_file]
+        ~exclude_vcdirs:false
+        repo_url repo_root
+      @@+ fun dl ->
+      OpamSystem.remove stdout_file;
+      Done (download_dir dl)
 
 end

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -115,7 +115,8 @@ module Make (VCS: VCS) = struct
       let fset = OpamStd.String.Set.of_list files in
       List.iter (fun f ->
           let basename = OpamFilename.remove_prefix repo_root f in
-          if not (OpamStd.String.Set.mem basename fset)
+          if not (OpamFilename.(starts_with (VCS.vc_dir repo_root) f) ||
+                  OpamStd.String.Set.mem basename fset)
           then OpamFilename.remove f)
         (OpamFilename.rec_files repo_root);
       OpamLocal.rsync_dirs ~args:["--files-from"; stdout_file]

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -10,7 +10,6 @@
 (**************************************************************************)
 
 open OpamTypes
-open OpamTypesBase
 open OpamStd.Op
 open OpamProcess.Job.Op
 
@@ -77,16 +76,16 @@ module Make (VCS: VCS) = struct
       if VCS.exists dirname then
         VCS.fetch dirname url @@+ fun () ->
         VCS.is_up_to_date dirname url @@+ function
-        | true -> Done (Up_to_date (D dirname))
+        | true -> Done (Up_to_date None)
         | false ->
           VCS.reset dirname url @@+ fun () ->
-          Done (Result (D dirname))
+          Done (Result None)
       else
         (OpamFilename.mkdir dirname;
          VCS.init dirname url @@+ fun () ->
          VCS.fetch dirname url @@+ fun () ->
          VCS.reset dirname url @@+ fun () ->
-         Done (Result (D dirname)))
+         Done (Result None))
 
   let revision repo_root =
     VCS.revision repo_root @@+ fun r ->
@@ -122,8 +121,8 @@ module Make (VCS: VCS) = struct
       OpamLocal.rsync_dirs ~args:["--files-from"; stdout_file]
         ~exclude_vcdirs:false
         repo_url repo_root
-      @@+ fun dl ->
+      @@+ fun _dl ->
       OpamSystem.remove stdout_file;
-      Done (download_dir dl)
+      Done (Result None)
 
 end

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -339,6 +339,9 @@ let descr st nv =
 let url st nv =
   OpamStd.Option.Op.(opam_opt st nv >>= OpamFile.OPAM.url)
 
+let primary_url st nv =
+  OpamStd.Option.Op.(url st nv >>| OpamFile.URL.url)
+
 let files st nv =
   match opam_opt st nv with
   | None -> []

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -80,6 +80,9 @@ val opam_opt: 'a switch_state -> package -> OpamFile.OPAM.t option
 (** Return the URL file for the given package *)
 val url: 'a switch_state -> package -> OpamFile.URL.t option
 
+(** Returns the primary URL from the URL file of the given package *)
+val primary_url: 'a switch_state -> package -> url option
+
 (** Return the Descr file for the given package (or an empty descr if none) *)
 val descr: 'a switch_state -> package -> OpamFile.Descr.t
 

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -127,14 +127,15 @@ let repositories rt repos =
 
 (* fixme: this doesn't extract the archive, so we won't get the source package's
    opam file unless we're going through VC. *)
-let fetch_dev_package url srcdir nv =
+let fetch_dev_package url srcdir ?working_dir nv =
   let remote_url = OpamFile.URL.url url in
   let mirrors = remote_url :: OpamFile.URL.mirrors url in
   let checksum = OpamFile.URL.checksum url in
   log "updating %a" (slog OpamUrl.to_string) remote_url;
-  OpamRepository.pull_url (OpamPackage.to_string nv) srcdir checksum mirrors
+  OpamRepository.pull_url
+    (OpamPackage.to_string nv) srcdir checksum ?working_dir mirrors
 
-let pinned_package st ?version name =
+let pinned_package st ?version ?working_dir name =
   log "update-pinned-package %s" (OpamPackage.Name.to_string name);
   let open OpamStd.Option.Op in
   let root = st.switch_global.root in
@@ -183,7 +184,7 @@ let pinned_package st ?version name =
     | _ -> None
   in
   (* Do the update *)
-  fetch_dev_package urlf srcdir nv @@+ fun result ->
+  fetch_dev_package urlf srcdir ?working_dir nv @@+ fun result ->
   let new_source_opam =
     OpamPinned.find_opam_file_in_source name srcdir >>= fun f ->
     let warns, opam_opt = OpamFileTools.lint_file f in
@@ -289,10 +290,10 @@ let pinned_package st ?version name =
   | Result  _, _ ->
     Done ((fun st -> st), true)
 
-let dev_package st nv =
+let dev_package st ?working_dir nv =
   log "update-dev-package %a" (slog OpamPackage.to_string) nv;
   if OpamPackage.Set.mem nv st.pinned then
-    pinned_package st ~version:nv.version nv.name
+    pinned_package st ~version:nv.version ?working_dir nv.name
   else
   match OpamSwitchState.url st nv with
   | None     -> Done ((fun st -> st), false)
@@ -301,17 +302,20 @@ let dev_package st nv =
       Done ((fun st -> st), false)
     else
       fetch_dev_package url
-        (OpamPath.Switch.dev_package st.switch_global.root st.switch nv.name) nv
+        (OpamPath.Switch.dev_package st.switch_global.root st.switch nv.name)
+        ?working_dir
+        nv
       @@| fun result ->
       (fun st -> st), match result with Result _ -> true | _ -> false
 
-let dev_packages st packages =
+let dev_packages st ?(working_dir=OpamPackage.Set.empty) packages =
   log "update-dev-packages";
   let command nv =
+    let working_dir = OpamPackage.Set.mem nv working_dir in
     OpamProcess.Job.ignore_errors
       ~default:(false, (fun st -> st), OpamPackage.Set.empty)
     @@ fun () ->
-    dev_package st nv @@| fun (st_update, changed) ->
+    dev_package st ~working_dir nv @@| fun (st_update, changed) ->
     true, st_update, match changed with
     | true -> OpamPackage.Set.singleton nv
     | false -> OpamPackage.Set.empty
@@ -334,13 +338,14 @@ let dev_packages st packages =
   in
   success, st, updated_set
 
-let pinned_packages st names =
+let pinned_packages st ?(working_dir=OpamPackage.Name.Set.empty) names =
   log "update-pinned-packages";
   let command name =
+    let working_dir = OpamPackage.Name.Set.mem name working_dir in
     OpamProcess.Job.ignore_errors
       ~default:((fun st -> st), OpamPackage.Name.Set.empty)
     @@ fun () ->
-    pinned_package st name @@| fun (st_update, changed) ->
+    pinned_package st ~working_dir name @@| fun (st_update, changed) ->
     st_update,
     match changed with
     | true -> OpamPackage.Name.Set.singleton name

--- a/src/state/opamUpdate.mli
+++ b/src/state/opamUpdate.mli
@@ -74,9 +74,9 @@ val pinned_package:
     any *)
 val download_package_source:
   'a switch_state -> package -> dirname ->
-  generic_file download option OpamProcess.job
+  unit download option OpamProcess.job
 
 (** Low-level function to retrieve the package source into its local cache *)
 val fetch_dev_package:
   OpamFile.URL.t -> dirname -> ?working_dir:bool -> package ->
-  generic_file download OpamProcess.job
+  unit download OpamProcess.job

--- a/src/state/opamUpdate.mli
+++ b/src/state/opamUpdate.mli
@@ -32,31 +32,40 @@ val repositories: rw repos_state -> repository list -> bool * rw repos_state
     first in the switch cache and then in the global cache. Return the
     packages whose contents have changed upstream.
 
+    Packages that are members of the [working_dir] and are bound to a local
+    directory under version control are synchronised with its working state,
+    bypassing version control.
+
     Side-effect: update the reinstall file, adding installed changed packages to
     the current switch to-reinstall set.
 
     The returned boolean is true if all updates were successful. *)
 val dev_packages:
-  rw switch_state -> package_set -> bool * rw switch_state * package_set
+  rw switch_state -> ?working_dir:package_set -> package_set ->
+  bool * rw switch_state * package_set
 
-(** Updates a single dev or pinned package from its upstream; returns true
-    if changed, false otherwise, and a switch_state update function, applying
-    possible changes in packages metadata *)
+(** Updates a single dev or pinned package from its upstream. If [working_dir]
+    is set, and the package is bound to a local, version-controlled dir, use the
+    working dir state instead of what has been commited to version control.
+
+    Returns true if changed, false otherwise, and a switch_state update
+    function, applying possible changes in packages metadata *)
 val dev_package:
-  rw switch_state -> package ->
+  rw switch_state -> ?working_dir:bool -> package ->
   ((rw switch_state -> rw switch_state) * bool) OpamProcess.job
 
 (** A subset of update_dev_packages that only takes packages names and only
     works on pinned packages. Also updates the reinstall file of the current
     switch *)
 val pinned_packages:
-  rw switch_state -> name_set -> rw switch_state * package_set
+  rw switch_state -> ?working_dir:name_set -> name_set ->
+  rw switch_state * package_set
 
 (** Updates a dev pinned package from its upstream; returns true if changed,
     false otherwise, and a switch_state update function that applies possible
     changes in packages metadata. Updates the on-disk overlay *)
 val pinned_package:
-  rw switch_state -> ?version:version -> name ->
+  rw switch_state -> ?version:version -> ?working_dir:bool -> name ->
   ((rw switch_state -> rw switch_state) * bool) OpamProcess.job
 
 (** Download or synchronise the upstream source for the given package into the
@@ -69,4 +78,5 @@ val download_package_source:
 
 (** Low-level function to retrieve the package source into its local cache *)
 val fetch_dev_package:
-  OpamFile.URL.t -> dirname -> package -> generic_file download OpamProcess.job
+  OpamFile.URL.t -> dirname -> ?working_dir:bool -> package ->
+  generic_file download OpamProcess.job

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -2,8 +2,8 @@
 
 SRC_EXTS = cppo extlib re cmdliner graph cudf dose uutf jsonm opam-file-format
 
-URL_cppo = http://mjambon.com/releases/cppo/cppo-1.1.2.tar.gz
-MD5_cppo = f1a551639c0c667ee8840d95ea5b2ab7
+URL_cppo = https://github.com/mjambon/cppo/archive/v1.3.2.tar.gz
+MD5_cppo = 133c9f8afadb6aa1c5ba0f5eb55c5648
 
 URL_extlib = https://github.com/ygrek/ocaml-extlib/archive/1.7.0.tar.gz
 MD5_extlib = b50b02d9e40d35cc20c82d9c881a1bf6 
@@ -58,14 +58,15 @@ https://opam.ocaml.org/2.0~dev/cache/md5/$(shell echo $(MD5_$(1)) | cut -c -2)/$
 endef
 
 define get_from_cache
-{ $(FETCH) $(call cache_url,$(1)) && mv $(MD5_$(1)) $(notdir $(URL_$(1))); }
+{ $(FETCH) $(call cache_url,$(1)) && \
+  mv $(MD5_$(1)) $(notdir $(URL_$(1))) && \
+  $(MD5CHECK) $(notdir $(URL_$(1))) $(MD5_$(1)); }
 endef
 
 %.download:
 	[ -e  $(notdir $(URL_$*)) ] || \
-	$(FETCH) $(URL_$*) || \
+	$(FETCH) $(URL_$*) && $(MD5CHECK) $(notdir $(URL_$*)) $(MD5_$*) || \
 	$(call get_from_cache,$*)
-	$(MD5CHECK) $(notdir $(URL_$*)) $(MD5_$*)
 
 %.stamp: %.download
 	mkdir -p tmp


### PR DESCRIPTION
The removal of "mixed mode" should be made painless by a new message
that warns you about uncommitted changes. Also, greatly improved
internal interface for downloading packages.