### PR TITLE
Add a 'post' dependency flag.

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -823,6 +823,11 @@ files.
 
     * `build` dependencies are no longer needed at run-time: they won't trigger
       recompilations of your package.
+    * `post` dependencies will be installed along with the package, but are not
+      required to build it. This can be used to cut build cycles of
+      interdependent packages, while making sure they get installed together.
+      Note that, in case of failed or interrupted builds, opam can not guarantee
+      the invariant that `!build` dependencies are always installed.
     * `with-test` dependencies are only needed when building tests (when the
       package is explicitely installed with `--with-test`)
     * likewise, `with-doc` dependecies are only required when building the
@@ -839,7 +844,7 @@ files.
 
     Variables in the filtered package formula are evaluated as for
     [`depends:`](#opamfield-depends), with the same specific variables
-    available.
+    available (except for `post`, which wouldn't make sense).
 
     Note that `depopts: [ "foo" { = "3" } ]` means that the optional dependency
     only applies for `foo` version `3`, not that your package can't be installed

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1073,6 +1073,10 @@ let package_selection =
     mk_flag ["nobuild"]  ~section
       "Exclude build dependencies (they are included by default)."
   in
+  let post =
+    mk_flag ["post"]  ~section
+      "Include dependencies tagged as $(i,post)."
+  in
   let dev =
     mk_flag ["dev"]  ~section
       "Include development packages in dependencies."
@@ -1113,11 +1117,12 @@ let package_selection =
   in
   let filter
       depends_on required_by conflicts_with coinstallable_with resolve recursive
-      depopts nobuild dev doc_flag test field_match has_flag has_tag
+      depopts nobuild post dev doc_flag test field_match has_flag has_tag
     =
     let dependency_toggles = {
       OpamListCommand.
-      recursive; depopts; build = not nobuild; test; doc = doc_flag; dev
+      recursive; depopts; build = not nobuild; post; test; doc = doc_flag;
+      dev
     } in
     List.map (fun flag -> OpamListCommand.Flag flag) has_flag @
     List.map (fun tag -> OpamListCommand.Tag tag) has_tag @
@@ -1145,8 +1150,8 @@ let package_selection =
   in
   Term.(const filter $
         depends_on $ required_by $ conflicts_with $ coinstallable_with $
-        resolve $ recursive $ depopts $ nobuild $ dev $ doc_flag $ test $
-        field_match $ has_flag $ has_tag)
+        resolve $ recursive $ depopts $ nobuild $ post $ dev $ doc_flag $
+        test $ field_match $ has_flag $ has_tag)
 
 let package_listing_section = "OUTPUT FORMAT OPTIONS"
 

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -57,7 +57,8 @@ let orphans ?changes ?(transitive=false) t =
       let recompile_cone =
         OpamPackage.Set.of_list @@
         OpamSolver.reverse_dependencies
-          ~depopts:true ~installed:true ~unavailable:true ~build:true
+          ~depopts:true ~installed:true ~unavailable:true
+          ~build:true ~post:false
           universe ch
       in
       orphans %% recompile_cone
@@ -83,7 +84,8 @@ let orphans ?changes ?(transitive=false) t =
       let new_orphans =
         OpamPackage.Set.of_list @@
         OpamSolver.reverse_dependencies
-          ~depopts:false ~installed:false ~unavailable:true ~build:true
+          ~depopts:false ~installed:false ~unavailable:true
+          ~build:true ~post:false
           universe full_orphans
       in
       let full, versions = full_partition (new_orphans++orphan_versions) in
@@ -900,7 +902,7 @@ let remove_t ?ask ~autoremove ~force atoms t =
     in
     let to_remove =
       OpamPackage.Set.of_list
-        (OpamSolver.reverse_dependencies ~build:true
+        (OpamSolver.reverse_dependencies ~build:true ~post:true
            ~depopts:false ~installed:true universe packages) in
     let to_keep =
       (if autoremove then t.installed_roots %% t.installed else t.installed)
@@ -908,7 +910,7 @@ let remove_t ?ask ~autoremove ~force atoms t =
     in
     let to_keep =
       OpamPackage.Set.of_list
-        (OpamSolver.dependencies ~build:true
+        (OpamSolver.dependencies ~build:true ~post:true
            ~depopts:true ~installed:true universe to_keep) in
     (* to_keep includes the depopts, because we don't want to autoremove
        them. But that may re-include packages that we wanted removed, so we
@@ -922,7 +924,7 @@ let remove_t ?ask ~autoremove ~force atoms t =
         else (* restrict to the dependency cone of removed pkgs *)
           to_remove %%
           (OpamPackage.Set.of_list
-             (OpamSolver.dependencies ~build:true
+             (OpamSolver.dependencies ~build:true ~post:true
                 ~depopts:true ~installed:true universe to_remove))
       else to_remove in
     let t, solution =

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -22,6 +22,7 @@ type dependency_toggles = {
   recursive: bool;
   depopts: bool;
   build: bool;
+  post: bool;
   test: bool;
   doc: bool;
   dev: bool;
@@ -31,6 +32,7 @@ let default_dependency_toggles = {
   recursive = false;
   depopts = false;
   build = true;
+  post = false;
   test = false;
   doc = false;
   dev = false;
@@ -148,7 +150,8 @@ let packages_of_atoms st atoms =
 let package_dependencies st tog nv =
   get_opam st nv |>
   OpamPackageVar.all_depends
-    ~build:tog.build ~test:tog.test ~doc:tog.doc ~dev:tog.dev
+    ~build:tog.build ~post:tog.post
+    ~test:tog.test ~doc:tog.doc ~dev:tog.dev
     ~depopts:tog.depopts
     st
 
@@ -221,7 +224,7 @@ let apply_selector ~base st = function
       | Depends_on _ -> OpamSolver.reverse_dependencies
       | _ -> assert false
     in
-    deps_fun ~depopts:tog.depopts ~build:tog.build
+    deps_fun ~depopts:tog.depopts ~build:tog.build ~post:tog.post
       ~installed:false ~unavailable:true
       (get_universe st tog)
       (packages_of_atoms st atoms)
@@ -663,7 +666,8 @@ let display st format packages =
       in
       let deps_packages =
         OpamSolver.dependencies
-          ~depopts:true ~installed:false ~unavailable:true ~build:true
+          ~depopts:true ~installed:false ~unavailable:true
+          ~build:true ~post:false
           universe packages
       in
       List.filter (fun nv -> OpamPackage.Set.mem nv packages) deps_packages |>

--- a/src/client/opamListCommand.mli
+++ b/src/client/opamListCommand.mli
@@ -20,6 +20,7 @@ type dependency_toggles = {
   recursive: bool;
   depopts: bool;
   build: bool;
+  post: bool;
   test: bool;
   doc: bool;
   dev: bool;

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3261,10 +3261,20 @@ module CompSyntax = struct
     let depends =
       OpamFormula.map (fun (n, formula) ->
           let cstr (op, v) =
-            Atom (Constraint (op, FString (OpamPackage.Version.to_string v)))
+            OpamFormula.ands [
+              Atom (Constraint (op, FString (OpamPackage.Version.to_string v)));
+            ]
           in
-          Atom (n, (OpamFormula.map cstr formula)))
-        comp.packages
+          let post_flag =
+            Filter (FIdent ([], OpamVariable.of_string "post", None))
+          in
+          Atom (n, OpamFormula.ands
+                  [OpamFormula.map cstr formula; Atom post_flag]))
+        (OpamFormula.ands [
+            Atom (OpamPackage.Name.of_string "ocaml",
+                  Atom (`Eq, OpamPackage.Version.of_string comp.version));
+            comp.packages
+          ])
     in
     let url =
       OpamStd.Option.map

--- a/src/format/opamFilter.ml
+++ b/src/format/opamFilter.ml
@@ -539,7 +539,7 @@ let variables_of_filtered_formula ff =
          acc f)
     [] ff
 
-let filter_deps ~build ?test ?doc ?dev ?default_version ?default deps =
+let filter_deps ~build ~post ?test ?doc ?dev ?default_version ?default deps =
   let env var =
     let get_opt = function
       | Some b -> Some (B b)
@@ -547,6 +547,7 @@ let filter_deps ~build ?test ?doc ?dev ?default_version ?default deps =
     in
     match OpamVariable.Full.to_string var with
     | "build" -> Some (B build)
+    | "post" -> Some (B post)
     | "with-test" -> get_opt test
     | "with-doc" -> get_opt doc
     | "dev" -> get_opt dev

--- a/src/format/opamFilter.mli
+++ b/src/format/opamFilter.mli
@@ -158,14 +158,14 @@ val string_of_filtered_formula: filtered_formula -> string
 
 val variables_of_filtered_formula: filtered_formula -> full_variable list
 
-(** Resolves the build, test, doc, dev flags in a filtered formula (which is
-    supposed to have been pre-processed to remove switch and global variables).
-    [default] determines the behaviour on undefined filters, and the function
-    may raise if it is undefined. If a constraint resolves to an invalid
-    version, it is dropped, or replaced with [default_version] if specified. If
-    test, doc or dev are unspecified, they are assumed to be filtered out
-    already and encountering them will raise an assert. *)
+(** Resolves the build, post, test, doc, dev flags in a filtered formula
+    (which is supposed to have been pre-processed to remove switch and global
+    variables). [default] determines the behaviour on undefined filters, and the
+    function may raise if it is undefined. If a constraint resolves to an
+    invalid version, it is dropped, or replaced with [default_version] if
+    specified. If test, doc or dev are unspecified, they are assumed to be
+    filtered out already and encountering them will raise an assert. *)
 val filter_deps:
-  build:bool -> ?test:bool -> ?doc:bool -> ?dev:bool ->
+  build:bool -> post:bool -> ?test:bool -> ?doc:bool -> ?dev:bool ->
   ?default_version:version -> ?default:bool ->
   filtered_formula -> formula

--- a/src/solver/opamSolver.mli
+++ b/src/solver/opamSolver.mli
@@ -54,7 +54,7 @@ val cudf_versions_map: universe -> package_set -> int OpamPackage.Map.t
 (** Creates a CUDF universe from an OPAM universe, including the given
     packages *)
 val load_cudf_universe:
-  ?depopts:bool -> build:bool ->
+  ?depopts:bool -> build:bool -> post:bool ->
   universe -> ?version_map:int package_map -> package_set -> Cudf.universe
 
 (**  Build a request *)
@@ -83,7 +83,7 @@ val installable_subset: universe -> package_set -> package_set
 (** Return the topological sort of the transitive dependency closures
     of a collection of packages.*)
 val dependencies :
-  depopts:bool -> build:bool ->
+  depopts:bool -> build:bool -> post:bool ->
   installed:bool ->
   ?unavailable:bool ->
   universe ->
@@ -92,7 +92,7 @@ val dependencies :
 
 (** Same as [dependencies] but for reverse dependencies *)
 val reverse_dependencies :
-  depopts:bool -> build:bool ->
+  depopts:bool -> build:bool -> post:bool ->
   installed:bool ->
   ?unavailable:bool ->
   universe ->

--- a/src/state/opamPackageVar.mli
+++ b/src/state/opamPackageVar.mli
@@ -54,16 +54,17 @@ val resolve_switch_raw:
 
 val is_dev_package: 'a switch_state -> OpamFile.OPAM.t -> bool
 
-(** The defaults are [true] for [build], false for [dev] and defined by
-    OpamStateConfig for [test] and [bool]. *)
+(** The defaults are [true] for [build], false for [dev] and [post], and
+    defined by OpamStateConfig for [test] and [bool]. *)
 val filter_depends_formula:
-  ?build:bool -> ?test:bool -> ?doc:bool -> ?dev:bool -> ?default:bool ->
-  env:OpamFilter.env ->
+  ?build:bool -> ?post:bool -> ?test:bool -> ?doc:bool -> ?dev:bool ->
+  ?default:bool -> env:OpamFilter.env ->
   filtered_formula -> formula
 
 (** Assumes [filter_default=false] by default, i.e. dependencies with undefined
     filters are discarded. *)
 val all_depends:
-  ?build:bool -> ?test:bool -> ?doc:bool -> ?dev:bool -> ?filter_default:bool ->
+  ?build:bool -> ?post:bool -> ?test:bool -> ?doc:bool -> ?dev:bool ->
+  ?filter_default:bool ->
   ?depopts:bool ->
   'a switch_state -> OpamFile.OPAM.t -> formula


### PR DESCRIPTION
This resolves #2649, and provides a solution for ocaml/opam-repository#7543, and a better story for `base` packages (#2996). It also allows to have the `ocaml` package be installed with the switch, rather than lazily afterwards, which apparently created some confusion.

Two notes though:
- maybe find a better name ? Dependencies tagged `reverse` may, or may not, actually be reverse dependencies (e.g. `a` with `depends: ["b" {reverse}]` does not imply that `b` depends on `a`, although that may often be the case). Better avoid this kind of confusion
- ~~I added the flag before realising that it was mostly equivalent to just specifying `!build`, which may actually be easier to understand (a dependency that is not active at build time). So we could remove commit ae4f3764, and adapt the repository rewriting in 697fba64, adding some documentation.~~ EDIT: I take this back, it doesn't really match. We could still use `!build` instead or `reverse`, but it's actually a bit convoluted.

Hence this PR is more for review on the concept at the moment