### PR TITLE
Get rid of jsonm dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,6 @@ src_ext/cmdliner/
 src_ext/extlib/
 src_ext/re/
 src_ext/graph/
-src_ext/jsonm/
-src_ext/uutf/
 src_ext/opam_file_format/
 src_ext/*.stamp
 src_ext/*.tbz

--- a/.merlin.in
+++ b/.merlin.in
@@ -1,4 +1,4 @@
-PKG ocamlgraph cmdliner dose3 cudf re jsonm
+PKG ocamlgraph cmdliner dose3 cudf re
 
 S src/*
 B _obuild/*

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -13,7 +13,7 @@ install-bootstrap () {
     eval $(opam config env --root=$OPAMBSROOT)
     if [ "$OPAM_TEST" = "1" ]; then
         opam pin add opam-file-format "git://github.com/ocaml/opam-file-format.git" --no-action --yes
-        opam install ocamlfind lwt.3.0.0 cohttp.0.22.0 ssl cmdliner dose3 jsonm opam-file-format --yes
+        opam install ocamlfind lwt.3.0.0 cohttp.0.22.0 ssl cmdliner dose3 opam-file-format --yes
         # Allow use of ocamlfind packages in ~/local/lib
         FINDCONF=$(ocamlfind printconf conf)
         sed "s%^path=.*%path=\"$HOME/local/lib:$(opam config var lib)\"%" $FINDCONF >$FINDCONF.1

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,9 @@ Changes prefixed with "(*)" are potentially breaking to scripts or existing
 repositories (changes that are automatically handled by the format upgrade tools
 are not marked).
 
+
+* Remove jsonm and transitive uutf dependency.
+
 2.0.0~beta3
 * (*) Renamed `--soft-request` to `--best-effort`
 * Fixed and improved speed of the package file tracking mechanism

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -12,7 +12,7 @@ HAS_PACKAGES = @hasalldeps@
 USE_BYTE := $(if $(subst no,,@OCAMLOPT@),,true)
 LIBEXT := $(if $(USE_BYTE),.cma,.cmxa)
 
-PACKS = @OCAML_PKG_unix@ @OCAML_PKG_bigarray@ @OCAML_PKG_extlib@ @OCAML_PKG_re@ @OCAML_PKG_re_glob@ @OCAML_PKG_cmdliner@ @OCAML_PKG_ocamlgraph@ @OCAML_PKG_cudf@ @OCAML_PKG_dose3_common@ @OCAML_PKG_dose3_algo@ @OCAML_PKG_jsonm@ @OCAML_PKG_opam_file_format@
+PACKS = @OCAML_PKG_unix@ @OCAML_PKG_bigarray@ @OCAML_PKG_extlib@ @OCAML_PKG_re@ @OCAML_PKG_re_glob@ @OCAML_PKG_cmdliner@ @OCAML_PKG_ocamlgraph@ @OCAML_PKG_cudf@ @OCAML_PKG_dose3_common@ @OCAML_PKG_dose3_algo@ @OCAML_PKG_opam_file_format@
 
 CONF_OCAMLFLAGS = @CONF_OCAMLFLAGS@
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ libraries, rather than use `make lib-ext` which would cause conflicts. It's
 easier to already have a working opam installation in this case, so you can do
 it as a second step.
 
-* Make sure to have ocamlfind, ocamlgraph, cmdliner >= 0.9.8, jsonm, cudf,
+* Make sure to have ocamlfind, ocamlgraph, cmdliner >= 0.9.8, cudf,
   dose3, re >= 1.2.0, opam-file-format installed. Or run `opam install
   opam-lib --deps-only` if you already have a working instance. Re-run
   `./configure` once done
@@ -117,9 +117,7 @@ The release cycle respects [Semantic Versioning](http://semver.org/).
 ## Copyright and license
 
 The version comparison function in `src/core/opamVersionCompare.ml` is part of
-the Dose library and Copyright 2011 Ralf Treinen. Some code in
-`src/core/opamJson.ml` is taken from the documentation of `Jsonm` and is
-Copyright 2012 Daniel C. Bünzli. See the specific file for details.
+the Dose library and Copyright 2011 Ralf Treinen.
 
 All other code is:
 

--- a/configure
+++ b/configure
@@ -588,7 +588,6 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 hasalldeps
 OCAML_PKG_opam_file_format
-OCAML_PKG_jsonm
 OCAML_PKG_dose3_algo
 OCAML_PKG_dose3_common
 OCAML_PKG_cudf
@@ -4771,32 +4770,6 @@ $as_echo "not found" >&6; }
   fi
 
 
-
-
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for OCaml findlib package jsonm" >&5
-$as_echo_n "checking for OCaml findlib package jsonm... " >&6; }
-
-  unset found
-  unset pkg
-  found=no
-  for pkg in jsonm  ; do
-    if $OCAMLFIND query $pkg >/dev/null 2>/dev/null; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: found" >&5
-$as_echo "found" >&6; }
-      OCAML_PKG_jsonm=$pkg
-      found=yes
-      break
-    fi
-  done
-  if test "$found" = "no" ; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
-$as_echo "not found" >&6; }
-    OCAML_PKG_jsonm=no
-  fi
-
-
-
-
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for OCaml findlib package opam-file-format" >&5
 $as_echo_n "checking for OCaml findlib package opam-file-format... " >&6; }
 
@@ -4831,7 +4804,6 @@ if test "x${enable_checks}" != "xno" && {
        test "x$OCAML_PKG_ocamlgraph" = "xno" ||
        test "x$OCAML_PKG_cudf" = "xno" ||
        test "x$OCAML_PKG_dose3_common" = "xno" ||
-       test "x$OCAML_PKG_jsonm" = "xno" ||
        test "x$OCAML_PKG_opam_file_format" = "xno"; }; then :
 
   echo "============================================================================"

--- a/configure.ac
+++ b/configure.ac
@@ -132,7 +132,6 @@ AC_CHECK_OCAML_PKG([ocamlgraph])
 AC_CHECK_OCAML_PKG([cudf])
 AC_CHECK_OCAML_PKG(dose3.common,dose.common)
 AC_CHECK_OCAML_PKG(dose3.algo,dose.algo)
-AC_CHECK_OCAML_PKG([jsonm])
 AC_CHECK_OCAML_PKG([opam-file-format])
 
 dnl echo
@@ -142,7 +141,6 @@ dnl echo "cmdliner...................... ${OCAML_PKG_cmdliner}"
 dnl echo "graph......................... ${OCAML_PKG_ocamlgraph}"
 dnl echo "cudf.......................... ${OCAML_PKG_cudf}"
 dnl echo "dose3......................... ${OCAML_PKG_dose3}"
-dnl echo "jsonm......................... ${OCAML_PKG_jsonm}"
 echo
 
 
@@ -153,7 +151,6 @@ AS_IF([test "x${enable_checks}" != "xno" && {
        test "x$OCAML_PKG_ocamlgraph" = "xno" ||
        test "x$OCAML_PKG_cudf" = "xno" ||
        test "x$OCAML_PKG_dose3_common" = "xno" ||
-       test "x$OCAML_PKG_jsonm" = "xno" ||
        test "x$OCAML_PKG_opam_file_format" = "xno"; }],[
   echo "============================================================================"
   echo "Some dependencies are missing. If you are just interested in the stand-alone"

--- a/opam-core.opam
+++ b/opam-core.opam
@@ -26,6 +26,5 @@ depends: [
   "base-bigarray"
   "ocamlgraph"
   "re" {>= "1.5.0"}
-  "jsonm"
 ]
 available: ocaml-version >= "4.01.0"

--- a/src/Makefile
+++ b/src/Makefile
@@ -37,7 +37,7 @@ endif
 
 ifneq ($(HAS_LIBEXT),)
   EXT_INCDIRS = ../src_ext/lib
-  LIBS = unix bigarray extlib re cmdliner graph cudf dose_common dose_algo uutf jsonm opam-file-format
+  LIBS = unix bigarray extlib re cmdliner graph cudf dose_common dose_algo opam-file-format
 else
   ifeq ($(HAS_PACKAGES),)
     ifeq ($(findstring clean,$(MAKECMDGOALS)),)

--- a/src/core.META.in
+++ b/src/core.META.in
@@ -1,5 +1,5 @@
 version = "@PACKAGE_VERSION@"
 description = "OCaml Package Manager core internal stdlib"
-requires = "bigarray, unix, ocamlgraph, re, re.str, jsonm"
+requires = "bigarray, unix, ocamlgraph, re, re.str"
 archive(byte) = "opam-core.cma"
 archive(native) = "opam-core.cmxa"

--- a/src/core/core.ocp
+++ b/src/core/core.ocp
@@ -28,7 +28,6 @@ begin library "opam-core"
     "ocamlgraph"
     "re"
     "re.str"
-    "jsonm"
   ]
 
 end

--- a/src/core/opamJson.ml
+++ b/src/core/opamJson.ml
@@ -8,51 +8,81 @@
 (*                                                                        *)
 (**************************************************************************)
 
-include Jsonm
-
 type t =
   [ `Null | `Bool of bool | `Float of float| `String of string
   | `A of t list | `O of (string * t) list ]
 
-let json_to_dst ~minify dst (json:t) =
-  let enc e l = ignore (encode e (`Lexeme l)) in
-  let rec value v k e = match v with
-    | `A vs -> arr vs k e
-    | `O ms -> obj ms k e
-    | `Null | `Bool _ | `Float _ | `String _ as v -> enc e v; k e
-  and arr vs k e = enc e `As; arr_vs vs k e
-  and arr_vs vs k e = match vs with
-    | v :: vs' -> value v (arr_vs vs' k) e
-    | [] -> enc e `Ae; k e
-  and obj ms k e = enc e `Os; obj_ms ms k e
-  and obj_ms ms k e = match ms with
-    | (n, v) :: ms -> enc e (`Name n); value v (obj_ms ms k) e
-    | [] -> enc e `Oe; k e
+let addc b c = Buffer.add_char b c
+let adds b s = Buffer.add_string b s
+let adds_esc b s =
+  let len = String.length s in
+  let max_idx = len - 1 in
+  let flush b start i =
+    if start < len then Buffer.add_substring b s start (i - start);
   in
-  let e = encoder ~minify dst in
-  let finish e = ignore (encode e `End) in
-  match json with
-  | `A _ | `O _ as json -> value json finish e
-  | _ -> invalid_arg "invalid json text"
+  let rec loop start i = match i > max_idx with
+  | true -> flush b start i
+  | false ->
+      let next = i + 1 in
+      match String.get s i with
+      | '"' -> flush b start i; adds b "\\\""; loop next next
+      | '\\' -> flush b start i; adds b "\\\\"; loop next next
+      | '\x00' .. '\x1F' | '\x7F' (* US-ASCII control chars *) as c ->
+          flush b start i;
+          adds b (Printf.sprintf "\\u%04X" (Char.code c));
+          loop next next
+      | _ -> loop start next
+  in
+  loop 0 0
+
+let enc_json_string b s = addc b '"'; adds_esc b s; addc b '"'
+let enc_vsep b = addc b ','
+let enc_lexeme b = function
+| `Null -> adds b "null"
+| `Bool true -> adds b "true"
+| `Bool false -> adds b "false"
+| `Float f -> Printf.bprintf b "%.16g" f
+| `String s -> enc_json_string b s
+| `Name n -> enc_json_string b n; addc b ':'
+| `As -> addc b '['
+| `Ae -> addc b ']'
+| `Os -> addc b '{'
+| `Oe -> addc b '}'
+
+let enc_json b (json:t) =
+  let enc = enc_lexeme in
+  let enc_sep seq enc_seq k b = match seq with
+  | [] -> enc_seq seq k b
+  | seq -> enc_vsep b; enc_seq seq k b
+  in
+  let rec value v k b = match v with
+    | `A vs -> arr vs k b
+    | `O ms -> obj ms k b
+    | `Null | `Bool _ | `Float _ | `String _ as v -> enc b v; k b
+  and arr vs k b = enc b `As; arr_vs vs k b
+  and arr_vs vs k b = match vs with
+    | v :: vs' -> value v (enc_sep vs' arr_vs k) b
+    | [] -> enc b `Ae; k b
+  and obj ms k b = enc b `Os; obj_ms ms k b
+  and obj_ms ms k b = match ms with
+    | (n, v) :: ms -> enc b (`Name n); value v (enc_sep ms obj_ms k) b
+    | [] -> enc b `Oe; k b
+  in
+  value json (fun _ -> ()) b
 
 let to_string (json:t) =
-  let buf = Buffer.create 1024 in
-  json_to_dst ~minify:false (`Buffer buf) json;
-  Buffer.contents buf
+  let b = Buffer.create 1024 in
+  enc_json b json;
+  Buffer.contents b
 
-let json_buffer = ref []
+let json_buffer =
+  ref []
 
 let append key json =
   json_buffer := (key,json) :: !json_buffer
 
 let flush oc =
-  json_to_dst ~minify:false (`Channel oc)
-    (`O (List.rev !json_buffer))
-
-(*---------------------------------------------------------------------------
-   Copyright (c) 2012 Daniel C. Bünzli
-
-   Permission to use, copy, modify, and/or distribute this software for any
-   purpose with or without fee is hereby granted, provided that the above
-   copyright notice and this permission notice appear in all copies.
-  ---------------------------------------------------------------------------*)
+  let b = Buffer.create 1024 in
+  let json = (`O (List.rev !json_buffer)) in
+  let json = enc_json b json; Buffer.contents b in
+  output_string oc json; flush oc

--- a/src/core/opamJson.mli
+++ b/src/core/opamJson.mli
@@ -8,13 +8,16 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Wrapper on Jsonm; only needed for some debug options *)
+(** Json encoder; only needed for some debug options
+
+    {b Warning.} Assumes given strings are UTF-8 encoded this is
+    not checked by the module. *)
 
 type t =
   [ `Null | `Bool of bool | `Float of float| `String of string
   | `A of t list | `O of (string * t) list ]
 
-val to_string: t -> string
+val to_string : t -> string
 
 val append: string -> t -> unit
 

--- a/src/core/opamJson.mli
+++ b/src/core/opamJson.mli
@@ -16,8 +16,6 @@ type t =
 
 val to_string: t -> string
 
-val of_string: string -> t
-
 val append: string -> t -> unit
 
 val flush: out_channel -> unit

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -2,7 +2,7 @@ ifneq ($(filter-out archives cache-archives,$(MAKECMDGOALS)),)
 -include ../Makefile.config
 endif
 
-SRC_EXTS = cppo extlib re cmdliner graph cudf dose uutf jsonm opam_file_format
+SRC_EXTS = cppo extlib re cmdliner graph cudf dose opam_file_format
 
 URL_cppo = https://github.com/mjambon/cppo/archive/v1.3.2.tar.gz
 MD5_cppo = 133c9f8afadb6aa1c5ba0f5eb55c5648
@@ -24,12 +24,6 @@ MD5_cudf = 2047222fcf78278c6a24ac619fc39abb
 
 URL_dose = https://gforge.inria.fr/frs/download.php/file/35975/dose3-5.0.tar.gz
 MD5_dose = 228c6a73a0759783fd01181047046610
-
-URL_uutf = http://erratique.ch/software/uutf/releases/uutf-0.9.3.tbz
-MD5_uutf = 708c0421e158b390c7cc341f37b40add
-
-URL_jsonm = http://erratique.ch/software/jsonm/releases/jsonm-0.9.1.tbz
-MD5_jsonm = 631a5dabdada83236c83056f60e42685
 
 URL_opam_file_format = https://github.com/ocaml/opam-file-format/archive/2.0.0-beta3.tar.gz
 MD5_opam_file_format = fb461d14a44aac3a43751aa936e79143
@@ -161,7 +155,7 @@ clean:
 	$(MAKE) -f $(OCAMLMAKEFILE) subprojs SUBTARGET=cleanup
 
 distclean:
-	rm -rf cudf extlib re graph dose cmdliner uutf jsonm opam_file_format ._ncdi ._bcdi ._d
+	rm -rf cudf extlib re graph dose cmdliner opam_file_format ._ncdi ._bcdi ._d
 	rm -f depends.ocp
 	rm -f *.tar.gz *.tbz *.stamp *.download
 	rm -f *.cm* *.o *.a *.lib *.obj
@@ -169,11 +163,7 @@ distclean:
 	[ -d archives ] && ([ "$$(find archives -maxdepth 0 -type d -empty)" != "" ] && rmdir archives || echo "WARNING! $$(pwd)/archives/ not empty so left") || true
 
 LIB_EXTS = extlib re cmdliner graph cudf dose_common dose_versioning dose_pef dose_opam dose_algo \
-           uutf jsonm opam_file_format
-
-proj_uutf: proj_cmdliner
-
-proj_jsonm: proj_uutf
+           opam_file_format
 
 proj_cudf: proj_extlib
 
@@ -253,12 +243,6 @@ SRC_dose_algo = defaultgraphs.ml diagnostic.ml dominators.ml flatten.ml \
 								statistics.ml depsolver_int.ml depsolver.ml strongconflicts_int.ml\
 								strongconflicts.ml strongdeps.ml
 $(call SUB_PACK_LIB,dose,algo,extlib graph cudf)
-
-SRC_uutf = uutf.ml
-$(call BASIC_LIB,uutf,src)
-
-SRC_jsonm = jsonm.ml
-$(call BASIC_LIB,jsonm,src,uutf)
 
 SRC_opam_file_format = \
   opamParserTypes.mli \


### PR DESCRIPTION
Remove the `jsonm` and transitive `uutf` dependency. 

This allows to ease debian bootstrapping: latest versions of `jsonm` and `uutf` use `topkg` and hence `opam-installer` which is provided by `opam` itself.

@AltGr note that the output is now minified which used not to be the case. I hope it's not a problem as it allows for a very simple encoder implementation. If people need to read the json they can always pipe the output into `jsontrip -pp`.

/cc @hendriktews