### PR TITLE
Avoid name clash with next version of cmdliner.

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -547,13 +547,13 @@ let mk_flag ?section flags doc =
   let doc = Arg.info ?docs:section ~doc flags in
   Arg.(value & flag & doc)
 
-let mk_opt ?section ?vopt flags value doc conv default =
+let mk_opt ?section ?vopt flags value doc kind default =
   let doc = Arg.info ?docs:section ~docv:value ~doc flags in
-  Arg.(value & opt ?vopt conv default & doc)
+  Arg.(value & opt ?vopt kind default & doc)
 
-let mk_opt_all ?section ?vopt ?(default=[]) flags value doc conv =
+let mk_opt_all ?section ?vopt ?(default=[]) flags value doc kind =
   let doc = Arg.info ?docs:section ~docv:value ~doc flags in
-  Arg.(value & opt_all ?vopt conv default & doc)
+  Arg.(value & opt_all ?vopt kind default & doc)
 
 let mk_tristate_opt ?section flags value doc =
   let doc = Arg.info ?docs:section ~docv:value ~doc flags in
@@ -645,13 +645,13 @@ let term_info title ~doc ~man =
   let man = man @ help_sections in
   Term.info ~sdocs:global_option_section ~docs:"COMMANDS" ~doc ~man title
 
-let arg_list name doc conv =
+let arg_list name doc kind =
   let doc = Arg.info ~docv:name ~doc [] in
-  Arg.(value & pos_all conv [] & doc)
+  Arg.(value & pos_all kind [] & doc)
 
-let nonempty_arg_list name doc conv =
+let nonempty_arg_list name doc kind =
   let doc = Arg.info ~docv:name ~doc [] in
-  Arg.(non_empty & pos_all conv [] & doc)
+  Arg.(non_empty & pos_all kind [] & doc)
 
 (* Common flags *)
 let print_short_flag =


### PR DESCRIPTION
where `Arg.conv` is introduced. It would be nice if this could make it in the subsequent `rc`s before 2.0.0.