### PR TITLE
Factorise 'opam list' options

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -630,9 +630,6 @@ let jobs_flag =
      the $(b,\\$OPAMJOBS) environment variable."
     Arg.(some positive_integer) None
 
-let pattern_list =
-  arg_list "PATTERNS" "List of package patterns." Arg.string
-
 let name_list =
   arg_list "PACKAGES" "List of package names." package_name
 
@@ -843,11 +840,6 @@ let package_selection_section = "PACKAGE SELECTION"
 let package_selection =
   let section = package_selection_section in
   let docs = section in
-  let patterns =
-    Arg.(value & pos_all Arg.string [] & info [] ~docv:"PATTERNS" ~doc:
-           "Package patterns, i.e. package names or packages in the form \
-            $(b,NAME).$(b,VERSION), optionally containing globs $(b,*).")
-  in
   let depends_on =
     let doc =
       "List only packages that depend on one of (comma-separated) $(docv)."
@@ -965,7 +957,8 @@ let package_selection =
            [OpamListCommand.Solution (dependency_toggles, deps)]) @
        (List.map (fun (field,patt) ->
             OpamListCommand.Pattern
-              ({OpamListCommand.default_pattern_selector with fields = [field]},
+              ({OpamListCommand.default_pattern_selector with
+                OpamListCommand.fields = [field]},
                patt))
            field_match) @
        (List.map (fun flag -> OpamListCommand.Flag flag) has_flag) @

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -94,6 +94,7 @@ val global_options: global_options Term.t
 (** Apply global options *)
 val apply_global_options: global_options -> unit
 
+
 (** {3 Build options} *)
 
 (** Abstract type for build options *)
@@ -107,6 +108,7 @@ val build_options: build_options Term.t
 (** Applly build options *)
 val apply_build_options: build_options -> unit
 
+
 (** {3 Package listing and filtering options} *)
 
 (** Man section name *)
@@ -115,9 +117,13 @@ val package_selection_section: string
 (** Build a package selection filter *)
 val package_selection: OpamListCommand.selector OpamFormula.formula Term.t
 
+(** Man section name *)
+val package_listing_section: string
+
 (** Package selection filter based on the current state of packages (installed,
     available, etc.) *)
-
+val package_listing:
+  (force_all_versions:bool -> OpamListCommand.package_listing_format) Term.t
 
 (** {3 Converters} *)
 

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -47,9 +47,6 @@ val repo_kind_flag: OpamUrl.backend option Term.t
 (** --jobs *)
 val jobs_flag: int option Term.t
 
-(** patterns *)
-val pattern_list: string list Term.t
-
 (** package names *)
 val name_list: name list Term.t
 

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -159,7 +159,7 @@ type 'a default = [> `default of string] as 'a
 (** Enumeration with a default command *)
 val enum_with_default: (string * 'a default) list -> 'a Arg.converter
 
-val opamlist_column: OpamListCommand.output_format Arg.converter
+val opamlist_columns: OpamListCommand.output_format list Arg.converter
 
 (** {2 Subcommands} *)
 

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -110,6 +110,18 @@ val build_options: build_options Term.t
 (** Applly build options *)
 val apply_build_options: build_options -> unit
 
+(** {3 Package listing and filtering options} *)
+
+(** Man section name *)
+val package_selection_section: string
+
+(** Build a package selection filter *)
+val package_selection: OpamListCommand.selector OpamFormula.formula Term.t
+
+(** Package selection filter based on the current state of packages (installed,
+    available, etc.) *)
+
+
 (** {3 Converters} *)
 
 (** Repository name converter *)

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -186,6 +186,24 @@ let rec value_strings value =
     List.fold_left (fun acc v -> SS.union acc (value_strings v))
       (value_strings v) vl
 
+let pattern_selector patterns =
+  let name_patt =
+    { default_pattern_selector with exact = true; fields = ["name"] }
+  in
+  let version_patt =
+    { default_pattern_selector with exact = true; fields = ["version"] }
+  in
+  OpamFormula.ors
+    (List.map (fun patt ->
+         match OpamStd.String.cut_at patt '.' with
+         | None ->
+           Atom (Pattern (name_patt, patt))
+         | Some (name, version) ->
+           OpamFormula.ands
+             [Atom (Pattern (name_patt, name));
+              Atom (Pattern (version_patt, version))])
+        patterns)
+
 let apply_selector ~base st = function
   | Any -> base
   | Installed -> st.installed

--- a/src/client/opamListCommand.mli
+++ b/src/client/opamListCommand.mli
@@ -99,6 +99,9 @@ type output_format =
                            the system *)
   | VC_ref             (** The version-control branch or tag the package url is
                            bound to, if any *)
+  | Depexts of string list (** The external dependencies associated with any
+                               subset of the given tags (or all, associated to
+                               their respective tags, if the list is empty *)
 
 val default_list_format: output_format list
 

--- a/src/client/opamListCommand.mli
+++ b/src/client/opamListCommand.mli
@@ -63,6 +63,9 @@ val filter:
   base:package_set -> 'a switch_state ->
   selector OpamFormula.formula -> package_set
 
+(** Or-filter on package patterns (NAME or NAME.VERSION) *)
+val pattern_selector: string list -> selector OpamFormula.formula
+
 (** Lists the external dependencies matching the given flags for the given set
     of packages *)
 val print_depexts: 'a switch_state -> package_set -> string list -> unit

--- a/src/client/opamListCommand.mli
+++ b/src/client/opamListCommand.mli
@@ -116,37 +116,24 @@ val string_of_field: output_format -> string
 
 val field_of_string: string -> output_format
 
+type package_listing_format = {
+  short: bool;
+  header: bool;
+  columns: output_format list;
+  all_versions: bool;
+  wrap: [`Wrap of string | `Truncate | `None] option;
+  separator: string;
+  value_printer: [`Normal | `Pretty | `Normalised];
+  order: [`Standard | `Dependency | `Custom of package -> package -> int];
+}
+
+val default_package_listing_format: package_listing_format
 
 (** Outputs a list of packages as a table according to the formatting options.
     [normalise] supersedes [prettify] and uses a canonical way of displaying
     package definition file fields. [prettify] uses a nicer to read format for the
     package definition file fields. *)
-val display:
-  'a switch_state ->
-  header:bool ->
-  format:output_format list ->
-  dependency_order:bool ->
-  all_versions:bool ->
-  ?wrap:[`Wrap of string | `Truncate | `None] ->
-  ?separator:string ->
-  ?prettify:bool ->
-  ?normalise:bool ->
-  ?order:(package -> package -> int) ->
-  package_set -> unit
-
-(** Display all available packages that match any of the regexps. *)
-val list:
-  'a global_state ->
-  print_short:bool ->
-  filter:[`all|`installed|`roots|`installable] ->
-  order:[`normal|`depends] ->
-  exact_name:bool ->
-  case_sensitive:bool ->
-  ?depends:(atom list) ->
-  ?reverse_depends:bool -> ?recursive_depends:bool -> ?resolve_depends:bool ->
-  ?depopts:bool -> ?depexts:string list -> ?dev:bool ->
-  string list ->
-  unit
+val display: 'a switch_state -> package_listing_format -> package_set -> unit
 
 (** Display a general summary of a collection of packages. *)
 val info:

--- a/src/client/opamListCommand.mli
+++ b/src/client/opamListCommand.mli
@@ -56,6 +56,7 @@ type selector =
   | Flag of package_flag
   | Tag of string
   | From_repository of repository_name list
+  | Owns_file of filename
 
 (** Applies a formula of selectors to filter the package from a given switch
     state *)

--- a/src/client/opamMain.mli
+++ b/src/client/opamMain.mli
@@ -34,13 +34,10 @@ val default: command
 val init: command
 
 (** opam list *)
-val list: command
+val list: ?force_search:bool -> unit -> command
 
 (** opam show *)
 val show: command
-
-(** opam search *)
-val search: command
 
 (** opam install *)
 val install: command


### PR DESCRIPTION
Removes the discrepancy with 'opam search', which is now an alias,
allows reusing them in other scopes for better expressivity and
consistency.