### PR TITLE
[WIP]  Move most of the external tools calls to a single module 

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -416,7 +416,7 @@ let make_command st opam ?dir ?text_command (cmd, args) =
     ~resolve_path:OpamStateConfig.(not !r.dryrun)
     ~metadata:["context", context]
     ~verbose:(OpamConsole.verbose ())
-    cmd args
+    (OpamExternalTools.custom (cmd, args))
 
 let remove_commands t nv =
   match installed_opam_opt t nv with

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -26,7 +26,7 @@ let default_compiler =
   ]
 
 let eval_variables = [
-  OpamVariable.of_string "sys-ocaml-version", OpamExternalTools.OCaml.vnum (fun cmd args -> (cmd, args)),
+  OpamVariable.of_string "sys-ocaml-version", OpamExternalTools.OCaml.vnum,
   "OCaml version present on your system independently of opam, if any";
 ]
 

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -26,7 +26,7 @@ let default_compiler =
   ]
 
 let eval_variables = [
-  OpamVariable.of_string "sys-ocaml-version", ["ocamlc"; "-vnum"],
+  OpamVariable.of_string "sys-ocaml-version", OpamExternalTools.OCaml.vnum (fun cmd args -> (cmd, args)),
   "OCaml version present on your system independently of opam, if any";
 ]
 

--- a/src/client/opamInitDefaults.mli
+++ b/src/client/opamInitDefaults.mli
@@ -19,7 +19,7 @@ val repository_url: url
 
 val default_compiler: formula
 
-val eval_variables: (OpamVariable.t * string list * string) list
+val eval_variables: (OpamVariable.t * (string * string list) * string) list
 
 (** Default initial configuration file for use by [opam init] if nothing is
     supplied. *)

--- a/src/client/opamInitDefaults.mli
+++ b/src/client/opamInitDefaults.mli
@@ -19,7 +19,7 @@ val repository_url: url
 
 val default_compiler: formula
 
-val eval_variables: (OpamVariable.t * (string * string list) * string) list
+val eval_variables: (OpamVariable.t * OpamExternalTools.t * string) list
 
 (** Default initial configuration file for use by [opam init] if nothing is
     supplied. *)

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -751,7 +751,7 @@ let run_hook_job t name ?(local=[]) w =
            OpamSystem.make_command
              ~verbose:(OpamConsole.verbose ())
              ~env:(OpamTypesBase.env_array shell_env)
-             ~name ~text cmd args)
+             ~name ~text (OpamExternalTools.custom (cmd, args)))
     | [] -> None
   in
   let env v =

--- a/src/core/opamExternalTools.ml
+++ b/src/core/opamExternalTools.ml
@@ -8,96 +8,118 @@
 (*                                                                        *)
 (**************************************************************************)
 
+type t = (string * string list)
+
+let unpack x = x
+let custom x = x
+
+let has_space (cmd, _) = String.contains cmd ' '
+let cmd_to_string (cmd, _) = cmd
+
+let to_string (cmd, args) =
+  (* TODO: Add backslashs to quotes for each args *)
+  let quote x = if String.contains x ' ' then "'" ^ x ^ "'" else x in
+  let args = List.map quote args in
+  String.concat " " (cmd::args)
+
 module Unzip = struct
-  let extract cmd ~file ~dir = cmd "unzip" [file; "-d"; dir]
+  let extract ~file ~dir = ("unzip", [file; "-d"; dir])
 end
 
 module Tar = struct
-  let extract_gzip cmd ~file ~dir = cmd "tar" ["xfz"; file; "-C"; dir]
-  let extract_bzip2 cmd ~file ~dir = cmd "tar" ["xfj"; file; "-C"; dir]
-  let extract_xz cmd ~file ~dir = cmd "tar" ["xfJ"; file; "-C"; dir]
-  let extract_lzma cmd ~file ~dir = cmd "tar" ["xfY"; file; "-C"; dir]
+  let extract_gzip ~file ~dir = ("tar", ["xfz"; file; "-C"; dir])
+  let extract_bzip2 ~file ~dir = ("tar", ["xfj"; file; "-C"; dir])
+  let extract_xz ~file ~dir = ("tar", ["xfJ"; file; "-C"; dir])
+  let extract_lzma ~file ~dir = ("tar", ["xfY"; file; "-C"; dir])
 
-  let create_gzip cmd ~output ~inputs = cmd "tar" ("czhf" :: output :: inputs)
+  let create_gzip ~output ~inputs = ("tar", ("czhf" :: output :: inputs))
 end
 
 module Patch = struct
-  let apply cmd ~file = cmd "patch" ["-p1"; "-i"; file]
+  let apply ~file = ("patch", ["-p1"; "-i"; file])
+end
+
+module Diff = struct
+  let dirs ~dir1 ~dir2 = ("diff", ["-ruaN"; dir1; dir2])
 end
 
 module Rm = struct
-  let recursive cmd ~dir = cmd "rm" ["-rf"; dir]
+  let recursive ~dir = ("rm", ["-rf"; dir])
 end
 
 module Cmd = struct
-  let rm_recursive cmd ~dir = cmd "cmd" ["/d"; "/v:off"; "/c"; "rd"; "/s"; "/q"; dir]
-  let get_os_version cmd = cmd "cmd" ["/C"; "ver"]
+  let rm_recursive ~dir = ("cmd", ["/d"; "/v:off"; "/c"; "rd"; "/s"; "/q"; dir])
+  let get_os_version = ("cmd", ["/C"; "ver"])
 end
 
 module Sw_vers = struct
-  let get_os_version cmd = cmd "sw_vers" ["-productVersion"]
+  let get_os_version = ("sw_vers", ["-productVersion"])
 end
 
 module Getprop = struct
-  let get_os_version cmd = cmd "getprop" ["ro.build.version.release"]
+  let get_os_version = ("getprop", ["ro.build.version.release"])
 end
 
 module Sleep = struct
-  let one_second cmd = cmd "sleep" ["1"]
+  let one_second = ("sleep", ["1"])
 end
 
 module Cp = struct
-  let cp cmd ~src ~dst = cmd "cp" [src; dst]
-  let recursive cmd ~srcs ~dst = cmd "cp" ("-PRp" :: srcs @ [dst])
+  let cp ~src ~dst = ("cp", [src; dst])
+  let recursive ~srcs ~dst = ("cp", ("-PRp" :: srcs @ [dst]))
 end
 
 module Mv = struct
-  let mv cmd ~src ~dst = cmd "mv" [src; dst]
+  let mv ~src ~dst = ("mv", [src; dst])
 end
 
 module Install = struct
-  let exec cmd ~src ~dst = cmd "install" ["-m"; "0755"; src; dst]
-  let file cmd ~src ~dst = cmd "install" ["-m"; "0644"; src; dst]
+  let exec ~src ~dst = ("install", ["-m"; "0755"; src; dst])
+  let file ~src ~dst = ("install", ["-m"; "0644"; src; dst])
 end
 
 module Sysctl = struct
-  let get_hw_ncpu cmd = cmd "sysctl" ["-n"; "hw.ncpu"]
+  let get_hw_ncpu = ("sysctl", ["-n"; "hw.ncpu"])
 end
 
 module Getconf = struct
-  let get_nproc cmd = cmd "getconf" ["_NPROCESSORS_ONLN"]
+  let get_nproc = ("getconf", ["_NPROCESSORS_ONLN"])
 end
 
 module Lsb_release = struct
-  let get_id cmd = cmd "lsb_release" ["-i"; "-s"]
-  let get_release cmd = cmd "lsb_release" ["-s"; "-r"]
+  let get_id = ("lsb_release", ["-i"; "-s"])
+  let get_release = ("lsb_release", ["-s"; "-r"])
 end
 
 module Tput = struct
-  let cols cmd = cmd "tput" ["cols"]
+  let cols = ("tput", ["cols"])
 end
 
 module Stty = struct
-  let size cmd = cmd "stty" ["size"]
+  let size = ("stty", ["size"])
 end
 
 module Uname = struct
-  let kern_name cmd = cmd "uname" ["-s"]
-  let kern_version cmd = cmd "uname" ["-r"]
-  let arch cmd = cmd "uname" ["-m"]
-  let freebsd_version cmd = cmd "uname" ["-U"]
+  let kern_name = ("uname", ["-s"])
+  let kern_version = ("uname", ["-r"])
+  let arch = ("uname", ["-m"])
+  let freebsd_version = ("uname", ["-U"])
 end
 
 module Openssl = struct
-  let sha256 cmd ~file = cmd "openssl" ["sha256"; file]
-  let sha512 cmd ~file = cmd "openssl" ["sha512"; file]
+  let sha256 ~file = ("openssl", ["sha256"; file])
+  let sha512 ~file = ("openssl", ["sha512"; file])
 end
 
 module Git = struct
-  let get_user_name cmd = cmd "git" ["config"; "--get"; "user.name"]
-  let get_user_email cmd = cmd "git" ["config"; "--get"; "user.email"]
+  let get_user_name = ("git", ["config"; "--get"; "user.name"])
+  let get_user_email = ("git", ["config"; "--get"; "user.email"])
 end
 
 module OCaml = struct
-  let vnum cmd = cmd "ocaml" ["-vnum"]
+  let vnum = ("ocaml", ["-vnum"])
+end
+
+module Command = struct
+  let lookup ~cmd = ("/bin/sh", ["-c"; "command -v "^cmd])
 end

--- a/src/core/opamExternalTools.ml
+++ b/src/core/opamExternalTools.ml
@@ -1,0 +1,103 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2018 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+module Unzip = struct
+  let extract cmd ~file ~dir = cmd "unzip" [file; "-d"; dir]
+end
+
+module Tar = struct
+  let extract_gzip cmd ~file ~dir = cmd "tar" ["xfz"; file; "-C"; dir]
+  let extract_bzip2 cmd ~file ~dir = cmd "tar" ["xfj"; file; "-C"; dir]
+  let extract_xz cmd ~file ~dir = cmd "tar" ["xfJ"; file; "-C"; dir]
+  let extract_lzma cmd ~file ~dir = cmd "tar" ["xfY"; file; "-C"; dir]
+
+  let create_gzip cmd ~output ~inputs = cmd "tar" ("czhf" :: output :: inputs)
+end
+
+module Patch = struct
+  let apply cmd ~file = cmd "patch" ["-p1"; "-i"; file]
+end
+
+module Rm = struct
+  let recursive cmd ~dir = cmd "rm" ["-rf"; dir]
+end
+
+module Cmd = struct
+  let rm_recursive cmd ~dir = cmd "cmd" ["/d"; "/v:off"; "/c"; "rd"; "/s"; "/q"; dir]
+  let get_os_version cmd = cmd "cmd" ["/C"; "ver"]
+end
+
+module Sw_vers = struct
+  let get_os_version cmd = cmd "sw_vers" ["-productVersion"]
+end
+
+module Getprop = struct
+  let get_os_version cmd = cmd "getprop" ["ro.build.version.release"]
+end
+
+module Sleep = struct
+  let one_second cmd = cmd "sleep" ["1"]
+end
+
+module Cp = struct
+  let cp cmd ~src ~dst = cmd "cp" [src; dst]
+  let recursive cmd ~srcs ~dst = cmd "cp" ("-PRp" :: srcs @ [dst])
+end
+
+module Mv = struct
+  let mv cmd ~src ~dst = cmd "mv" [src; dst]
+end
+
+module Install = struct
+  let exec cmd ~src ~dst = cmd "install" ["-m"; "0755"; src; dst]
+  let file cmd ~src ~dst = cmd "install" ["-m"; "0644"; src; dst]
+end
+
+module Sysctl = struct
+  let get_hw_ncpu cmd = cmd "sysctl" ["-n"; "hw.ncpu"]
+end
+
+module Getconf = struct
+  let get_nproc cmd = cmd "getconf" ["_NPROCESSORS_ONLN"]
+end
+
+module Lsb_release = struct
+  let get_id cmd = cmd "lsb_release" ["-i"; "-s"]
+  let get_release cmd = cmd "lsb_release" ["-s"; "-r"]
+end
+
+module Tput = struct
+  let cols cmd = cmd "tput" ["cols"]
+end
+
+module Stty = struct
+  let size cmd = cmd "stty" ["size"]
+end
+
+module Uname = struct
+  let kern_name cmd = cmd "uname" ["-s"]
+  let kern_version cmd = cmd "uname" ["-r"]
+  let arch cmd = cmd "uname" ["-m"]
+  let freebsd_version cmd = cmd "uname" ["-U"]
+end
+
+module Openssl = struct
+  let sha256 cmd ~file = cmd "openssl" ["sha256"; file]
+  let sha512 cmd ~file = cmd "openssl" ["sha512"; file]
+end
+
+module Git = struct
+  let get_user_name cmd = cmd "git" ["config"; "--get"; "user.name"]
+  let get_user_email cmd = cmd "git" ["config"; "--get"; "user.email"]
+end
+
+module OCaml = struct
+  let vnum cmd = cmd "ocaml" ["-vnum"]
+end

--- a/src/core/opamExternalTools.mli
+++ b/src/core/opamExternalTools.mli
@@ -1,0 +1,123 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2018 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+type t
+
+val unpack : t -> (string * string list)
+
+(** NOTE: Please try to use this function as little as possible *)
+val custom : (string * string list) -> t
+
+val has_space : t -> bool
+val cmd_to_string : t -> string
+
+(** For printing only *)
+val to_string : t -> string
+
+module Unzip : sig
+  val extract : file:string -> dir:string -> t
+end
+
+module Tar : sig
+  val extract_gzip : file:string -> dir:string -> t
+  val extract_bzip2 : file:string -> dir:string -> t
+  val extract_xz : file:string -> dir:string -> t
+  val extract_lzma : file:string -> dir:string -> t
+  val create_gzip : output:string -> inputs:string list -> t
+end
+
+module Patch : sig
+  val apply : file:string -> t
+end
+
+module Diff : sig
+  val dirs : dir1:string -> dir2:string -> t
+end
+
+module Rm : sig
+  val recursive : dir:string -> t
+end
+
+module Cmd : sig
+  val rm_recursive : dir:string -> t
+  val get_os_version : t
+end
+
+module Sw_vers : sig
+  val get_os_version : t
+end
+
+module Getprop : sig
+  val get_os_version : t
+end
+
+module Sleep : sig
+  val one_second : t
+end
+
+module Cp : sig
+  val cp : src:string -> dst:string -> t
+  val recursive : srcs:string list -> dst:string -> t
+end
+
+module Mv : sig
+  val mv : src:string -> dst:string -> t
+end
+
+module Install : sig
+  val exec : src:string -> dst:string -> t
+  val file : src:string -> dst:string -> t
+end
+
+module Sysctl : sig
+  val get_hw_ncpu : t
+end
+
+module Getconf : sig
+  val get_nproc : t
+end
+
+module Lsb_release : sig
+  val get_id : t
+  val get_release : t
+end
+
+module Tput : sig
+  val cols : t
+end
+
+module Stty : sig
+  val size : t
+end
+
+module Uname : sig
+  val kern_name : t
+  val kern_version : t
+  val arch : t
+  val freebsd_version : t
+end
+
+module Openssl : sig
+  val sha256 : file:string -> t
+  val sha512 : file:string -> t
+end
+
+module Git : sig
+  val get_user_name : t
+  val get_user_email : t
+end
+
+module OCaml : sig
+  val vnum : t
+end
+
+module Command : sig
+  val lookup : cmd:string -> t
+end

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -87,9 +87,8 @@ let exec dirname ?env ?name ?metadata ?keep_going cmds =
     (fun () -> OpamSystem.commands ?env ?name ?metadata ?keep_going cmds)
 
 let move_dir ~src ~dst =
-  OpamExternalTools.Mv.mv
-    (OpamSystem.command ~verbose:(OpamSystem.verbose_for_base_commands ()))
-    ~src:(Dir.to_string src) ~dst:(Dir.to_string dst)
+  OpamSystem.command ~verbose:(OpamSystem.verbose_for_base_commands ())
+    (OpamExternalTools.Mv.mv ~src:(Dir.to_string src) ~dst:(Dir.to_string dst))
 
 let exists_dir dirname =
   try (Unix.stat (Dir.to_string dirname)).Unix.st_kind = Unix.S_DIR
@@ -220,9 +219,8 @@ let install ?exec ~src ~dst () =
 
 let move ~src ~dst =
   if src <> dst then
-    OpamExternalTools.Mv.mv
-      (OpamSystem.command ~verbose:(OpamSystem.verbose_for_base_commands ()))
-      ~src:(to_string src) ~dst:(to_string dst)
+    OpamSystem.command ~verbose:(OpamSystem.verbose_for_base_commands ())
+      (OpamExternalTools.Mv.mv ~src:(to_string src) ~dst:(to_string dst))
 
 let readlink src =
   if exists src then

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -87,8 +87,9 @@ let exec dirname ?env ?name ?metadata ?keep_going cmds =
     (fun () -> OpamSystem.commands ?env ?name ?metadata ?keep_going cmds)
 
 let move_dir ~src ~dst =
-  OpamSystem.command ~verbose:(OpamSystem.verbose_for_base_commands ())
-    [ "mv"; Dir.to_string src; Dir.to_string dst ]
+  OpamExternalTools.Mv.mv
+    (OpamSystem.command ~verbose:(OpamSystem.verbose_for_base_commands ()))
+    ~src:(Dir.to_string src) ~dst:(Dir.to_string dst)
 
 let exists_dir dirname =
   try (Unix.stat (Dir.to_string dirname)).Unix.st_kind = Unix.S_DIR
@@ -219,8 +220,9 @@ let install ?exec ~src ~dst () =
 
 let move ~src ~dst =
   if src <> dst then
-    OpamSystem.command ~verbose:(OpamSystem.verbose_for_base_commands ())
-      [ "mv"; to_string src; to_string dst ]
+    OpamExternalTools.Mv.mv
+      (OpamSystem.command ~verbose:(OpamSystem.verbose_for_base_commands ()))
+      ~src:(to_string src) ~dst:(to_string dst)
 
 let readlink src =
   if exists src then

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -50,7 +50,7 @@ val env_of_list: (string * string) list -> string array
 (** Execute a list of commands in a given directory *)
 val exec: Dir.t -> ?env:(string * string) list -> ?name:string ->
   ?metadata:(string * string) list -> ?keep_going:bool ->
-  (OpamSystem.command * OpamSystem.args) list -> unit
+  OpamExternalTools.t list -> unit
 
 (** Move a directory *)
 val move_dir: src:Dir.t -> dst:Dir.t -> unit

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -49,7 +49,8 @@ val env_of_list: (string * string) list -> string array
 
 (** Execute a list of commands in a given directory *)
 val exec: Dir.t -> ?env:(string * string) list -> ?name:string ->
-  ?metadata:(string * string) list -> ?keep_going:bool -> string list list -> unit
+  ?metadata:(string * string) list -> ?keep_going:bool ->
+  (OpamSystem.command * OpamSystem.args) list -> unit
 
 (** Move a directory *)
 val move_dir: src:Dir.t -> dst:Dir.t -> unit

--- a/src/core/opamHash.ml
+++ b/src/core/opamHash.ml
@@ -92,7 +92,7 @@ let compute ?(kind=default_kind) file = match kind with
     try
       if not OpamCoreConfig.(!r.use_openssl) then raise Exit else
       match
-        command_of_kind kind OpamSystem.read_command_output ~file
+       OpamSystem.read_command_output (command_of_kind kind ~file)
       with
       | [l] ->
         let len = len kind in

--- a/src/core/opamHash.ml
+++ b/src/core/opamHash.ml
@@ -82,13 +82,17 @@ let to_json s = `String (to_string s)
 let to_path (kind,s) =
   [string_of_kind kind; String.sub s 0 2; s]
 
+let command_of_kind = function
+  | `SHA256 -> OpamExternalTools.Openssl.sha256
+  | `SHA512 -> OpamExternalTools.Openssl.sha512
+
 let compute ?(kind=default_kind) file = match kind with
   | `MD5 -> md5 (Digest.to_hex (Digest.file file))
   | (`SHA256 | `SHA512) as kind ->
     try
       if not OpamCoreConfig.(!r.use_openssl) then raise Exit else
       match
-        OpamSystem.read_command_output ["openssl"; string_of_kind kind; file]
+        command_of_kind kind OpamSystem.read_command_output ~file
       with
       | [l] ->
         let len = len kind in

--- a/src/core/opamProcess.mli
+++ b/src/core/opamProcess.mli
@@ -34,8 +34,7 @@ val command:
   ?allow_stdin:bool ->
   ?stdout:string ->
   ?text:string ->
-  string ->
-  string list ->
+  OpamExternalTools.t ->
   command
 
 val string_of_command: command -> string

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -560,7 +560,7 @@ module OpamSys = struct
     let cmd =
       List.find Sys.file_exists (List.map (fun d -> Filename.concat d cmd) path)
     in
-    let ic = Unix.open_process_in (cmd^" "^String.concat " " args) in
+    let ic = Unix.open_process_in (String.concat " " (cmd::args)) in
     try
       let r = f ic in
       ignore (Unix.close_process_in ic) ; r

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -379,7 +379,7 @@ module Sys : sig
   val os: unit -> os
 
   (** The output of the command "uname", with the given argument. Memoised. *)
-  val uname: string -> string option
+  val uname: ((string -> string list -> string option) -> string option) -> string option
 
   (** Append .exe (only if missing) to executable filenames on Windows *)
   val executable_name : string -> string

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -379,7 +379,7 @@ module Sys : sig
   val os: unit -> os
 
   (** The output of the command "uname", with the given argument. Memoised. *)
-  val uname: ((string -> string list -> string option) -> string option) -> string option
+  val uname: OpamExternalTools.t -> string option
 
   (** Append .exe (only if missing) to executable filenames on Windows *)
   val executable_name : string -> string

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -412,6 +412,7 @@ let run_process
     ?verbose ?(env=default_env) ~name ?metadata ?stdout ?allow_stdin cmd =
   let chrono = OpamConsole.timer () in
   runs := cmd :: !runs;
+
   if OpamExternalTools.has_space cmd then
     OpamConsole.warning "Command %S contains space characters" (OpamExternalTools.cmd_to_string cmd);
 
@@ -578,11 +579,11 @@ module Tar = struct
     in
     let ext =
       List.fold_left
-        (fun acc (ext, cmd) -> match acc with
+        (fun acc (ext, c) -> match acc with
           | Some f -> Some f
           | None   ->
             if match_ext file ext
-            then Some (command cmd)
+            then Some (command c)
             else None)
         None
         extensions in
@@ -591,7 +592,7 @@ module Tar = struct
     | None   ->
       match guess_type file with
       | None   -> None
-      | Some cmd -> Some (command cmd)
+      | Some c -> Some (command c)
 
 end
 

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -142,12 +142,9 @@ val make_command:
   ?verbose:bool -> ?env:string array -> ?name:string -> ?text:string ->
   ?metadata:(string * string) list -> ?allow_stdin:bool -> ?stdout:string ->
   ?dir:string -> ?resolve_path:bool ->
-  string -> string list -> OpamProcess.command
+  OpamExternalTools.t -> OpamProcess.command
 
 (** OLD COMMAND API, DEPRECATED *)
-
-type command = string
-type args = string list
 
 (** Test whether a command exists in the environment, and returns it (resolved
     if found in PATH) *)
@@ -157,13 +154,13 @@ val resolve_command: ?env:string array -> ?dir:string -> string -> string option
     environment. *)
 val command: ?verbose:bool -> ?env:string array -> ?name:string ->
   ?metadata:(string * string) list -> ?allow_stdin:bool ->
-  command -> args -> unit
+  OpamExternalTools.t -> unit
 
 (** [commands cmds] executes the commands [cmds] in the correct OPAM
     environment. It stops whenever one command fails unless [keep_going] is set
     to [true]. In this case, the first error is re-raised at the end. *)
 val commands: ?verbose:bool -> ?env:string array -> ?name:string ->
-  ?metadata:(string * string) list -> ?keep_going:bool -> (command * args) list -> unit
+  ?metadata:(string * string) list -> ?keep_going:bool -> OpamExternalTools.t list -> unit
 
 (** [read_command_output cmd] executes the command [cmd] in the
     correct OPAM environment and return the lines from stdout if the command
@@ -171,7 +168,7 @@ val commands: ?verbose:bool -> ?env:string array -> ?name:string ->
     with a non-empty exit-code, throw an error. *)
 val read_command_output: ?verbose:bool -> ?env:string array ->
   ?metadata:(string * string) list ->  ?allow_stdin:bool ->
-  command -> args -> string list
+  OpamExternalTools.t -> string list
 
 (** END *)
 

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -146,8 +146,8 @@ val make_command:
 
 (** OLD COMMAND API, DEPRECATED *)
 
-(** a command is a list of words *)
-type command = string list
+type command = string
+type args = string list
 
 (** Test whether a command exists in the environment, and returns it (resolved
     if found in PATH) *)
@@ -157,13 +157,13 @@ val resolve_command: ?env:string array -> ?dir:string -> string -> string option
     environment. *)
 val command: ?verbose:bool -> ?env:string array -> ?name:string ->
   ?metadata:(string * string) list -> ?allow_stdin:bool ->
-  command -> unit
+  command -> args -> unit
 
 (** [commands cmds] executes the commands [cmds] in the correct OPAM
     environment. It stops whenever one command fails unless [keep_going] is set
     to [true]. In this case, the first error is re-raised at the end. *)
 val commands: ?verbose:bool -> ?env:string array -> ?name:string ->
-  ?metadata:(string * string) list -> ?keep_going:bool -> command list -> unit
+  ?metadata:(string * string) list -> ?keep_going:bool -> (command * args) list -> unit
 
 (** [read_command_output cmd] executes the command [cmd] in the
     correct OPAM environment and return the lines from stdout if the command
@@ -171,7 +171,7 @@ val commands: ?verbose:bool -> ?env:string array -> ?name:string ->
     with a non-empty exit-code, throw an error. *)
 val read_command_output: ?verbose:bool -> ?env:string array ->
   ?metadata:(string * string) list ->  ?allow_stdin:bool ->
-  command -> string list
+  command -> args -> string list
 
 (** END *)
 

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1038,7 +1038,7 @@ module ConfigSyntax = struct
     best_effort_prefix : string option;
     solver : arg list option;
     global_variables : (variable * variable_contents * string) list;
-    eval_variables : (variable * (string * string list) * string) list;
+    eval_variables : (variable * OpamExternalTools.t * string) list;
     validation_hook : arg list option;
     default_compiler : formula;
   }
@@ -1171,7 +1171,7 @@ module ConfigSyntax = struct
         (Pp.V.map_list ~depth:2
            (Pp.V.map_triple
               (Pp.V.ident -| Pp.of_module "variable" (module OpamVariable))
-              (Pp.V.map_pair Pp.V.string (Pp.V.map_list Pp.V.string))
+              (assert false)
               Pp.V.string));
       "repository-validation-command", Pp.ppacc_opt
         with_validation_hook validation_hook
@@ -1224,7 +1224,7 @@ module InitConfigSyntax = struct
     solver : arg list option;
     wrappers : Wrappers.t;
     global_variables : (variable * variable_contents * string) list;
-    eval_variables : (variable * (string * string list) * string) list;
+    eval_variables : (variable * OpamExternalTools.t * string) list;
   }
 
   let opam_version t = t.opam_version
@@ -1346,7 +1346,7 @@ module InitConfigSyntax = struct
         (Pp.V.map_list ~depth:2
            (Pp.V.map_triple
               (Pp.V.ident -| Pp.of_module "variable" (module OpamVariable))
-              (Pp.V.map_pair Pp.V.string (Pp.V.map_list Pp.V.string))
+              (assert false)
               Pp.V.string));
     ] @
     List.map

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1038,7 +1038,7 @@ module ConfigSyntax = struct
     best_effort_prefix : string option;
     solver : arg list option;
     global_variables : (variable * variable_contents * string) list;
-    eval_variables : (variable * string list * string) list;
+    eval_variables : (variable * (string * string list) * string) list;
     validation_hook : arg list option;
     default_compiler : formula;
   }
@@ -1171,7 +1171,7 @@ module ConfigSyntax = struct
         (Pp.V.map_list ~depth:2
            (Pp.V.map_triple
               (Pp.V.ident -| Pp.of_module "variable" (module OpamVariable))
-              (Pp.V.map_list Pp.V.string)
+              (Pp.V.map_pair Pp.V.string (Pp.V.map_list Pp.V.string))
               Pp.V.string));
       "repository-validation-command", Pp.ppacc_opt
         with_validation_hook validation_hook
@@ -1224,7 +1224,7 @@ module InitConfigSyntax = struct
     solver : arg list option;
     wrappers : Wrappers.t;
     global_variables : (variable * variable_contents * string) list;
-    eval_variables : (variable * string list * string) list;
+    eval_variables : (variable * (string * string list) * string) list;
   }
 
   let opam_version t = t.opam_version
@@ -1346,7 +1346,7 @@ module InitConfigSyntax = struct
         (Pp.V.map_list ~depth:2
            (Pp.V.map_triple
               (Pp.V.ident -| Pp.of_module "variable" (module OpamVariable))
-              (Pp.V.map_list Pp.V.string)
+              (Pp.V.map_pair Pp.V.string (Pp.V.map_list Pp.V.string))
               Pp.V.string));
     ] @
     List.map

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -126,7 +126,7 @@ module Config: sig
   val with_global_variables:
     (variable * variable_contents * string) list -> t -> t
   val with_eval_variables:
-    (variable * (string * string list) * string) list -> t -> t
+    (variable * OpamExternalTools.t * string) list -> t -> t
   val with_validation_hook_opt:
     arg list option -> t -> t
   val with_default_compiler:
@@ -165,7 +165,7 @@ module Config: sig
   val global_variables: t -> (variable * variable_contents * string) list
 
   (** variable, command, docstring *)
-  val eval_variables: t -> (variable * (string * string list) * string) list
+  val eval_variables: t -> (variable * OpamExternalTools.t * string) list
 
   val validation_hook: t -> arg list option
 
@@ -188,7 +188,7 @@ module InitConfig: sig
   val solver: t -> arg list option
   val wrappers: t -> Wrappers.t
   val global_variables: t -> (variable * variable_contents * string) list
-  val eval_variables: t -> (variable * (string * string list) * string) list
+  val eval_variables: t -> (variable * OpamExternalTools.t * string) list
 
   val with_opam_version: opam_version -> t -> t
   val with_repositories:
@@ -202,7 +202,7 @@ module InitConfig: sig
   val with_solver: arg list option -> t -> t
   val with_wrappers: Wrappers.t -> t -> t
   val with_global_variables: (variable * variable_contents * string) list -> t -> t
-  val with_eval_variables: (variable * (string * string list) * string) list -> t -> t
+  val with_eval_variables: (variable * OpamExternalTools.t * string) list -> t -> t
 
   (** [add t1 t2] is [t2], with the field values falling back to those of [t1]
       when not set in [t2] *)

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -126,7 +126,7 @@ module Config: sig
   val with_global_variables:
     (variable * variable_contents * string) list -> t -> t
   val with_eval_variables:
-    (variable * string list * string) list -> t -> t
+    (variable * (string * string list) * string) list -> t -> t
   val with_validation_hook_opt:
     arg list option -> t -> t
   val with_default_compiler:
@@ -165,7 +165,7 @@ module Config: sig
   val global_variables: t -> (variable * variable_contents * string) list
 
   (** variable, command, docstring *)
-  val eval_variables: t -> (variable * string list * string) list
+  val eval_variables: t -> (variable * (string * string list) * string) list
 
   val validation_hook: t -> arg list option
 
@@ -188,7 +188,7 @@ module InitConfig: sig
   val solver: t -> arg list option
   val wrappers: t -> Wrappers.t
   val global_variables: t -> (variable * variable_contents * string) list
-  val eval_variables: t -> (variable * string list * string) list
+  val eval_variables: t -> (variable * (string * string list) * string) list
 
   val with_opam_version: opam_version -> t -> t
   val with_repositories:
@@ -202,7 +202,7 @@ module InitConfig: sig
   val with_solver: arg list option -> t -> t
   val with_wrappers: Wrappers.t -> t -> t
   val with_global_variables: (variable * variable_contents * string) list -> t -> t
-  val with_eval_variables: (variable * string list * string) list -> t -> t
+  val with_eval_variables: (variable * (string * string list) * string) list -> t -> t
 
   (** [add t1 t2] is [t2], with the field values falling back to those of [t1]
       when not set in [t2] *)

--- a/src/repository/opamDarcs.ml
+++ b/src/repository/opamDarcs.ml
@@ -22,7 +22,7 @@ module VCS = struct
   let darcs repo_root =
     let dir = OpamFilename.Dir.to_string repo_root in
     fun ?verbose ?env ?stdout args ->
-      OpamSystem.make_command ~dir ?verbose ?env ?stdout "darcs" args
+      OpamSystem.make_command ~dir ?verbose ?env ?stdout (OpamExternalTools.custom ("darcs", args))
 
   let with_tag repo_url = match repo_url.OpamUrl.hash with
     | None -> fun cmd -> cmd

--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -94,7 +94,7 @@ let tool_return url ret =
       else Done ()
 
 let download_command ~compress ?checksum ~url ~dst =
-  let cmd, args =
+  let cmd =
     match
       download_args
         ~url
@@ -108,7 +108,7 @@ let download_command ~compress ?checksum ~url ~dst =
       OpamConsole.error_and_exit `Configuration_error
         "Empty custom download command"
   in
-  OpamSystem.make_command cmd args @@> tool_return url
+  OpamSystem.make_command (OpamExternalTools.custom cmd) @@> tool_return url
 
 let really_download
     ?(quiet=false) ~overwrite ?(compress=false) ?checksum ?(validate=true)

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -25,7 +25,7 @@ module VCS : OpamVCS.VCS = struct
   let git repo_root =
     let dir = OpamFilename.Dir.to_string repo_root in
     fun ?verbose ?env ?stdout args ->
-      OpamSystem.make_command ~dir ?verbose ?env ?stdout "git" args
+      OpamSystem.make_command ~dir ?verbose ?env ?stdout (OpamExternalTools.custom ("git", args))
 
   let init repo_root repo_url =
     OpamFilename.mkdir repo_root;

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -99,5 +99,5 @@ let make_index_tar_gz repo_root =
     let to_include = [ "version"; "packages"; "repo" ] in
     match List.filter Sys.file_exists to_include with
     | [] -> ()
-    | d  -> OpamExternalTools.Tar.create_gzip OpamSystem.command ~output:"index.tar.gz" ~inputs:d
+    | d  -> OpamSystem.command (OpamExternalTools.Tar.create_gzip ~output:"index.tar.gz" ~inputs:d)
   )

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -99,5 +99,5 @@ let make_index_tar_gz repo_root =
     let to_include = [ "version"; "packages"; "repo" ] in
     match List.filter Sys.file_exists to_include with
     | [] -> ()
-    | d  -> OpamSystem.command ("tar" :: "czhf" :: "index.tar.gz" :: d)
+    | d  -> OpamExternalTools.Tar.create_gzip OpamSystem.command ~output:"index.tar.gz" ~inputs:d
   )

--- a/src/repository/opamHg.ml
+++ b/src/repository/opamHg.ml
@@ -22,7 +22,7 @@ module VCS = struct
   let hg repo_root =
     let dir = OpamFilename.Dir.to_string repo_root in
     fun ?verbose ?env ?stdout args ->
-      OpamSystem.make_command ~dir ?verbose ?env ?stdout "hg" args
+      OpamSystem.make_command ~dir ?verbose ?env ?stdout (OpamExternalTools.custom ("hg", args))
 
   let init repo_root _repo_url =
     OpamFilename.mkdir repo_root;

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -26,7 +26,7 @@ let rsync_trim = function
     | _ -> []
 
 let call_rsync check args =
-  OpamSystem.make_command "rsync" args
+  OpamSystem.make_command (OpamExternalTools.custom ("rsync", args))
   @@> fun r ->
   match r.OpamProcess.r_code with
   | 0 -> Done (Some (rsync_trim r.OpamProcess.r_stdout))

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -56,7 +56,7 @@ let fetch_from_cache =
   let currently_downloading = ref [] in
   let rec no_concurrent_dls key f x =
     if List.mem key !currently_downloading then
-      Run (OpamProcess.command "sleep" ["1"],
+      Run (OpamExternalTools.Sleep.one_second OpamProcess.command,
            (fun _ -> no_concurrent_dls key f x))
     else
       (currently_downloading := key :: !currently_downloading;

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -56,7 +56,7 @@ let fetch_from_cache =
   let currently_downloading = ref [] in
   let rec no_concurrent_dls key f x =
     if List.mem key !currently_downloading then
-      Run (OpamExternalTools.Sleep.one_second OpamProcess.command,
+      Run (OpamProcess.command OpamExternalTools.Sleep.one_second,
            (fun _ -> no_concurrent_dls key f x))
     else
       (currently_downloading := key :: !currently_downloading;
@@ -355,7 +355,7 @@ let validate_repo_update repo update =
         OpamSystem.make_command
           ~name:"validation-hook"
           ~verbose:OpamCoreConfig.(!r.verbose_level >= 2)
-          cmd args
+          (OpamExternalTools.custom (cmd, args))
       | [] -> failwith "Empty validation hook"
     in
     cmd @@> fun r ->

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -87,10 +87,9 @@ let get_diff parent_dir dir1 dir2 =
   OpamSystem.make_command
     ~verbose:OpamCoreConfig.(!r.verbose_level >= 2)
     ~dir:(OpamFilename.Dir.to_string parent_dir) ~stdout:patch
-    "diff"
-    [ "-ruaN";
-      OpamFilename.Base.to_string dir1;
-      OpamFilename.Base.to_string dir2; ]
+    (OpamExternalTools.Diff.dirs
+       ~dir1:(OpamFilename.Base.to_string dir1)
+       ~dir2:(OpamFilename.Base.to_string dir2))
   @@> function
   | { OpamProcess.r_code = 0; _ } -> finalise(); Done None
   | { OpamProcess.r_code = 1; _ } as r ->

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -203,10 +203,8 @@ let template nv =
   let maintainer =
     let from_git = try
         match
-          OpamSystem.read_command_output
-            ["git"; "config"; "--get"; "user.name"],
-          OpamSystem.read_command_output
-            ["git"; "config"; "--get"; "user.email"]
+          OpamExternalTools.Git.get_user_name OpamSystem.read_command_output,
+          OpamExternalTools.Git.get_user_email OpamSystem.read_command_output
         with
         | [name], [email] ->
           Some [Printf.sprintf "%s <%s>" name email]

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -203,8 +203,8 @@ let template nv =
   let maintainer =
     let from_git = try
         match
-          OpamExternalTools.Git.get_user_name OpamSystem.read_command_output,
-          OpamExternalTools.Git.get_user_email OpamSystem.read_command_output
+          OpamSystem.read_command_output OpamExternalTools.Git.get_user_name,
+          OpamSystem.read_command_output OpamExternalTools.Git.get_user_email
         with
         | [name], [email] ->
           Some [Printf.sprintf "%s <%s>" name email]

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -587,7 +587,7 @@ let from_1_3_dev2_to_1_3_dev5 root conf =
               | Some ocamlc ->
                 let vnum =
                   OpamSystem.read_command_output ~verbose:false
-                    [ OpamFilename.to_string ocamlc ; "-vnum" ]
+                    (OpamFilename.to_string ocamlc) ["-vnum" ]
                 in
                 config |>
                 OpamFile.Dot_config.with_file_depends
@@ -870,7 +870,7 @@ let from_2_0_alpha_to_2_0_alpha2 root conf =
     )
     (OpamFile.Config.installed_switches conf);
   OpamFile.Config.with_eval_variables [
-    OpamVariable.of_string "sys-ocaml-version", ["ocamlc"; "-vnum"],
+    OpamVariable.of_string "sys-ocaml-version", OpamExternalTools.OCaml.vnum (fun cmd args -> (cmd, args)),
     "OCaml version present on your system independently of opam, if any";
   ] conf
 
@@ -959,7 +959,7 @@ let from_2_0_alpha3_to_2_0_beta root conf =
          ])
        conf) |>
   OpamFile.Config.with_eval_variables
-    ((OpamVariable.of_string "arch", ["uname"; "-m"],
+    ((OpamVariable.of_string "arch", OpamExternalTools.Uname.arch (fun cmd args -> (cmd, args)),
       "Host architecture, as returned by 'uname -m'")
      :: OpamFile.Config.eval_variables conf)
 

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -587,7 +587,7 @@ let from_1_3_dev2_to_1_3_dev5 root conf =
               | Some ocamlc ->
                 let vnum =
                   OpamSystem.read_command_output ~verbose:false
-                    (OpamFilename.to_string ocamlc) ["-vnum" ]
+                    (OpamExternalTools.custom (OpamFilename.to_string ocamlc, ["-vnum" ]))
                 in
                 config |>
                 OpamFile.Dot_config.with_file_depends
@@ -870,7 +870,7 @@ let from_2_0_alpha_to_2_0_alpha2 root conf =
     )
     (OpamFile.Config.installed_switches conf);
   OpamFile.Config.with_eval_variables [
-    OpamVariable.of_string "sys-ocaml-version", OpamExternalTools.OCaml.vnum (fun cmd args -> (cmd, args)),
+    OpamVariable.of_string "sys-ocaml-version", OpamExternalTools.OCaml.vnum,
     "OCaml version present on your system independently of opam, if any";
   ] conf
 
@@ -959,7 +959,7 @@ let from_2_0_alpha3_to_2_0_beta root conf =
          ])
        conf) |>
   OpamFile.Config.with_eval_variables
-    ((OpamVariable.of_string "arch", OpamExternalTools.Uname.arch (fun cmd args -> (cmd, args)),
+    ((OpamVariable.of_string "arch", OpamExternalTools.Uname.arch,
       "Host architecture, as returned by 'uname -m'")
      :: OpamFile.Config.eval_variables conf)
 

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -73,7 +73,7 @@ let load lock_kind =
   let eval_variables = OpamFile.Config.eval_variables config in
   let global_variables =
     let env = lazy (OpamEnv.get_pure () |> OpamTypesBase.env_array) in
-    List.fold_left (fun acc (v, cmd, doc) ->
+    List.fold_left (fun acc (v, (cmd, args), doc) ->
         OpamVariable.Map.update v
           (fun previous_value ->
              (lazy
@@ -82,7 +82,7 @@ let load lock_kind =
                     OpamSystem.read_command_output
                       ~env:(Lazy.force env)
                       ~allow_stdin:false
-                      cmd
+                      cmd args
                   in
                   Some (S (OpamStd.String.strip (String.concat "\n" ret)))
                 with e ->

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -73,7 +73,7 @@ let load lock_kind =
   let eval_variables = OpamFile.Config.eval_variables config in
   let global_variables =
     let env = lazy (OpamEnv.get_pure () |> OpamTypesBase.env_array) in
-    List.fold_left (fun acc (v, (cmd, args), doc) ->
+    List.fold_left (fun acc (v, cmd, doc) ->
         OpamVariable.Map.update v
           (fun previous_value ->
              (lazy
@@ -82,7 +82,7 @@ let load lock_kind =
                     OpamSystem.read_command_output
                       ~env:(Lazy.force env)
                       ~allow_stdin:false
-                      cmd args
+                      cmd
                   in
                   Some (S (OpamStd.String.strip (String.concat "\n" ret)))
                 with e ->

--- a/src/state/opamSysPoll.ml
+++ b/src/state/opamSysPoll.ml
@@ -11,9 +11,9 @@
 open OpamCompat
 open OpamStd.Option.Op
 
-let command_output c =
+let command_output c args =
   match List.filter (fun s -> String.trim s <> "")
-          (OpamSystem.read_command_output c)
+          (OpamSystem.read_command_output c args)
   with
   | [""] -> None
   | [s] -> Some s
@@ -36,7 +36,7 @@ let normalise_arch raw =
 
 let arch_lazy = lazy (
   let raw = match Sys.os_type with
-    | "Unix" | "Cygwin" -> OpamStd.Sys.uname "-m"
+    | "Unix" | "Cygwin" -> OpamStd.Sys.uname OpamExternalTools.Uname.arch
     | "Win32" ->
       (match OpamStd.Env.getopt "PROCESSOR_ARCHITECTURE" with
        | Some "X86" as a -> OpamStd.Env.getopt "PROCESSOR_ARCHITEW6432" ++ a
@@ -52,7 +52,7 @@ let arch () = Lazy.force arch_lazy
 let os_lazy = lazy (
   match Sys.os_type with
   | "Unix" ->
-    (match OpamStd.Sys.uname "-s" with
+    (match OpamStd.Sys.uname OpamExternalTools.Uname.kern_name with
       | Some "Darwin" -> Some "macos"
       | Some s -> norm s
       | None -> None)
@@ -79,7 +79,7 @@ let os_release_field =
     with Not_found -> None
 
 let is_android, android_release =
-  let prop = lazy (command_output ["getprop"; "ro.build.version.release"]) in
+  let prop = lazy (OpamExternalTools.Getprop.get_os_version command_output) in
   (fun () -> Lazy.force prop <> None),
   (fun () -> Lazy.force prop)
 
@@ -92,7 +92,7 @@ let os_distribution_lazy = lazy (
   | Some "linux" as linux ->
     (if is_android () then Some "android" else
      os_release_field "ID" >>= norm >>+ fun () ->
-     command_output ["lsb_release"; "-i"; "-s"] >>= norm >>+ fun () ->
+     OpamExternalTools.Lsb_release.get_id command_output >>= norm >>+ fun () ->
      try
        List.find Sys.file_exists ["/etc/redhat-release";
                                   "/etc/centos-release";
@@ -108,19 +108,19 @@ let os_version_lazy = lazy (
   match os () with
   | Some "linux" ->
     android_release () >>= norm >>+ fun () ->
-    command_output ["lsb_release"; "-s"; "-r"] >>= norm >>+ fun () ->
+    OpamExternalTools.Lsb_release.get_release command_output >>= norm >>+ fun () ->
     os_release_field "VERSION_ID" >>= norm
   | Some "macos" ->
-    command_output ["sw_vers"; "-productVersion"] >>= norm
+    OpamExternalTools.Sw_vers.get_os_version command_output >>= norm
   | Some ("win32" | "cygwin") ->
     (try
-       command_output ["cmd"; "/C"; "ver"] >>= fun s ->
+       OpamExternalTools.Cmd.get_os_version command_output >>= fun s ->
        Scanf.sscanf s "%_s@[ Version %s@]" norm
      with Scanf.Scan_failure _ | End_of_file -> None)
   | Some "freebsd" ->
-    OpamStd.Sys.uname "-U" >>= norm
+    OpamStd.Sys.uname OpamExternalTools.Uname.freebsd_version >>= norm
   | _ ->
-    OpamStd.Sys.uname "-r" >>= norm
+    OpamStd.Sys.uname OpamExternalTools.Uname.kern_version >>= norm
 )
 let os_version () = Lazy.force os_version_lazy
 


### PR DESCRIPTION
This PR aims at improving the way of describing and looking for external programs calls. This should also ease portability checks for Windows (cc @dra27) and minimal distributions such as Alpine Linux for example by checking which packages to install, what options are not available on the distribution/OS you want to port opam on.

Related to  #3197

This is WIP because of some ```assert false``` to fill up in ```src/format/opamFile.ml``` and calls to ```OpamExternalTools.custom``` for Git/Hg/Darcs/…
Also I would know if the change to the API is ok before continuing further.