### PR TITLE
Fix 'opam show <dir|file>'

### DIFF
--- a/src/client/opamAuxCommands.mli
+++ b/src/client/opamAuxCommands.mli
@@ -76,10 +76,13 @@ val autopin:
   rw switch_state * atom list
 
 (** The read-only version of [autopin ~simulate:true]: this doesn't require a
-    write-locked switch, and doesn't update the local packages *)
+    write-locked switch, and doesn't update the local packages. [keep_url] can
+    be used to not update the opam files' [url] section (useful when just
+    querying the files, rather than really using the pinnings) *)
 val simulate_autopin:
   'a switch_state ->
   ?quiet:bool ->
+  ?keep_url:bool ->
   ?locked:bool ->
   [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
   'a switch_state * atom list

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -748,6 +748,7 @@ let info st ~fields ~raw_opam ~where ?normalise ?(show_empty=false) atoms =
   in
   OpamPackage.names_of_packages packages |>
   OpamPackage.Name.Set.iter (fun name ->
+      (* Like OpamSwitchState.get_package, but restricted to [packages] *)
       let nvs = OpamPackage.packages_of_name packages name in
       let choose =
         try OpamPackage.Set.choose (nvs %% st.pinned) with Not_found ->

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -24,7 +24,7 @@ let string_of_pinned opam =
        (OpamFile.OPAM.url opam))
     (bold (OpamPackage.Version.to_string (OpamFile.OPAM.version opam)))
 
-let read_opam_file_for_pinning name f url =
+let read_opam_file_for_pinning ?(quiet=false) name f url =
   match OpamFileTools.lint_file f with
   | warns, None ->
     OpamConsole.error
@@ -36,7 +36,7 @@ let read_opam_file_for_pinning name f url =
   | warns, Some opam0 ->
     let opam = OpamFormatUpgrade.opam_file ~filename:f opam0 in
     let warns = if opam <> opam0 then OpamFileTools.lint opam else warns in
-    if warns <> [] then
+    if not quiet && warns <> [] then
       (OpamConsole.warning
          "Failed checks on %s package definition from source at %s:"
          (OpamPackage.Name.to_string name)

--- a/src/client/opamPinCommand.mli
+++ b/src/client/opamPinCommand.mli
@@ -57,12 +57,12 @@ val unpin_one: 'a switch_state -> package -> 'a switch_state
 (** List the pinned packages to the user. *)
 val list: 'a switch_state -> short:bool -> unit
 
-(** Lints the given opam file, prints warnings or errors accordingly, upgrades
-    it to current format, adds references to files below the 'files/' subdir
-    (unless the file is directly below the specified, local [url]), and returns
-    it *)
+(** Lints the given opam file, prints warnings or errors accordingly (unless
+    [quiet]), upgrades it to current format, adds references to files below the
+    'files/' subdir (unless the file is directly below the specified, local
+    [url]), and returns it *)
 val read_opam_file_for_pinning:
-  name -> OpamFile.OPAM.t OpamFile.t -> url -> OpamFile.OPAM.t option
+  ?quiet:bool -> name -> OpamFile.OPAM.t OpamFile.t -> url -> OpamFile.OPAM.t option
 
 (** The default version for pinning a package: depends on the state, what is
     installed and available, and defaults to [~dev]. *)

--- a/src/format/opamFilter.ml
+++ b/src/format/opamFilter.ml
@@ -551,7 +551,7 @@ let filter_deps ~build ~post ?test ?doc ?dev ?default_version ?default deps =
   let env var =
     let get_opt = function
       | Some b -> Some (B b)
-      | None -> assert false
+      | None -> invalid_arg "filter_deps"
     in
     match OpamVariable.Full.to_string var with
     | "build" -> Some (B build)


### PR DESCRIPTION
and add a `--no-lint` option

The interface is still a little weird if you query the `url` field, since this
goes through a local pinning: you will get the local dir.