### PR TITLE
Fully test native Windows in the testsuite

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,10 +19,12 @@ environment:
 #      DEP_MODE: lib-pkg
     - OCAML_PORT: msvc
       DEP_MODE: lib-pkg
+      GIT_FOR_WINDOWS: 1
     - OCAML_PORT: msvc64
     - OCAML_PORT: mingw
     - OCAML_PORT: mingw64
       DEP_MODE: lib-pkg
+      GIT_FOR_WINDOWS: 1
 
 cache:
   - C:\projects\opam\bootstrap

--- a/appveyor_build.cmd
+++ b/appveyor_build.cmd
@@ -154,10 +154,15 @@ if "%DEP_MODE%" equ "lib-pkg" set WITH_MCCS=
 goto :EOF
 
 :test
-if "%OCAML_PORT%" neq "" (
-  echo Running the opam command...
-  opam || exit /b 1
-)
+rem Configure Git for Windows (for the testsuite, this isn't strictly necessary
+rem as Git-for-Windows will pick up $HOME/.gitconfig for Cygwin's git)
+git config --global user.email travis@example.com
+git config --global user.name Travis
+rem Configure Cygwin's Git
+"%CYG_ROOT%\bin\bash.exe" -lc "git config --global user.email travis@example.com"
+"%CYG_ROOT%\bin\bash.exe" -lc "git config --global user.name Travis"
+set OPAMCOLOR=always
+"%CYG_ROOT%\bin\bash.exe" -lc "make -C $APPVEYOR_BUILD_FOLDER tests" || (for %%I in (%APPVEYOR_BUILD_FOLDER%\_build\default\tests\failed-*.log) do appveyor PushArtifact %%I) && exit /b 1
 rem Can't yet do an opam init with the native Windows builds
 if "%OCAML_PORT%" equ "" "%CYG_ROOT%\bin\bash.exe" -lc "make -C $APPVEYOR_BUILD_FOLDER run-appveyor-test" || exit /b 1
 goto :EOF

--- a/appveyor_build.cmd
+++ b/appveyor_build.cmd
@@ -148,7 +148,9 @@ set LIB_EXT=
 if "%DEP_MODE%" equ "lib-ext" set LIB_EXT=^&^& make lib-ext
 set PRIVATE_RUNTIME=
 if "%OCAML_PORT:~0,5%" equ "mingw" set PRIVATE_RUNTIME=--with-private-runtime
-"%CYG_ROOT%\bin\bash.exe" -lc "cd $APPVEYOR_BUILD_FOLDER %LIB_PKG% && ./configure %PRIVATE_RUNTIME% %LIB_EXT% && make opam %POST_COMMAND%" || exit /b 1
+set WITH_MCCS=--with-mccs
+if "%DEP_MODE%" equ "lib-pkg" set WITH_MCCS=
+"%CYG_ROOT%\bin\bash.exe" -lc "cd $APPVEYOR_BUILD_FOLDER %LIB_PKG% && ./configure %PRIVATE_RUNTIME% %WITH_MCCS% %LIB_EXT% && make opam %POST_COMMAND%" || exit /b 1
 goto :EOF
 
 :test

--- a/appveyor_build.cmd
+++ b/appveyor_build.cmd
@@ -53,8 +53,8 @@ rem in the list just so that the Cygwin version is always displayed on the log).
 rem CYGWIN_COMMANDS is a corresponding command to run with --version to test
 rem whether the package works. This is used to verify whether the installation
 rem needs upgrading.
-set CYGWIN_PACKAGES=cygwin make patch curl diffutils tar unzip
-set CYGWIN_COMMANDS=cygcheck make patch curl diff tar unzip
+set CYGWIN_PACKAGES=cygwin make patch curl diffutils tar unzip git
+set CYGWIN_COMMANDS=cygcheck make patch curl diff tar unzip git
 
 if "%OCAML_PORT%" equ "mingw" (
   set CYGWIN_PACKAGES=%CYGWIN_PACKAGES% mingw64-i686-gcc-g++
@@ -162,7 +162,14 @@ rem Configure Cygwin's Git
 "%CYG_ROOT%\bin\bash.exe" -lc "git config --global user.email travis@example.com"
 "%CYG_ROOT%\bin\bash.exe" -lc "git config --global user.name Travis"
 set OPAMCOLOR=always
-"%CYG_ROOT%\bin\bash.exe" -lc "make -C $APPVEYOR_BUILD_FOLDER tests" || (for %%I in (%APPVEYOR_BUILD_FOLDER%\_build\default\tests\failed-*.log) do appveyor PushArtifact %%I) && exit /b 1
+set PATH_SHIM=
+if "%OCAML_PORT%" neq "" if "%GIT_FOR_WINDOWS%" equ "1" (
+  set PATH_SHIM=PATH=/cygdrive/c/Program\ Files/Git/cmd:$PATH
+  "C:\Program Files\Git\cmd\git.exe" config --global core.autocrlf
+  "C:\Program Files\Git\cmd\git.exe" config --global core.autocrlf true
+  "C:\Program Files\Git\cmd\git.exe" config --global core.autocrlf
+)
+"%CYG_ROOT%\bin\bash.exe" -lc "%PATH_SHIM% make -C $APPVEYOR_BUILD_FOLDER tests" || (for %%I in (%APPVEYOR_BUILD_FOLDER%\_build\default\tests\failed-*.log) do appveyor PushArtifact %%I) && exit /b 1
 rem Can't yet do an opam init with the native Windows builds
 if "%OCAML_PORT%" equ "" "%CYG_ROOT%\bin\bash.exe" -lc "make -C $APPVEYOR_BUILD_FOLDER run-appveyor-test" || exit /b 1
 goto :EOF

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,6 @@
 OCAMLC = ocamlc
 OS_TYPE := $(shell $(OCAMLC) -config | sed -ne "s/os_type: //p" | tr -d '\r')
+EXT_LIB := $(shell $(OCAMLC) -config | sed -ne "s/ext_lib: .//p" | tr -d '\r')
 
 TMP_DIR_ACT = $(realpath .)/tmp
 ifeq ($(OS_TYPE),Win32)
@@ -190,6 +191,7 @@ endif
 endif
 	$(OPAMBIN) update
 	$(OPAMBIN) switch create system --packages ocaml.system
+	$(OPAMBIN) config set ext_lib $(EXT_LIB)
 
 list:
 	$(OPAMBIN) list -A
@@ -295,10 +297,12 @@ switch-alias:
 	$(CHECK) -l switch-alias-2 ocaml.system P1.1 P2.1
 	$(OPAMBIN) switch export $(TMP_DIR)/export
 	$(OPAMBIN) switch create test system
+	$(OPAMBIN) config set ext_lib $(EXT_LIB)
 	$(CHECK) -l switch-alias-3 ocaml.system
 	$(OPAMBIN)	switch import $(TMP_DIR)/export
 	$(CHECK) -l switch-alias-4 ocaml.system P1.1 P2.1
 	$(OPAMBIN) switch create test2 20
+	$(OPAMBIN) config set ext_lib $(EXT_LIB)
 	$(CHECK) -l switch-alias-5 ocaml.20
 	$(OPAMBIN) install P1
 	$(CHECK) -l switch-alias-6 ocaml.20 P1.1
@@ -308,7 +312,9 @@ switch-alias:
 
 switch-env-packages:
 	$(CHECK) -l switch-env-packages-1 ocaml.system P1.1 P2.1
-	$(OPAMBIN) switch install 10+a+b --packages=ocaml.10+a+b,P1,P2,P3,P4
+	$(OPAMBIN) switch create 10+a+b --empty
+	$(OPAMBIN) config set ext_lib $(EXT_LIB)
+	$(OPAMBIN) install ocaml.10+a+b P1 P2 P3 P4
 	$(CHECK) -l switch-env-packages-2 ocaml.10+a+b P1.1 P2.1 P3.1~weird-version.test P4.3
 	./test-TEST.sh $(wildcard $(OPAM_ROOT)/10+a+b/build/P4.3/P4*.env) "1"
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,12 @@
-TMP_DIR   = $(realpath .)/tmp
+OCAMLC = ocamlc
+OS_TYPE := $(shell $(OCAMLC) -config | sed -ne "s/os_type: //p" | tr -d '\r')
+
+TMP_DIR_ACT = $(realpath .)/tmp
+ifeq ($(OS_TYPE),Win32)
+  TMP_DIR := $(shell echo $(TMP_DIR_ACT)| cygpath -m -f -)
+else
+  TMP_DIR=$(TMP_DIR_ACT)
+endif
 OPAM_ROOT = $(TMP_DIR)/OPAM.ROOT
 OPAM_REPO = $(TMP_DIR)/OPAM.REPO
 
@@ -16,7 +24,7 @@ unexport OCAMLLIB
 ifndef OPAM
   OPAM = $(firstword $(realpath ../../install/default/bin/opam$(EXE) ../_build/install/default/bin/opamMain.exe))
 endif
-ENV   = PATH=$(PATH) $(DEBUG) OPAMKEEPBUILDDIR=1 OPAMROOT=$(OPAM_ROOT) OPAMSWITCH= OPAMNOBASEPACKAGES=1 OPAMYES=1 OPAM=$(OPAM)
+ENV   = PATH="$(PATH)" $(DEBUG) OPAMKEEPBUILDDIR=1 OPAMROOT=$(OPAM_ROOT) OPAMSWITCH= OPAMNOBASEPACKAGES=1 OPAMYES=1 OPAM=$(OPAM)
 OPAMBIN  = $(ENV) $(OPAM)
 ifndef CHECK
   CHECK = $(ENV) $(firstword $(realpath ../src/tools/opam_check.exe ../_build/default/src/tools/opam_check.exe))
@@ -174,7 +182,11 @@ else
 	  mkdir -p $$dir; \
 	  cp $$f $$dir/$$md5; \
 	done
+ifeq ($(OS_TYPE),Win32)
+	echo 'archive-mirrors: "$(shell echo "$(OPAM_REPO)" | cygpath -w -f - | sed -e 's/\\/\\\\/g')\\cache"' >> $(OPAM_REPO)/repo
+else
 	echo 'archive-mirrors: "$(OPAM_REPO)/cache"' >> $(OPAM_REPO)/repo
+endif
 endif
 	$(OPAMBIN) update
 	$(OPAMBIN) switch create system --packages ocaml.system
@@ -259,13 +271,13 @@ endif
 
 upgrade:
 	$(CHECK) -l upgrade-1 ocaml.system P1.1 P2.1 P3.1~weird-version.test P4.1
-	eval `$(OPAMBIN) config env`; [ "X$$P1" = "Xversion1" ]
+	eval `$(OPAMBIN) config env | tr -d '\r'`; [ "X$$P1" = "Xversion1" ]
 	$(OPAMBIN) upgrade
 ifeq ($(REPOKIND), git)
 	$(CHECK) -l upgrade-2 ocaml.system P1.1 P2.1 P3.1~weird-version.test P4.3
 else
 	$(CHECK) -l upgrade-2 ocaml.system P1.2 P2.1 P3.1~weird-version.test P4.3
-	eval `$(OPAMBIN) config env`; [ "X$$P1" = "Xversion2" ]
+	eval `$(OPAMBIN) config env | tr -d '\r'`; [ "X$$P1" = "Xversion2" ]
 endif
 
 downgrade:
@@ -311,4 +323,4 @@ packages/%.tar.gz: packages/%
 clean:
 	rm -f test.log fulltest.log
 	rm -f $(ARCHIVES)
-	rm -rf $(TMP_DIR)
+	rm -rf $(TMP_DIR_ACT)

--- a/tests/packages/P1-0.opam
+++ b/tests/packages/P1-0.opam
@@ -5,7 +5,7 @@ name: "P1"
 version: "0"
 
 setenv: [P1 = "version0"]
-substs: "P1.config"
+substs: [ "P1.config" "P1.install" ]
 
 build: [
   [ "ocamlc" "-a" "p1.ml" "-o" "p1.cma" ]

--- a/tests/packages/P1-0/P1.install.in
+++ b/tests/packages/P1-0/P1.install.in
@@ -2,5 +2,5 @@ lib: [
   "p1.cmi"
   "p1.cma"
   "p1.cmxa"
-  "p1.a"
+  "p1.%{ext_lib}%"
 ]

--- a/tests/packages/P1-1.opam
+++ b/tests/packages/P1-1.opam
@@ -23,7 +23,7 @@ build: [
 available: os != "NO" | os != "NO" & os != "YES"
 
 (* List of files to substitute env variables *)
-substs: [ "P1.config" ]
+substs: [ "P1.config" "P1.install" ]
 
 (* Libraries *)
 libraries: [ "p1" ]

--- a/tests/packages/P1-1/P1.install.in
+++ b/tests/packages/P1-1/P1.install.in
@@ -2,8 +2,8 @@ lib: [
   "p1.cmi"
   "p1.cma"
   "p1.cmxa"
-  "p1.a"
-  "?this_file_will_not_exits_but_that's_ok"
+  "p1.%{ext_lib}%"
+  "?this_file_will_not_exist_but_that's_ok"
 ]
 share: [ "build.sh" ]
 doc: [

--- a/tests/packages/P1-2.opam
+++ b/tests/packages/P1-2.opam
@@ -3,7 +3,7 @@ name: "P1"
 version: "2"
 depends: [ "ocaml" {<= "10" | = "system"} ]
 maintainer: "contact@ocamlpro.com"
-substs:     [ "P1.config" ]
+substs:     [ "P1.config" "P1.install" ]
 libraries:  [ "p1" ]
 build: [ "./build.sh" ]
 setenv: [P1 = "version2"]

--- a/tests/packages/P1-2/P1.install.in
+++ b/tests/packages/P1-2/P1.install.in
@@ -1,6 +1,6 @@
 lib: [
   "p1.cma"
   "p1.cmxa"
-  "p1.a"
+  "p1.%{ext_lib}%"
   "p1.cmi"
 ]

--- a/tests/packages/P2.opam
+++ b/tests/packages/P2.opam
@@ -2,7 +2,7 @@ opam-version: "1"
 name: "P2"
 version:    "1"
 maintainer: "contact@ocamlpro.com"
-substs:     [ "config" "P2.config" ]
+substs:     [ "config" "P2.config" "P2.install" ]
 depends: ["ocaml" "P1"]
 libraries:  [ "p2" ]
 build: [ "./build.sh" ]

--- a/tests/packages/P2/P2.install.in
+++ b/tests/packages/P2/P2.install.in
@@ -1,6 +1,6 @@
 lib: [
   "p2.cma"
   "p2.cmxa"
-  "p2.a"
+  "p2.%{ext_lib}%"
   "p2.cmi"
 ]

--- a/tests/packages/P2/build.sh
+++ b/tests/packages/P2/build.sh
@@ -1,7 +1,7 @@
 #! /bin/sh -eu
 
-OFLAGS="`${OPAM} config var P1:asmcomp`"
-CFLAGS="`${OPAM} config var P1:bytecomp`"
+OFLAGS="`${OPAM} config var P1:asmcomp | tr -d '\r'`"
+CFLAGS="`${OPAM} config var P1:bytecomp | tr -d '\r'`"
 
 echo "Bytecode Compilation"
 ocamlc ${CFLAGS} -a p2.ml -o p2.cma

--- a/tests/packages/P3.opam
+++ b/tests/packages/P3.opam
@@ -3,5 +3,5 @@ name: "P3"
 version: "1~weird-version.test"
 maintainer: "contact@ocamlpro.com"
 depends: ["ocaml" "P1"]
-substs: [ "P3.config" ]
+substs: [ "P3.config" "P3.install" ]
 build: [ "./build.sh" ]

--- a/tests/packages/P3/P3.install.in
+++ b/tests/packages/P3/P3.install.in
@@ -2,12 +2,12 @@ lib: [
   (* p3 *)
   "p3.cma"
   "p3.cmxa"
-  "p3.a"
+  "p3.%{ext_lib}%"
   "p3.cmi"
 
   (* p3_bar *)
   "p3_bar.cma"
   "p3_bar.cmxa"
-  "p3_bar.a"
+  "p3_bar.%{ext_lib}%"
   "p3_bar.cmi"
 ]

--- a/tests/packages/P3/build.sh
+++ b/tests/packages/P3/build.sh
@@ -3,7 +3,7 @@
 echo "Building P3 version ${OPAM_PACKAGE_VERSION}"
 
 if [ "x${OPAM_PACKAGE_NAME}" = "xP3" ]; then
-    LIB=$(${OPAM} config var lib)
+    LIB=$(${OPAM} config var lib | tr -d '\r')
     ocamlc -a -I $LIB/P1 -I $LIB/P2 p3.ml -o p3.cma
     ocamlopt -a -I $LIB/P1 -I $LIB/P2 p3.ml -o p3.cmxa
     ocamlc -a -I $LIB/P1 -I $LIB/P2 p3_bar.ml -o p3_bar.cma

--- a/tests/packages/P4/build.sh
+++ b/tests/packages/P4/build.sh
@@ -13,7 +13,7 @@ else
 fi
 
 echo "Building P4 with ${OPAM}"
-LIBDIR="`${OPAM} config var lib`"
+LIBDIR="`${OPAM} config var lib | tr -d '\r'`"
 COMP="-I ${LIBDIR}/P1 -I ${LIBDIR}/P2 -I ${LIBDIR}/P3"
 LINK="p1.cmxa p2.cmxa p3.cmxa p3_bar.cmxa"
 

--- a/tests/packages/P5/build.sh
+++ b/tests/packages/P5/build.sh
@@ -1,6 +1,6 @@
 #! /bin/sh -eu
 
-FLAGS="-I `${OPAM} config var P1:lib`"
+FLAGS="-I `${OPAM} config var P1:lib | tr -d '\r'`"
 
 echo "Bytecode Compilation"
 ocamlc ${FLAGS} -a p5.ml -o p5.cma


### PR DESCRIPTION
This PR contains one commit which is still work-in-progress and all the work is dependent on #3242, #3248 and #3255. It also has to point the testsuite to my unstable fork of opam-repository, so it's definitely not for merging just yet. The squashing of the three base PRs means that GitHub's review interface is largely useless, but this can start the conversations going about the architectural changes.

This PR adds sufficient native Windows support to opam to create a full testsuite pass, and in full VT100 TechniColor. There is still more to come, as it excludes all of the shell integration and additional features required to support Windows *well*.

The PR is best viewed in two sections: the first 22 commits add/fix the required support; the remaining 14 commits concern porting the testsuite.

## (Relatively) Minor changes

 - Added extlib's `Option.map_default` to `OpamStd.Option`
 - The detection of the C++ compiler I added in #3216 broke MSVC, which doesn't require additional detection anyway (the Microsoft C compiler has in fact been a C++ compiler for decades...)
 - `Filename` module is now included in `OpamCompat` (`Filename.extension` is required)
 - There's a bug in a presumably previously untested Windows (code-)path in `OpamSystem.resolve_command`which caused it to return the directory the resolved command resided in, rather than the command!
 - `Filename.check_suffix` added to `OpamFilename.Base` and also a function `OpamFilename.Base.add_extension`

## Windows-related changes

 - opam is going to need to use tools provided by either Cygwin/MSYS2 or WSL for some time to come. In many cases, Cygwin tools can accept Windows-style paths if the back-slashes are converted to forward-slashes, but this is not universally the case. Cygwin provides a utility called `cygpath` for converting between all the various styles (Microsoft have recently introduced `wslpath` for WSL). Support for this is added in opam with three low-level functions. One `OpamStd.is_cygwin_variant` determines whether a given executable **itself** requires Cygwin, doesn't require Cygwin itself, but is linked to a library which does, or is a native Windows executable. This is used to provide `OpamSystem.get_cygpath_function` which returns a lazy function for a given command which will convert a supplied path if this is required. Finally, `OpamUrl.map_file_url` allows this function to be applied to `file://`-style URLs. This support is then used to patch invocations to `git`, `rsync`, and `tar` which allows the Cygwin versions of these commands to be used by opam.
 - Windows does not permit files or directories to be unlinked if anything is open (it is possible to open files and directories with special flags which do permit this, but it's best to pretend these don't exist in terms of architecture, because an annoying user can always open the file or have a shell with a directory you want to delete as a working directory!). This causes two problems:
   + Getting rid of lock files when an error has occurred. Where possible, I have "fixed" this by releasing locks (**This solution is potentially unsound, and I think needs replacing**).
   + This doesn't help for unhandled exceptions, so I've added a sledgehammer for this purpose `OpamSystem.release_all_locks`. The locking subsystem now keeps a Hashtbl of all lock fds which it knows haven't been released, and this function simply closes them all.
 - Windows file locking doesn't support promotion or demotion or recursive/re-entrant locking in the same way as Unix (underlying differences of architecture). I've added a guard which prevents a write lock from being acquired a second time and I've changed the promotion code for read->write. This adds the possibility that promoting a lock could result in losing it. **This should probably be changed to have a weird Windows-only lock which is taken out in order to promote/demote a lock**
 - The locking features added in #3248 are utilised to fix the writing of state files in `OpamRepository`
 - Cygwin executables follow a different command line escaping principle from Windows executables. There 's a huge piece of work in `OpamProcess` which means that parameters should definitely be passed correctly to Cygwin executables and which also allows scripts to be executed as though Windows supported `#!`.
 - New function `OpamSystem.classify_executable` determines whether a given executable file is a script or a binary. This is used to fix `OpamSystem.install` for Windows, since it really doesn't make sense to be using Cygwin's `install` command. Various warnings are displayed if inappropriate things get installed (like shell scripts) simply because I couldn't be bothered to split that off into the branch with the shell integration.
 - A shim (with warning) is added when processing `.install` files so that if an executable file `foo` is not found, but `foo.exe` exists then `foo.exe` is installed.
 - Several bugs in the URL handling were fixed - mainly down to not using filename concatenation functions and/or ensuring that backslashes don't get introduced when manipulating `file://` URLs, etc.
 - Interpolating variables is fundamentally broken once those variables start including back-slashes, since it means that interpolating them into `.config` files doesn't work. Tempting as it is to introduce yet another interpolation operator, a simpler scheme is used here: if the first line of the file being interpolated begins `opam-version:`, then opam assumes that any interpolation within double-quotes should escape backslashes. It's worked quite nicely in tests - looking at opam-repository, it didn't look as though this was likely to introduce regressions (since anything beginning `opam-version:` is extremely likely to be a file where having unescaped backslash characters before was a syntax error).

## LF/CRLF endings

This is a fundamental problem which I think must be addressed before 2.0.0 is released. Git-for-Windows by default sets `core.autocrlf` to true, which means that files in git remotes are very likely to get checked out with CRLF line endings, even if they were checked in with LF line endings originally (e.g. opam-repository). This has two key consequences for opam:

 1. It means that checksums need to be checked both against the file and, if it's a text file, the "other" version of the file. I've implemented this, admittedly in a sub-optimal manner (this shouldn't matter too much, since we're talking about very small files here, typically)
 2. It means that patch files, especially when processing git remotes, need a lot of special handling or you get CRLF errors and warnings from the `patch` utility, which is surprisingly obtuse about CRLF mismatches. There is a WIP commit in this branch handling the common case for this. The procedure I have come up with here is to pre-process diff files before `patch` is called. One effect of this is to ensure that the patch headers will always use Unix LF line-endings (this should eliminate warnings from patch about stripping trailing CRs). Each file to be patched is then analysed, and the patch updated to either include or strip CR characters based on what is actually on the disk. For example, `git diff` will (correctly) produce a patch with Unix line endings for two commits (which have LF normalised endings) even though the files on disk have CRLF checked out line-endings (from core.autocrlf) - so `patch` won't be able to apply the resulting diff file. This seems to be working quite nicely - there's also the possibility (not yet implemented) to work around an inadequacy of some versions of `patch` on Unix which don't correctly implement file renaming. My implementation needs ~more~ some error handling and the code-paths for context diffs aren't yet implemented, but this is both necessary for the testsuite to pass and, more to the point, working. **The intention is that this processing would be always run, since a Unix opam could still be presented with patch files generated on Windows**.

## Testsuite changes

There's a little catalogue of alterations to the testsuite to permit correct operation for AppVeyor:

 - `opam_check` was linked against `opam-client`, but this is a nuisance for mingw as it pulls `opam-solver` in (which means it needs manifesting on mingw as in #3255). I've changed it link `opam-state` only, as that's sufficient.
 - Various tweaks to `tests/Makefile` and the shell scripts in the testsuite both to cope with spaces in `PATH` and also the stray `\r` characters which come from the output of native Windows executables.
 - Running under MSVC means `.a` cannot be used as a hard-coded extension for library files. I have better solutions in the pipeline (#2930, etc.) for passing this around, but for now `opam config set` is used to create a variable `ext_lib` containing the correct extension.
 - a few tweaks to the build commands mean that `jbuilder runtest` is now run with `--no-buffer`, so you get to see the results as they happen!
 - The git commands in `tests/Makefile` were a real mess of copy-and-paste with subtle differences, so I factored them out to a macro to ensure that noone will ever understand them again!
 - The trick for interpolating variables with backslashes mentioned above necessitates using proper `.config.in` files. I don't think that's relevant to any of the tests (nor even good practice to have a `.config` with no `opam-version` header now?)
 - The testsuite now executes opam from `_build/install`. The commit mentions that this is done to allow execution of `opam-putenv`, but this isn't yet required. It is however required for the mingw builds, since the manifests are only available in the install directory, not the source directory.
 - AppVeyor doesn't recognise `[m` as equivalent to `[0m`. I like colour, so this is altered both in `tests/Makefile` **and also in a couple of places in opam itself**. I can't imagine a regression there, since recognising `[m` as reset and not `[0m` as reset would be extremely strange.
 - AppVeyor is then finally tweaked to run the testsuite on all 6 Windows ports and also to install the ocamlfind package. **At the moment, this has to be done from my personal fork of opam-repository.**
 - AppVeyor is configured to test Git-for-Windows and Cygwin's Git for the 4 native ports. Note that using Git-for-Windows from a Cygwin port should remain an unsupported piece of stupidity (if you're using Cygwin, you should use Cygwin. Period.)