### PR TITLE
Fix lib-ext build of extlib

### DIFF
--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -150,7 +150,7 @@ copy: build
 
 addmli = $(foreach ml,$(2),$(wildcard $(addsuffix .mli,$(basename $(1)/$(ml)))) $(1)/$(ml))
 
-SRC_extlib = extBytes.ml extBuffer.ml enum.ml extHashtbl.ml extList.ml extString.ml global.ml install.ml	\
+SRC_extlib = extBytes.ml extBuffer.ml enum.ml extHashtbl.ml extList.ml extString.ml global.ml \
 IO.ml option.ml pMap.ml refList.ml std.ml uChar.ml unzip.ml uTF8.ml optParse.ml	\
 dynArray.ml dllist.ml bitSet.ml base64.ml extArray.ml extLib.ml
 


### PR DESCRIPTION
d7bf17fffe354ea0ca72b385ac500a016d78e4b9 reverted a change in c87c77cfec457e3c1410bce5848326910c9228c4 breaking opam-admin.top when compiled
using lib-ext.