### PR TITLE
Force git diff to not use external diff

### DIFF
--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -143,7 +143,7 @@ module VCS : OpamVCS.VCS = struct
     (* Git diff is to the working dir, but doesn't work properly for
        unregistered directories. *)
     OpamSystem.raise_on_process_error r;
-    git repo_root ~stdout:patch_file [ "diff" ; "-R" ; "-p" ; rref; "--" ]
+    git repo_root ~stdout:patch_file [ "diff" ; "--no-ext-diff" ; "-R" ; "-p" ; rref; "--" ]
     @@> fun r ->
     if not (OpamProcess.check_success_and_cleanup r) then
       (finalise ();
@@ -155,7 +155,7 @@ module VCS : OpamVCS.VCS = struct
 
   let is_up_to_date repo_root repo_url =
     let rref = remote_ref repo_url in
-    git repo_root [ "diff" ; "--quiet" ; rref; "--" ]
+    git repo_root [ "diff" ; "--no-ext-diff" ; "--quiet" ; rref; "--" ]
     @@> function
     | { OpamProcess.r_code = 0; _ } -> Done true
     | { OpamProcess.r_code = 1; _ } as r ->
@@ -178,7 +178,7 @@ module VCS : OpamVCS.VCS = struct
       Done (Some "HEAD")
 
   let is_dirty dir =
-    git dir [ "diff"; "--quiet" ]
+    git dir [ "diff" ; "--no-ext-diff" ; "--quiet" ]
     @@> function
     | { OpamProcess.r_code = 0; _ } -> Done false
     | { OpamProcess.r_code = 1; _ } as r ->


### PR DESCRIPTION
`opam update` failed several times due to external git diff driver.

I use:
```
GIT_EXTERNAL_DIFF=/home/user/.opam/4.05.0/bin/patdiff-git-wrapper
```

```
...
00:01.000  PARALLEL                Collected task for job 0 (ret:0)
00:01.000  PARALLEL                Next task in job 0: /usr/bin/git add .
00:01.005  PARALLEL                Collected task for job 0 (ret:0)
00:01.005  PARALLEL                Next task in job 0: /usr/bin/git diff -R -p refs/remotes/opam-ref --
00:01.010  PARALLEL                Collected task for job 0 (ret:128)
00:01.010  SYSTEM                  rm /home/user/.opam/log/git-diff-19973-5f1023
00:01.010  SYSTEM                  error: Git error: refs/remotes/opam-ref not found.
```

```
$ opam --version
2.0.0~beta6
```
