### PR TITLE
Switch defaults configuration file

### DIFF
--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -127,6 +127,9 @@ module I = OpamFile.InitConfig
 
 let (@|) g f = OpamStd.Op.(g @* f) ()
 
+let switch_defaults =
+  OpamFile.SwitchDefaults.empty
+
 let init_config ?(sandboxing=true) () =
   I.empty |>
   I.with_repositories
@@ -137,4 +140,5 @@ let init_config ?(sandboxing=true) () =
   I.with_recommended_tools @| recommended_tools |>
   I.with_required_tools @| required_tools ~sandboxing |>
   I.with_init_scripts @| init_scripts |>
-  I.with_dl_tool @| dl_tool
+  I.with_dl_tool @| dl_tool |>
+  I.with_switch_defaults switch_defaults

--- a/src/client/opamInitDefaults.mli
+++ b/src/client/opamInitDefaults.mli
@@ -21,6 +21,10 @@ val default_compiler: formula
 
 val eval_variables: (OpamVariable.t * string list * string) list
 
+(** Default switch defaults configuration file (also embedded in
+    {!init_config}). *)
+val switch_defaults: OpamFile.SwitchDefaults.t
+
 (** Default initial configuration file for use by [opam init] if nothing is
     supplied. *)
 val init_config: ?sandboxing:bool -> unit -> OpamFile.InitConfig.t

--- a/src/client/opamSwitchCommand.mli
+++ b/src/client/opamSwitchCommand.mli
@@ -25,6 +25,7 @@ val install:
   ?repos:repository_name list ->
   update_config:bool ->
   packages:atom conjunction -> 
+  switch_defaults: OpamFile.SwitchDefaults.t ->
   ?local_compiler:bool ->
   switch ->
   unlocked global_state * rw switch_state

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -173,6 +173,23 @@ module Config: sig
 
 end
 
+(** Switch defaults file *)
+module SwitchDefaults: sig
+  include IO_FILE
+
+  val opam_version: t -> opam_version
+  val switch_variables:
+    t -> ((variable * variable_contents * string) * filter option) list
+
+  val with_opam_version: opam_version -> t -> t
+  val with_switch_variables:
+    ((variable * variable_contents * string) * filter option) list -> t -> t
+
+  (** [add t1 t2] is [t2], with the field values falling back to those of [t1]
+      when not set in [t2] *)
+  val add: t -> t -> t
+end
+
 (** Init config file [/etc/opamrc] *)
 module InitConfig: sig
   include IO_FILE
@@ -192,6 +209,7 @@ module InitConfig: sig
   val recommended_tools: t -> (string list * string option * filter option) list
   val required_tools: t -> (string list * string option * filter option) list
   val init_scripts: t -> ((string * string) * filter option) list
+  val switch_defaults: t -> SwitchDefaults.t option
 
   val with_opam_version: opam_version -> t -> t
   val with_repositories:
@@ -209,6 +227,7 @@ module InitConfig: sig
   val with_recommended_tools: (string list * string option * filter option) list -> t -> t
   val with_required_tools: (string list * string option * filter option) list -> t -> t
   val with_init_scripts: ((string * string) * filter option) list -> t -> t
+  val with_switch_defaults: SwitchDefaults.t -> t -> t
 
   (** [add t1 t2] is [t2], with the field values falling back to those of [t1]
       when not set in [t2] *)

--- a/src/state/opamSwitchAction.ml
+++ b/src/state/opamSwitchAction.ml
@@ -16,7 +16,7 @@ open OpamPackage.Set.Op
 let log fmt = OpamConsole.log "SWACT" fmt
 let slog = OpamConsole.slog
 
-let gen_switch_config root ?(synopsis="") ?repos _switch =
+let gen_switch_config root ?(synopsis="") ?repos ?(configure_switch = fun x -> x) _switch =
   let vars =
     List.map (fun (s,p) -> OpamVariable.of_string s, S p) [
       ("user" ,
@@ -27,6 +27,7 @@ let gen_switch_config root ?(synopsis="") ?repos _switch =
        with Not_found -> "group");
     ]
   in
+  configure_switch
   { OpamFile.Switch_config.
     opam_version = OpamVersion.current_nopatch;
     synopsis;
@@ -43,7 +44,7 @@ let install_switch_config root switch config =
     (OpamPath.Switch.switch_config root switch)
     config
 
-let create_empty_switch gt ?synopsis ?repos switch =
+let create_empty_switch gt ?synopsis ?repos ?configure_switch switch =
   log "create_empty_switch at %a" (slog OpamSwitch.to_string) switch;
   let root = gt.root in
   let switch_dir = OpamPath.Switch.root root switch in
@@ -57,7 +58,9 @@ let create_empty_switch gt ?synopsis ?repos switch =
     (* Create base directories *)
     OpamFilename.mkdir switch_dir;
 
-    let config = gen_switch_config root ?synopsis ?repos switch in
+    let config =
+      gen_switch_config root ?synopsis ?repos ?configure_switch switch
+    in
 
     OpamFilename.mkdir (OpamPath.Switch.lib_dir root switch config);
     OpamFilename.mkdir (OpamPath.Switch.stublibs root switch config);

--- a/src/state/opamSwitchAction.mli
+++ b/src/state/opamSwitchAction.mli
@@ -18,6 +18,7 @@ open OpamStateTypes
     registers it in the global config and returns the updated global state *)
 val create_empty_switch:
   rw global_state -> ?synopsis:string -> ?repos:repository_name list ->
+  ?configure_switch:(OpamFile.Switch_config.t -> OpamFile.Switch_config.t) ->
   switch -> rw global_state
 
 (** Writes the current state file to disk (installed, pinned, root packages etc.).
@@ -33,6 +34,7 @@ val set_current_switch:
     prefix *)
 val gen_switch_config:
   dirname -> ?synopsis:string -> ?repos:repository_name list ->
+  ?configure_switch:(OpamFile.Switch_config.t -> OpamFile.Switch_config.t) ->
   switch -> OpamFile.Switch_config.t
 
 (** (Re-)install the configuration for a given root and switch *)


### PR DESCRIPTION
Please note at this stage that I'm not interested in **any** discussion/opinion regarding the variables added in 37d477a, as that whole bit is still being separately worked on (TL;DR I expect to replace them with a single triple/quartet variable)!

However, I'm extremely keen to hear opinions on the rest of this! This GPR adds a new format `OpamFile.SwitchDefaults` which allows the following kind of file to be set-up:

```
opam-version: "2.0"
switch-variables: [
  [
    switch-arch
    "%{sys-ocaml-arch}%"
    "Switch architecture (taken from system OCaml compiler)"
  ] {ocaml-system:installed}
  [
    switch-cc
    "%{sys-ocaml-cc}%"
    "Switch C compiler type (taken from system OCaml compiler)"
  ] {ocaml-system:installed}
  [
    switch-libc
    "%{sys-ocaml-libc}%"
    "Switch C runtime flavour (taken from system OCaml compiler)"
  ] {ocaml-system:installed}
  [switch-arch "%{arch}%" "Switch architecture"] {!ocaml-system:installed}
  [switch-cc "cc" "Switch C compiler type"] {!ocaml-system:installed}
  [switch-libc "msvc" "Switch C runtime flavour"]
    {!ocaml-system:installed & os = "win32"}
  [switch-libc "libc" "Switch C runtime flavour"]
    {!ocaml-system:installed & os != "win32"}
]
```

This list of variables is then filtered at `opam switch create` and added to the switch configuration as normal. The default switch configuration can be embedded into /etc/opamrc as a `switch-defaults` section and an example of this is included in 37d477a. There are two areas (in addition to general comments on how this is working) where I'd appreciate some further input:

## Locations to search for switch initialisation files

So far, we have `~/.opamrc` and `/etc/opamrc` (as well as the ability to specify a file for `opam init` to use). I am therefore wondering if the `opam init` process should write the `switch-defaults` file (e.g. to `~/.opam/opam-init/switch-defaults.config`) or whether we should just have a new chain of files (so look for `~/.opam/opam-init/switch-defaults.config`, then the `switch-defaults` section of `~/.opamrc`, then the `switch-defaults` section of `/etc/opamrc`).

I was also wondering whether we should be considering having switch-defaults files in *repositories* - the variables set-up here are to with opam being used for OCaml - should really be homed in the default repository? Indeed, it makes me wonder whether the proper home for `sys-ocaml-version`, etc. is really a configuration file in opam-repository, and not in OpamInitDefaults at all? Doing this also brings up the important question of how these configuration should be merged or overridden. But it has the nice property that if, say, you have an opam set-up mixing OCaml switches and Coq switches that the action of declaring a new switch with the Coq repository would automatically set that switch up with the switch global variables which a Coq installation might expect (but this may need to worry about *merging* the `switch-variables` lists of both Coq and OCaml).

## Ability to override switch-variables at `opam switch create`

In addition to being able to specify a switch-defaults configuration file at `opam switch create`, it should clearly also be possible to specify values of particular variables at `opam switch create` (effectively providing a mechanism for `opam config set`). I would propose adding a further field to `switch-defaults`:

```
switch-variables-validation: [
  [switch-arch "x86_64|i686|other" "Sets the host architecture for this switch ($(b,x86_64), $(b,i686) or $(b,other))"] # Clearly not the actual validation...
  [switch-cc "cc|cl" "Sets the C compiler type for this switch ($(b,cc): POSIX C, or $(b,cl): Microsoft C)"]
  [switch-libc "libc|msvc" "Sets the C runtime flavour for this switch ($(b,libc): POSIX C, or $(b,msvc): Microsoft C runtime)"]
]
```
`opam switch create` would use this file to generate `--conf-switch-arch`, `--conf-switch-cc` and `--conf-switch-libc` including both validation of the values which can be given and also help text. For my Windows work, this then provides a truly generic way to have `opam switch create 4.04.1-msvc32 --packages=ocaml --conf-switch-arch=i686` (rather than my earlier prototypes where `--arch`, `--cc` and `--libc` were hard-coded options)