### PR TITLE
do not output `opam-version` twice in `install --json`

### DIFF
--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -873,7 +873,6 @@ let apply ?ask t action ~requested solution =
 
 let resolve ?(verbose=true) t action ~orphans ~requested request =
   if OpamClientConfig.(!r.json_out <> None) then (
-    OpamJson.append "opam-version" (`String OpamVersion.(to_string (full ())));
     OpamJson.append "command-line"
       (`A (List.map (fun s -> `String s) (Array.to_list Sys.argv)));
     OpamJson.append "switch" (OpamSwitch.to_json t.switch)


### PR DESCRIPTION
This fixes invalid JSON output as a repeated key is not allowed:

```
{
  "opam-version": "2.0~alpha5 (33f70c51dffb22010df343bf781b68b17a69f497)",
  "command-line": [
    "opam",
    "install",
    "--show-actions",
    "--json=actions.json",
    "mirage.2.9.1",
    "lwt.2.6.0",
    "core.113.33.02+4.03"
  ],
  "opam-version": "2.0~alpha5 (33f70c51dffb22010df343bf781b68b17a69f497)",
  "command-line": [
    "opam",
    "install",
    "--show-actions",
    "--json=actions.json",
    "mirage.2.9.1",
    "lwt.2.6.0",
    "core.113.33.02+4.03"
  ],
```