### PR TITLE
install.sh: Fix use of "du" to always use -k

### DIFF
--- a/shell/install.sh
+++ b/shell/install.sh
@@ -209,7 +209,7 @@ if [ -d "$OPAMROOT" ]; then
             echo "Please move it away or run with --no-backup"
         fi
         FREE=$(df -k "$OPAMROOT" | awk 'NR>1 {print $4}')
-        NEEDED=$(du -s "$OPAMROOT" | awk '{print $1}')
+        NEEDED=$(du -sk "$OPAMROOT" | awk '{print $1}')
         if ! [ $NEEDED -lt $FREE ]; then
             echo "Error: not enough free space to backup. You can retry with --no-backup,"
             echo "--fresh, or remove '$OPAMROOT'"


### PR DESCRIPTION
Fixes the case where on some systems "du" prints the summary with the
unit (K) appended, causing an error like the following:

    ./install.sh: 213: [: Illegal number: 6593020K