### PR TITLE
opam-list: explain in man why some listed packages are underlined

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -319,8 +319,8 @@ let list ?(force_search=false) () =
     `P "Unless the $(b,--short) switch is used, the output format displays one \
         package per line, and each line contains the name of the package, the \
         installed version or `--' if the package is not installed, and a short \
-        description. In color mode, root packages (e.g., manually installed) \
-        are underlined.";
+        description. In color mode, manually installed packages (as opposed to \
+        automatically installed ones because of dependencies) are underlined.";
     `P ("See section $(b,"^selection_docs^") for all the ways to select the \
          packages to be displayed, and section $(b,"^display_docs^") to \
          customise the output format.");

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -316,6 +316,11 @@ let list ?(force_search=false) () =
     `P "Without argument, the command displays the list of currently installed \
         packages. With pattern arguments, lists all available packages \
         matching one of the patterns.";
+    `P "Unless the $(b,--short) switch is used, the output format displays one \
+        package per line, and each line contains the name of the package, the \
+        installed version or `--' if the package is not installed, and a short \
+        description. In color mode, root packages (e.g., manually installed) \
+        are underlined.";
     `P ("See section $(b,"^selection_docs^") for all the ways to select the \
          packages to be displayed, and section $(b,"^display_docs^") to \
          customise the output format.");


### PR DESCRIPTION
In the 1.2.2 manual, `opam help list` held the following:

    DESCRIPTION
       This command displays the list of installed packages when called
       without argument, or the list of available packages matching the given
       pattern.

       Unless the --short switch is used, the output format displays one
       package per line, and each line contains the name of the package, the
       installed version or -- if the package is not installed, and a short
       description. In color mode, root packages (eg. manually installed) are
       underlined.

In opam 2.0, the underlined mention has disappeared:

    DESCRIPTION
       List selections of opam packages.

       Without argument, the command displays the list of currently installed
       packages. With pattern arguments, lists all available packages matching
       one of the patterns.

       See section PACKAGE SELECTION OPTIONS for all the ways to select the
       packages to be displayed, and section OUTPUT FORMAT OPTIONS to
       customise the output format.

I propose to re-add the explanation for the underlined packages (as you wish, of course!).