### PR TITLE
Fix renaming of test and doc

### DIFF
--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -186,6 +186,8 @@ let opam_file_from_1_2_to_2_0 ?filename opam =
        | "ocaml-native" -> mkvar "native"
        | "ocaml-native-tools" -> mkvar "native-tools"
        | "ocaml-native-dynlink" -> mkvar "native-dynlink"
+       | "test" -> OpamVariable.Full.global (OpamVariable.of_string "with-test")
+       | "doc" -> OpamVariable.Full.global (OpamVariable.of_string "with-doc")
        | _ -> v)
     | _ -> v
   in


### PR DESCRIPTION
beta3 renames the `test` and `doc` predicates to `with-test` and `with-doc`, but opam admin upgrade doesn't convert the predicates from old repositories.

@altgr - I patched this just because the warnings about wrong predicates were clogging my debug logs if the state was recomputed. If it saves you 10 seconds' work, then here you go!