### PR TITLE
update the Basic guide to recommend 4.04 instead of 4.02.3

### DIFF
--- a/doc/pages/Usage.md
+++ b/doc/pages/Usage.md
@@ -21,8 +21,8 @@ details.
 ```
 # ** Get started **
 opam init            # Initialize ~/.opam
-opam init --compiler=ocaml-base-compiler.4.02.3
-                     # Initialize with a freshly compiled OCaml 4.02.3
+opam init --compiler=ocaml-base-compiler.4.04.0
+                     # Initialize with a freshly compiled OCaml 4.04.0
 
 # ** Lookup **
 opam list -a         # List all available packages


### PR DESCRIPTION
I see that the instructions seem to have been rewritten for opam2 recently, but the change is not in production on the website (which is reasonable if you ask me given that all distribution-installed OPAMs will remain 1.x for a some time). Is there a way to get a change to the production website?

(I plan to move to 4.04.1 or 4.05.0 once one of these is released, so another similar PR may show up at some point.)

(Also: @AltGr, I sent you an unrelated email last week, please check your mailbox.)