### PR TITLE
Disable caching in OpamSystem.resolve_command

### DIFF
--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -369,21 +369,8 @@ let resolve_command =
       | _ -> None
     else None
   in
-  let cached_results = Hashtbl.create 17 in
   fun ?(env=default_env) ?dir name ->
-    if dir <> None && is_external_cmd name && Filename.is_relative name then
-      resolve env ?dir name (* no caching *)
-    else
-    let path = env_var env "PATH" in
-    try Hashtbl.find (Hashtbl.find cached_results path) name
-    with Not_found ->
-      let r = resolve env ?dir name in
-      (try Hashtbl.add (Hashtbl.find cached_results path) name r
-       with Not_found ->
-         let phash = Hashtbl.create 17 in
-         Hashtbl.add phash name r;
-         Hashtbl.add cached_results path phash);
-      r
+    resolve env ?dir name
 
 let runs = ref []
 let print_stats () =


### PR DESCRIPTION
`OpamSystem.resolve_command` caches results. This cannot work - the ocamlfind package, for example, installs an `ocaml` script which is intended to wrap the system-installed `ocaml` command. This script is not invoked if `ocaml` has been previously executed, because the path to the system-installed `ocaml` command is cached.

There are various shims which could mitigate this for opam-installed binaries/scripts only, but it seems better just not to cache the results at all.
