### PR TITLE
Fix handling of addresses in the form 'name@host:/foo'

### DIFF
--- a/src/core/opamUrl.ml
+++ b/src/core/opamUrl.ml
@@ -88,6 +88,7 @@ let looks_like_ssh_path =
     Re.(compile @@ seq [
         group @@ repn (diff any (set "/:")) 2 None;
         char ':';
+        opt @@ char '/';
         opt @@ group @@ seq [
           alt [
             diff any digit;


### PR DESCRIPTION
It seems safer to exclude the extra `/` in this case when converting to the 
normal `[git+]ssh://name@host/foo`

Closes #3211