### PR TITLE
In commands, resolve undefined to "" rather than no argument

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -763,6 +763,9 @@ files.
       detect that the package is not installed from a release tarball, and may
       need additional preprocessing (_e.g._ `automake`).
 
+    If a term is undefined (_e.g._ an undefined variable), the empty string is
+    used as positional argument.
+
 - <a id="opamfield-install">
   `install: [ [ <string> { <filter> } ... ] { <filter> } ... ]`</a>:
   the list of commands that will be run in order to install the package.

--- a/src/format/opamFilter.ml
+++ b/src/format/opamFilter.ml
@@ -426,7 +426,7 @@ let arguments env (a,f) =
       | Some (S s) -> [s]
       | Some (B b) -> [string_of_bool b]
       | Some (L sl) -> sl
-      | None -> log "ERR in replacement: undefined ident %S" i; []
+      | None -> log "ERR in replacement: undefined ident %S" i; [""]
   else
     []
 


### PR DESCRIPTION
After some discussion with @dra27, it seems in general safer to hold the 
positional argument with an empty string rather than shift the possible 
remaining arguments.

So for example, with

    build: ["some-command" foo "bar"]

Previously, if `foo` wasn't defined, that would become `["some-command"
"bar"]`. To avoid that, you had to use a string interpolation such as:

    build: ["some-command" "%{foo}%" "bar"]

which is a little heavy under the fingers. With this patch, the behaviour
would be the same.

Obtaining the previous behaviour is still possible by using an explicit 
filter:

    build: ["some-command" foo {?foo} "bar"]

which makes it explicit that the positional argument might be present or not