### PR TITLE
Following #3058, this brings the system detection code in

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -196,6 +196,8 @@ td.sublib {
   <td>Defines the types holding global, repository and switch states</td></tr>
 <tr><th><a href="ocamldoc/OpamFormatUpgrade.html">opamFormatUpgrade.ml</a></th>
   <td>Handles upgrade of an opam root from earlier opam versions</td></tr>
+<tr><th><a href="ocamldoc/OpamSysPoll.html">opamSysPoll.ml</a></th>
+  <td>Detection of host system (arch, os, distribution)</td></tr>
 <tr><th><a href="ocamldoc/OpamGlobalState.html">opamGlobalState.ml</a></th>
   <td>Loading and handling of the global state of an opam root</td></tr>
 <tr><th><a href="ocamldoc/OpamRepositoryState.html">opamRepositoryState.ml</a></th>

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -375,9 +375,10 @@ let make_command st opam ?dir ?text_command (cmd, args) =
     OpamProcess.make_command_text name ~args cmd
   in
   let context =
+    let open OpamStd.Option.Op in
     String.concat " | " [
       OpamVersion.(to_string current);
-      OpamStd.Sys.os_string () ^"/"^ OpamStd.Sys.arch ();
+      (OpamSysPoll.os () +! "unknown") ^"/"^ (OpamSysPoll.arch () +! "unknown");
       (OpamStd.List.concat_map " " OpamPackage.to_string
          OpamPackage.Set.(elements @@
                           inter st.compiler_packages st.installed_roots));

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -996,7 +996,9 @@ let build_options =
        (or the deprecated $(b,\\$OPAMBUILDDOC)) to \"true\"." in
   let make =
     mk_opt ~section ["m";"make"] "MAKE"
-      "Use $(docv) as the default 'make' command."
+      "Use $(docv) as the default 'make' command. Deprecated: use $(b,opam \
+       config set[-global] make MAKE) instead. Has no effect if the $(i,make) \
+       variable is defined."
       Arg.(some string) None in
   let show =
     mk_flag ~section ["show-actions"]

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -831,7 +831,7 @@ let config =
           (if self_upgrade_status global_options = `Running then
              OpamFilename.prettify (fst (self_upgrade_exe (OpamStateConfig.(!r.root_dir))))
            else "no");
-        print "os" "%s" (OpamStd.Sys.os_string ());
+        print "os" "%s" OpamStd.Option.Op.(OpamSysPoll.os () +! "unknown");
         try
           OpamGlobalState.with_ `Lock_none @@ fun gt ->
           OpamSwitchState.with_ `Lock_none gt @@ fun state ->

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -831,7 +831,11 @@ let config =
           (if self_upgrade_status global_options = `Running then
              OpamFilename.prettify (fst (self_upgrade_exe (OpamStateConfig.(!r.root_dir))))
            else "no");
-        print "os" "%s" OpamStd.Option.Op.(OpamSysPoll.os () +! "unknown");
+        print "system" "arch=%s os=%s os-distribution=%s os-version=%s"
+          OpamStd.Option.Op.(OpamSysPoll.arch () +! "unknown")
+          OpamStd.Option.Op.(OpamSysPoll.os () +! "unknown")
+          OpamStd.Option.Op.(OpamSysPoll.os_distribution () +! "unknown")
+          OpamStd.Option.Op.(OpamSysPoll.os_version () +! "unknown");
         try
           OpamGlobalState.with_ `Lock_none @@ fun gt ->
           OpamSwitchState.with_ `Lock_none gt @@ fun state ->
@@ -870,7 +874,7 @@ let config =
                 nprint "local" nlocal @
                 nprint "version-controlled" nvcs) ^
              match default with
-             | Some v -> Printf.sprintf "(default repo at %s)" v
+             | Some v -> Printf.sprintf " (default repo at %s)" v
              | None -> ""
             );
           print "pinned" "%s"

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -391,16 +391,16 @@ let list ?(force_search=false) () =
   let depexts =
     mk_flag ["e";"external"] ~section:display_docs
       "Instead of displaying the packages, display their external dependencies \
-       that are associated with the system as specified by $(b,--vars). This \
-       excludes other display options. Rather than using this directly, you \
-       should probably head for the `depext' plugin, that can infer your \
-       system's package management system and handle the system installations. \
-       Run `opam depext'."
+       that are associated with the current system. This excludes other \
+       display options. Rather than using this directly, you should probably \
+       head for the `depext' plugin, that will use your system package \
+       management system to handle the installation of the dependencies. Run \
+       `opam depext'."
   in
   let vars =
     mk_opt ["vars"] "[VAR=STR,...]" ~section:display_docs
       "Define the given variable bindings. Typically useful with \
-       $(b,--external) to define values for $(i,arch), $(i,os), \
+       $(b,--external) to override the values for $(i,arch), $(i,os), \
        $(i,os-distribution), $(i,os-version), $(i,os-family)."
       OpamArg.variable_bindings []
   in

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -20,7 +20,7 @@ let default_compiler =
   OpamFormula.ors [
     OpamFormula.Atom (OpamPackage.Name.of_string "ocaml-system",
                       OpamFormula.Atom
-                        (`Geq, OpamPackage.Version.of_string "4.01.0"));
+                        (`Geq, OpamPackage.Version.of_string "4.02.3"));
     OpamFormula.Atom (OpamPackage.Name.of_string "ocaml-base-compiler",
                       OpamFormula.Empty);
   ]

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -26,8 +26,6 @@ let default_compiler =
   ]
 
 let eval_variables = [
-  OpamVariable.of_string "arch", ["uname"; "-m"],
-  "Host architecture, as returned by 'uname -m'";
   OpamVariable.of_string "sys-ocaml-version", ["ocamlc"; "-vnum"],
   "OCaml version present on your system independently of opam, if any";
 ]

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -249,9 +249,9 @@ let read_lines f =
   with Sys_error _ -> []
 
 (* Compat function (Windows) *)
-let interrupt p = match OpamStd.Sys.os () with
-  | OpamStd.Sys.Win32 -> Unix.kill p.p_pid Sys.sigkill
-  | _ -> Unix.kill p.p_pid Sys.sigint
+let interrupt p =
+  if OpamStd.Sys.is_windows then Unix.kill p.p_pid Sys.sigkill
+  else Unix.kill p.p_pid Sys.sigint
 
 let run_background command =
   let { cmd; args;
@@ -338,7 +338,7 @@ let set_verbose_f, print_verbose_f, isset_verbose_f, stop_verbose_f =
     stop ();
     (* implem relies on sigalrm, not implemented on win32.
        This will fall back to buffered output. *)
-    if OpamStd.Sys.(os () = Win32) then () else
+    if OpamStd.Sys.is_windows then () else
     let files = OpamStd.List.sort_nodup compare files in
     let ics =
       List.map
@@ -443,7 +443,7 @@ let dontwait p =
 let dead_childs = Hashtbl.create 13
 let wait_one processes =
   if processes = [] then raise (Invalid_argument "wait_one");
-  if OpamStd.Sys.(os () = Win32) then
+  if OpamStd.Sys.is_windows then
     (* No waiting for any child pid on Windows, this is highly sub-optimal
        but should at least work. Todo: C binding for better behaviour *)
     let p = List.hd processes in

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -351,6 +351,9 @@ module Sys : sig
   (** Queried lazily, but may change on SIGWINCH *)
   val terminal_columns : unit -> int
 
+  (** True only if the host OS is Win32 (not cygwin) *)
+  val is_windows: bool
+
   (** The user's home directory. Queried lazily *)
   val home: unit -> string
 
@@ -371,10 +374,8 @@ module Sys : sig
   (** Queried lazily *)
   val os: unit -> os
 
-  val os_string: unit -> string
-
-  (** Queried lazily *)
-  val arch: unit -> string
+  (** The output of the command "uname", with the given argument. Memoised. *)
+  val uname: string -> string option
 
   (** Append .exe (only if missing) to executable filenames on Windows *)
   val executable_name : string -> string
@@ -387,7 +388,7 @@ module Sys : sig
 
   (** The separator character used in the PATH variable (varies depending on
       OS) *)
-  val path_sep: unit -> char
+  val path_sep: char
 
   (** Splits a PATH-like variable separated with [path_sep]. More involved than
       it seems, because there may be quoting on Windows. *)

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -74,7 +74,7 @@ let mkdir dir =
   aux dir
 
 let rm_command =
-  if OpamStd.Sys.(os () = Win32) then
+  if OpamStd.Sys.is_windows then
     "cmd /d /v:off /c rd /s /q"
   else
     "rm -rf"
@@ -302,7 +302,7 @@ let default_env =
 
 let env_var env var =
   let len = Array.length env in
-  let f = if OpamStd.(Sys.os () = Sys.Win32) then String.uppercase_ascii else fun x -> x in
+  let f = if OpamStd.Sys.is_windows then String.uppercase_ascii else fun x -> x in
   let prefix = f var^"=" in
   let pfxlen = String.length prefix in
   let rec aux i =
@@ -317,12 +317,11 @@ let env_var env var =
 (* OCaml 4.05.0 no longer follows the updated PATH to resolve commands. This
    makes unqualified commands absolute as a workaround. *)
 let resolve_command =
-  let is_windows = OpamStd.(Sys.os () = Sys.Win32) in
   let is_external_cmd name =
     OpamStd.String.contains_char name Filename.dir_sep.[0]
   in
   let check_perms =
-    if is_windows then fun f ->
+    if OpamStd.Sys.is_windows then fun f ->
       try (Unix.stat f).Unix.st_kind = Unix.S_REG
       with e -> OpamStd.Exn.fatal e; false
     else fun f ->
@@ -346,7 +345,7 @@ let resolve_command =
       in
       if check_perms cmd then Some cmd else None
     else (* bare command, lookup in PATH *)
-    if is_windows then
+    if OpamStd.Sys.is_windows then
       let path = OpamStd.Sys.split_path_variable (env_var env "PATH") in
       let name =
         if Filename.check_suffix name ".exe" then name else name ^ ".exe"

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -23,7 +23,7 @@ let slog = OpamConsole.slog
 let split_var v = OpamStd.Sys.split_path_variable v
 
 let join_var l =
-  String.concat (String.make 1 (OpamStd.Sys.path_sep ())) l
+  String.concat (String.make 1 OpamStd.Sys.path_sep) l
 
 (* To allow in-place updates, we store intermediate values of path-like as a
    pair of list [(rl1, l2)] such that the value is [List.rev_append rl1 l2] and
@@ -123,7 +123,11 @@ let expand (updates: env_update list) : env =
   let rec apply_updates reverts acc = function
     | (var, op, arg, doc) :: updates ->
       let zip, reverts =
-        let f, var = if OpamStd.Sys.(os () = Win32) then String.uppercase_ascii, String.uppercase_ascii var else (fun x -> x), var in
+        let f, var =
+          if OpamStd.Sys.is_windows then
+            String.uppercase_ascii, String.uppercase_ascii var
+          else (fun x -> x), var
+        in
         match OpamStd.List.find_opt (fun (v, _, _) -> f v = var) acc with
         | Some (_, z, _doc) -> z, reverts
         | None ->
@@ -150,7 +154,7 @@ let expand (updates: env_update list) : env =
 
 let add (env: env) (updates: env_update list) =
   let env =
-    if OpamStd.(Sys.os () = Sys.Win32) then
+    if OpamStd.Sys.is_windows then
       (*
        * Environment variable names are case insensitive on Windows
        *)

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -939,7 +939,7 @@ let from_2_0_alpha3_to_2_0_beta root conf =
        (OpamFormula.ors [
            OpamFormula.Atom (OpamPackage.Name.of_string "ocaml-system",
                              OpamFormula.Atom
-                               (`Geq, OpamPackage.Version.of_string "4.01.0"));
+                               (`Geq, OpamPackage.Version.of_string "4.02.3"));
            OpamFormula.Atom (OpamPackage.Name.of_string "ocaml-base-compiler",
                              OpamFormula.Empty);
          ])

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -18,6 +18,50 @@ let log fmt = OpamConsole.log "FMT_UPG" fmt
 
 (* - Package and aux functions - *)
 
+let upgrade_depexts_to_2_0_beta5 filename depexts =
+  let arch = OpamVariable.of_string "arch" in
+  let os = OpamVariable.of_string "os" in
+  let os_family = OpamVariable.of_string "os-family" in
+  let distro = OpamVariable.of_string "os-distribution" in
+  let eq var v = FOp (FIdent ([], var, None), `Eq, FString v) in
+  (* Transform all known tags into the corresponding filters *)
+  let rec transform_filter =
+    let transform_tag = function
+      | "amd64"       -> eq arch "x86_64"
+      | "x86"         -> eq arch "x86_32"
+      | "arm"|"armv7" -> eq arch "arm32"
+      | "ppc"         -> eq arch "ppc32"
+      | "x86_64" | "ppc64" as a -> eq arch a
+      | "osx"         -> eq os "macos"
+      | "linux" | "unix" | "xenserver" | "freebsd" | "openbsd" | "netbsd"
+      | "dragonfly" | "win32" | "cygwin" as o -> eq os o
+
+      | "nixpkgs"     -> eq distro "nixos"
+      | "arch"        -> eq distro "archlinux"
+      | "homebrew" | "macports" | "debian" | "ubuntu" | "centos" | "fedora"
+      | "rhel" | "opensuse" | "oraclelinux" | "mageia" | "alpine"
+      | "archlinux" | "gentoo" | "nixos" as d -> eq distro d
+
+      | "bsd"         -> eq os_family "bsd"
+      | "mswindows"   -> eq os_family "windows"
+      | "source"      -> failwith "\"source\" tag"
+      | s             -> failwith ("Unknown tag "^s)
+    in
+    function
+    | FAnd (f1, f2) -> FAnd (transform_filter f1, transform_filter f2)
+    | FString s -> transform_tag s
+    | _ -> raise Exit (* the filter is already in the new format if it
+                         contains anything else *)
+  in
+  OpamStd.List.filter_map
+    (fun (names, filter) ->
+       try Some (names, transform_filter filter) with
+       | Exit -> Some (names, filter)
+       | Failure m ->
+         OpamConsole.warning "Ignored depext in %s: %s" filename m;
+         None)
+    depexts
+
 let opam_file_from_1_2_to_2_0 ?filename opam =
   let ocaml_pkgname = OpamPackage.Name.of_string "ocaml" in
 
@@ -258,48 +302,7 @@ let opam_file_from_1_2_to_2_0 ?filename opam =
       (OpamFile.OPAM.dev_repo opam)
   in
   let depexts =
-    let arch = OpamVariable.of_string "arch" in
-    let os = OpamVariable.of_string "os" in
-    let os_family = OpamVariable.of_string "os-family" in
-    let distro = OpamVariable.of_string "os-distribution" in
-    let eq var v = FOp (FIdent ([], var, None), `Eq, FString v) in
-    (* Transform all known tags into the corresponding filters *)
-    let rec transform_filter =
-      let transform_tag = function
-        | "amd64"       -> eq arch "x86_64"
-        | "x86"         -> eq arch "x86_32"
-        | "arm"|"armv7" -> eq arch "arm32"
-        | "ppc"         -> eq arch "ppc32"
-        | "x86_64" | "ppc64" as a -> eq arch a
-        | "osx"         -> eq os "macos"
-        | "linux" | "unix" | "xenserver" | "freebsd" | "openbsd" | "netbsd"
-        | "dragonfly" | "win32" | "cygwin" as o -> eq os o
-
-        | "nixpkgs"     -> eq distro "nixos"
-        | "arch"        -> eq distro "archlinux"
-        | "homebrew" | "macports" | "debian" | "ubuntu" | "centos" | "fedora"
-        | "rhel" | "opensuse" | "oraclelinux" | "mageia" | "alpine"
-        | "archlinux" | "gentoo" | "nixos" as d -> eq distro d
-
-        | "bsd"         -> eq os_family "bsd"
-        | "mswindows"   -> eq os_family "windows"
-        | "source"      -> failwith "\"source\" tag"
-        | s             -> failwith ("Unknown tag "^s)
-      in
-      function
-      | FAnd (f1, f2) -> FAnd (transform_filter f1, transform_filter f2)
-      | FString s -> transform_tag s
-      | _ -> raise Exit (* the filter is already in the new format if it
-                           contains anything else *)
-    in
-    OpamStd.List.filter_map
-      (fun (names, filter) ->
-         try Some (names, transform_filter filter) with
-         | Exit -> Some (names, filter)
-         | Failure m ->
-           OpamConsole.warning "Ignored depext in %s: %s" filename m;
-           None)
-      (OpamFile.OPAM.depexts opam)
+    upgrade_depexts_to_2_0_beta5 filename (OpamFile.OPAM.depexts opam)
   in
   opam |>
   OpamFile.OPAM.with_opam_version (OpamVersion.of_string "2.0") |>
@@ -949,7 +952,49 @@ let from_2_0_alpha3_to_2_0_beta root conf =
       "Host architecture, as returned by 'uname -m'")
      :: OpamFile.Config.eval_variables conf)
 
-let latest_version = v2_0_beta
+let v2_0_beta5 = OpamVersion.of_string "2.0~beta5"
+
+let from_2_0_beta_to_2_0_beta5 root conf =
+  List.iter (fun switch ->
+      let switch_meta_dir =
+        root / OpamSwitch.to_string switch / ".opam-switch"
+      in
+      let switch_config = OpamFile.make (switch_meta_dir // "switch-config") in
+      let module C = OpamFile.Switch_config in
+      let config = C.safe_read switch_config in
+      let rem_variables = List.map OpamVariable.of_string ["os"; "make"] in
+      let config =
+        { config with
+          C.variables =
+            List.filter (fun (var,_) -> not (List.mem var rem_variables))
+              config.C.variables;
+        }
+      in
+      OpamFile.Switch_config.write switch_config config;
+      let opam_files_dirs =
+        OpamFilename.dirs (switch_meta_dir / "packages") @
+        OpamFilename.dirs (switch_meta_dir / "overlay")
+      in
+      List.iter (fun d ->
+          let opam = OpamFile.make (d // "opam") in
+          try
+            OpamFile.OPAM.read opam |> fun o ->
+            OpamFile.OPAM.with_depexts
+              (upgrade_depexts_to_2_0_beta5 (OpamFile.to_string opam)
+                 (OpamFile.OPAM.depexts o))
+              o |>
+            OpamFile.OPAM.write_with_preserved_format opam
+          with e -> OpamStd.Exn.fatal e)
+        opam_files_dirs
+    )
+    (OpamFile.Config.installed_switches conf);
+  let rem_eval_variables = List.map OpamVariable.of_string ["arch"] in
+  OpamFile.Config.with_eval_variables
+    (List.filter (fun (v,_,_) -> not (List.mem v rem_eval_variables))
+       (OpamFile.Config.eval_variables conf))
+    conf
+
+let latest_version = v2_0_beta5
 
 let as_necessary global_lock root config =
   let config_version = OpamFile.Config.opam_version config in
@@ -1005,7 +1050,8 @@ let as_necessary global_lock root config =
         update_to v2_0_alpha from_1_3_dev7_to_2_0_alpha |>
         update_to v2_0_alpha2 from_2_0_alpha_to_2_0_alpha2 |>
         update_to v2_0_alpha3 from_2_0_alpha2_to_2_0_alpha3 |>
-        update_to v2_0_beta from_2_0_alpha3_to_2_0_beta
+        update_to v2_0_beta from_2_0_alpha3_to_2_0_beta |>
+        update_to v2_0_beta5 from_2_0_beta_to_2_0_beta5
       in
       OpamConsole.msg
         "Update done, please run 'opam update' and retry your command\n";

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -55,9 +55,15 @@ let load lock_kind =
   in
   let config = OpamFile.Config.with_installed_switches switches config in
   let global_variables =
+    List.fold_left (fun acc (v,value) ->
+        OpamVariable.Map.add v (value, "Inferred from system") acc)
+      OpamVariable.Map.empty
+      (OpamSysPoll.variables)
+  in
+  let global_variables =
     List.fold_left (fun acc (v,value,doc) ->
         OpamVariable.Map.add v (lazy (Some value), doc) acc)
-      OpamVariable.Map.empty
+      global_variables
       (OpamFile.Config.global_variables config)
   in
   let eval_variables = OpamFile.Config.eval_variables config in

--- a/src/state/opamPackageVar.ml
+++ b/src/state/opamPackageVar.ml
@@ -22,6 +22,7 @@ let global_variable_names = [
   "jobs",                 "The number of parallel jobs set up in opam \
                            configuration";
   "root",                 "The current opam root directory";
+  "make",                 "The 'make' command to use";
 ]
 
 let package_variable_names = [
@@ -65,6 +66,7 @@ let resolve_global gt full_var =
       | "opam-version"  -> Some (V.string OpamVersion.(to_string current))
       | "jobs"          -> Some (V.int (OpamFile.Config.jobs gt.config))
       | "root"          -> Some (V.string (OpamFilename.Dir.to_string gt.root))
+      | "make"          -> Some (V.string OpamStateConfig.(Lazy.force !r.makecmd))
       | _               -> None
 
 (** Resolve switch-global variables only, as allowed by the 'available:'

--- a/src/state/opamPackageVar.ml
+++ b/src/state/opamPackageVar.ml
@@ -21,7 +21,6 @@ let global_variable_names = [
   "switch",               "The local name (alias) of the current switch";
   "jobs",                 "The number of parallel jobs set up in opam \
                            configuration";
-  "arch",                 "The current arch, as returned by \"uname -m\"";
   "root",                 "The current opam root directory";
 ]
 

--- a/src/state/opamSwitchAction.ml
+++ b/src/state/opamSwitchAction.ml
@@ -26,7 +26,6 @@ let gen_switch_config root ?(synopsis="") ?repos _switch =
        try (Unix.getgrgid (Unix.getgid ())).Unix.gr_name
        with Not_found -> "group");
       ("make" , OpamStateConfig.(Lazy.force !r.makecmd));
-      ("os"   , OpamStd.Sys.os_string ());
     ]
   in
   { OpamFile.Switch_config.

--- a/src/state/opamSwitchAction.ml
+++ b/src/state/opamSwitchAction.ml
@@ -25,7 +25,6 @@ let gen_switch_config root ?(synopsis="") ?repos _switch =
       ("group",
        try (Unix.getgrgid (Unix.getgid ())).Unix.gr_name
        with Not_found -> "group");
-      ("make" , OpamStateConfig.(Lazy.force !r.makecmd));
     ]
   in
   { OpamFile.Switch_config.

--- a/src/state/opamSysPoll.ml
+++ b/src/state/opamSysPoll.ml
@@ -1,0 +1,144 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2017 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+open OpamCompat
+open OpamStd.Option.Op
+
+let command_output c =
+  match List.filter (fun s -> String.trim s <> "")
+          (OpamSystem.read_command_output c)
+  with
+  | [""] -> None
+  | [s] -> Some s
+  | _ -> None
+  | exception (OpamSystem.Process_error _ | OpamSystem.Command_not_found _) ->
+    None
+
+let norm s = if s = "" then None else Some (String.lowercase_ascii s)
+
+let normalise_arch raw =
+  match String.lowercase_ascii raw with
+  | "x86" | "i386" | "i586" | "i686" -> "x86_32"
+  | "x86_64" | "amd64" -> "x86_64"
+  | "powerpc" | "ppc" | "ppcle" -> "ppc32"
+  | "ppc64" | "ppc64le" -> "ppc64"
+  | "aarch64_be" | "aarch64" | "armv8b" | "armv8l" -> "arm64"
+  | a when List.exists (fun prefix -> OpamStd.String.starts_with ~prefix a)
+        ["armv5"; "armv6"; "earmv6"; "armv7"; "earmv7"] -> "arm32"
+  | s -> s
+
+let arch_lazy = lazy (
+  let raw = match Sys.os_type with
+    | "Unix" | "Cygwin" -> OpamStd.Sys.uname "-m"
+    | "Win32" ->
+      (match OpamStd.Env.getopt "PROCESSOR_ARCHITECTURE" with
+       | Some "X86" as a -> OpamStd.Env.getopt "PROCESSOR_ARCHITEW6432" ++ a
+       | arch -> arch)
+    | _ -> None
+  in
+  match raw with
+  | None | Some "" -> None
+  | Some a -> Some (normalise_arch a)
+)
+let arch () = Lazy.force arch_lazy
+
+let os_lazy = lazy (
+  match Sys.os_type with
+  | "Unix" ->
+    (match OpamStd.Sys.uname "-s" with
+      | Some "Darwin" -> Some "macos"
+      | Some s -> norm s
+      | None -> None)
+  | s -> norm s
+)
+let os () = Lazy.force os_lazy
+
+let os_release_field =
+  let os_release_file = lazy (
+    List.find Sys.file_exists ["/etc/os-release"; "/usr/lib/os-release"] |>
+    OpamProcess.read_lines |>
+    List.map (fun s -> Scanf.sscanf s "%s@= %s" (fun x v ->
+        x,
+        try Scanf.sscanf v "\"%s@\"" (fun s -> s)
+        with Scanf.Scan_failure _ -> v))
+  ) in
+  fun f ->
+    OpamStd.Option.of_Not_found (List.assoc f) (Lazy.force os_release_file)
+
+let is_android, android_release =
+  let prop = lazy (command_output ["getprop"; "ro.build.version.release"]) in
+  (fun () -> Lazy.force prop <> None),
+  (fun () -> Lazy.force prop)
+
+let os_distribution_lazy = lazy (
+  match os () with
+  | Some "macos" as macos ->
+    if OpamSystem.resolve_command "brew" <> None then Some "homebrew"
+    else if OpamSystem.resolve_command "port" <> None then Some "macports"
+    else macos
+  | Some "linux" as linux ->
+    (if is_android () then Some "android" else
+     os_release_field "ID" >>= norm >>+ fun () ->
+     command_output ["lsb_release"; "-i"; "-s"] >>= norm >>+ fun () ->
+     try
+       List.find Sys.file_exists ["/etc/redhat-release";
+                                  "/etc/centos-release";
+                                  "/etc/gentoo-release";
+                                  "/etc/issue"] |>
+       fun s -> Scanf.sscanf s " %s " norm
+     with Not_found -> linux)
+  | os -> os
+)
+let os_distribution () = Lazy.force os_distribution_lazy
+
+let os_version_lazy = lazy (
+  match os () with
+  | Some "linux" ->
+    android_release () >>= norm >>+ fun () ->
+    command_output ["lsb_release"; "-s"; "-r"] >>= norm >>+ fun () ->
+    os_release_field "VERSION_ID" >>= norm
+  | Some "macos" ->
+    command_output ["sw_vers"; "-productVersion"] >>= norm
+  | Some ("win32" | "cygwin") ->
+    (try
+       command_output ["cmd"; "/C"; "ver"] >>= fun s ->
+       Scanf.sscanf s "%_s@[ Version %s@]" norm
+     with Scanf.Scan_failure _ -> None)
+  | Some "freebsd" ->
+    OpamStd.Sys.uname "-U" >>= norm
+  | _ ->
+    OpamStd.Sys.uname "-r" >>= norm
+)
+let os_version () = Lazy.force os_version_lazy
+
+let os_family_lazy = lazy (
+  match os () with
+  | Some "linux" ->
+    (os_release_field "ID_LIKE" >>= fun s ->
+     Scanf.sscanf s "%s" norm (* first word *))
+    >>+ os_distribution
+  | Some ("freebsd" | "openbsd" | "netbsd" | "dragonfly") -> Some "bsd"
+  | Some ("win32" | "cygwin") -> Some "windows"
+  | os -> os
+)
+let os_family () = Lazy.force os_family_lazy
+
+let variables =
+  List.map
+    (fun (n, v) ->
+       OpamVariable.of_string n,
+       lazy (Lazy.force v >>| fun v -> OpamTypes.S v))
+    [
+      "arch", arch_lazy;
+      "os", os_lazy;
+      "os-distribution", os_distribution_lazy;
+      "os-version", os_version_lazy;
+      "os-family", os_family_lazy;
+    ]

--- a/src/state/opamSysPoll.mli
+++ b/src/state/opamSysPoll.mli
@@ -1,0 +1,20 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2017 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** This module polls various aspects of the host, to define the [arch], [os],
+    etc. variables *)
+
+val arch: unit -> string option
+val os: unit -> string option
+val os_distribution: unit -> string option
+val os_version: unit -> string option
+val os_family: unit -> string option
+
+val variables: (OpamVariable.t * OpamTypes.variable_contents option Lazy.t) list

--- a/src/tools/opam_installer.ml
+++ b/src/tools/opam_installer.ml
@@ -59,7 +59,7 @@ let do_commands project_root =
       OpamConsole.error "Could not find %S" (OpamFilename.to_string src)
   in
   let cp =
-    if OpamStd.(Sys.os () = Sys.Win32) then
+    if OpamStd.Sys.is_windows then
       fun ?exec ~opt ~src ~dst ->
         let (src, dst) =
           if not (OpamFilename.exists src) then
@@ -85,7 +85,7 @@ let do_commands project_root =
       OpamConsole.warning "%S doesn't exist" (OpamFilename.to_string f)
   in
   let rm =
-    if OpamStd.(Sys.os () = Sys.Win32) then
+    if OpamStd.Sys.is_windows then
       fun ~opt f ->
         let f =
           if OpamFilename.exists f then


### PR DESCRIPTION
This includes definition of the `arch`, `os`, `os-distribution`,
etc. variables, to be used anywhere in packages. The code of
`opam-depext` will also be much simpler, only the interaction with the
host package manager will remain.

Closes #3058