### PR TITLE
Fix universe passed to package actions before removals

### DIFF
--- a/src/solver/opamActionGraph.ml
+++ b/src/solver/opamActionGraph.ml
@@ -134,6 +134,7 @@ module type SIG = sig
   include OpamParallel.GRAPH with type V.t = package OpamTypes.action
   val reduce: t -> t
   val explicit: ?noop_remove:(package -> bool) -> t -> t
+  val fold_descendants: (V.t -> 'a -> 'a) -> 'a -> t -> V.t -> 'a
 end
 
 module Make (A: ACTION) : SIG with type package = A.package = struct
@@ -266,4 +267,9 @@ module Make (A: ACTION) : SIG with type package = A.package = struct
         | `Install _ | `Reinstall _ | `Change _ | `Build _ -> ())
       g;
     g
+
+  let rec fold_descendants f acc t v =
+    fold_succ (fun v acc ->
+        fold_descendants f (f v acc) t v)
+      t v acc
 end

--- a/src/solver/opamActionGraph.mli
+++ b/src/solver/opamActionGraph.mli
@@ -43,7 +43,12 @@ module type SIG = sig
       The argument [noop_remove] is a function that should return `true`
       for package where the `remove` action is known not to modify the
       filesystem (such as `conf-*` package). *)
-  val explicit: ?noop_remove:(package -> bool) -> t -> t end
+  val explicit: ?noop_remove:(package -> bool) -> t -> t
+
+  (** Folds on all recursive successors of the given action, excluding itself,
+      depth-first. Assumes an acyclic graph. *)
+  val fold_descendants: (V.t -> 'a -> 'a) -> 'a -> t -> V.t -> 'a
+end
 
 module Make (A: ACTION) : SIG with type package = A.package
 


### PR DESCRIPTION
packages that were going to be removed weren't passed properly as installed.

This should fix #3079