### PR TITLE
Helpers to track build and package errors

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -392,17 +392,10 @@ let make_command st opam ?dir ?text_command (cmd, args) =
               nv.name
           in
           let rev = OpamProcess.Job.run (OpamRepository.revision src u) in
-          let dirty =
-            OpamProcess.Job.run @@
-            OpamRepository.is_dirty
-              (OpamUrl.parse (OpamFilename.Dir.to_string src)
-                 ~backend:u.OpamUrl.backend)
-          in
-          Printf.sprintf "pinned(%s%s%s)"
+          Printf.sprintf "pinned(%s%s)"
             (OpamUrl.to_string u)
             (OpamStd.Option.to_string
                (fun r -> "#"^OpamPackage.Version.to_string r) rev)
-            (if dirty then ", dirty" else "")
       else
         match
           OpamRepositoryState.find_package_opt st.switch_repos

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -367,13 +367,61 @@ let opam_local_env_of_status ret =
          | None -> "0"
          | Some r -> string_of_int r.OpamProcess.r_code)))
 
-let make_command ~env ~name ?dir ?text_command (cmd, args) =
+let make_command st opam ?dir ?text_command (cmd, args) =
+  let nv = OpamFile.OPAM.package opam in
+  let name = OpamPackage.name_to_string nv in
+  let env = OpamTypesBase.env_array (compilation_env st opam) in
   let dir = OpamStd.Option.map OpamFilename.Dir.to_string dir in
   let text =
     let cmd, args = OpamStd.Option.default (cmd, args) text_command in
     OpamProcess.make_command_text name ~args cmd
   in
+  let context =
+    String.concat " | " [
+      OpamVersion.(to_string current);
+      OpamStd.Sys.os_string () ^"/"^ OpamStd.Sys.arch ();
+      (OpamStd.List.concat_map " " OpamPackage.to_string
+         OpamPackage.Set.(elements @@
+                          inter st.compiler_packages st.installed_roots));
+      if OpamPackage.Set.mem nv st.pinned then
+        match OpamFile.OPAM.get_url opam with
+        | None -> "pinned"
+        | Some u ->
+          let src =
+            OpamPath.Switch.pinned_package st.switch_global.root st.switch
+              nv.name
+          in
+          let rev = OpamProcess.Job.run (OpamRepository.revision src u) in
+          let dirty =
+            OpamProcess.Job.run @@
+            OpamRepository.is_dirty
+              (OpamUrl.parse (OpamFilename.Dir.to_string src)
+                 ~backend:u.OpamUrl.backend)
+          in
+          Printf.sprintf "pinned(%s%s%s)"
+            (OpamUrl.to_string u)
+            (OpamStd.Option.to_string
+               (fun r -> "#"^OpamPackage.Version.to_string r) rev)
+            (if dirty then ", dirty" else "")
+      else
+        match
+          OpamRepositoryState.find_package_opt st.switch_repos
+            (OpamSwitchState.repos_list st) nv
+        with
+        | None -> "no repo"
+        | Some (r, _) ->
+          let rt = st.switch_repos in
+          let repo = OpamRepositoryName.Map.find r rt.repositories in
+          let stamp =
+            OpamFile.Repo.stamp
+              (OpamRepositoryName.Map.find r rt.repos_definitions)
+          in
+          OpamUrl.to_string repo.repo_url ^
+          OpamStd.Option.to_string (fun s -> "#"^s) stamp
+    ]
+  in
   OpamSystem.make_command ~env ~name ?dir ~text
+    ~metadata:["context", context]
     ~verbose:(OpamConsole.verbose ()) ~check_existence:false
     cmd args
 
@@ -495,8 +543,6 @@ let remove_package_aux
     | Some o -> o
     | None -> OpamFile.OPAM.create nv
   in
-  let env = OpamTypesBase.env_array (compilation_env t opam) in
-  let name = OpamPackage.name_to_string nv in
   let build_dir =
     OpamStd.Option.default_map
       (OpamFilename.opt_dir
@@ -504,7 +550,7 @@ let remove_package_aux
        build_dir
   in
   let wrappers = get_wrappers t in
-  let mk_cmd = make_command ~env ~name ?dir:build_dir in
+  let mk_cmd = make_command t opam ?dir:build_dir in
   OpamProcess.Job.of_list ~keep_going:true
     (List.map mk_cmd (get_wrapper t opam wrappers OpamFile.Wrappers.pre_remove))
   @@+ fun error_pre ->
@@ -615,10 +661,9 @@ let build_package t ?(test=false) ?(doc=false) build_dir nv =
         | [] -> None
         | cmd::args -> Some (cmd, args))
   in
-  let env = OpamTypesBase.env_array (compilation_env t opam) in
   let name = OpamPackage.name_to_string nv in
   let wrappers = get_wrappers t in
-  let mk_cmd = make_command ~env ~name ~dir:build_dir in
+  let mk_cmd = make_command t opam ~dir:build_dir in
   OpamProcess.Job.of_list
     (List.map mk_cmd (get_wrapper t opam wrappers OpamFile.Wrappers.pre_build) @
      List.map (fun ((cmd,args) as ca) ->
@@ -660,14 +705,13 @@ let install_package t ?(test=false) ?(doc=false) ?build_dir nv =
     OpamStd.List.filter_map
       (function [] -> None | cmd::args -> Some (cmd, args))
   in
-  let env = OpamTypesBase.env_array (compilation_env t opam) in
   let name = OpamPackage.name_to_string nv in
   let dir = match build_dir with
     | None -> OpamPath.Switch.build t.switch_global.root t.switch nv
     | Some d -> d
   in
   let wrappers = get_wrappers t in
-  let mk_cmd = make_command ~env ~name ~dir in
+  let mk_cmd = make_command t opam ~dir in
   let rec run_commands = function
     | (cmd,args as ca)::commands ->
       mk_cmd ~text_command:ca

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -91,14 +91,22 @@ let option_default d = function
 let make_info ?code ?signal
     ~cmd ~args ~cwd ~env_file ~stdout_file ~stderr_file ~metadata () =
   let b = ref [] in
-  let print name str = b := (name, str) :: !b in
+  let home = OpamStd.Sys.home () in
+  let print name str =
+    let str =
+      if OpamStd.String.starts_with ~prefix:home str
+      then "~"^OpamStd.String.remove_prefix ~prefix:home str
+      else str
+    in
+    b := (name, str) :: !b
+  in
   let print_opt name = function
     | None   -> ()
     | Some s -> print name s in
 
-  print     "command"      (String.concat " " (cmd :: args));
-  print     "path"         cwd;
   List.iter (fun (k,v) -> print k v) metadata;
+  print     "path"         cwd;
+  print     "command"      (String.concat " " (cmd :: args));
   print_opt "exit-code"    (option_map string_of_int code);
   print_opt "signalled"    (option_map string_of_int signal);
   print_opt "env-file"     env_file;

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -423,7 +423,8 @@ let make_command
   else
     command_not_found cmd
 
-let run_process ?verbose ?(env=default_env) ~name ?metadata ?allow_stdin command =
+let run_process
+    ?verbose ?(env=default_env) ~name ?metadata ?stdout ?allow_stdin command =
   let chrono = OpamConsole.timer () in
   runs := command :: !runs;
   match command with
@@ -442,7 +443,8 @@ let run_process ?verbose ?(env=default_env) ~name ?metadata ?allow_stdin command
 
       let r =
         OpamProcess.run
-          (OpamProcess.command ~env ~name ~verbose ?metadata ?allow_stdin
+          (OpamProcess.command
+             ~env ~name ~verbose ?metadata ?allow_stdin ?stdout
              cmd args)
       in
       let str = String.concat " " (cmd :: args) in
@@ -482,7 +484,11 @@ let commands ?verbose ?env ?name ?metadata ?(keep_going=false) commands =
 
 let read_command_output ?verbose ?env ?metadata ?allow_stdin cmd =
   let name = log_file None in
-  let r = run_process ?verbose ?env ~name ?metadata ?allow_stdin cmd in
+  let r =
+    run_process ?verbose ?env ~name ?metadata ?allow_stdin
+      ~stdout:(name^".stdout")
+      cmd
+  in
   OpamProcess.cleanup r;
   raise_on_process_error r;
   r.OpamProcess.r_stdout

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1712,12 +1712,14 @@ module RepoSyntax = struct
     root_url     : url option;
     dl_cache     : string list option;
     announce     : (string * filter option) list;
+    stamp        : string option;
   }
 
   let create
       ?browse ?upstream ?opam_version
-      ?(redirect=[]) ?root_url ?dl_cache ?(announce=[]) () =
-    { opam_version; browse; upstream; redirect; root_url; dl_cache; announce; }
+      ?(redirect=[]) ?root_url ?dl_cache ?(announce=[]) ?stamp () =
+    { opam_version; browse; upstream; redirect; root_url; dl_cache; announce;
+      stamp; }
 
   let empty = create ()
 
@@ -1728,6 +1730,7 @@ module RepoSyntax = struct
   let root_url t = t.root_url
   let dl_cache t = OpamStd.Option.default [] t.dl_cache
   let announce t = t.announce
+  let stamp t = t.stamp
 
   let with_opam_version opam_version t =
     { t with opam_version = Some opam_version }
@@ -1737,6 +1740,8 @@ module RepoSyntax = struct
   let with_root_url root_url t = { t with root_url = Some root_url }
   let with_dl_cache dl_cache t = { t with dl_cache = Some dl_cache }
   let with_announce announce t = { t with announce }
+  let with_stamp id t = { t with stamp = Some id }
+  let with_stamp_opt stamp t = { t with stamp }
 
   let fields = [
     "opam-version", Pp.ppacc_opt
@@ -1755,6 +1760,9 @@ module RepoSyntax = struct
       with_announce announce
       (Pp.V.map_list ~depth:1
          (Pp.V.map_option Pp.V.string (Pp.opt Pp.V.filter)));
+    "stamp", Pp.ppacc_opt
+      with_stamp stamp
+      Pp.V.string
   ]
 
   let pp =

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -872,6 +872,7 @@ module Repo: sig
     ?browse:string -> ?upstream:string -> ?opam_version:OpamVersion.t ->
     ?redirect:(string * filter option) list -> ?root_url:url ->
     ?dl_cache:string list -> ?announce:(string * filter option) list ->
+    ?stamp:string ->
     unit -> t
 
   (** The minimum OPAM version required for this repository, if defined *)
@@ -895,6 +896,8 @@ module Repo: sig
 
   val announce: t -> (string * filter option) list
 
+  val stamp: t -> string option
+
   val with_opam_version : OpamVersion.t -> t -> t
 
   val with_browse: string -> t -> t
@@ -908,6 +911,10 @@ module Repo: sig
   val with_dl_cache: string list -> t -> t
 
   val with_announce: (string * filter option) list -> t -> t
+
+  val with_stamp: string -> t -> t
+
+  val with_stamp_opt: string option -> t -> t
 end
 
 (** {2 urls.txt file *} *)


### PR DESCRIPTION
Adds a "stamp" field for repositories served over HTTP, and useful info to process error reports during package builds