### PR TITLE
update default ocaml compiler to latest release

### DIFF
--- a/shell/opam_installer.sh
+++ b/shell/opam_installer.sh
@@ -7,7 +7,7 @@ set -ue
 
 VERSION='1.2.2'
 
-default_ocaml=4.02.1
+default_ocaml=4.05.0
 
 usage() {
 cat <<EOF


### PR DESCRIPTION
If 4.05.0 seems too recent I'm happy to replace with 4.04.2, but 4.02.1 seems definitely wrong.