### PR TITLE
Resolve paths of commands before calling Unix.execvpe

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -542,7 +542,7 @@ let init
 
           (* Check for the external dependencies *)
           let check_external_dep name =
-            OpamSystem.command_exists name
+            OpamSystem.resolve_command name <> None
           in
           OpamConsole.msg "Checking for available remotes: ";
           let repo_types =

--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -48,10 +48,12 @@ let check_and_run_external_commands () =
         ) else
           Unix.environment ()
       in
-      if OpamSystem.command_exists ~env command then
+      match OpamSystem.resolve_command ~env command with
+      | Some command ->
         let argv = Array.of_list (command :: args) in
         raise (OpamStd.Sys.Exec (command, argv, env))
-      else if has_init then
+      | None when not has_init -> ()
+      | None ->
         (* Look for a corresponding package *)
         match OpamStateConfig.(!r.current_switch) with
         | None -> ()

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -673,6 +673,21 @@ module Job = struct
     in
     aux None l
 
+  let of_fun_list ?(keep_going=false) l =
+    let rec aux err = function
+      | [] -> Done err
+      | cmdf::commands ->
+        let cmd = cmdf () in
+        let cont = fun r ->
+          if is_success r then aux err commands
+          else if keep_going then
+            aux OpamStd.Option.Op.(err ++ Some (cmd,r)) commands
+          else Done (Some (cmd,r))
+        in
+        Run (cmd,cont)
+    in
+    aux None l
+
   let seq job start = List.fold_left (@@+) (Done start) job
 
   let seq_map f l =

--- a/src/core/opamProcess.mli
+++ b/src/core/opamProcess.mli
@@ -194,6 +194,11 @@ module Job: sig
   val of_list: ?keep_going:bool -> command list ->
     (command * result) option Op.job
 
+  (** As [of_list], but takes a list of functions that return the commands. The
+      functions will only be evaluated when the command needs to be run. *)
+  val of_fun_list: ?keep_going:bool -> (unit -> command) list ->
+    (command * result) option Op.job
+
   (** Returns the job made of the the given homogeneous jobs run sequentially *)
   val seq: ('a -> 'a Op.job) list -> 'a -> 'a Op.job
 

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -389,6 +389,10 @@ module Sys : sig
       OS) *)
   val path_sep: unit -> char
 
+  (** Splits a PATH-like variable separated with [path_sep]. More involved than
+      it seems, because there may be quoting on Windows. *)
+  val split_path_variable: string -> string list
+
   (** {3 Exit handling} *)
 
   (** Like Pervasives.at_exit but with the possibility to call manually

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -136,12 +136,12 @@ val directories_with_links: string -> string list
     latter, if concurrent commands are running). [name] is used for
     naming log files. [text] is what is displayed in the status line
     for this command. May raise Command_not_found, unless
-    [check_existence] is set to false (in which case you can end up
+    [resolve_path] is set to false (in which case you can end up
     with a process error instead) *)
 val make_command:
   ?verbose:bool -> ?env:string array -> ?name:string -> ?text:string ->
   ?metadata:(string * string) list -> ?allow_stdin:bool -> ?stdout:string ->
-  ?dir:string -> ?check_existence:bool ->
+  ?dir:string -> ?resolve_path:bool ->
   string -> string list -> OpamProcess.command
 
 (** OLD COMMAND API, DEPRECATED *)
@@ -149,8 +149,9 @@ val make_command:
 (** a command is a list of words *)
 type command = string list
 
-(** Test whether a command exists in the environment. *)
-val command_exists: ?env:string array -> ?dir:string -> string -> bool
+(** Test whether a command exists in the environment, and returns it (resolved
+    if found in PATH) *)
+val resolve_command: ?env:string array -> ?dir:string -> string -> string option
 
 (** [command cmd] executes the command [cmd] in the correct OPAM
     environment. *)

--- a/src/repository/opamRepositoryConfig.ml
+++ b/src/repository/opamRepositoryConfig.ml
@@ -35,7 +35,7 @@ let default = {
         else ["curl", `Curl; "wget", `Default]
       in
       let cmd, kind =
-        List.find (fun (c,_) -> OpamSystem.command_exists c) tools
+        List.find (fun (c,_) -> OpamSystem.resolve_command c <> None) tools
       in
       [ CIdent cmd, None ], kind
     with Not_found ->

--- a/src/solver/opamCudfSolver.ml
+++ b/src/solver/opamCudfSolver.ml
@@ -95,11 +95,13 @@ module Aspcud_def = struct
   let command_name = "aspcud"
 
   let is_present = lazy (
-    OpamSystem.command_exists command_name &&
+    match OpamSystem.resolve_command command_name with
+    | None -> false
+    | Some cmd ->
     try
       match
         OpamSystem.read_command_output ~verbose:false ~allow_stdin:false
-          [command_name; "-v"]
+          [cmd; "-v"]
       with
       | [] -> false
       | s::_ ->
@@ -141,7 +143,7 @@ module Aspcud_old_def = struct
 
   let command_name = Aspcud_def.command_name
 
-  let is_present = lazy (OpamSystem.command_exists command_name)
+  let is_present = lazy (OpamSystem.resolve_command command_name <> None)
 
   let command_args = Aspcud_def.command_args
 
@@ -155,7 +157,7 @@ module Mccs_def = struct
 
   let command_name = "mccs"
 
-  let is_present = lazy (OpamSystem.command_exists command_name)
+  let is_present = lazy (OpamSystem.resolve_command command_name <> None)
 
   let command_args = [
     CString "-i", None; CIdent "input", None;
@@ -184,7 +186,7 @@ module Packup_def = struct
 
   let command_name = "packup"
 
-  let is_present = lazy (OpamSystem.command_exists command_name)
+  let is_present = lazy (OpamSystem.resolve_command command_name <> None)
 
   let command_args = [
     CIdent "input", None; CIdent "output", None;

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -20,9 +20,7 @@ let slog = OpamConsole.slog
 
 (* - Environment and updates handling - *)
 
-let split_var v =
-  let sep = OpamStd.Sys.path_sep () in
-  OpamStd.String.split_delim v sep
+let split_var v = OpamStd.Sys.split_path_variable v
 
 let join_var l =
   String.concat (String.make 1 (OpamStd.Sys.path_sep ())) l

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -512,8 +512,8 @@ let from_1_3_dev2_to_1_3_dev5 root conf =
               let ocamlc =
                 try
                   let path =
-                    OpamStd.Env.get "PATH" |> fun p ->
-                    OpamStd.String.split p (OpamStd.Sys.path_sep ()) |>
+                    OpamStd.Env.get "PATH" |>
+                    OpamStd.Sys.split_path_variable |>
                     List.filter (fun s ->
                         not (OpamStd.String.starts_with
                                ~prefix:(OpamFilename.Dir.to_string root) s))


### PR DESCRIPTION
Work around bug in OCaml 4.05.0: https://caml.inria.fr/mantis/view.php?id=7640

The resolution is only done for non-qualified command paths