### PR TITLE
This implements #3102, globally providing plugins for convenience

### DIFF
--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -224,7 +224,11 @@ let move ~src ~dst =
 
 let readlink src =
   if exists src then
-    try of_string (Unix.readlink (to_string src))
+    try
+      let rl = Unix.readlink (to_string src) in
+      if Filename.is_relative rl then
+        of_string (Filename.concat (dirname src) rl)
+      else of_string rl
     with Unix.Unix_error _ -> src
   else
     OpamSystem.internal_error "%s does not exist." (to_string src)

--- a/src/format/opamPath.ml
+++ b/src/format/opamPath.ml
@@ -55,6 +55,23 @@ let backup_dir t = t / "backup"
 
 let backup t = backup_dir t /- backup_file ()
 
+let plugins t = t / "plugins"
+
+let plugins_bin t = plugins t / "bin"
+
+let plugin_bin t name =
+  let sname = OpamPackage.Name.to_string name in
+  let basename =
+    if OpamStd.String.starts_with ~prefix:"opam-" sname then sname
+    else "opam-" ^ sname
+  in
+  plugins_bin t // basename
+
+let plugin t name =
+  let sname = OpamPackage.Name.to_string name in
+  assert (sname <> "bin");
+  plugins t / sname
+
 module Switch = struct
 
   let root t a = OpamSwitch.get_root t a

--- a/src/format/opamPath.mli
+++ b/src/format/opamPath.mli
@@ -61,6 +61,20 @@ val backup_dir: t -> dirname
 (** Backup file for state export *)
 val backup: t -> switch_selections OpamFile.t
 
+(** The directory for plugins data {i $opam/plugins} *)
+val plugins: t -> dirname
+
+(** The directory for shared plugin binaries {i $opam/plugins/bin} *)
+val plugins_bin: t -> dirname
+
+(** The globally installed binary of the given plugin {i
+    $opam/plugins/bin/opam-foo} *)
+val plugin_bin: t -> name -> filename
+
+(** The directory for a given plugin's data {i $opam/plugins/$name}. ["bin"] is
+    forbidden. *)
+val plugin: t -> name -> dirname
+
 (** Switch related paths *)
 module Switch: sig
 

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -236,9 +236,9 @@ let updates ~opamswitch ?force_path st =
     else [] in
   switch @ update
 
-let get_pure () =
+let get_pure ?(updates=[]) () =
   let env = List.map (fun (v,va) -> v,va,None) (OpamStd.Env.list ()) in
-  add env []
+  add env updates
 
 (* This function is used by 'opam config env' and 'opam switch' to
    display the environment variables. We have to make sure that
@@ -301,9 +301,9 @@ let path ~force_path root switch =
   let (_, path_value, _) = List.find (fun (v, _, _) -> v = "PATH") env in
   path_value
 
-let full_with_path ~force_path root switch =
+let full_with_path ~force_path ?(updates=[]) root switch =
   let env0 = List.map (fun (v,va) -> v,va,None) (OpamStd.Env.list ()) in
-  add env0 (switch_path_update ~force_path root switch)
+  add env0 (switch_path_update ~force_path root switch @ updates)
 
 let is_up_to_date st =
   let opamswitch =

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -27,8 +27,9 @@ val get_full:
     to ensure opam dirs are leading. *)
 val get_opam: force_path:bool -> 'a switch_state -> env
 
-(** Returns the running environment, with any opam modifications cleaned out *)
-val get_pure: unit -> env
+(** Returns the running environment, with any opam modifications cleaned out,
+    and optionally the given updates *)
+val get_pure: ?updates:env_update list -> unit -> env
 
 (** Update an environment, including reverting opam changes that could have been
     previously applied (therefore, don't apply to an already updated env as
@@ -57,7 +58,8 @@ val path: force_path:bool -> dirname -> switch -> string
 
 (** Returns the full environment with only the PATH variable updated, as per
     [path] *)
-val full_with_path: force_path:bool -> dirname -> switch -> env
+val full_with_path:
+  force_path:bool -> ?updates:env_update list -> dirname -> switch -> env
 
 (** {2 Shell and initialisation support} *)
 


### PR DESCRIPTION
i.e. making the latest installed instance of the plugin available
across switches (an existing instance from the current switch still
prevails).

This is simply done through a symlink in ~/.opam/plugins/bin, which is
removed on uninstall.