### PR TITLE
Fix PATH lookup for `opam exec` on OCaml 4.06

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -277,9 +277,9 @@ let help_sections = [
   `P "$(i,OPAMYES) see option `--yes'.";
 
   `S "EXIT STATUS";
-  `P "As an exception to the following, the `exec' command mimics a shell and \
-      returns 127 if the command was not found, 126 if it didn't have the \
-      required permissions, and the command's exit value otherwise."
+  `P "As an exception to the following, the `exec' command returns 127 if the \
+      command was not found or couldn't be executed, and the command's exit \
+      value otherwise."
 ] @
   List.map (fun (reason, code) ->
       `I (string_of_int code, match reason with

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -321,4 +321,6 @@ let exec gt ~inplace_path command =
     OpamTypesBase.env_array
       (OpamEnv.get_full ~opamswitch ~force_path:(not inplace_path) st)
   in
-  raise (OpamStd.Sys.Exec (cmd, args, env))
+  match OpamSystem.resolve_command ~env cmd with
+  | Some cmd -> raise (OpamStd.Sys.Exec (cmd, args, env))
+  | None -> raise (OpamStd.Sys.Exit 127)

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -37,8 +37,8 @@ MD5_opam-file-format = 5408798ca3af6e36379dd34b1b618b9c
 URL_result = https://github.com/janestreet/result/archive/1.2.tar.gz
 MD5_result = 3d5b66c5526918f0f2ca9d6811ef09c8
 
-URL_jbuilder = https://github.com/janestreet/jbuilder/archive/08050696fb701dafcd1372aadfaa800a50bc01ca.tar.gz
-MD5_jbuilder = 53b65232ebb5fd319acf90922342615d
+URL_jbuilder = https://github.com/janestreet/jbuilder/archive/1.0+beta16.tar.gz
+MD5_jbuilder = baef04fc99d52e98736db9e53a72bfce
 
 URL_ocaml = http://caml.inria.fr/pub/distrib/ocaml-4.06/ocaml-4.06.0.tar.gz
 MD5_ocaml = 66e5439eb63dbb8b8224cba5d1b20947


### PR DESCRIPTION
Seems I had missed this one.