### PR TITLE
Support make distclean at toplevel

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,9 +1,11 @@
+ifeq ($(findstring clean,$(MAKECMDGOALS)),)
 -include ../Makefile.config
 
 .NOTPARALLEL:
 
 ifndef version
   $(error Please run ./configure)
+endif
 endif
 
 all:
@@ -38,7 +40,9 @@ ifneq ($(HAS_LIBEXT),)
   LIBS = unix bigarray extlib re cmdliner graph cudf dose_common dose_algo uutf jsonm opam-file-format
 else
   ifeq ($(HAS_PACKAGES),)
-    $(error Dependencies missing. Either run 'make lib-ext' or install them and re-run './configure')
+    ifeq ($(findstring clean,$(MAKECMDGOALS)),)
+      $(error Dependencies missing. Either run 'make lib-ext' or install them and re-run './configure')
+    endif
   endif
   export PACKS
   # Reset command name for ocamlfind

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -119,7 +119,7 @@ clean:
 	$(MAKE) -f $(OCAMLMAKEFILE) subprojs SUBTARGET=cleanup
 
 distclean:
-	rm -rf cudf extlib re graph dose cmdliner uutf jsonm opam_file_format
+	rm -rf cudf extlib re graph dose cmdliner uutf jsonm opam_file_format ._ncdi ._bcdi ._d
 	rm -f depends.ocp
 	rm -f *.tar.gz *.tbz *.stamp
 	rm -f *.cm* *.o *.a *.lib *.obj


### PR DESCRIPTION
Patch Makefile to support total clean of source tree via make distclean and ensure that it can be run twice (so don't attempt to regenerate Makefile.config)