### PR TITLE
fixing outdated link to OpenSUSE build server in Install.md

### DIFF
--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -107,7 +107,7 @@ cave resolve -x repository/ocaml-unofficial
 
 RPMs for Fedora, CentOS and Red Hat Enterprise Linux are available with
 instructions on the
-[OpenSUSE Build Server](http://software.opensuse.org/download.html?project=home%3Aocaml&package=opam).
+[OpenSUSE Build Server](https://software.opensuse.org/package/opam).
 
 #### Mageia
 


### PR DESCRIPTION
It appears that the link to the rpm in the installation instructions is not working anymore. I believe [this is the correct one](https://software.opensuse.org/package/opam).