### PR TITLE
Fix two glitches when removing failed installations

### DIFF
--- a/src/client/opamAction.mli
+++ b/src/client/opamAction.mli
@@ -51,7 +51,7 @@ val removal_needs_download: 'a switch_state -> package -> bool
     in [changes] even if the files have been modified since. *)
 val remove_package:
   rw switch_state -> ?silent:bool ->
-  ?changes:OpamDirTrack.t -> ?force:bool ->
+  ?changes:OpamDirTrack.t -> ?force:bool -> ?build_dir:dirname ->
   package -> unit OpamProcess.job
 
 (** Returns [true] whenever [remove_package] is a no-op. *)

--- a/src/core/opamDirTrack.ml
+++ b/src/core/opamDirTrack.ml
@@ -213,7 +213,7 @@ let revert ?title ?(verbose=OpamConsole.verbose()) ?(force=false)
           rmfile f;
           acc
         | Contents_changed dg ->
-          if check_digest fname dg = `Changed then
+          if check_digest f dg = `Changed then
             (already, modified, nonempty, (op,fname)::cannot)
           else
             acc (* File has changed, assume the removal script reverted it *)


### PR DESCRIPTION
I hit this testing ocamlfind on the Windows port. It should be possible to trigger the problem elsewhere by putting an incorrect filename in `ocamlfind.install` (for my particular test I expected the problem - it's to do with opam not knowing to install ocamlfind.exe instead of ocamlfind).

There seems to be a typo in `OpamDirTrack.revert` - it doesn't qualify the filename used when reading the checksum (so I get a stat error).

The other more serious problem is to do with the default directory used for `OpamAction.remove_package` - it assumes that the sources will have been put in the "remove" directory but if something fails during installation then the sources will be in the "build" directory. I have fixed this by adding an optional parameter but this should maybe be thought through so more - initially the uninstall worked because I happened to be in my root **OPAM** source directory so opam merrily ran its own configure script because it was in the current directory! Perhaps if there is no build directory, OPAM should change to a temporary empty directory - or raise an error if it's asked to run a relative-path command? For Windows, this behaviour is very important because `PATH` implicitly begins with `.:` (i.e. an executable in the current directory always takes precedence over `PATH` itself, even if you don't prefix `./`).