### PR TITLE
fix src_ext build on some versions of GNU make

### DIFF
--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -1,6 +1,6 @@
 -include ../Makefile.config
 
-SRC_EXTS = cppo extlib re cmdliner graph cudf dose uutf jsonm opam-file-format
+SRC_EXTS = cppo extlib re cmdliner graph cudf dose uutf jsonm opam_file_format
 
 URL_cppo = https://github.com/mjambon/cppo/archive/v1.3.2.tar.gz
 MD5_cppo = 133c9f8afadb6aa1c5ba0f5eb55c5648
@@ -29,8 +29,8 @@ MD5_uutf = 708c0421e158b390c7cc341f37b40add
 URL_jsonm = http://erratique.ch/software/jsonm/releases/jsonm-0.9.1.tbz
 MD5_jsonm = 631a5dabdada83236c83056f60e42685
 
-URL_opam-file-format = https://github.com/ocaml/opam-file-format/archive/2.0-alpha5.tar.gz
-MD5_opam-file-format = 2ccdf87e2bd8ed8541dda1d3369b3199
+URL_opam_file_format = https://github.com/ocaml/opam-file-format/archive/2.0-alpha5.tar.gz
+MD5_opam_file_format = 2ccdf87e2bd8ed8541dda1d3369b3199
 
 ARCHIVES = $(foreach lib,$(SRC_EXTS),$(notdir $(URL_$(lib))))
 lib_of = $(foreach lib,$(SRC_EXTS),$(if $(findstring $(1),$(URL_$(lib))),$(lib),,))
@@ -119,13 +119,13 @@ clean:
 	$(MAKE) -f $(OCAMLMAKEFILE) subprojs SUBTARGET=cleanup
 
 distclean:
-	rm -rf cudf extlib re graph dose cmdliner uutf jsonm opam-file-format
+	rm -rf cudf extlib re graph dose cmdliner uutf jsonm opam_file_format
 	rm -f depends.ocp
 	rm -f *.tar.gz *.tbz *.stamp
 	rm -f *.cm* *.o *.a *.lib
 	rm -rf lib
 
-LIB_EXTS = extlib re cmdliner graph cudf dose_common dose_versioning dose_pef dose_opam dose_algo uutf jsonm opam-file-format
+LIB_EXTS = extlib re cmdliner graph cudf dose_common dose_versioning dose_pef dose_opam dose_algo uutf jsonm opam_file_format
 
 inst_objs = cp $(1)/*.cm*i lib
 
@@ -143,7 +143,7 @@ copy: build
 	$(call inst_objs,dose/algo)
 	$(call inst_objs,uutf/src)
 	$(call inst_objs,jsonm/src)
-	$(call inst_objs,opam-file-format/src)
+	$(call inst_objs,opam_file_format/src)
 	$(call inst_objs,.)
 
 # --
@@ -282,18 +282,18 @@ define PROJ_jsonm
 endef
 export PROJ_jsonm
 
-SRC_opam-file-format = \
+SRC_opam_file_format = \
   opamParserTypes.mli \
   opamLexer.mli opamLexer.mll \
   opamParser.mly \
   opamPrinter.mli  opamPrinter.ml
 
-define PROJ_opam-file-format
-  SOURCES = $(call addmli,opam-file-format/src,$(SRC_opam-file-format))
+define PROJ_opam_file_format
+  SOURCES = $(call addmli,opam_file_format/src,$(SRC_opam_file_format))
   RESULT = opam-file-format
   LIB_PACK_NAME =
 endef
-export PROJ_opam-file-format
+export PROJ_opam_file_format
 
 # --
 


### PR DESCRIPTION
Hyphens in dependencies can be computed as uptodate, and so
opam-file-format doesnt get compiled. The trivial change to an
underscore fixes the build on Ubuntu 16.04 among others.

Fixes #2773