### PR TITLE
Expose `with_tags` in the OpamFile.OPAM signature

### DIFF
--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -539,6 +539,8 @@ module OPAM: sig
 
   val add_flags: package_flag list -> t -> t
 
+  val with_tags: string list -> t -> t
+
   val with_env: env_update list -> t -> t
 
   val with_dev_repo: url -> t -> t


### PR DESCRIPTION
What are the chances that the one field that I want to set using OpamFile.OPAM isn't exposed? Non-zero probability, it turns out...
