### PR TITLE
Fixes the version parsing starting with 'v' for pinning.

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2265,7 +2265,7 @@ let pin ?(unpin_only=false) () =
   in
   let pin_target kind target =
     let looks_like_version_re =
-      Re.(compile @@ seq [bos; digit; rep @@ diff any (set "/\\"); eos])
+      Re.(compile @@ seq [bos; opt @@ char 'v'; digit; rep @@ diff any (set "/\\"); eos])
     in
     let auto () =
       if target = "-" then


### PR DESCRIPTION
Fixes #3245: pin_target is now smart enough to detect Janestreet's
version naming convention as a version and not as a directory.