### PR TITLE
Fix `opam config subst`

### DIFF
--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -30,11 +30,7 @@ let load_config global_lock root =
 
 let load lock_kind =
   let root = OpamStateConfig.(!r.root_dir) in
-
   log "LOAD-GLOBAL-STATE @ %a" (slog OpamFilename.Dir.to_string) root;
- (* Protect against removal of CWD *)
-  if OpamFilename.exists_dir root then
-    Sys.chdir (OpamFilename.Dir.to_string root);
   (* Always take a global read lock, this is only used to prevent concurrent
      ~/.opam format changes *)
   let global_lock = OpamFilename.flock `Lock_read (OpamPath.lock root) in

--- a/src/state/opamGlobalState.mli
+++ b/src/state/opamGlobalState.mli
@@ -15,7 +15,7 @@ open OpamTypes
 open OpamStateTypes
 
 (** Loads the global state (from the opam root obtained through
-    [OpamStateConfig.(!r.root)]). Also places [CWD] at the opam root. *)
+    [OpamStateConfig.(!r.root)]) *)
 val load: 'a lock -> 'a global_state
 
 (** Loads the global state as [load], and calls the given function while keeping


### PR DESCRIPTION
Don't Sys.chdir to opamroot

This was intended to solve issues with removed CWD during the run of opam, but
may cause further issues with filename resolution: not worth it for now.

Is a partial revert of "Don't let opam-lib leave empty dirs in /tmp"
(commit 73854c23214f6848b041d5736b5b2ba81d960bf0.)