### PR TITLE
Clarify the story on building/running/installing tests and doc

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -589,23 +589,29 @@ let remove_package t ?silent ?changes ?force nv =
   else
     remove_package_aux t ?silent ?changes ?force nv
 
+let local_vars ~test ~doc =
+  OpamVariable.Map.of_list [
+    OpamVariable.of_string "with-test", Some (B test);
+    OpamVariable.of_string "with-doc", Some (B doc);
+  ]
+
 let build_package t ?(test=false) ?(doc=false) build_dir nv =
   let opam = OpamSwitchState.opam t nv in
   let commands =
-    OpamFile.OPAM.build opam @
-    (if test then OpamFile.OPAM.build_test opam else []) @
-    (if doc then OpamFile.OPAM.build_doc opam else [])
-  in
-  let commands =
-    let local =
-      OpamVariable.Map.of_list [
-        OpamVariable.of_string "build-test", Some (B test);
-        OpamVariable.of_string "build-doc", Some (B doc);
-      ]
-    in
-    OpamFilter.commands (OpamPackageVar.resolve ~opam ~local t) commands |>
-    OpamStd.List.filter_map
-      (function [] -> None | cmd::args -> Some (cmd, args))
+    OpamFilter.commands
+      (OpamPackageVar.resolve ~opam ~local:(local_vars ~test ~doc) t)
+      (OpamFile.OPAM.build opam) @
+    (if test then
+       OpamFilter.commands (OpamPackageVar.resolve ~opam t)
+         (OpamFile.OPAM.run_test opam)
+     else []) @
+    (if doc then
+       OpamFilter.commands (OpamPackageVar.resolve ~opam t)
+         (OpamFile.OPAM.deprecated_build_doc opam)
+     else [])
+    |> OpamStd.List.filter_map (function
+        | [] -> None
+        | cmd::args -> Some (cmd, args))
   in
   let env = OpamTypesBase.env_array (compilation_env t opam) in
   let name = OpamPackage.name_to_string nv in
@@ -643,20 +649,14 @@ let build_package t ?(test=false) ?(doc=false) build_dir nv =
 
 (* Assumes the package has already been compiled in its build dir.
    Does not register the installation in the metadata ! *)
-let install_package t ?(doc=false) ?build_dir nv =
+let install_package t ?(test=false) ?(doc=false) ?build_dir nv =
   let opam = OpamSwitchState.opam t nv in
-  let commands = OpamFile.OPAM.install opam in
   let commands =
-    let local =
-      OpamVariable.Map.singleton
-        (OpamVariable.of_string "build-doc") (Some (B doc))
-    in
-    OpamFilter.commands (OpamPackageVar.resolve ~opam ~local t) commands
-  in
-  let commands =
+    OpamFile.OPAM.install opam |>
+    OpamFilter.commands
+      (OpamPackageVar.resolve ~opam ~local:(local_vars ~test ~doc) t) |>
     OpamStd.List.filter_map
       (function [] -> None | cmd::args -> Some (cmd, args))
-      commands
   in
   let env = OpamTypesBase.env_array (compilation_env t opam) in
   let name = OpamPackage.name_to_string nv in

--- a/src/client/opamAction.mli
+++ b/src/client/opamAction.mli
@@ -40,7 +40,7 @@ val build_package:
     [None] on success, [Some exn] on error. Do not update OPAM's
     metadata. See {!build_package} to build the package. *)
 val install_package:
-  rw switch_state -> ?doc:bool -> ?build_dir:dirname -> package ->
+  rw switch_state -> ?test:bool -> ?doc:bool -> ?build_dir:dirname -> package ->
   exn option OpamProcess.job
 
 (** Find out if the package source is needed for uninstall *)

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -884,15 +884,18 @@ let build_options =
       "Reject the installation of packages that don't provide a checksum for the upstream archives. \
        This is equivalent to setting $(b,\\$OPAMREQUIRECHECKSUMS) to \"true\"." in
   let build_test =
-    mk_flag ~section ["t";"build-test"]
-      "Build and $(b,run) the package unit-tests. \
-       This only affects packages listed on the command-line. \
-       This is equivalent to setting $(b,\\$OPAMBUILDTEST) to \"true\"." in
+    mk_flag ~section ["t";"with-test";"build-test"]
+      "Build and $(b,run) the package unit-tests. This only affects packages \
+       listed on the command-line. The $(build-test) form is deprecated as \
+       this also affects installation. This is equivalent to setting \
+       $(b,\\$OPAMWITHTEST) (or the deprecated $(b,\\$OPAMBUILDTEST)) to \
+       \"true\"." in
   let build_doc =
-    mk_flag ~section ["d";"build-doc"]
-      "Build the package documentation. \
-       This only affects packages listed on the command-line. \
-       This is equivalent to setting $(b,\\$OPAMBUILDDOC) to \"true\"." in
+    mk_flag ~section ["d";"with-doc";"build-doc"]
+      "Build the package documentation. This only affects packages listed on \
+       the command-line. The $(b,--build-doc) form is deprecated as this does \
+       also installation. This is equivalent to setting $(b,\\$OPAMWITHDOC) \
+       (or the deprecated $(b,\\$OPAMBUILDDOC)) to \"true\"." in
   let make =
     mk_opt ~section ["m";"make"] "MAKE"
       "Use $(docv) as the default 'make' command."
@@ -998,11 +1001,11 @@ let package_selection =
       "Include development packages in dependencies."
   in
   let doc_flag =
-    mk_flag ["doc"] ~section
+    mk_flag ["doc";"with-doc"] ~section
       "Include doc-only dependencies."
   in
   let test =
-    mk_flag ["t";"test"] ~section
+    mk_flag ["t";"test";"with-test"] ~section
       "Include test-only dependencies."
   in
   let field_match =

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -518,11 +518,14 @@ let parallel_apply t action ~requested action_graph =
            | Some exn -> store_time (); Done (`Exception exn)
            | None -> store_time (); Done (`Successful (installed, removed)))
       | `Install nv ->
+        let test =
+          OpamStateConfig.(!r.build_test) && OpamPackage.Set.mem nv requested
+        in
         let doc =
           OpamStateConfig.(!r.build_doc) && OpamPackage.Set.mem nv requested
         in
         let build_dir = OpamPackage.Map.find_opt nv inplace in
-        (OpamAction.install_package t ~doc ?build_dir nv @@+ function
+        (OpamAction.install_package t ~test ~doc ?build_dir nv @@+ function
           | None ->
             add_to_install nv;
             store_time ();

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -264,8 +264,7 @@ module OPAM: sig
 
     (* Build instructions *)
     build      : command list;
-    build_test : command list;
-    build_doc  : command list;
+    run_test   : command list;
     install    : command list;
     remove     : command list;
 
@@ -312,6 +311,8 @@ module OPAM: sig
     (* Deprecated, for compat and proper linting *)
     ocaml_version: (OpamFormula.relop * string) OpamFormula.formula option;
     os         : (bool * string) generic_formula;
+    deprecated_build_test : command list;
+    deprecated_build_doc  : command list;
   }
 
   include IO_FILE with type t := t
@@ -426,10 +427,13 @@ module OPAM: sig
   val tags: t -> string list
 
   (** Commands to build and run the tests *)
-  val build_test: t -> command list
+  val run_test: t -> command list
 
   (** Commands to build the documentation *)
-  val build_doc: t -> command list
+  val deprecated_build_doc: t -> command list
+
+  (** Commands to build the tests *)
+  val deprecated_build_test: t -> command list
 
   (** Messages to display before taking action *)
   val messages: t -> (string * filter option) list
@@ -504,9 +508,7 @@ module OPAM: sig
   (** Construct as [build] *)
   val with_build: command list -> t -> t
 
-  val with_build_test: command list -> t -> t
-
-  val with_build_doc: command list -> t -> t
+  val with_run_test: command list -> t -> t
 
   val with_install: command list -> t -> t
 
@@ -559,6 +561,10 @@ module OPAM: sig
   val with_extensions: value OpamStd.String.Map.t -> t -> t
 
   val add_extension: t -> string -> value -> t
+
+  val with_deprecated_build_doc: command list -> t -> t
+
+  val with_deprecated_build_test: command list -> t -> t
 
   val with_descr: Descr.t -> t -> t
   val with_descr_opt: Descr.t option -> t -> t

--- a/src/format/opamFilter.ml
+++ b/src/format/opamFilter.ml
@@ -532,8 +532,8 @@ let filter_deps ~build ~test ~doc ~dev ?default deps =
   let env var =
     match OpamVariable.Full.to_string var with
     | "build" -> Some (B build)
-    | "test" -> Some (B test)
-    | "doc" -> Some (B doc)
+    | "with-test" -> Some (B test)
+    | "with-doc" -> Some (B doc)
     | "dev" -> Some (B dev)
     | _ -> None
   in

--- a/src/state/opamPackageVar.ml
+++ b/src/state/opamPackageVar.ml
@@ -47,7 +47,7 @@ let package_variable_names = [
 
 let predefined_depends_variables =
   List.map OpamVariable.Full.of_string [
-    "build"; "test"; "doc"; "dev";
+    "build"; "with-test"; "with-doc"; "dev";
   ]
 
 let resolve_global gt full_var =

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -102,8 +102,8 @@ let initk k =
     ?switch_from
     ?jobs:(env_int "JOBS" >>| fun s -> lazy s)
     ?dl_jobs:(env_int "DOWNLOADJOBS")
-    ?build_test:(env_bool "BUILDTEST")
-    ?build_doc:(env_bool "BUILDDOC")
+    ?build_test:(env_bool "WITHTEST" ++ env_bool "BUILDTEST")
+    ?build_doc:(env_bool "WITHDOC" ++ env_bool "BUILDDOC")
     ?dryrun:(env_bool "DRYRUN")
     ?makecmd:(env_string "MAKECMD" >>| fun s -> lazy s)
     ?ignore_constraints_on:


### PR DESCRIPTION
- `build-test:`, `build-doc:` are deprecated
- they should be integrated into `build:` and `install:`, with filters
 based on the new variables `with-test`, `with-doc`
- variables `test` and `doc` available in the `depends:`, `depopts:`
 fields renamed to `with-test`, `with-doc` for consistency
- likewise, command-line options `--build-test` renamed to
 `--with-test`, etc.
- `run-test:` is also available and will be run after `build:`, when
 tests have been requested

NOTE: the updated repository migration breaks build/test handling in opam 2.0
up to beta2 (will add the new variables in the package defs). Hold on merging
this to the repo-rewriting opam-admin on opam.ocaml.org/2.0 at least until a
newer beta is released.