### PR TITLE
parse_url: return actual protocol instead of assuming http

### DIFF
--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -82,11 +82,16 @@ let parse_url (s,c) =
          (proto2^urlsplit^address, c), url_kind_of_string proto1
        | None ->
          let addr = match proto with
-           | "git" -> s (* git:// urls legit *)
-           | _ ->
+           | "hg" | "darcs" ->
+             (* backwards compatibility hack, allow:
+              *   hg://example.com (http)
+              *   hg://https://example.com (https)
+              * for hg / darcs
+              *)
              if Re_str.string_match (Re_str.regexp (".*"^urlsplit)) address 0
              then address
              else "http://" ^ address (* assume http transport by default *)
+           | _ -> s
          in
          (addr,c), url_kind_of_string proto)
     | [address] -> (address,c), `local


### PR DESCRIPTION
I'm using opam-lib v1.3.0 to generate nix packages from the opam-repository with [opam2nix](https://github.com/timbertson/opam2nix-packages). I know opam 2 is coming, so I'm not sure whether opam-lib is also due for an upgrade or is still being actively maintained.

Anyway, I recently upgraded from 1.2.x -> 1.3, and was surprised to see masses of generated URLs go from `https` -> `http`. Simple repro:

```
# let url = OpamFile.URL.read_from_string "archive: \"https://example.com/foo.tgz\"";;
val url : OpamFile.URL.t = <abstr>

# OpamFile.URL.url url;;
- : OpamTypes.address = ("http://example.com/foo.tgz", None)
```

Looking at the code for `parse_url`, it seems to be splitting on `://` and then looking for _another_ `://`, and if it can't find that then it'll assume http. This PR just returns the original url with protocol included. With that, there's no need for the `git://` branch nor the "assume http" logic, since we know the URL has a scheme.