### PR TITLE
Experiment: add a global cache of git objects

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -271,7 +271,7 @@ let prepare_package_source st nv dir =
     let dl_file_job (basename, urlf) =
       OpamProcess.Job.catch (fun e -> Done (Some e)) @@ fun () ->
       OpamRepository.pull_file
-        ~cache_dir:(OpamPath.download_cache st.switch_global.root)
+        ~cache_dir:(OpamRepositoryPath.download_cache st.switch_global.root)
         ~silent_hits:true
         (OpamPackage.to_string nv ^ "/" ^ OpamFilename.Base.to_string basename)
         (OpamFilename.create dir basename)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2336,7 +2336,10 @@ let source =
         mkdir dir;
         match
           OpamProcess.Job.run
-            (OpamRepository.pull_tree (OpamPackage.to_string nv) dir []
+            (OpamRepository.pull_tree
+               ~cache_dir:(OpamRepositoryPath.download_cache
+                             OpamStateConfig.(!r.root_dir))
+               (OpamPackage.to_string nv) dir []
                [url])
         with
         | Not_available u -> OpamConsole.error_and_exit "%s is not available" u
@@ -2682,7 +2685,7 @@ let clean =
     if download_cache then
       (OpamConsole.msg "Clearing cache of downloaded files\n";
        rmdir (OpamPath.archives_dir root);
-       cleandir (OpamPath.download_cache root));
+       cleandir (OpamRepositoryPath.download_cache root));
     if logs then
       (OpamConsole.msg "Clearing logs\n";
        cleandir (OpamPath.log root))

--- a/src/repository/opamDarcs.ml
+++ b/src/repository/opamDarcs.ml
@@ -48,7 +48,7 @@ module VCS = struct
   (* Marks the current state, in the form of a reversing patch on top of the
      fetched state *)
 
-  let fetch repo_root repo_url =
+  let fetch ?cache_dir:_ repo_root repo_url =
     (* Just do a fresh pull into a temp directory, and replace _darcs/
        There is no easy way to diff or make sure darcs forgets about local
        patches otherwise. *)

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -39,7 +39,7 @@ module B = struct
 
   let name = `http
 
-  let fetch_repo_update repo_name repo_root url =
+  let fetch_repo_update repo_name ?cache_dir:_ repo_root url =
     log "pull-repo-update";
     let quarantine =
       OpamFilename.Dir.(of_string (to_string repo_root ^ ".new"))
@@ -67,7 +67,7 @@ module B = struct
       | Some patch -> OpamRepositoryBackend.Update_patch patch
 
 
-  let pull_url dirname checksum remote_url =
+  let pull_url ?cache_dir:_ dirname checksum remote_url =
     log "pull-file into %a: %a"
       (slog OpamFilename.Dir.to_string) dirname
       (slog OpamUrl.to_string) remote_url;

--- a/src/repository/opamHg.ml
+++ b/src/repository/opamHg.ml
@@ -34,7 +34,7 @@ module VCS = struct
     | None -> fun cmd -> cmd
     | Some r -> fun cmd -> cmd @ ["--rev"; r]
 
-  let fetch repo_root repo_url =
+  let fetch ?cache_dir:_ repo_root repo_url =
     hg repo_root
       (withrev repo_url [ "pull"; "-f"; OpamUrl.base_url repo_url ])
     @@> fun r ->

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -135,7 +135,7 @@ module B = struct
   let pull_dir_quiet local_dirname url =
     rsync_dirs url local_dirname
 
-  let fetch_repo_update repo_name repo_root url =
+  let fetch_repo_update repo_name ?cache_dir:_ repo_root url =
     log "pull-repo-update";
     let quarantine =
       OpamFilename.Dir.(of_string (to_string repo_root ^ ".new"))
@@ -179,7 +179,7 @@ module B = struct
         | None -> OpamRepositoryBackend.Update_empty
         | Some p -> OpamRepositoryBackend.Update_patch p
 
-  let pull_url local_dirname _checksum remote_url =
+  let pull_url ?cache_dir:_ local_dirname _checksum remote_url =
     OpamFilename.mkdir local_dirname;
     let dir = OpamFilename.Dir.to_string local_dirname in
     let remote_url =

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -166,7 +166,7 @@ let pull_from_upstream
   in
   OpamProcess.Job.with_text text @@
   (if working_dir then B.sync_dirty destdir url
-   else B.pull_url destdir cksum url)
+   else B.pull_url ?cache_dir destdir cksum url)
   @@| function
   | (Result (Some file) | Up_to_date (Some file)) as ret ->
     if validate_and_add_to_cache label url cache_dir file checksums then

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -21,10 +21,12 @@ type update =
 
 module type S = sig
   val name: OpamUrl.backend
-  val pull_url: dirname -> OpamHash.t option -> url ->
+  val pull_url:
+    ?cache_dir:dirname -> dirname -> OpamHash.t option -> url ->
     filename option download OpamProcess.job
   val fetch_repo_update:
-    repository_name -> dirname -> url -> update OpamProcess.job
+    repository_name -> ?cache_dir:dirname -> dirname -> url ->
+    update OpamProcess.job
   val revision: dirname -> version option OpamProcess.job
   val sync_dirty: dirname -> url -> filename option download OpamProcess.job
 end

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -45,7 +45,7 @@ module type S = sig
       [checksum] can be used for retrieval but is NOT checked by this
       function. *)
   val pull_url:
-    dirname -> OpamHash.t option -> url ->
+    ?cache_dir:dirname -> dirname -> OpamHash.t option -> url ->
     filename option download OpamProcess.job
 
   (** [pull_repo_update] fetches the remote update from [url] to the local
@@ -53,7 +53,8 @@ module type S = sig
       verifications. The file or directory returned is always temporary and
       should be cleaned up by the caller. *)
   val fetch_repo_update:
-    repository_name -> dirname -> url -> update OpamProcess.job
+    repository_name -> ?cache_dir:dirname -> dirname -> url ->
+    update OpamProcess.job
 
   (** Return the (optional) revision of a given repository. Only useful for VCS
       backends. Is not expected to work with [pull_repo_update], which doesn't

--- a/src/repository/opamRepositoryPath.ml
+++ b/src/repository/opamRepositoryPath.ml
@@ -13,6 +13,8 @@ open OpamFilename.Op
 
 let create root name = root / "repo" / OpamRepositoryName.to_string name
 
+let download_cache root = root / "download-cache"
+
 let repo repo_root = repo_root // "repo" |> OpamFile.make
 
 let packages_dir repo_root = repo_root / "packages"

--- a/src/repository/opamRepositoryPath.mli
+++ b/src/repository/opamRepositoryPath.mli
@@ -14,7 +14,11 @@
 open OpamTypes
 
 (** Repository local path: {i $opam/repo/<name>} *)
-val create: OpamFilename.Dir.t -> repository_name -> dirname
+val create: dirname -> repository_name -> dirname
+
+(** Prefix where to store the downloaded files cache: {i $opam/download-cache}.
+    Warning, this is relative to the opam root, not a repository root. *)
+val download_cache: dirname -> dirname
 
 (** Return the repo file *)
 val repo: dirname -> OpamFile.Repo.t OpamFile.t

--- a/src/repository/opamVCS.mli
+++ b/src/repository/opamVCS.mli
@@ -28,7 +28,7 @@ module type VCS = sig
       in a staging area.
       Be aware that the remote URL might have been changed, so make sure
       to update accordingly. *)
-  val fetch: dirname -> url -> unit OpamProcess.job
+  val fetch: ?cache_dir:dirname -> dirname -> url -> unit OpamProcess.job
 
   (** Reset the master branch of the repository to match the remote repository
       state. This might still fetch more data (git submodules...), so is

--- a/src/state/opamPath.ml
+++ b/src/state/opamPath.ml
@@ -43,8 +43,6 @@ let init  t = t / "opam-init"
 
 let log t = t / "log"
 
-let download_cache t = t / "download-cache"
-
 let backup_file =
   let file = lazy Unix.(
       let tm = gmtime (Unix.gettimeofday ()) in

--- a/src/state/opamPath.mli
+++ b/src/state/opamPath.mli
@@ -55,9 +55,6 @@ val init: t -> dirname
 (** Log dir {i $opam/log} *)
 val log: t -> dirname
 
-(** Prefix where to store the downloaded files cache {i $opam/download-cache} *)
-val download_cache: t -> dirname
-
 (** The directory where global backups are stored *)
 val backup_dir: t -> dirname
 

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -153,6 +153,7 @@ let fetch_dev_package url srcdir ?(working_dir=false) nv =
   let checksum = OpamFile.URL.checksum url in
   log "updating %a" (slog OpamUrl.to_string) remote_url;
   OpamRepository.pull_tree
+    ~cache_dir:(OpamRepositoryPath.download_cache OpamStateConfig.(!r.root_dir))
     (OpamPackage.to_string nv) srcdir checksum ~working_dir mirrors
 
 let pinned_package st ?version ?(working_dir=false) name =
@@ -453,7 +454,7 @@ let cleanup_source st old_opam_opt new_opam =
 
 let download_package_source st nv dirname =
   let opam = OpamSwitchState.opam st nv in
-  let cache_dir = OpamPath.download_cache st.switch_global.root in
+  let cache_dir = OpamRepositoryPath.download_cache st.switch_global.root in
   let cache_urls = active_caches st nv in
 
   let fetch_source_job =


### PR DESCRIPTION
This should speed things up a lot when downloading the same git repositories
(or different forks) multiple times; it needs some testing, though, and we
need to consider what happens if the cache is wiped (the local git clones
might still rely on it).

As usual, there might also be issues with older git versions. Concurrent 
downloads _should_ work, but we need to verify that too.

It already gives a huge speedup when pinning lots of packages to the same
repository, though.