### PR TITLE
repo upgrade: remove base-metaocaml-ocamlfind from hardcoded base packages

### DIFF
--- a/src/client/opamAdminRepoUpgrade.ml
+++ b/src/client/opamAdminRepoUpgrade.ml
@@ -108,7 +108,6 @@ let all_base_packages =
       "base-bigarray";
       "base-threads";
       "base-unix";
-      "base-metaocaml-ocamlfind";
     ])
 
 let cache_file : string list list OpamFile.t =


### PR DESCRIPTION
The hardcoded `base` packages don't have the `ocaml` dependency added, and
can't have their `available:` rewritten as dependencies to the
`ocaml-xxx` implementation packages. This was due to the ordering problem that
`{post}` dependencies fixed, so they could be removed altogether, but let's
not change more than necessary.