### PR TITLE
RFC: allow recursive lookup of opam files for  `opam pin .`

### DIFF
--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -137,9 +137,12 @@ let resolve_locals_pinned st atom_or_local_list =
   let pinned_packages_of_dir st dir =
     OpamPackage.Set.filter
       (fun nv ->
-         OpamStd.Option.Op.(OpamSwitchState.primary_url st nv >>=
-                            OpamUrl.local_dir)
-         = Some dir)
+         match
+           OpamStd.Option.Op.(OpamSwitchState.primary_url_with_subpath st nv >>=
+                              OpamUrl.local_dir)
+         with
+         | None -> false
+         | Some suburl -> OpamFilename.dir_starts_with ~prefix:dir suburl)
       st.pinned
   in
   let atoms =

--- a/src/client/opamAuxCommands.mli
+++ b/src/client/opamAuxCommands.mli
@@ -40,9 +40,9 @@ val name_and_dir_of_opam_file: filename -> name option * dirname
     If [locked], the [*.locked] counterparts of opam files are used if present.
 *)
 val resolve_locals:
-  ?quiet:bool -> ?locked:bool ->
+  ?quiet:bool -> ?locked:bool -> ?recurse:bool ->
   [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
-  (name * OpamUrl.t * OpamFile.OPAM.t OpamFile.t) list * atom list
+  (name * OpamUrl.t * string option * OpamFile.OPAM.t OpamFile.t) list * atom list
 
 (** Resolves the opam files and directories in the list to package name and
     location, according to what is currently pinned, and returns the
@@ -72,6 +72,7 @@ val autopin:
   ?simulate:bool ->
   ?quiet:bool ->
   ?locked:bool ->
+  ?recurse:bool ->
   [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
   rw switch_state * atom list
 
@@ -81,6 +82,7 @@ val simulate_autopin:
   'a switch_state ->
   ?quiet:bool ->
   ?locked:bool ->
+  ?recurse:bool ->
   [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
   'a switch_state * atom list
 
@@ -92,4 +94,5 @@ val simulate_autopin:
 val get_compatible_compiler:
   ?repos:repository_name list ->
   ?locked:bool ->
+  ?recurse:bool ->
   'a repos_state -> dirname -> atom list

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -455,11 +455,16 @@ let update
              let cache_url =
                OpamUrl.of_string (OpamFilename.Dir.to_string src_cache)
              in
-             match OpamSwitchState.primary_url st nv with
-             | Some { OpamUrl.backend = #OpamUrl.version_control as vc; _ } ->
-               OpamProcess.Job.run @@
-               OpamRepository.is_dirty { cache_url with OpamUrl.backend = vc }
-             | _ -> false)
+             match OpamSwitchState.url st nv  with
+             | None -> false
+             | Some urlf ->
+               match OpamFile.URL.url urlf with
+               | { OpamUrl.backend = #OpamUrl.version_control as vc; _ } ->
+                 let subpath = OpamFile.URL.subpath urlf in
+                 OpamProcess.Job.run @@
+                 OpamRepository.is_dirty ?subpath
+                   { cache_url with OpamUrl.backend = vc }
+               | _ -> false)
           dev_packages
     in
     OpamPackage.Set.iter (fun nv ->

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -124,14 +124,17 @@ let get_installed_atoms t atoms =
 
 (* Check atoms for pinned packages, and update them. Returns the state that
    may have been reloaded if there were changes *)
-let update_dev_packages_t atoms t =
+let update_dev_packages_t ?(only_installed=false) atoms t =
   if OpamClientConfig.(!r.skip_dev_update) then t else
   let working_dir = OpamClientConfig.(!r.working_dir) in
   let to_update =
     List.fold_left (fun to_update (name,_) ->
         try
           let nv = OpamPackage.package_of_name t.pinned name in
-          if OpamSwitchState.is_dev_package t nv then
+          if OpamSwitchState.is_dev_package t nv &&
+             ( not only_installed ||
+               OpamPackage.Set.exists (fun nv -> nv.name = name) t.installed )
+          then
             OpamPackage.Set.add nv to_update
           else to_update
         with Not_found -> to_update)
@@ -155,7 +158,8 @@ let update_dev_packages_t atoms t =
   )
 
 let compute_upgrade_t
-    ?(strict_upgrade=true) ?(auto_install=false) ~all atoms t =
+    ?(strict_upgrade=true) ?(auto_install=false) ?(only_installed=false)
+    ~all atoms t =
   let names = OpamPackage.Name.Set.of_list (List.rev_map fst atoms) in
   let atoms =
     List.map (function
@@ -189,7 +193,7 @@ let compute_upgrade_t
           packages, atom :: not_installed)
       (OpamPackage.Set.empty,[]) atoms in
   let to_install =
-    if not_installed = [] then [] else
+    if only_installed || not_installed = [] then [] else
     if auto_install ||
        OpamConsole.confirm "%s %s not installed. Install %s ?"
          (OpamStd.Format.pretty_list
@@ -236,11 +240,11 @@ let compute_upgrade_t
        ~upgrade:upgrade_atoms
        ())
 
-let upgrade_t ?strict_upgrade ?auto_install ?ask ?(check=false) ~all atoms t =
+let upgrade_t ?strict_upgrade ?auto_install ?ask ?(check=false) ?only_installed ~all atoms t =
   log "UPGRADE %a"
     (slog @@ function [] -> "<all>" | a -> OpamFormula.string_of_atoms a)
     atoms;
-  match compute_upgrade_t ?strict_upgrade ?auto_install ~all atoms t with
+  match compute_upgrade_t ?strict_upgrade ?auto_install ?only_installed ~all atoms t with
   | requested, Conflicts cs ->
     log "conflict!";
     if not (OpamPackage.Name.Set.is_empty requested) then
@@ -331,10 +335,10 @@ let upgrade_t ?strict_upgrade ?auto_install ?ask ?(check=false) ~all atoms t =
     OpamSolution.check_solution t result;
     t
 
-let upgrade t ?check ~all names =
+let upgrade t ?check ?only_installed ~all names =
   let atoms = OpamSolution.sanitize_atom_list t names in
-  let t = update_dev_packages_t atoms t in
-  upgrade_t ?check ~strict_upgrade:(not all) ~all atoms t
+  let t = update_dev_packages_t ?only_installed atoms t in
+  upgrade_t ?check ~strict_upgrade:(not all) ?only_installed ~all atoms t
 
 let fixup t =
   log "FIXUP";
@@ -455,16 +459,11 @@ let update
              let cache_url =
                OpamUrl.of_string (OpamFilename.Dir.to_string src_cache)
              in
-             match OpamSwitchState.url st nv  with
-             | None -> false
-             | Some urlf ->
-               match OpamFile.URL.url urlf with
-               | { OpamUrl.backend = #OpamUrl.version_control as vc; _ } ->
-                 let subpath = OpamFile.URL.subpath urlf in
-                 OpamProcess.Job.run @@
-                 OpamRepository.is_dirty ?subpath
-                   { cache_url with OpamUrl.backend = vc }
-               | _ -> false)
+             match OpamSwitchState.primary_url st nv with
+             | Some { OpamUrl.backend = #OpamUrl.version_control as vc; _ } ->
+               OpamProcess.Job.run @@
+               OpamRepository.is_dirty { cache_url with OpamUrl.backend = vc }
+             | _ -> false)
           dev_packages
     in
     OpamPackage.Set.iter (fun nv ->

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -62,12 +62,15 @@ val update:
     versions. The specified atoms are kept installed (or newly installed after a
     confirmation). The upgrade concerns them only unless [all] is specified. *)
 val upgrade:
-  rw switch_state -> ?check:bool -> all:bool -> atom list -> rw switch_state
+  rw switch_state ->
+  ?check:bool -> ?only_installed:bool ->
+  all:bool -> atom list -> rw switch_state
 
 (** Low-level version of [upgrade], bypassing the package name sanitization
     and dev package update, and offering more control *)
 val upgrade_t:
   ?strict_upgrade:bool -> ?auto_install:bool -> ?ask:bool -> ?check:bool ->
+  ?only_installed:bool ->
   all:bool -> atom list -> rw switch_state -> rw switch_state
 
 (** Recovers from an inconsistent universe *)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1423,7 +1423,11 @@ let upgrade =
        $(i,PACKAGES) was not specified, and can be useful with $(i,PACKAGES) \
        to upgrade while ensuring that some packages get or remain installed."
   in
-  let upgrade global_options build_options fixup check all atom_locs =
+  let installed =
+    mk_flag ["installed"]
+      "When a directory is provided as argument, do not install pinned package \
+       that are not yet installed." in
+  let upgrade global_options build_options fixup check only_installed all atom_locs =
     apply_global_options global_options;
     apply_build_options build_options;
     let all = all || atom_locs = [] in
@@ -1438,11 +1442,11 @@ let upgrade =
     else
       OpamSwitchState.with_ `Lock_write gt @@ fun st ->
       let atoms = OpamAuxCommands.resolve_locals_pinned st atom_locs in
-      ignore @@ OpamClient.upgrade st ~check ~all atoms;
+      ignore @@ OpamClient.upgrade st ~check ~only_installed ~all atoms;
       `Ok ()
   in
-  Term.(ret (const upgrade $global_options $build_options $fixup $check $all
-             $atom_or_dir_list)),
+  Term.(ret (const upgrade $global_options $build_options $fixup $check
+             $installed $all $atom_or_dir_list)),
   term_info "upgrade" ~doc ~man
 
 (* REPOSITORY *)

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -614,14 +614,20 @@ let list st ~short =
   let lines nv =
     try
       let opam = OpamSwitchState.opam st nv in
-      let url = OpamFile.OPAM.get_url opam in
+      let url = OpamFile.OPAM.url opam in
       let kind, target =
         if OpamSwitchState.is_version_pinned st nv.name then
           "version", OpamPackage.Version.to_string nv.version
         else
         match url with
-        | Some u ->
-          OpamUrl.string_of_backend u.OpamUrl.backend, OpamUrl.to_string u
+        | Some url ->
+          let u = OpamFile.URL.url url in
+          let subpath =
+            match OpamFile.URL.subpath url with
+            | None -> ""
+            | Some s -> " ("^s^")" in
+          OpamUrl.string_of_backend u.OpamUrl.backend,
+          OpamUrl.to_string u ^ subpath
         | None -> "local definition", ""
       in
       let state, extra =

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -64,7 +64,11 @@ let get_source_definition ?version st nv url =
   OpamUpdate.fetch_dev_package url srcdir nv @@| function
   | Not_available _ -> raise Not_found
   | Up_to_date _ | Result _ ->
-    match OpamPinned.find_opam_file_in_source nv.name srcdir with
+    let subsrcdir =
+      match OpamFile.URL.subpath url with
+      | None -> srcdir
+      | Some subpath -> OpamFilename.Op.(srcdir / subpath) in
+    match OpamPinned.find_opam_file_in_source nv.name subsrcdir with
     | None -> None
     | Some f ->
       match read_opam_file_for_pinning nv.name f (OpamFile.URL.url url) with
@@ -367,12 +371,14 @@ and source_pin
     st name
     ?version ?edit:(need_edit=false) ?opam:opam_opt ?(quiet=false)
     ?(force=false) ?(ignore_extra_pins=OpamClientConfig.(!r.ignore_pin_depends))
+    ?subpath
     target_url
   =
-  log "pin %a to %a %a"
+  log "pin %a to %a %a%a"
     (slog OpamPackage.Name.to_string) name
     (slog (OpamStd.Option.to_string OpamPackage.Version.to_string)) version
-    (slog (OpamStd.Option.to_string ~none:"none" OpamUrl.to_string)) target_url;
+    (slog (OpamStd.Option.to_string ~none:"none" OpamUrl.to_string)) target_url
+    (slog (OpamStd.Option.to_string ~none:"" (fun x -> " ("^x^")"))) subpath;
   let installed_version =
     try
       Some (OpamPackage.version
@@ -444,7 +450,7 @@ and source_pin
 
   let nv = OpamPackage.create name pin_version in
 
-  let urlf = OpamStd.Option.Op.(target_url >>| OpamFile.URL.create) in
+  let urlf = OpamStd.Option.Op.(target_url >>| OpamFile.URL.create ?subpath) in
 
   let temp_file =
     OpamPath.Switch.Overlay.tmp_opam st.switch_global.root st.switch name

--- a/src/client/opamPinCommand.mli
+++ b/src/client/opamPinCommand.mli
@@ -35,7 +35,7 @@ exception Nothing_to_do
 val source_pin:
   rw switch_state -> name ->
   ?version:version -> ?edit:bool -> ?opam:OpamFile.OPAM.t -> ?quiet:bool ->
-  ?force:bool -> ?ignore_extra_pins:bool ->
+  ?force:bool -> ?ignore_extra_pins:bool -> ?subpath: string ->
   url option ->
   rw switch_state
 

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -434,7 +434,15 @@ let parallel_apply t _action ~requested ?add_roots action_graph =
             !t_ref.conf_files; }
     in
     let nv = action_contents action in
-    let source_dir = OpamSwitchState.source_dir t nv in
+    let opam = OpamSwitchState.opam t nv in
+    let source_dir =
+      let raw = OpamSwitchState.source_dir t nv in
+      match OpamFile.OPAM.url opam with
+      | None -> raw
+      | Some url ->
+        match OpamFile.URL.subpath url with
+        | None -> raw
+        | Some subpath -> OpamFilename.Op.(raw / subpath) in
     if OpamClientConfig.(!r.fake) then
       match action with
       | `Build _ -> Done (`Successful (installed, removed))

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -255,6 +255,9 @@ let is_exec file =
 let starts_with dirname filename =
   OpamStd.String.starts_with ~prefix:(Dir.to_string dirname) (to_string filename)
 
+let dir_starts_with ~prefix dirname =
+  OpamStd.String.starts_with ~prefix:(Dir.to_string prefix) (Dir.to_string dirname)
+
 let remove_prefix prefix filename =
   let prefix =
     let str = Dir.to_string prefix in

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -204,6 +204,9 @@ val extract_generic_file: generic_file -> Dir.t -> unit
 (** Check whether a filename starts by a given Dir.t *)
 val starts_with: Dir.t -> t -> bool
 
+(** Check whether a dirname starts by a given Dir.t *)
+val dir_starts_with: prefix:Dir.t -> Dir.t -> bool
+
 (** Check whether a filename ends with a given suffix *)
 val ends_with: string -> t -> bool
 

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1821,11 +1821,12 @@ module URLSyntax = struct
     mirrors : url list;
     checksum: OpamHash.t list;
     errors  : (string * Pp.bad_format) list;
+    subpath : string option;
   }
 
-  let create ?(mirrors=[]) ?(checksum=[]) url =
+  let create ?(mirrors=[]) ?(checksum=[]) ?subpath url =
     {
-      url; mirrors; checksum; errors = [];
+      url; mirrors; checksum; errors = []; subpath;
     }
 
   let empty = {
@@ -1833,15 +1834,18 @@ module URLSyntax = struct
     mirrors = [];
     checksum= [];
     errors  = [];
+    subpath = None;
   }
 
   let url t = t.url
   let mirrors t = t.mirrors
   let checksum t = t.checksum
+  let subpath t = t.subpath
 
   let with_url url t = { t with url }
   let with_mirrors mirrors t = { t with mirrors }
   let with_checksum checksum t = { t with checksum = checksum }
+  let with_subpath subpath t = { t with subpath = Some subpath }
 
   let fields =
     let with_url url t =
@@ -1868,6 +1872,9 @@ module URLSyntax = struct
            (Pp.V.string -| Pp.of_module "checksum" (module OpamHash)));
       "mirrors", Pp.ppacc with_mirrors mirrors
         (Pp.V.map_list ~depth:1 Pp.V.url);
+      "subpath", Pp.ppacc_opt
+        with_subpath subpath
+        Pp.V.string;
     ]
 
   let pp_contents =

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -235,7 +235,9 @@ module URL: sig
 
   include IO_FILE
 
-  val create: ?mirrors:url list -> ?checksum:OpamHash.t list -> url -> t
+  val create:
+    ?mirrors:url list -> ?checksum:OpamHash.t list -> ?subpath:string ->
+    url -> t
 
   (** URL address *)
   val url: t -> url
@@ -247,6 +249,8 @@ module URL: sig
 
   (** Constructor *)
   val with_checksum: OpamHash.t list -> t -> t
+
+  val subpath: t -> string option
 
 end
 

--- a/src/repository/opamDarcs.ml
+++ b/src/repository/opamDarcs.ml
@@ -150,7 +150,7 @@ module VCS = struct
 
   let current_branch _dir = Done None (* No branches in Darcs *)
 
-  let is_dirty dir =
+  let is_dirty ?subpath:_ dir =
     darcs dir [ "whatsnew"; "--quiet"; "--summary" ]
     @@> fun r -> Done (OpamProcess.check_success_and_cleanup r)
 

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -177,8 +177,12 @@ module VCS : OpamVCS.VCS = struct
     | _ ->
       Done (Some "HEAD")
 
-  let is_dirty dir =
-    git dir [ "diff"; "--quiet" ]
+  let is_dirty ?subpath dir =
+    let subpath =
+      match subpath with
+      | None -> []
+      | Some dir -> ["--" ; dir] in
+    git dir ([ "diff"; "--quiet" ; "HEAD" ] @ subpath)
     @@> function
     | { OpamProcess.r_code = 0; _ } -> Done false
     | { OpamProcess.r_code = 1; _ } as r ->

--- a/src/repository/opamHg.ml
+++ b/src/repository/opamHg.ml
@@ -99,7 +99,7 @@ module VCS = struct
     | { OpamProcess.r_code = 0; OpamProcess.r_stdout = [b]; _ } -> Done (Some b)
     | _ -> Done None
 
-  let is_dirty dir =
+  let is_dirty ?subpath:_ dir =
     hg dir [ "stat" ] @@> fun r ->
     OpamSystem.raise_on_process_error r;
     Done (r.OpamProcess.r_stdout = [])

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -438,6 +438,6 @@ let current_branch url =
   on_local_version_control url ~default:(Done None) @@
   fun dir (module VCS) -> VCS.current_branch dir
 
-let is_dirty url =
+let is_dirty ?subpath url =
   on_local_version_control url ~default:(Done false) @@
-  fun dir (module VCS) -> VCS.is_dirty dir
+  fun dir (module VCS) -> VCS.is_dirty ?subpath dir

--- a/src/repository/opamRepository.mli
+++ b/src/repository/opamRepository.mli
@@ -64,7 +64,7 @@ val current_branch: url -> string option OpamProcess.job
 
 (** Returns true if the url points to a local, version-controlled directory that
     has uncommitted changes *)
-val is_dirty: url -> bool OpamProcess.job
+val is_dirty: ?subpath:string -> url -> bool OpamProcess.job
 
 (** Find a backend *)
 val find_backend: repository -> (module OpamRepositoryBackend.S)

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -25,7 +25,7 @@ module type VCS = sig
   val versionned_files: dirname -> string list OpamProcess.job
   val vc_dir: dirname -> dirname
   val current_branch: dirname -> string option OpamProcess.job
-  val is_dirty: dirname -> bool OpamProcess.job
+  val is_dirty: ?subpath:string -> dirname -> bool OpamProcess.job
 end
 
 

--- a/src/repository/opamVCS.mli
+++ b/src/repository/opamVCS.mli
@@ -61,7 +61,7 @@ module type VCS = sig
       recorded in the VCS as current. This differs from [is_up_to_date], which
       compares specifically to the last fetched state. This should always be
       [false] after [reset] has been called. *)
-  val is_dirty: dirname -> bool OpamProcess.job
+  val is_dirty: ?subpath:string -> dirname -> bool OpamProcess.job
 end
 
 (** Create a backend from a [VCS] implementation. *)

--- a/src/state/opamPinned.ml
+++ b/src/state/opamPinned.ml
@@ -46,32 +46,48 @@ let name_of_opam_filename dir file =
   try Some (OpamPackage.Name.of_string name)
   with Failure _ -> None
 
-let files_in_source d =
+let files_in_source ?(recurse = false) d =
   let baseopam = OpamFilename.Base.of_string "opam" in
-  let files =
-    List.filter (fun f ->
-        OpamFilename.basename f = baseopam ||
-        OpamFilename.check_suffix f ".opam")
-      (OpamFilename.files d) @
-    OpamStd.List.filter_map (fun d ->
-        if OpamFilename.(basename_dir d = Base.of_string "opam") ||
-           OpamStd.String.ends_with ~suffix:".opam"
-             (OpamFilename.Dir.to_string d)
-        then OpamFilename.opt_file OpamFilename.Op.(d//"opam")
-        else None)
+  let rec files acc base d =
+    let acc =
+      OpamStd.List.filter_map (fun f ->
+          if OpamFilename.basename f = baseopam ||
+             OpamFilename.check_suffix f ".opam" then
+            Some (f, base)
+          else
+            None)
+        (OpamFilename.files d) @ acc in
+    List.fold_left
+      (fun acc d ->
+         if OpamFilename.(basename_dir d = Base.of_string "opam") ||
+            OpamStd.String.ends_with ~suffix:".opam"
+              (OpamFilename.Dir.to_string d)
+         then
+           match OpamFilename.opt_file OpamFilename.Op.(d//"opam") with
+           | None -> acc
+           | Some f -> (f, base) :: acc
+         else if recurse then
+           let basename = OpamFilename.(Base.to_string (basename_dir d)) in
+           let base = match base with
+             | None -> Some basename
+             | Some base -> Some (Filename.concat base basename) in
+           files acc base d
+         else
+           acc)
+      acc
       (OpamFilename.dirs d)
   in
   OpamStd.List.filter_map
-    (fun f ->
+    (fun (f, subpath) ->
        try
          (* Ignore empty files *)
          if (Unix.stat (OpamFilename.to_string f)).Unix.st_size = 0 then None
-         else Some (name_of_opam_filename d f, OpamFile.make f)
+         else Some (name_of_opam_filename d f, OpamFile.make f, subpath)
        with Unix.Unix_error _ ->
          OpamConsole.error "Can not read %s, ignored."
            (OpamFilename.to_string f);
          None)
-    files
+    (files [] None d)
 
 let orig_opam_file opam =
   let open OpamStd.Option.Op in

--- a/src/state/opamPinned.mli
+++ b/src/state/opamPinned.mli
@@ -34,7 +34,9 @@ val find_opam_file_in_source: name -> dirname -> OpamFile.OPAM.t OpamFile.t opti
 
 (** Finds all package definition files in a given source dir [opam],
     [pkgname.opam/opam], etc. *)
-val files_in_source: dirname -> (name option * OpamFile.OPAM.t OpamFile.t) list
+val files_in_source:
+  ?recurse:bool ->
+  dirname -> (name option * OpamFile.OPAM.t OpamFile.t * string option) list
 
 (** From an opam file location, sitting below the given project directory, find
     the corresponding package name if specified ([<name>.opam] or

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -356,6 +356,15 @@ let url st nv =
 let primary_url st nv =
   OpamStd.Option.Op.(url st nv >>| OpamFile.URL.url)
 
+let primary_url_with_subpath st nv =
+  match url st nv with
+  | None -> None
+  | Some urlf ->
+    let url = OpamFile.URL.url urlf in
+    match OpamFile.URL.subpath urlf with
+    | None -> Some url
+    | Some subpath -> Some (OpamUrl.Op.(url / subpath))
+
 let files st nv =
   match opam_opt st nv with
   | None -> []

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -83,6 +83,8 @@ val url: 'a switch_state -> package -> OpamFile.URL.t option
 (** Returns the primary URL from the URL file of the given package *)
 val primary_url: 'a switch_state -> package -> url option
 
+val primary_url_with_subpath: 'a switch_state -> package -> url option
+
 (** Return the Descr file for the given package (or an empty descr if none) *)
 val descr: 'a switch_state -> package -> OpamFile.Descr.t
 

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -168,6 +168,7 @@ let pinned_package st ?version ?(working_dir=false) name =
   | None | Some (_, None) -> Done ((fun st -> st), false)
   | Some (opam, Some urlf) ->
     let url = OpamFile.URL.url urlf in
+    let subpath = OpamFile.URL.subpath urlf in
     let version =
       OpamFile.OPAM.version_opt opam ++
       version +!
@@ -212,11 +213,12 @@ let pinned_package st ?version ?(working_dir=false) name =
         | Some h ->
           OpamRepository.current_branch url @@| fun branch -> branch = Some h)
        @@+ function false -> Done () | true ->
-         OpamRepository.is_dirty url
+         OpamRepository.is_dirty ?subpath url
          @@| function false -> () | true ->
            OpamConsole.note
-             "Ignoring uncommitted changes in %s (`--working-dir' not active)."
-             url.OpamUrl.path)
+             "Ignoring uncommitted changes in %s%s (`--working-dir' not active)."
+             url.OpamUrl.path
+             (match subpath with None -> "" | Some s -> "/" ^ s))
     @@+ fun () ->
     (* Do the update *)
     fetch_dev_package urlf srcdir ~working_dir nv @@+ fun result ->


### PR DESCRIPTION
This prototype allows `opam pin .` to pin opam files found in subdirectories.

Rational
--------

When a source tree contains multiple package definitions, the current usage is to define every opam file in the project root. But `jbuilder` is also able to handle opam file in subdirectories (typically in a `vendors` subdirectory). It might useful to add the same flexibility in opam.

Note: running a script that individually pin all subpackages, e.g. https://gitlab.com/tezos/tezos/blob/master/scripts/opam-pin.sh, would not allow to use `--kind=git` for subdirectories.

Proposed implementation
-----------------------

This prototype contains two patches:

- The first patch extends `OpamFile.URL` to add a `subpath` field. When building such a package, the source will be fetched as usual, but then only the 'subpath' of the fetched source will be copied to the 'build_dir'. This field is only useful "VCS" backends, and not for the 'rsync' backend.

- The second patch implements a recursive lookup of opam files. Opam files found in subdirectories are pinned with a correct 'subpath'.

User interface
--------------

With this prototype implementation there is only two ways for using the new 'subpath' field: either commit the 'subpath' field in the opam repository, or use `opam pin .`.

A more complete CLI might add:

- `opam pin add tezos-base git+https://gitlab.com/tezos/tezos --subpath lib_base`
- `opam pin . --rec` if we do not want to activate the recursive lookup by default

- `opam update -u .` only update/upgrade sources for development packages found in subdirectories
- `opam upgrade . --installed` only upgrade installed package (the current behaviour is to propose installation of all the sub package)

Note
----

After a thought, we might implement the 'recursive' lookup without relying on the new `subpath` field but this way we might more easily ignore updates that do not modify the 'subpath' of a given package.