### PR TITLE
Add some handling to preserve backtraces through wrappers on OCaml 4.05+

### DIFF
--- a/shell/context_flags.ml
+++ b/shell/context_flags.ml
@@ -15,8 +15,10 @@ match Sys.argv.(1) with
     exit 1
   end else if ocaml_major = 4 && ocaml_minor < 3 then
     Printf.printf "4.0%d" ocaml_minor
-  else if ocaml_major = 4 && ocaml_minor < 6 then
+  else if ocaml_major = 4 && ocaml_minor < 5 then
     Printf.printf "4.03"
+  else if ocaml_major = 4 && ocaml_minor < 6 then
+    Printf.printf "4.05"
   else
     Printf.printf "4.06"
 | _ ->

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -671,10 +671,9 @@ let init
         gt, OpamRepositoryState.unlock rt,
         OpamFile.InitConfig.default_compiler init_config
       with e ->
-        OpamStd.Exn.register_backtrace e;
+        OpamStd.Exn.finalise e @@ fun () ->
         if not (OpamConsole.debug ()) && root_empty then
-          OpamFilename.rmdir root;
-        raise e)
+          OpamFilename.rmdir root)
   in
   let _updated = match update_config with
     | `no  -> false

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -299,13 +299,13 @@ let install gt ?rt ?synopsis ?repos ~update_config ~packages switch =
   let packages =
     try OpamSolution.sanitize_atom_list st packages
     with e ->
+      OpamStd.Exn.finalise e @@ fun () ->
       if update_config then
         (OpamEnv.clear_dynamic_init_scripts gt;
          OpamStd.Option.iter
            (ignore @* OpamSwitchAction.set_current_switch `Lock_write gt)
            old_switch_opt);
-      ignore (clear_switch gt switch);
-      raise e
+      ignore (clear_switch gt switch)
   in
   let gt = OpamGlobalState.unlock gt in
   try

--- a/src/core/jbuild
+++ b/src/core/jbuild
@@ -15,12 +15,12 @@
 
 (rule
   ((targets (opamCompat.ml))
-   (deps (opamCompat.ml.4.01 opamCompat.ml.4.02 opamCompat.ml.4.03 opamCompat.ml.4.06))
+   (deps (opamCompat.ml.4.01 opamCompat.ml.4.02 opamCompat.ml.4.03 opamCompat.ml.4.05 opamCompat.ml.4.06))
    (action (copy ${@}.${read:ocaml-compat.sexp} ${@}))))
 
 (rule
   ((targets (opamCompat.mli))
-   (deps (opamCompat.mli.4.01 opamCompat.mli.4.02 opamCompat.mli.4.03 opamCompat.ml.4.06))
+   (deps (opamCompat.mli.4.01 opamCompat.mli.4.02 opamCompat.mli.4.03 opamCompat.ml.4.05 opamCompat.ml.4.06))
    (action (copy ${@}.${read:ocaml-compat.sexp} ${@}))))
 
 (rule

--- a/src/core/opamCompat.ml.4.01
+++ b/src/core/opamCompat.ml.4.01
@@ -41,6 +41,11 @@ module Filename = struct
   let get_temp_dir_name () = temp_dir_name
 end
 
+module Printexc = struct
+  include Printexc
+  let raise_with_backtrace e _bt = raise e
+end
+
 module Unix = struct
   include Unix
 

--- a/src/core/opamCompat.ml.4.02
+++ b/src/core/opamCompat.ml.4.02
@@ -24,6 +24,11 @@ module Char = struct
   let lowercase_ascii = lowercase
 end
 
+module Printexc = struct
+  include Printexc
+  let raise_with_backtrace e _bt = raise e
+end
+
 module Unix = struct
   include Unix
 

--- a/src/core/opamCompat.ml.4.03
+++ b/src/core/opamCompat.ml.4.03
@@ -14,6 +14,11 @@ module Filename = Filename
 module String = String
 module Char = Char
 
+module Printexc = struct
+  include Printexc
+  let raise_with_backtrace e _bt = raise e
+end
+
 module Unix = struct
   include Unix
 

--- a/src/core/opamCompat.ml.4.05
+++ b/src/core/opamCompat.ml.4.05
@@ -1,6 +1,6 @@
 (**************************************************************************)
 (*                                                                        *)
-(*    Copyright 2018 OCamlPro                                             *)
+(*    Copyright 2014 OCamlPro                                             *)
 (*                                                                        *)
 (*  All rights reserved. This file is distributed under the terms of the  *)
 (*  GNU Lesser General Public License version 2.1, with the special       *)
@@ -8,12 +8,15 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Compatibility layer (Bytes, etc.) for different OCaml versions *)
-
 module Bytes = Bytes
 module Buffer = Buffer
 module Filename = Filename
 module String = String
 module Char = Char
 module Printexc = Printexc
-module Unix = Unix
+
+module Unix = struct
+  include Unix
+
+  let map_file = Bigarray.Genarray.map_file
+end

--- a/src/core/opamCompat.ml.4.06
+++ b/src/core/opamCompat.ml.4.06
@@ -13,4 +13,5 @@ module Buffer = Buffer
 module Filename = Filename
 module String = String
 module Char = Char
+module Printexc = Printexc
 module Unix = Unix

--- a/src/core/opamCompat.mli.4.01
+++ b/src/core/opamCompat.mli.4.01
@@ -43,6 +43,11 @@ module Filename : sig
   val get_temp_dir_name : unit -> string
 end
 
+module Printexc : sig
+  include module type of Printexc
+  val raise_with_backtrace: exn -> raw_backtrace -> 'a
+end
+
 module Unix : sig
   include module type of Unix
   val map_file : Unix.file_descr -> ?pos:int64 -> ('a, 'b) Bigarray.kind ->

--- a/src/core/opamCompat.mli.4.02
+++ b/src/core/opamCompat.mli.4.02
@@ -26,6 +26,11 @@ module Char : sig
   val lowercase_ascii: char -> char
 end
 
+module Printexc : sig
+  include module type of Printexc
+  val raise_with_backtrace: exn -> raw_backtrace -> 'a
+end
+
 module Unix : sig
   include module type of Unix
   val map_file : Unix.file_descr -> ?pos:int64 -> ('a, 'b) Bigarray.kind ->

--- a/src/core/opamCompat.mli.4.03
+++ b/src/core/opamCompat.mli.4.03
@@ -16,6 +16,11 @@ module Filename = Filename
 module String = String
 module Char = Char
 
+module Printexc : sig
+  include module type of Printexc
+  val raise_with_backtrace: exn -> raw_backtrace -> 'a
+end
+
 module Unix : sig
   include module type of Unix
   val map_file : Unix.file_descr -> ?pos:int64 -> ('a, 'b) Bigarray.kind ->

--- a/src/core/opamCompat.mli.4.05
+++ b/src/core/opamCompat.mli.4.05
@@ -1,6 +1,6 @@
 (**************************************************************************)
 (*                                                                        *)
-(*    Copyright 2018 OCamlPro                                             *)
+(*    Copyright 2016 OCamlPro                                             *)
 (*                                                                        *)
 (*  All rights reserved. This file is distributed under the terms of the  *)
 (*  GNU Lesser General Public License version 2.1, with the special       *)
@@ -16,4 +16,10 @@ module Filename = Filename
 module String = String
 module Char = Char
 module Printexc = Printexc
-module Unix = Unix
+
+module Unix : sig
+  include module type of Unix
+  val map_file : Unix.file_descr -> ?pos:int64 -> ('a, 'b) Bigarray.kind ->
+                 'c Bigarray.layout -> bool -> int array ->
+                 ('a, 'b, 'c) Bigarray.Genarray.t
+end

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -362,9 +362,8 @@ let with_flock flag ?dontblock file f =
     OpamSystem.funlock lock;
     r
   with e ->
-    OpamStd.Exn.register_backtrace e;
-    OpamSystem.funlock lock;
-    raise e
+    OpamStd.Exn.finalise e @@ fun () ->
+    OpamSystem.funlock lock
 
 let with_flock_upgrade flag ?dontblock lock f =
   if OpamSystem.lock_isatleast flag lock then f ()
@@ -376,9 +375,8 @@ let with_flock_upgrade flag ?dontblock lock f =
       OpamSystem.flock_update old_flag lock;
       r
     with e ->
-      OpamStd.Exn.register_backtrace e;
-      OpamSystem.flock_update old_flag lock;
-      raise e
+      OpamStd.Exn.finalise e @@ fun () ->
+      OpamSystem.flock_update old_flag lock
   )
 
 let with_flock_write_then_read ?dontblock file write read =
@@ -390,9 +388,8 @@ let with_flock_write_then_read ?dontblock file write read =
     OpamSystem.funlock lock;
     r
   with e ->
-    OpamStd.Exn.register_backtrace e;
-    OpamSystem.funlock lock;
-    raise e
+    OpamStd.Exn.finalise e @@ fun () ->
+    OpamSystem.funlock lock
 
 let prettify_path s =
   let aux ~short ~prefix =

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1060,6 +1060,11 @@ module Exn = struct
       in
       Printf.sprintf "Backtrace:\n%s" b
 
+  let finalise e f =
+    let bt = Printexc.get_raw_backtrace () in
+    f ();
+    Printexc.raise_with_backtrace e bt
+
 end
 
 

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -293,7 +293,7 @@ module Exn : sig
   (** To use when catching default exceptions: ensures we don't catch fatal errors
       like C-c. try-with should _always_ (by decreasing order of preference):
       - either catch specific exceptions
-      - or re-raise the same exception
+      - or re-raise the same exception (preferably with [Exn.finalise])
       - or call this function on the caught exception *)
   val fatal: exn -> unit
 
@@ -304,6 +304,10 @@ module Exn : sig
 
   (** Return a pretty-printed backtrace *)
   val pretty_backtrace: exn -> string
+
+  (** Runs the given finaliser, then reraises the given exception, while
+      preserving backtraces (when the OCaml version permits, e.g. >= 4.05.0) *)
+  val finalise: exn -> (unit -> unit) -> 'a
 
 end
 

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -186,8 +186,7 @@ let in_dir dir fn =
     reset_cwd ();
     r
   with e ->
-    reset_cwd ();
-    raise e
+    OpamStd.Exn.finalise e reset_cwd
 
 let list kind dir =
   try
@@ -244,8 +243,8 @@ let with_tmp_dir fn =
     remove_dir dir;
     e
   with e ->
-    remove_dir dir;
-    raise e
+    OpamStd.Exn.finalise e @@ fun () ->
+    remove_dir dir
 
 let with_tmp_dir_job fjob =
   let dir = mk_temp_dir () in

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -115,7 +115,9 @@ module MakeIO (F : IO_Arg) = struct
       close_out oc;
       Stats.write_files := filename :: !Stats.write_files;
       log "Wrote %s in %.3fs" filename (chrono ())
-    with e -> close_out oc; OpamFilename.remove f; raise e
+    with e ->
+      OpamStd.Exn.finalise e @@ fun () ->
+      close_out oc; OpamFilename.remove f
 
   let read_opt f =
     let filename = OpamFilename.prettify f in
@@ -129,7 +131,7 @@ module MakeIO (F : IO_Arg) = struct
         close_in ic;
         log ~level:3 "Read %s in %.3fs" filename (chrono ());
         Some r
-      with e -> close_in ic; raise e
+      with e -> OpamStd.Exn.finalise e (fun () -> close_in ic)
     with
     | OpamSystem.File_not_found _ ->
       None

--- a/src/format/opamPp.ml
+++ b/src/format/opamPp.ml
@@ -228,8 +228,9 @@ let fallback pp1 pp2 =
   let parse ~pos x =
     try pp1.parse ~pos x with e ->
       OpamStd.Exn.fatal e;
+      let bt = Printexc.get_raw_backtrace () in
       try pp2.parse ~pos x with _ ->
-        raise e
+        Printexc.raise_with_backtrace e bt
   in
   { pp1 with parse }
 

--- a/src/solver/opamCudfSolver.ml
+++ b/src/solver/opamCudfSolver.ml
@@ -73,10 +73,9 @@ let call_external_solver command ~criteria ?timeout (_, universe,_ as cudf) =
     OpamFilename.remove solver_out;
     r
   with e ->
+    OpamStd.Exn.finalise e @@ fun () ->
     OpamFilename.remove solver_in;
-    OpamFilename.remove solver_out;
-    raise e
-
+    OpamFilename.remove solver_out
 
 module External (E: ExternalArg) : S = struct
   let name = E.name

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -147,7 +147,7 @@ let with_write_lock ?dontblock gt f =
 let with_ lock f =
   let gt = load lock in
   try let r = f gt in ignore (unlock gt); r
-  with e -> ignore (unlock gt); raise e
+  with e -> OpamStd.Exn.finalise e (fun () -> ignore (unlock gt))
 
 let write gt =
   OpamFile.Config.write (OpamPath.config gt.root) gt.config

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -263,7 +263,7 @@ let with_write_lock ?dontblock rt f =
 let with_ lock gt f =
   let rt = load lock gt in
   try let r = f rt in ignore (unlock rt); r
-  with e -> ignore (unlock rt); raise e
+  with e -> OpamStd.Exn.finalise e (fun () -> ignore (unlock rt))
 
 let write_config rt =
   OpamFile.Repos_config.write (OpamPath.repos_config rt.repos_global.root)

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -791,9 +791,9 @@ let with_ lock ?rt ?(switch=OpamStateConfig.get_switch ()) gt f =
   let cleanup_backup = do_backup lock st in
   try let r = f st in ignore (unlock st); cleanup_backup true; r
   with e ->
+    OpamStd.Exn.finalise e @@ fun () ->
     ignore (unlock st);
-    if not OpamCoreConfig.(!r.keep_log_dir) then cleanup_backup false;
-    raise e
+    if not OpamCoreConfig.(!r.keep_log_dir) then cleanup_backup false
 
 let update_repositories gt update_fun switch =
   OpamFilename.with_flock `Lock_write (OpamPath.Switch.lock gt.root switch)


### PR DESCRIPTION
This should finally enable us to get usable backtraces without hacks!