### PR TITLE
Fix the format upgrade of filters mentionning the 'os' variable

### DIFF
--- a/src/client/opamAdminRepoUpgrade.ml
+++ b/src/client/opamAdminRepoUpgrade.ml
@@ -194,6 +194,7 @@ let do_upgrade repo_root =
       *)
 
       let opam = OpamFile.Comp.to_package ~package:nv comp descr in
+      let opam = OpamFormatUpgrade.opam_file_from_1_2_to_2_0 opam in
       let opam = O.with_conflict_class [ocaml_conflict_class] opam in
       let opam =
         match OpamFile.OPAM.url opam with

--- a/src/state/opamFileTools.mli
+++ b/src/state/opamFileTools.mli
@@ -53,3 +53,6 @@ val add_aux_files:
 (** {2 Tools to manipulate the [OpamFile.OPAM.t] contents} *)
 val map_all_variables:
   (full_variable -> full_variable) -> OpamFile.OPAM.t -> OpamFile.OPAM.t
+
+val map_all_filters:
+  (filter -> filter) -> OpamFile.OPAM.t -> OpamFile.OPAM.t


### PR DESCRIPTION
when that variable refers to `darwin` (or `osx`, which was probably a
mistake, but there are some occurences)

Closes #3148