### PR TITLE
Add ? operator to filter syntax

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -12,6 +12,7 @@ install-bootstrap () {
     opam init --root=$OPAMBSROOT --yes --no-setup --compiler=$OCAML_VERSION
     eval $(opam config env --root=$OPAMBSROOT)
     if [ "$OPAM_TEST" = "1" ]; then
+        opam pin add opam-file-format "git://github.com/ocaml/opam-file-format.git" --no-action --yes
         opam install ocamlfind lwt.2.5.2 cohttp.0.20.2 ssl cmdliner dose3 jsonm opam-file-format --yes
         # Allow use of ocamlfind packages in ~/local/lib
         FINDCONF=$(ocamlfind printconf conf)

--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -412,6 +412,7 @@ is `true`. This is evaluated just when the command is going to be run.
 ```BNF
 <filter> ::= <filter> <logop> <filter>
            | "!" <filter>
+           | "?" <filter>
            | ( <filter> )
            | <filter> <relop> <filter>
            | <varident>
@@ -427,6 +428,8 @@ The following are allowed in filters:
 - Idents
 - Parentheses
 - Logical operators (binary AND `&`, binary OR `|`, prefix, unary NOT `!`)
+- The unary operator `?` for detecting whether an expression contains undefined
+  variables
 - Binary relational operators (`=`, `!=`, `<`, `<=`, `>`, `>=`)
 
 The comparisons are done using [Version Order](#version-ordering). Relational
@@ -434,7 +437,9 @@ operators have a higher precedence than logical operators.
 
 Undefined values are propagated through relational operators, and logical
 operators unless absorbed (`undef & false` is `false`, `undef | true` is
-`true`).
+`true`). Undefined values may be detected using the `?` operator, for example,
+`!(?foo & foo != bar)` requires either `foo` to be undefined or equal in value
+to `bar`.
 
 ### Filtered package formulas
 
@@ -453,6 +458,7 @@ The definition is similar to that of `<package-formula>`, except that two cases
 
 <filtered-version-formula> ::= <filtered-version-formula> <logop> <filtered-version-formula>
                              | "!" <filtered-version-formula>
+                             | "?" <filtered-version-formula>
                              | "(" <filtered-version-formula> ")"
                              | <relop> <version>
                              | <filter>

--- a/src/format/opamFormat.ml
+++ b/src/format/opamFormat.ml
@@ -285,6 +285,7 @@ module V = struct
         | Group (pos,g) -> parse_filter ~pos g
         | Relop (_,op,e,f) -> FOp (aux e, op, aux f)
         | Pfxop (_,`Not,e) -> FNot (aux e)
+        | Pfxop (_,`Defined,e) -> FDefined (aux e)
         | Logop(_,`And,e,f)-> FAnd (aux e, aux f)
         | Logop(_,`Or, e,f)-> FOr (aux e, aux f)
         | _ -> unexpected ()
@@ -318,6 +319,9 @@ module V = struct
         | FNot f ->
           group_if ~cond:(context = `Relop)
             (Pfxop (pos_null, `Not, aux ~context:`Not f))
+        | FDefined f ->
+          group_if ~cond:(context = `Relop)
+            (Pfxop (pos_null, `Defined, aux ~context:`Defined f))
         | FUndef _ -> assert false
       in
       match f with

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -183,6 +183,7 @@ type filter =
   | FAnd of filter * filter
   | FOr of filter * filter
   | FNot of filter
+  | FDefined of filter
   | FUndef of filter
   (** Returned by reduce functions when the filter could not be resolved to an
       atom (due to undefined variables or string expansions). The argument

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -29,8 +29,8 @@ MD5_uutf = 708c0421e158b390c7cc341f37b40add
 URL_jsonm = http://erratique.ch/software/jsonm/releases/jsonm-0.9.1.tbz
 MD5_jsonm = 631a5dabdada83236c83056f60e42685
 
-URL_opam_file_format = https://github.com/ocaml/opam-file-format/archive/2.0-alpha5.tar.gz
-MD5_opam_file_format = 2ccdf87e2bd8ed8541dda1d3369b3199
+URL_opam_file_format = https://github.com/ocaml/opam-file-format/archive/9dbcf8a1ec44b6b3ec72e280de609db791c7a3d5.tar.gz
+MD5_opam_file_format = c71ee1aaa004b5d1491a559d735bd70f
 
 ARCHIVES = $(foreach lib,$(SRC_EXTS),$(notdir $(URL_$(lib))))
 lib_of = $(foreach lib,$(SRC_EXTS),$(if $(findstring $(1),$(URL_$(lib))),$(lib),,))
@@ -284,7 +284,8 @@ export PROJ_jsonm
 SRC_opam_file_format = \
   opamParserTypes.mli \
   opamLexer.mli opamLexer.mll \
-  opamParser.mly \
+  opamBaseParser.mly \
+	opamParser.mli opamParser.ml \
   opamPrinter.mli  opamPrinter.ml
 
 define PROJ_opam_file_format


### PR DESCRIPTION
See also https://github.com/ocaml/opam-file-format/pull/4 - this PR should have a commit updating `src_ext` before it is merged.

The `?` operator evaluates to false if the expression is undefined (i.e. contains undefined variables) and true in all other instances.

This operator removes the need for evil uses of `"%{variable}%"` (which expands to an empty string if variable is undefined). In particular, for the `ocaml-system` package, it allows a slightly less unclear `available` field:

```
available:
  sys-ocaml-version = "4.02.2" &
  !(?switch-arch & switch-arch != sys-ocaml-arch) &
  !(?switch-cc & switch-cc != sys-ocaml-cc) &
  !(?switch-libc & switch-libc != sys-ocaml-libc)
```