### PR TITLE
Make `version-lag` cubic

### DIFF
--- a/src/solver/opamCudf.mli
+++ b/src/solver/opamCudf.mli
@@ -164,7 +164,7 @@ val s_installed_root: string
 (** true if the package is pinned to this version *)
 val s_pinned: string
 
-(** the number of versions of the package since this one*)
+(** the number of versions of the package since this one, cubed *)
 val s_version_lag: string
 
 (** {2 Pretty-printing} *)

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -185,7 +185,8 @@ let opam2cudf universe ?(depopts=false) ~build ~post version_map package =
         (fun v (i,r) -> if v = version then i,i else i+1, r)
         all_versions (0,0)
     in
-    count - i
+    let linear_lag = (count - i) in
+    linear_lag * linear_lag * linear_lag
   in
   let extras =
     let e = [


### PR DESCRIPTION
This helps the solver a lot by penalising older versions more (and thus
making the decision of which package to roll back easier), and solves,
albeit not by a large margin, #3161.