### PR TITLE
Developer tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ it as a second step.
 If you are developing OPAM, you may enable developer features by including the
 `--enable-developer-mode` parameter with `./configure`.
 
+Developer features are controlled by setting additional environment variables:
+
+* `DEVELOPER_CACHE` - specifies the location of a directory to use for storing all
+  downloaded files. This directory must exist or OPAM will ignore the setting. See
+  the code for really_download in src/repository/opamDownload.ml for more details on
+  how this feature operates.
+
 ## Compiling without OCaml
 
 `make cold` is provided as a facility to compile OCaml, then bootstrap opam.

--- a/configure
+++ b/configure
@@ -608,6 +608,7 @@ EXE
 WIN32
 CONF_OCAMLFLAGS
 MCCS_DISABLED
+DEVELOPER_CACHE
 DEVELOPER
 OBJEXT
 EXEEXT
@@ -688,7 +689,8 @@ CC
 CFLAGS
 LDFLAGS
 LIBS
-CPPFLAGS'
+CPPFLAGS
+DEVELOPER_CACHE'
 
 
 # Initialize some variables set by options.
@@ -1335,6 +1337,8 @@ Some influential environment variables:
   LIBS        libraries to pass to the linker, e.g. -l<library>
   CPPFLAGS    (Objective) C/C++ preprocessor flags, e.g. -I<include dir> if
               you have headers in a nonstandard directory <include dir>
+  DEVELOPER_CACHE
+              Developer file cache location
 
 Use these variables to override the choices made by `configure' or to help
 it to find libraries and programs with nonstandard names/locations.
@@ -3759,6 +3763,36 @@ else
   DEVELOPER=false
 
 fi
+
+
+
+if test "x${DEVELOPER_CACHE}" != "x"; then :
+
+  if test "${enable_developer_mode+set}" = "set"; then :
+
+    if test "x${enable_developer_mode}" = "xno"; then :
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: --disable-developer-mode given; DEVELOPER_CACHE ignored" >&5
+$as_echo "$as_me: WARNING: --disable-developer-mode given; DEVELOPER_CACHE ignored" >&2;}
+
+fi
+else
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: ============================================================================" >&5
+$as_echo "$as_me: WARNING: ============================================================================" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: DEVELOPER_CACHE specified: developer mode has been automatically enabled" >&5
+$as_echo "$as_me: WARNING: DEVELOPER_CACHE specified: developer mode has been automatically enabled" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: ============================================================================" >&5
+$as_echo "$as_me: WARNING: ============================================================================" >&2;}
+    DEVELOPER=true
+
+fi
+else
+  DEVELOPER_CACHE="~/.opam-cache"
+
+fi
+DEVELOPER_CACHE=$(echo ${DEVELOPER_CACHE} | sed -e "s/\\\\/\\\\\\\\/g")
+
 
 if test "x${with_mccs}" = "xno"; then :
   MCCS_DISABLED=true

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,20 @@ AC_PROG_CC([$($OCAMLBESTCC -config | sed -n -e "s/native_c_compiler: \(.*\) .*/\
 
 AS_IF([test "x${enable_developer_mode}" = "xyes"], [AC_SUBST(DEVELOPER,true)], [AC_SUBST(DEVELOPER,false)])
 
+AC_ARG_VAR(DEVELOPER_CACHE, [Developer file cache location])
+
+AS_IF([test "x${DEVELOPER_CACHE}" != "x"], [
+  AS_IF([test "${enable_developer_mode+set}" = "set"], [
+    AS_IF([test "x${enable_developer_mode}" = "xno"], [
+      AC_MSG_WARN([--disable-developer-mode given; DEVELOPER_CACHE ignored])]
+    )], [
+    AC_MSG_WARN([============================================================================])
+    AC_MSG_WARN([DEVELOPER_CACHE specified: developer mode has been automatically enabled])
+    AC_MSG_WARN([============================================================================])
+    AC_SUBST(DEVELOPER,true)])], [AC_SUBST(DEVELOPER_CACHE,"~/.opam-cache")])
+DEVELOPER_CACHE=$(echo ${DEVELOPER_CACHE} | sed -e "s/\\\\/\\\\\\\\/g")
+AC_SUBST(DEVELOPER_CACHE)
+
 AS_IF([test "x${with_mccs}" = "xno"], [AC_SUBST(MCCS_DISABLED,true)], [AC_SUBST(MCCS_DISABLED,false)])
 
 AS_IF([test "x${CI}" != "x" -o "x${enable_developer_mode}" = "xyes"], [

--- a/src/core/opamCoreConfig.ml.in
+++ b/src/core/opamCoreConfig.ml.in
@@ -101,4 +101,10 @@ let r = ref default
 
 let update ?noop:_ = setk (fun cfg () -> r := cfg) !r
 
+type devopts = {
+  cache: string
+}
+
 let developer = @DEVELOPER@
+
+let devopts = {cache = "@DEVELOPER_CACHE@"}

--- a/src/core/opamCoreConfig.mli
+++ b/src/core/opamCoreConfig.mli
@@ -75,3 +75,10 @@ val update : ?noop:_ -> (unit -> unit) options_fun
 
 (** [true] if OPAM was compiled in developer mode *)
 val developer : bool
+
+type devopts = {
+  cache: string (** File cache - see code for OpamDownload.really_download *)
+}
+
+(** Developer options passed to configure *)
+val devopts : devopts

--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -104,39 +104,107 @@ let download_command ~compress ?checksum ~url ~dst =
   in
   OpamSystem.make_command cmd args @@> tool_return url
 
+let developer_index = "index.opam"
+
+let check_cache =
+  let directory = OpamCoreConfig.(devopts.cache) in
+  let cache = Filename.concat directory developer_index in
+  if OpamCoreConfig.developer && Sys.file_exists directory && (Unix.stat directory).Unix.st_kind = Unix.S_DIR && Sys.file_exists cache then
+    (*
+     * Switch all \ to / for maximum Windows-compatibility.
+     *)
+    begin
+      let directory = String.map (function '\\' -> '/' | c -> c) directory in
+      fun src ->
+        let c = open_in cache in
+        let result = ref "" in
+          try
+            while true do
+              let line = input_line c in
+              if String.length line > 32 then
+                if String.sub line 33 (String.length line - 33) = src then begin
+                  result := directory ^ "/" ^ String.sub line 0 32;
+                  raise Exit
+                end
+            done;
+            ""
+          with Exit -> !result
+             | End_of_file ->
+                 close_in c;
+                 ""
+    end
+  else
+    fun _ -> ""
+
+(*
+ * If OPAM is compiled in developer mode, the value of DEVELOPER_CACHE is captured
+ * (default ~/.opam-cache) and stored in OpamCoreConfig.devops.cache.
+ *
+ * This directory can have a file index.opam placed into it which is queried whenever
+ * a file download is requested. Each line of the index consists of the hexadecimal MD5
+ * digest of the file, followed by a space, followed by the URL. The file should be placed
+ * in the directory named as its checksum. For example:
+ *   12e6322c12c638ce1ab7d624f98b35f5 https://opam.ocaml.org/1.3/urls.txt
+ *   c145619f4796e2aecf5483903d45f281 https://opam.ocaml.org/1.3/index.tar.gz
+ * with https://opam.ocaml.org/urls.txt downloaded and renamed 12e6322c12c638ce1ab7d624f98b35f5
+ * and https://opam.ocaml.org/1.3/index.tar.gz downloaded and renamed c145619f4796e2aecf5483903d45f281
+ *
+ * Very useful when working on OPAM without an internet connection...
+ *)
 let really_download
     ?(quiet=false) ~overwrite ?(compress=false) ?checksum ?(validate=true)
     ~url ~dst =
   assert (url.OpamUrl.backend = `http);
-  let tmp_dst = dst ^ ".part" in
-  if Sys.file_exists tmp_dst then OpamSystem.remove tmp_dst;
-  OpamProcess.Job.catch
-    (function
-      | Failure s as e ->
-        OpamSystem.remove tmp_dst;
-        if not quiet then OpamConsole.error "%s" s;
-        raise e
-      | e ->
-        OpamSystem.remove tmp_dst;
-        OpamStd.Exn.fatal e;
-        log "Could not download file at %s." (OpamUrl.to_string url);
-        raise e)
-  @@ fun () ->
-  download_command ~compress ?checksum ~url ~dst:tmp_dst
-  @@+ fun () ->
-  if not (Sys.file_exists tmp_dst) then
-    failwith "Downloaded command succeeded, but resulting file not found"
-  else if Sys.file_exists dst && not overwrite then
-    OpamSystem.internal_error "The downloaded file will overwrite %s." dst;
-  if validate &&
-     OpamRepositoryConfig.(!r.force_checksums <> Some false) then
-    OpamStd.Option.iter (fun cksum ->
-        if not (OpamHash.check_file tmp_dst cksum) then
-          failwith (Printf.sprintf "Bad checksum, expected %s"
-                      (OpamHash.to_string cksum)))
-      checksum;
-  OpamSystem.mv tmp_dst dst;
-  Done ()
+  let url_str = OpamUrl.to_string url in
+  let cache = check_cache url_str in
+  if cache = "" then
+    let tmp_dst = dst ^ ".part" in
+    if Sys.file_exists tmp_dst then OpamSystem.remove tmp_dst;
+    log "Will download %s" url_str;
+    OpamProcess.Job.catch
+      (function
+        | Failure s as e ->
+          OpamSystem.remove tmp_dst;
+          if not quiet then OpamConsole.error "%s" s;
+          raise e
+        | e ->
+          OpamSystem.remove tmp_dst;
+          OpamStd.Exn.fatal e;
+          log "Could not download file at %s." (OpamUrl.to_string url);
+          raise e)
+    @@ fun () ->
+    download_command ~compress ?checksum ~url ~dst:tmp_dst
+    @@+ fun () ->
+    if not (Sys.file_exists tmp_dst) then
+      failwith "Downloaded command succeeded, but resulting file not found"
+    else if Sys.file_exists dst && not overwrite then
+      OpamSystem.internal_error "The downloaded file will overwrite %s." dst;
+    if validate &&
+       OpamRepositoryConfig.(!r.force_checksums <> Some false) then
+      OpamStd.Option.iter (fun cksum ->
+          if not (OpamHash.check_file tmp_dst cksum) then
+            failwith (Printf.sprintf "Bad checksum, expected %s"
+                        (OpamHash.to_string cksum)))
+        checksum;
+    let directory = OpamCoreConfig.(devopts.cache) in
+    let cache = Filename.concat directory developer_index in
+      if OpamCoreConfig.developer && Sys.file_exists directory && (Unix.stat directory).Unix.st_kind = Unix.S_DIR then begin
+        let digest = Digest.to_hex (Digest.file tmp_dst) in
+        OpamSystem.copy_file tmp_dst (Filename.concat directory digest);
+        let c = open_out_gen [Open_wronly; Open_append; Open_creat; Open_text] 0o666 cache in
+        output_string c (digest ^ " " ^ url_str ^ "\n");
+      close_out c;
+    end;
+    OpamSystem.mv tmp_dst dst;
+    Done ()
+  else
+    begin
+      log "Retrieved %s from developer cache" url_str;
+      if Sys.file_exists dst && not overwrite then
+        OpamSystem.internal_error "The downloaded file will overwrite %s." dst;
+      OpamSystem.copy_file cache dst;
+      Done ()
+    end
 
 let download_as ?quiet ?validate ~overwrite ?compress ?checksum url dst =
   match OpamUrl.local_file url with


### PR DESCRIPTION
This PR adds a few (hopefully) useful features for developing opam:

 - `make -C src_ext cache-archives` fetches all the tarballs for lib-ext and stores them in `src_ext/archives/` and these cached copies are used for future builds when running `make lib-ext` (the build system will download any file which is missing from the cache, but it's only updated by running `make -C src_ext cache-archive` again)
 - Debugging output is removed from bootstrap-ocaml.sh, so that actual errors can be seen...
 - A developer mode is added to allow builds of opam with special options. So far, only `DEVELOPER_CACHE` has been added. This option allows a directory to be specified where opam caches everything downloaded through the `OpamDownload` module. This sits above opam's own caching mechanisms meaning that `opam init` itself can use the cache (if downloading from an http repository, this completely breaks opam update, as the web server will never be queried again - this is considered a feature - you obviously develop using a local git clone for opam-repository, right?!). This mode is exceptionally useful for re-running `opam admin upgrade` when you lost your hashes cache...