### PR TITLE
Ensure ocamlfind is from a compatible installation

### DIFF
--- a/configure
+++ b/configure
@@ -604,6 +604,7 @@ LN_S
 JBUILDER
 FETCH
 OCAMLFIND
+OCAMLOBJINFO
 PATH_PREPEND
 EXE
 WIN32
@@ -3828,6 +3829,100 @@ $as_echo "$PATH_PREPEND_RESULT" >&6; }
 
 fi
 
+  if test -n "$ac_tool_prefix"; then
+  # Extract the first word of "${ac_tool_prefix}ocamlobjinfo", so it can be a program name with args.
+set dummy ${ac_tool_prefix}ocamlobjinfo; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_OCAMLOBJINFO+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$OCAMLOBJINFO"; then
+  ac_cv_prog_OCAMLOBJINFO="$OCAMLOBJINFO" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_OCAMLOBJINFO="${ac_tool_prefix}ocamlobjinfo"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+OCAMLOBJINFO=$ac_cv_prog_OCAMLOBJINFO
+if test -n "$OCAMLOBJINFO"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OCAMLOBJINFO" >&5
+$as_echo "$OCAMLOBJINFO" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+fi
+if test -z "$ac_cv_prog_OCAMLOBJINFO"; then
+  ac_ct_OCAMLOBJINFO=$OCAMLOBJINFO
+  # Extract the first word of "ocamlobjinfo", so it can be a program name with args.
+set dummy ocamlobjinfo; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_OCAMLOBJINFO+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$ac_ct_OCAMLOBJINFO"; then
+  ac_cv_prog_ac_ct_OCAMLOBJINFO="$ac_ct_OCAMLOBJINFO" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_ac_ct_OCAMLOBJINFO="ocamlobjinfo"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+ac_ct_OCAMLOBJINFO=$ac_cv_prog_ac_ct_OCAMLOBJINFO
+if test -n "$ac_ct_OCAMLOBJINFO"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_OCAMLOBJINFO" >&5
+$as_echo "$ac_ct_OCAMLOBJINFO" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+  if test "x$ac_ct_OCAMLOBJINFO" = x; then
+    OCAMLOBJINFO="no"
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    OCAMLOBJINFO=$ac_ct_OCAMLOBJINFO
+  fi
+else
+  OCAMLOBJINFO="$ac_cv_prog_OCAMLOBJINFO"
+fi
+
+
+
 
   # checking for ocamlfind
   if test -n "$ac_tool_prefix"; then
@@ -3922,6 +4017,24 @@ else
   OCAMLFIND="$ac_cv_prog_OCAMLFIND"
 fi
 
+  if test "$OCAMLFIND" != "no"; then :
+
+    if test "$OCAMLOBJINFO" = "no"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: ocamlobjinfo not found; cannot verify ocamlfind" >&5
+$as_echo "$as_me: WARNING: ocamlobjinfo not found; cannot verify ocamlfind" >&2;}
+else
+
+      if ! $OCAMLOBJINFO `$OCAMLFIND query -predicates byte -a-format findlib | tr -d '\015'` > /dev/null 2>&1; then :
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: site-lib is for a different version of OCaml; ocamlfind discarded." >&5
+$as_echo "site-lib is for a different version of OCaml; ocamlfind discarded." >&6; }
+        OCAMLFIND=no
+
+fi
+
+fi
+
+fi
 
 
 

--- a/m4/ocaml.m4
+++ b/m4/ocaml.m4
@@ -171,13 +171,27 @@ AC_DEFUN([AC_PROG_CAMLP4],
   AC_SUBST([CAMLP4RF])
 ])
 
+AC_DEFUN([AC_PROG_OCAMLOBJINFO],
+[dnl
+  AC_CHECK_TOOL([OCAMLOBJINFO],[ocamlobjinfo],[no])
+  AC_SUBST([OCAMLOBJINFO])
+])
 
 AC_DEFUN([AC_PROG_FINDLIB],
 [dnl
   AC_REQUIRE([AC_PROG_OCAML])dnl
+  AC_REQUIRE([AC_PROG_OCAMLOBJINFO])dnl
 
   # checking for ocamlfind
   AC_CHECK_TOOL([OCAMLFIND],[ocamlfind],[no])
+  AS_IF([test "$OCAMLFIND" != "no"],[
+    AS_IF([test "$OCAMLOBJINFO" = "no"],[AC_MSG_WARN([ocamlobjinfo not found; cannot verify ocamlfind])],[
+      AS_IF([! $OCAMLOBJINFO `$OCAMLFIND query -predicates byte -a-format findlib | tr -d '\015'` > /dev/null 2>&1],[
+        AC_MSG_RESULT([site-lib is for a different version of OCaml; ocamlfind discarded.])
+        OCAMLFIND=no
+      ])
+    ])
+  ])
   AC_SUBST([OCAMLFIND])
 ])
 


### PR DESCRIPTION
A minor niggle, but rather annoying doing the Windows testing when configure picks up another installation's ocamlfind and assumes there are working packages!

The changes are prepared for upstream in https://github.com/dra27/ocaml-autoconf/tree/various-improvements and noted on [the OCaml Forge](https://forge.ocamlcore.org/tracker/index.php?func=detail&aid=1471&group_id=69&atid=363), but ocaml-autoconf isn't very actively maintained.