### PR TITLE
src_ext management script

### DIFF
--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -108,7 +108,7 @@ ext-ignore:
 	@for l in $(filter-out jbuilder $(SRC_EXTS),$(PKG_EXTS)) ; do echo $$l >> jbuild-ignore ; done
 
 clone: $(JBUILDER_CLONE) $(SRC_EXTS:=.stamp) | ext-ignore
-	@
+	@rm -f cppo/ocamlbuild_plugin/jbuild
 
 .PHONY: pkg-ignore
 pkg-ignore:

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -3,7 +3,7 @@ MD5_cppo = b376e0f063f82daf5b1530479f5bcc5f
 
 $(call PKG_SAME,cppo)
 
-URL_extlib = https://github.com/ygrek/ocaml-extlib/releases/download/1.7.2/extlib-1.7.2.tar.gz
+URL_extlib = http://ygrek.org.ua/p/release/ocaml-extlib/extlib-1.7.2.tar.gz
 MD5_extlib = 0f550dd06242828399a73387c49e0eed
 
 $(call PKG_SAME,extlib)
@@ -23,7 +23,7 @@ MD5_ocamlgraph = 9d71ca69271055bd22d0dfe4e939831a
 
 $(call PKG_SAME,ocamlgraph)
 
-URL_cudf = https://gforge.inria.fr/frs/download.php/file/36602/cudf-0.9.tar.gz
+URL_cudf = https://gforge.inria.fr/frs/download.php/36602/cudf-0.9.tar.gz
 MD5_cudf = a4c0e652e56e74c7b388a43f9258d119
 
 $(call PKG_SAME,cudf)
@@ -43,13 +43,13 @@ MD5_opam-file-format = 5408798ca3af6e36379dd34b1b618b9c
 
 $(call PKG_SAME,opam-file-format)
 
-URL_result = https://github.com/janestreet/result/archive/1.3.tar.gz
-MD5_result = 2061d323b8b319de6f9605f63a54af56
+URL_result = https://github.com/janestreet/result/releases/download/1.3/result-1.3.tbz
+MD5_result = 4beebefd41f7f899b6eeba7414e7ae01
 
 $(call PKG_SAME,result)
 
-URL_jbuilder = https://github.com/ocaml/dune/archive/1.0+beta17.tar.gz
-MD5_jbuilder = c734e716e4fdb7e3564ed19b6eba2a1b
+URL_jbuilder = https://github.com/ocaml/dune/releases/download/1.0+beta17/jbuilder-1.0.beta17.tbz
+MD5_jbuilder = 03f11f4c6851d799ec7051ff48510ed4
 
 $(call PKG_SAME,jbuilder)
 

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -1,5 +1,5 @@
-URL_cppo = https://github.com/mjambon/cppo/archive/v1.6.1.tar.gz
-MD5_cppo = b376e0f063f82daf5b1530479f5bcc5f
+URL_cppo = https://github.com/mjambon/cppo/archive/v1.6.2.tar.gz
+MD5_cppo = 0c4f7b7f29b819bfd5b28200de67b3f5
 
 $(call PKG_SAME,cppo)
 

--- a/src_ext/update-sources.sh
+++ b/src_ext/update-sources.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+cd $(dirname $0)
+echo -n "Checking packages for new versions in opam: "
+DISAGREEMENTS=()
+while read name prefix version url; do
+  package=$name
+  if [[ $package = "findlib" ]] ; then package=ocamlfind ; fi
+  latest=$(opam show $package -f all-versions)
+  latest=${latest##* }
+  package_url=$(opam show $package.$latest -f url.src:)
+  md5=$(sed -n -e "s/MD5$prefix$name *= *\(.*\)/\1/p" Makefile.sources)
+  package_md5=$(opam show $package.$latest -f url.checksum: | sed -e "s/.*md5=\([a-fA-F0-9]\{32\}\).*/\1/")
+  if [[ $package_url = $url ]] ; then
+    if [[ $package_md5 = $md5 ]] ; then
+      echo -ne "[\033[0;32m$name\033[m] "
+      if [[ $latest != $version ]] ; then
+        DISAGREEMENTS+=" $name ($version vs $latest in opam)"
+      fi
+    else
+      echo "\n$name: [\033[1;33mWARN\033[m] MD5 is wrong for (should be $package_md5 according to opam)"
+    fi
+  else
+    if [[ $package_md5 = $md5 ]] ; then
+      echo -e "\n$name: [\033[1;33mWARN\033[m] URL is wrong for $name (should be $package_url according to opam)"
+    else
+      if [[ $latest = $version ]] ; then
+        echo -e "\n$name: [\033[1;33mWARN\033[m] URL and MD5 are wrong for $name (should be $package_url (md5=$package_md5) according to opam)"
+      else
+        echo -ne "[\033[0;31m$name\033[m: \033[1m$latest\033[m] "
+        sed -i -e "s/\(URL$prefix$name *= *\).*/\1${package_url////\\/}/" -e "s/\(MD5$prefix$name *= *\).*/\1$package_md5/" Makefile.sources
+      fi
+    fi
+  fi
+done < <(fgrep URL_ Makefile.sources | sed -e "s/URL\(_\(PKG_\)\?\)\([^ =]*\) *= *\(.*\/\([^0-9][^-]*-\)\?v\?\)\([0-9.]\+\([-+.][^\/]*\)\?\)\(\.tbz\|\.tar\.gz\)/\3 \1 \6 \4\6\8/" | sort)
+echo -e "\nComplete."
+if [[ ${#DISAGREEMENTS[@]} -gt 0 ]] ; then
+  echo "Disagreements over version:${DISAGREEMENTS[@]}"
+fi


### PR DESCRIPTION
Did you miss me?

Updates cppo to 1.6.2 in src_ext and also includes a little tweak to disable cppo's ocamlbuild plugin in src_ext mode (it's a nuisance if, like me, you more regularly type `jbuilder build` than `make`). The upgrade to 1.6.2 eliminates a jbuilder warning from cppo's test `jbuild` file (see also AltGr/ocaml-mccs#5)

I got bored of updating these references by hand, so I ~wasted~ invested a little time in a script. It has colours and everything. Blow away 7ac96c2 and run `src_ext/update-sources.sh` for colour-based update-prettiness...
