### PR TITLE
Transition more aggressively towards one-file package specifications

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -951,8 +951,9 @@ It has the following fields:
   an optional list of mirrors. They must use the same protocol as the main URL.
 
 These contents can be embedded within the [`url {}`](#opamsection-url) section
-of an `opam` file; however, if an `url` file is present alongside the `opam`
-file, its contents take precedence.
+of an `opam` file, which is the preferred way. You shouldn't have both an `url`
+file and an `opam` file with an `url {}` section: in that case, the `url` file
+will be ignored with a warning.
 
 #### files/
 

--- a/doc/pages/Packaging.md
+++ b/doc/pages/Packaging.md
@@ -23,8 +23,7 @@ Publish to the OPAM repository:
   tool (`opam install opam-publish`)
 * Or by hand:
     - Fork [https://github.com/ocaml/opam-repository](https://github.com/ocaml/opam-repository)
-    - Add your `opam`, `descr` and `url` files to
-      `packages/<pkgname>/<pkgname>.<version>`
+    - Add `packages/<pkgname>/<pkgname>.<version>/opam` with your metadata
     - File a [pull request](https://github.com/ocaml/opam-repository/compare/)
 
 

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -552,28 +552,33 @@ let add_aux_files ?dir ~files_subdir_hashes opam =
       OpamFilename.Op.(dir / "files")
     in
     let opam =
-      match try_read OpamFile.URL.read_opt url_file with
-      | Some url, None ->
-        if OpamFile.OPAM.url opam <> None then
-          log "Overriding url of %s through external url file at %s"
-            (OpamPackage.to_string (OpamFile.OPAM.package opam))
-            (OpamFilename.Dir.to_string dir);
-        OpamFile.OPAM.with_url url opam
-      | _, Some err ->
+      match OpamFile.OPAM.url opam, try_read OpamFile.URL.read_opt url_file with
+      | None, (Some url, None) -> OpamFile.OPAM.with_url url opam
+      | Some opam_url, (Some url, errs) ->
+        if url = opam_url && errs = None then
+          log "Duplicate definition of url in '%s' and opam file"
+            (OpamFile.to_string url_file)
+        else
+          OpamConsole.warning
+            "File '%s' ignored (conflicting url already specified in the \
+             'opam' file)"
+            (OpamFile.to_string url_file);
+        opam
+      | _, (_, Some err) ->
         OpamFile.OPAM.with_format_errors (err :: opam.format_errors) opam
-      | None, None -> opam
+      | _, (None, None) -> opam
     in
     let opam =
-      match try_read OpamFile.Descr.read_opt descr_file with
-      | Some descr, None ->
-        if OpamFile.OPAM.descr opam <> None then
-          log "Overriding descr of %s through external descr file at %s"
-            (OpamPackage.to_string (OpamFile.OPAM.package opam))
-            (OpamFilename.Dir.to_string dir);
-        OpamFile.OPAM.with_descr descr opam
-      | _, Some err ->
+      match OpamFile.OPAM.descr opam,
+            try_read OpamFile.Descr.read_opt descr_file with
+      | None, (Some descr, None) -> OpamFile.OPAM.with_descr descr opam
+      | Some _, (Some _, _) ->
+        log "Duplicate descr in '%s' and opam file"
+          (OpamFile.to_string descr_file);
+        opam
+      | _, (_, Some err) ->
         OpamFile.OPAM.with_format_errors (err :: opam.format_errors) opam
-      | None, None  -> opam
+      | _, (None, None)  -> opam
     in
     let opam =
       if not files_subdir_hashes then opam else

--- a/src/state/opamFileTools.mli
+++ b/src/state/opamFileTools.mli
@@ -43,10 +43,11 @@ val warns_to_string: (int * [`Warning|`Error] * string) list -> string
     of files below files/ *)
 val read_opam: dirname -> OpamFile.OPAM.t option
 
-(** Adds (or overrides) data from url, descr or files/ in the specified dir or
-    the opam file's metadata dir (only files and hashes are included for files
-    below files/) *)
-val add_aux_files: ?dir:dirname -> OpamFile.OPAM.t -> OpamFile.OPAM.t
+(** Adds (or overrides) data from 'url' and 'descr' files found in the specified
+    dir or the opam file's metadata dir. if [files_subdir_hashes] is [true],
+    also adds the names and hashes of files found below 'files/' *)
+val add_aux_files:
+  ?dir:dirname -> files_subdir_hashes:bool -> OpamFile.OPAM.t -> OpamFile.OPAM.t
 
 (** {2 Tools to manipulate the [OpamFile.OPAM.t] contents} *)
 val map_all_variables:

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -162,7 +162,7 @@ let pinned_package st ?version ?(working_dir=false) name =
      from the repo *)
   let add_extra_files srcdir file opam =
     if OpamFilename.dirname (OpamFile.filename file) <> srcdir
-    then OpamFileTools.add_aux_files opam
+    then OpamFileTools.add_aux_files ~files_subdir_hashes:true opam
     else opam
   in
   let old_source_opam_hash, old_source_opam =

--- a/src/tools/opam_format_upgrade.ml
+++ b/src/tools/opam_format_upgrade.ml
@@ -416,11 +416,18 @@ let do_upgrade () =
       let nv = OpamFile.OPAM.package opam0 in
       if not (List.mem nv.name ocaml_package_names) &&
          not (OpamPackage.Name.Set.mem nv.name all_base_packages) then
+        let opam = OpamFileTools.add_aux_files ~files_subdir_hashes:true opam0 in
         let opam =
-          OpamFormatUpgrade.opam_file_from_1_2_to_2_0 ~filename:opam_file opam0
+          OpamFormatUpgrade.opam_file_from_1_2_to_2_0 ~filename:opam_file opam
         in
         if opam <> opam0 then
           (OpamFile.OPAM.write_with_preserved_format opam_file opam;
+           List.iter OpamFilename.remove [
+             OpamFile.filename
+               (OpamRepositoryPath.descr repo.repo_root prefix package);
+             OpamFile.filename
+               (OpamRepositoryPath.url repo.repo_root prefix package);
+           ];
            OpamConsole.status_line "Updated %s" (OpamFile.to_string opam_file))
     )
     packages;

--- a/src/tools/opam_format_upgrade.ml
+++ b/src/tools/opam_format_upgrade.ml
@@ -438,9 +438,20 @@ let process args =
     | None -> do_upgrade ()
     | Some base_url ->
       OpamFilename.with_tmp_dir @@ fun tmp_mirror_dir ->
-      OpamFilename.copy_dir ~src:(OpamFilename.cwd ()) ~dst:tmp_mirror_dir;
-      OpamFilename.rmdir OpamFilename.Op.(tmp_mirror_dir / "2.0");
-      OpamFilename.rmdir OpamFilename.Op.(tmp_mirror_dir / ".git");
+      let open OpamFilename.Op in
+      let copy_dir d =
+        let src = OpamFilename.cwd () / d in
+        if OpamFilename.exists_dir src then
+          OpamFilename.copy_dir ~src ~dst:(tmp_mirror_dir / d)
+      in
+      let copy_file f =
+        let src = OpamFilename.cwd () // f in
+        if OpamFilename.exists src then
+          OpamFilename.copy ~src ~dst:(tmp_mirror_dir // f)
+      in
+      copy_dir "packages";
+      copy_dir "compilers";
+      copy_file "repo";
       OpamFilename.in_dir tmp_mirror_dir do_upgrade;
       let repo_file = OpamFile.make (OpamFilename.of_string "repo") in
       let repo0 = OpamFile.Repo.safe_read repo_file in


### PR DESCRIPTION
That is:
- use the single-file layout with upgrade-format
- warn and ignore extra url/descr files when both exist