### PR TITLE
Some more customisation for `opam init`; some var resolving fixes in `depends`

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -389,6 +389,10 @@ three scopes:
       (through the `--with-test` flag)
     * `with-doc`: similarly for documentation.
 
+    Within package definition files, the variables `name` and `version`, as
+    shortcuts to `_:name` and `_:version`, corresponding to the package being
+    defined, are always available.
+
 For a comprehensive list of predefined variables, and their current local
 values, run:
 

--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -792,8 +792,8 @@ files.
 
 - <a id="opamfield-depends">`depends: [ <filtered-package-formula> ... ]`</a>:
   the package dependencies. This describes the requirements on other packages
-  for this package to be built and installed. It contains a list of package
-  formulas, understood as a conjunction.
+  for this package to be built and installed. It contains a list of filtered
+  package formulas, understood as a conjunction.
 
     The filtered package formula can access the global and switch variables, but
     not variables from other packages. Additionally, special boolean variables

--- a/src/Makefile
+++ b/src/Makefile
@@ -140,9 +140,9 @@ SRC_format = \
   opamFormula.ml \
   opamTypes.mli \
   opamTypesBase.ml \
+  opamFilter.ml \
   opamPp.ml \
   opamFormat.ml \
-  opamFilter.ml \
   opamFile.ml
 
 define PROJ_format

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -587,7 +587,7 @@ let update
   rt
 
 let init
-    ?init_config ?repo ?(bypass_checks=false)
+    ?(init_config=OpamInitDefaults.init_config) ?repo ?(bypass_checks=false)
     shell dot_profile update_config =
   log "INIT %a"
     (slog @@ OpamStd.Option.to_string OpamRepositoryBackend.to_string) repo;
@@ -680,13 +680,6 @@ let init
                   missing)));
 
         (* Create ~/.opam/config *)
-        let init_config =
-          match init_config with
-          | None ->
-            OpamInitDefaults.init_config
-          | Some ic ->
-            OpamFile.InitConfig.add OpamInitDefaults.init_config ic
-        in
         let repos = match repo with
           | Some r -> [r.repo_name, (r.repo_url, r.repo_trust)]
           | None -> OpamFile.InitConfig.repositories init_config

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -15,7 +15,7 @@
 open OpamTypes
 open OpamStateTypes
 
-(** Initialize the client a consistent state. *)
+(** Initialize the client to a consistent state. *)
 val init:
   ?init_config:OpamFile.InitConfig.t ->
   ?repo:repository ->

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -618,7 +618,7 @@ let config =
     "set", `set, ["VAR";"VALUE"],
     "Set the given opam variable for the current switch. Warning: changing a \
      configured path will not move any files! This command does not perform \
-     anyvariable expansion.";
+     any variable expansion.";
     "unset", `unset, ["VAR"],
     "Unset the given opam variable for the current switch. Warning: \
      unsetting built-in configuration variables can cause problems!";

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -249,6 +249,8 @@ let init =
         let packages =
           OpamSwitchCommand.guess_compiler_package rt comp
         in
+        OpamConsole.header_msg "Creating initial switch (%s)"
+          (OpamFormula.string_of_atoms packages);
         OpamSwitchCommand.install
           gt ~rt ~packages ~update_config:true (OpamSwitch.of_string comp)
         |> ignore
@@ -266,6 +268,8 @@ let init =
         in
         match compiler_packages with
         | Some packages ->
+          OpamConsole.header_msg "Creating initial switch (%s)"
+            (OpamFormula.string_of_atoms packages);
           OpamSwitchCommand.install
             gt ~rt ~packages ~update_config:true
             (OpamSwitch.of_string "default")

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -184,7 +184,7 @@ let edit_raw name temp_file =
         else edit ()
     with e ->
       OpamStd.Exn.fatal e;
-      log "Editing error: %s" (Printexc.to_string e);
+      OpamConsole.error "%s" (Printexc.to_string e);
       if OpamStd.Sys.tty_in &&
          OpamConsole.confirm "Errors in %s, retry editing ?"
            (OpamFile.to_string temp_file)

--- a/src/format/format.ocp
+++ b/src/format/format.ocp
@@ -13,10 +13,10 @@ begin library "opam-format"
     "opamRepositoryName.ml"
     "opamTypes.mli"
     "opamTypesBase.ml"
+    "opamFilter.ml"
     "opamPp.ml"
     "opamFormat.ml"
     "opamLineLexer.mll"
-    "opamFilter.ml"
     "opamFile.ml"
   ]
 

--- a/src/format/opamFilter.mli
+++ b/src/format/opamFilter.mli
@@ -99,7 +99,7 @@ val eval_to_bool: ?default:bool -> env -> filter -> bool
     most common behaviour for using "filters" for filtering *)
 val opt_eval_to_bool: env -> filter option -> bool
 
-(** Like [to_value] but casts the result to a string *)
+(** Like [eval] but casts the result to a string *)
 val eval_to_string: ?default:string -> env -> filter -> string
 
 (** Reduces what can be, keeps the rest unchanged *)
@@ -138,10 +138,17 @@ val commands_variables: command list -> full_variable list
 (** Converts a generic formula to a filter, given a converter for atoms *)
 val of_formula: ('a -> filter) -> 'a generic_formula -> filter
 
-(** [default] indicates the result to assume when a filter is undefined; this is
-    normally [false] when computing the universe. Will raise as other filter
-    functions if undefined and [default] is not given. *)
-val filter_formula: ?default:bool -> env -> filtered_formula -> formula
+(** Resolves the filter in a filtered formula, reducing to a pure formula.
+
+    [default] is the assumed result for undefined filters. If a version filter
+    doesn't resolve to a valid version, the constraint is dropped unless
+    [default_version] is specified.
+
+    May raise, as other filter functions, if [default] is not provided and
+    filters don't resolve. *)
+val filter_formula:
+  ?default_version:version -> ?default:bool ->
+  env -> filtered_formula -> formula
 
 (** Reduces according to what is defined in [env], and returns the simplified
     formula *)
@@ -153,9 +160,12 @@ val variables_of_filtered_formula: filtered_formula -> full_variable list
 
 (** Resolves the build, test, doc, dev flags in a filtered formula (which is
     supposed to have been pre-processed to remove switch and global variables).
-    [default] determines the behaviour on undefined filters, raising if
-    undefined. If test, doc or dev are unspecified, they are assumed to be
-    filtered already and encountering them will raise an assert. *)
+    [default] determines the behaviour on undefined filters, and the function
+    may raise if it is undefined. If a constraint resolves to an invalid
+    version, it is dropped, or replaced with [default_version] if specified. If
+    test, doc or dev are unspecified, they are assumed to be filtered out
+    already and encountering them will raise an assert. *)
 val filter_deps:
-  build:bool -> ?test:bool -> ?doc:bool -> ?dev:bool -> ?default:bool ->
+  build:bool -> ?test:bool -> ?doc:bool -> ?dev:bool ->
+  ?default_version:version -> ?default:bool ->
   filtered_formula -> formula

--- a/src/format/opamFormat.ml
+++ b/src/format/opamFormat.ml
@@ -432,7 +432,15 @@ module V = struct
   let ext_version =
     pp ~name:"version-expr"
       (fun ~pos:_ -> function
-         | String (_,s) -> FString OpamPackage.Version.(to_string (of_string s))
+         | String (pos,s) ->
+           let _ =
+             try
+               OpamPackage.Version.of_string
+                 (OpamFilter.expand_string (fun _ -> Some (S "-")) s)
+             with Failure msg ->
+               bad_format ~pos "Invalid version string %S: %s" s msg
+           in
+           FString s
          | Ident (_,s) -> FIdent (filter_ident_of_string s)
          | _ -> unexpected ())
       (function

--- a/src/state/opamPath.ml
+++ b/src/state/opamPath.ml
@@ -19,14 +19,11 @@ let ( /- ) dir f = OpamFile.make (dir // f)
 
 let config t = t /- "config"
 
-let init_config_file () =
-  OpamStd.Option.Op.(
-    OpamFilename.opt_file
-      (OpamFilename.Dir.of_string (OpamStd.Sys.home ()) // ".opamrc") ++
-    OpamFilename.opt_file
-      (OpamFilename.Dir.of_string (OpamStd.Sys.etc ()) // "opamrc")
-    >>| OpamFile.make
-  )
+let init_config_files () =
+  List.map OpamFile.make [
+    OpamFilename.Dir.of_string (OpamStd.Sys.etc ()) // "opamrc";
+    OpamFilename.Dir.of_string (OpamStd.Sys.home ()) // ".opamrc";
+  ]
 
 let state_cache t = t / "repo" // "state.cache"
 

--- a/src/state/opamPath.mli
+++ b/src/state/opamPath.mli
@@ -28,9 +28,9 @@ val lock: t -> filename
 (** Main configuration file: {i $opam/config} *)
 val config: t -> OpamFile.Config.t OpamFile.t
 
-(** Gets an opam init config file, if present on the system (either
-    {i ~/.opamrc} or {i /etc/opamrc} *)
-val init_config_file: unit -> OpamFile.InitConfig.t OpamFile.t option
+(** The list of configuration files location used by default ({i /etc/opamrc}
+    and {i ~/.opamrc}). More general (lower priority) first. *)
+val init_config_files: unit -> OpamFile.InitConfig.t OpamFile.t list
 
 (** Lock for updates on the main config file (write lock when changes to
     switches, repositories lists are expected. No lock needed otherwise) *)


### PR DESCRIPTION
Note: stacking the config-files is done per field: the latest
definition for any given field overrides the previous ones.

Some might want to be able to merge e.g. repository definitions from
several config files, though ? That would be more complex... but in
practice, if you redefine e.g. `eval-variables:`, you need to include
the def for `sys-ocaml-version` or the default repository would be
broken.