### PR TITLE
make cold: fix the bootstrap compiler to install the faster compiler

### DIFF
--- a/shell/bootstrap-ocaml.sh
+++ b/shell/bootstrap-ocaml.sh
@@ -17,5 +17,5 @@ fi
 tar -zxvf ${V}.tar.gz
 cd ${V}
 ./configure -prefix "`pwd`/../ocaml"
-make world opt
+make world opt.opt
 make install


### PR DESCRIPTION
Without this, `ocamlc.byte` is installed and the build fails. We might
as well use ocamlopt.opt as the build time isn't that much slower
and we get a more complete OCaml environment.