### PR TITLE
Update README with C++ compiler information

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Either from an existing opam installation, use `opam pin add opam-devel
 
 * Make sure you have the required dependencies installed:
   - GNU make
+  - GNU C++ compiler
   - OCaml >= 4.02.3 (or see [below](#compiling-without-ocaml))
   - The `glpk` library (or see [below](#integrated-solver))
 * Run `./configure`


### PR DESCRIPTION
Running `make` after a `make lib-ext` fails with `error gcc: error trying to exec 'cc1plus': execvp: No such file or directory` when compiling 
`changed_criteria.cpp`. Adding documentation stating gcc-c++ must be installed in system (some distros, e.g. Fedora 27, don't have it in a fresh install).