### PR TITLE
Fix opam env messages

### DIFF
--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -30,23 +30,23 @@ val init:
 val install:
   rw switch_state ->
   ?autoupdate:atom list -> ?add_to_roots:bool -> ?deps_only:bool ->
-  atom list -> rw switch_state
+  atom list -> shell:shell -> rw switch_state
 
 (** Low-level version of [reinstall], bypassing the package name sanitization
     and dev package update, and offering more control *)
 val install_t:
-  rw switch_state -> ?ask:bool ->
+  rw switch_state -> ?ask:bool -> shell:shell ->
   atom list -> bool option -> deps_only:bool ->
   rw switch_state
 
 (** Reinstall the given set of packages. *)
 val reinstall:
-  rw switch_state -> atom list -> rw switch_state
+  rw switch_state -> atom list -> shell:shell -> rw switch_state
 
 (** Low-level version of [reinstall], bypassing the package name sanitization
     and dev package update, and offering more control *)
 val reinstall_t:
-  rw switch_state -> ?ask:bool -> ?force:bool -> atom list -> rw switch_state
+  rw switch_state -> ?ask:bool -> ?force:bool -> shell:shell -> atom list -> rw switch_state
 
 (** Update the local mirrors for the repositories and/or development packages.
     Returns [(success, changes, rt)], where [success] is [true] only if all
@@ -62,21 +62,21 @@ val update:
     versions. The specified atoms are kept installed (or newly installed after a
     confirmation). The upgrade concerns them only unless [all] is specified. *)
 val upgrade:
-  rw switch_state -> ?check:bool -> all:bool -> atom list -> rw switch_state
+  rw switch_state -> ?check:bool -> all:bool -> atom list -> shell:shell -> rw switch_state
 
 (** Low-level version of [upgrade], bypassing the package name sanitization
     and dev package update, and offering more control *)
 val upgrade_t:
   ?strict_upgrade:bool -> ?auto_install:bool -> ?ask:bool -> ?check:bool ->
-  all:bool -> atom list -> rw switch_state -> rw switch_state
+  shell:shell -> all:bool -> atom list -> rw switch_state -> rw switch_state
 
 (** Recovers from an inconsistent universe *)
-val fixup: rw switch_state -> rw switch_state
+val fixup: shell:shell -> rw switch_state -> rw switch_state
 
 (** Remove the given list of packages. *)
 val remove:
   rw switch_state -> autoremove:bool -> force:bool -> atom list ->
-  rw switch_state
+  shell:shell -> rw switch_state
 
 module PIN: sig
 
@@ -86,15 +86,16 @@ module PIN: sig
     rw switch_state ->
     OpamPackage.Name.t ->
     ?edit:bool -> ?version:version -> ?action:bool ->
+    shell:shell ->
     [< `Source of url | `Version of version | `Dev_upstream | `None ] ->
     rw switch_state
 
   val edit:
-    rw switch_state -> ?action:bool -> ?version:version -> OpamPackage.Name.t ->
-    rw switch_state
+    rw switch_state -> ?action:bool -> ?version:version -> shell:shell ->
+    OpamPackage.Name.t -> rw switch_state
 
   val unpin:
-    rw switch_state ->
+    shell:shell -> rw switch_state ->
     ?action:bool -> OpamPackage.Name.t list -> rw switch_state
 
   (** List the current pinned packages. *)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -659,18 +659,23 @@ end
 let config_doc = "Display configuration options for packages."
 let config =
   let doc = config_doc in
+  let shell_help = OpamStd.Sys.guess_shell_compat () in
   let commands = [
     "env", `env, [],
-    "Returns the bindings for the environment variables set in the current \
-     switch, e.g. PATH, in a format intended to be evaluated by a shell. With \
-     $(i,-v), add comments documenting the reason or package of origin for \
-     each binding. This is most usefully used as $(b,eval \\$(opam config \
-     env\\)) to have further shell commands be evaluated in the proper opam \
-     context. Can also be accessed through $(b,opam env).";
+    Printf.sprintf
+      "Returns the bindings for the environment variables set in the current \
+       switch, e.g. PATH, in a format intended to be evaluated by a shell. \
+       With $(i,-v), add comments documenting the reason or package of origin \
+       for each binding. This is most usefully used as $(b,%s) to have further \
+       shell commands be evaluated in the proper opam context. Can also be \
+       accessed through $(b,opam env)."
+      OpamEnv.(eval_string shell_help Manpage "config env" |> Manpage.escape);
     "revert-env", `revert_env, [],
-    "Reverts environment changes made by opam, e.g. $(b,eval \\$(opam config \
-     revert-env)) undoes what $(b,eval \\$(opam config env\\)) did, as much as \
-     possible.";
+    Printf.sprintf
+      "Reverts environment changes made by opam, e.g. $(b,%s) undoes what \
+       $(b,%s) did, as much as possible."
+      OpamEnv.(eval_string shell_help Manpage "config revert-env" |> Manpage.escape)
+      OpamEnv.(eval_string shell_help Manpage "config env" |> Manpage.escape);
     "setup", `setup, [],
     "Configure global and user parameters for opam. Use $(b, opam config \
      setup) to display more options. Use $(b,--list) to display the current \
@@ -1026,14 +1031,17 @@ let exec =
 let env_doc = "Prints appropriate shell variable assignments to stdout"
 let env =
   let doc = env_doc in
+  let shell_help = OpamStd.Sys.guess_shell_compat () in
   let man = [
     `S "DESCRIPTION";
-    `P "Returns the bindings for the environment variables set in the current \
-        switch, e.g. PATH, in a format intended to be evaluated by a shell. \
-        With $(i,-v), add comments documenting the reason or package of origin \
-        for each binding. This is most usefully used as $(b,eval \\$(opam \
-        env\\)) to have further shell commands be evaluated in the proper opam \
-        context.";
+    `P (Printf.sprintf
+          "Returns the bindings for the environment variables set in the \
+           current switch, e.g. PATH, in a format intended to be evaluated by \
+           a shell. With $(i,-v), add comments documenting the reason or \
+           package of origin for each binding. This is most usefully used as \
+           $(b,%s) to have further shell commands be evaluated in the proper \
+           opam context."
+          OpamEnv.(eval_string shell_help Manpage "env" |> Manpage.escape));
     `P "This is a shortcut, and equivalent to $(b,opam config env).";
   ] in
   let revert =
@@ -1830,6 +1838,7 @@ let switch =
     "install", `install, ["SWITCH"],
     "Deprecated alias for 'create'."
   ] in
+  let shell_help = OpamStd.Sys.guess_shell_compat () in
   let man = [
     `S "DESCRIPTION";
     `P "This command is used to manage \"switches\", which are independent \
@@ -1850,10 +1859,11 @@ let switch =
          package definitions are found locally, the user is automatically \
          prompted to install them after the switch is created unless \
          $(b,--no-install) is specified.");
-    `P "$(b,opam switch set) sets the default switch globally, but it is also \
-        possible to select a switch in a given shell session, using the \
-        environment. For that, use $(i,eval \\$(opam env \
-        --switch=SWITCH --set-switch\\)).";
+    `P (Printf.sprintf
+          "$(b,opam switch set) sets the default switch globally, but it is \
+           also possible to select a switch in a given shell session, using \
+           the environment. For that, use $(b,%s)."
+        OpamEnv.(eval_string shell_help ~set_opamswitch:true ManSwitch "SWITCH"));
   ] @ mk_subdoc ~defaults:["","list";"SWITCH","set"] commands
     @ [`S "OPTIONS"]
     @ [`S OpamArg.build_option_section]

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -73,7 +73,7 @@ let print_depexts_helper st actions =
          (OpamStd.String.Set.elements depexts))
   )
 
-let check_solution ?(quiet=false) st = function
+let check_solution ?(quiet=false) shell st = function
   | No_solution ->
     OpamConsole.msg "No solution found, exiting\n";
     OpamStd.Sys.exit_because `No_solution
@@ -81,14 +81,14 @@ let check_solution ?(quiet=false) st = function
     List.iter (post_message st) success;
     List.iter (post_message ~failed:true st) failed;
     print_depexts_helper st failed;
-    OpamEnv.check_and_print_env_warning st;
+    OpamEnv.check_and_print_env_warning shell st;
     OpamStd.Sys.exit_because `Package_operation_error
   | OK actions ->
     List.iter (post_message st) actions;
-    OpamEnv.check_and_print_env_warning st
+    OpamEnv.check_and_print_env_warning shell st
   | Nothing_to_do ->
     if not quiet then OpamConsole.msg "Nothing to do.\n";
-    OpamEnv.check_and_print_env_warning st
+    OpamEnv.check_and_print_env_warning shell st
   | Aborted     ->
     if not OpamClientConfig.(!r.show) then
       OpamStd.Sys.exit_because `Aborted

--- a/src/client/opamSolution.mli
+++ b/src/client/opamSolution.mli
@@ -55,7 +55,8 @@ val resolve_and_apply:
 (** Raise an error if no solution is found or in case of error. Unless [quiet]
     is set, print a message indicating that nothing was done on an empty
     solution. *)
-val check_solution: ?quiet:bool -> 'a switch_state -> solver_result -> unit
+val check_solution:
+  ?quiet:bool -> shell -> 'a switch_state -> solver_result -> unit
 
 (** {2 Atoms} *)
 

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -122,14 +122,14 @@ let list ~shell gt ~print_short =
       OpamConsole.warning
         "The environment is not in sync with the current switch.\n\
          You should run: %s"
-        (OpamEnv.eval_string shell gt (Some switch))
+        OpamEnv.(eval_string shell Root gt switch)
   | Some switch, `Default ->
     if not (OpamEnv.is_up_to_date_switch gt.root switch) then
       (OpamConsole.msg "\n";
        OpamConsole.warning
          "The environment is not in sync with the current switch.\n\
           You should run: %s"
-         (OpamEnv.eval_string shell gt (Some switch)))
+         OpamEnv.(eval_string shell Root gt switch))
   | _ -> ()
 
 let clear_switch ?(keep_debug=false) gt switch =

--- a/src/client/opamSwitchCommand.mli
+++ b/src/client/opamSwitchCommand.mli
@@ -23,16 +23,18 @@ val install:
   ?rt:'a repos_state ->
   ?synopsis:string ->
   ?repos:repository_name list ->
+  shell:shell ->
   update_config:bool ->
   packages:atom conjunction -> switch ->
   unlocked global_state * rw switch_state
 
 (** Install a compiler's base packages *)
 val install_compiler_packages:
-  rw switch_state -> atom conjunction -> rw switch_state
+  shell:shell -> rw switch_state -> atom conjunction -> rw switch_state
 
 (** Import a file which contains the packages to install.  *)
 val import:
+  shell:shell ->
   rw switch_state ->
   OpamFile.SwitchExport.t OpamFile.t option ->
   rw switch_state
@@ -47,10 +49,10 @@ val export: ?full:bool -> OpamFile.SwitchExport.t OpamFile.t option -> unit
 val remove: rw global_state -> ?confirm:bool -> switch -> rw global_state
 
 (** Changes the currently active switch *)
-val switch: 'a lock -> rw global_state -> switch -> 'a switch_state
+val switch: shell:shell -> 'a lock -> rw global_state -> switch -> 'a switch_state
 
 (** Reinstall the given compiler switch. *)
-val reinstall: rw switch_state -> rw switch_state
+val reinstall: shell:shell -> rw switch_state -> rw switch_state
 
 (** Sets the packages configured as the current switch compiler base *)
 val set_compiler:
@@ -60,7 +62,7 @@ val set_compiler:
 val show: unit -> unit
 
 (** List all the available compiler switches. *)
-val list: 'a global_state -> print_short:bool -> unit
+val list: shell:shell -> 'a global_state -> print_short:bool -> unit
 
 (** Returns all available compiler packages from a repo state *)
 val get_compiler_packages:

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -355,6 +355,8 @@ let eval_string shell gt ?(set_opamswitch=false) switch =
   match shell with
   | `fish ->
     Printf.sprintf "eval (opam env%s%s%s)" root switch setswitch
+  | `csh ->
+    Printf.sprintf "eval `opam env%s%s%s`" root switch setswitch
   | _ ->
     Printf.sprintf "eval $(opam env%s%s%s)" root switch setswitch
 

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -631,6 +631,12 @@ let setup_interactive root ~dot_profile shell =
   OpamConsole.msg "\n";
 
   OpamConsole.header_msg "Required setup - please read";
+  let fake_gt =
+    {global_lock = OpamSystem.lock_none;
+     root;
+     config = OpamFile.Config.empty;
+     global_variables = OpamVariable.Map.empty}
+  in
   OpamConsole.msg
     "\n\
     \  In normal operation, opam only alters files within ~/.opam.\n\
@@ -650,7 +656,7 @@ let setup_interactive root ~dot_profile shell =
     (OpamConsole.colorise `bold @@ string_of_shell shell)
     (OpamConsole.colorise `cyan @@ OpamFilename.prettify dot_profile)
     (OpamConsole.colorise `bold @@ source root ~shell (init_file shell))
-    (OpamConsole.colorise `bold @@ "eval $(opam env)");
+    (OpamConsole.colorise `bold @@ eval_string shell fake_gt None);
   match
     OpamConsole.read
       "Do you want opam to modify %s ? [N/y/f]\n\

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -323,7 +323,7 @@ let is_up_to_date st =
   is_up_to_date_raw
     (updates ~set_opamroot:false ~set_opamswitch:false ~force_path:false st)
 
-let eval_string gt ?(set_opamswitch=false) switch =
+let eval_string shell gt ?(set_opamswitch=false) switch =
   let root =
     let opamroot_cur = OpamFilename.Dir.to_string gt.root in
     let opamroot_env =
@@ -352,7 +352,7 @@ let eval_string gt ?(set_opamswitch=false) switch =
       else ""
   in
   let setswitch = if set_opamswitch then " --set-switch" else "" in
-  match OpamStd.Sys.guess_shell_compat () with
+  match shell with
   | `fish ->
     Printf.sprintf "eval (opam env%s%s%s)" root switch setswitch
   | _ ->
@@ -612,13 +612,13 @@ let display_setup root ~dot_profile shell =
   OpamConsole.msg "Global configuration:\n";
   List.iter print global_setup
 
-let check_and_print_env_warning st =
+let check_and_print_env_warning shell st =
   if (OpamFile.Config.switch st.switch_global.config = Some st.switch ||
       OpamStateConfig.(!r.switch_from <> `Command_line)) &&
      not (is_up_to_date st) then
     OpamConsole.formatted_msg
       "# Run %s to update the current shell environment\n"
-      (OpamConsole.colorise `bold (eval_string st.switch_global
+      (OpamConsole.colorise `bold (eval_string shell st.switch_global
                                      (Some st.switch)))
 
 let setup_interactive root ~dot_profile shell =

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -60,7 +60,7 @@ val compute_updates: ?force_path:bool -> 'a switch_state -> env_update list
 (** The shell command to run by the user to set his OPAM environment, adapted to
     the current shell (as returned by [eval `opam config env`]) *)
 val eval_string:
-  'a global_state -> ?set_opamswitch:bool -> switch option -> string
+  shell -> 'a global_state -> ?set_opamswitch:bool -> switch option -> string
 
 (** Returns the updated contents of the PATH variable for the given opam root
     and switch (set [force_path] to ensure the opam path is leading) *)
@@ -102,4 +102,4 @@ val clear_dynamic_init_scripts: rw global_state -> unit
 
 (** Print a warning if the environment is not set-up properly.
     (General message) *)
-val check_and_print_env_warning: 'a switch_state -> unit
+val check_and_print_env_warning: shell -> 'a switch_state -> unit

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -57,10 +57,14 @@ val is_up_to_date_switch: dirname -> switch -> bool
     its set of installed packages *)
 val compute_updates: ?force_path:bool -> 'a switch_state -> env_update list
 
+type _ eval_string = Root : ('a global_state -> switch -> string) eval_string
+                   | Manpage : (string -> string) eval_string
+                   | ManSwitch : (string -> string) eval_string
+
 (** The shell command to run by the user to set his OPAM environment, adapted to
     the current shell (as returned by [eval `opam config env`]) *)
 val eval_string:
-  shell -> 'a global_state -> ?set_opamswitch:bool -> switch option -> string
+  shell -> ?set_opamswitch:bool -> 'a eval_string -> 'a
 
 (** Returns the updated contents of the PATH variable for the given opam root
     and switch (set [force_path] to ensure the opam path is leading) *)

--- a/src/state/opamSwitchAction.ml
+++ b/src/state/opamSwitchAction.ml
@@ -128,7 +128,7 @@ let set_current_switch shell lock gt ?rt switch =
       "Can not set external switch '%s' globally. To set it in the current \
        shell use:\n %s"
       (OpamSwitch.to_string switch)
-      (OpamEnv.eval_string shell gt ~set_opamswitch:true (Some switch));
+      OpamEnv.(eval_string shell ~set_opamswitch:true Root gt switch);
   let config = OpamFile.Config.with_switch switch gt.config in
   let gt = { gt with config } in
   OpamGlobalState.write gt;

--- a/src/state/opamSwitchAction.ml
+++ b/src/state/opamSwitchAction.ml
@@ -122,13 +122,13 @@ let add_to_reinstall st ~unpinned_only packages =
     OpamFile.PkgList.write reinstall_file reinstall;
   { st with reinstall = st.reinstall ++ add_reinst_packages }
 
-let set_current_switch lock gt ?rt switch =
+let set_current_switch shell lock gt ?rt switch =
   if OpamSwitch.is_external switch then
     OpamConsole.error_and_exit `Bad_arguments
       "Can not set external switch '%s' globally. To set it in the current \
        shell use:\n %s"
       (OpamSwitch.to_string switch)
-      (OpamEnv.eval_string gt ~set_opamswitch:true (Some switch));
+      (OpamEnv.eval_string shell gt ~set_opamswitch:true (Some switch));
   let config = OpamFile.Config.with_switch switch gt.config in
   let gt = { gt with config } in
   OpamGlobalState.write gt;

--- a/src/state/opamSwitchAction.mli
+++ b/src/state/opamSwitchAction.mli
@@ -27,7 +27,7 @@ val write_selections: rw switch_state -> unit
 (** Updates the defined default switch and loads its state; fails and exits with
     a message if the switch is external *)
 val set_current_switch:
-  'a lock -> rw global_state -> ?rt:'b repos_state -> switch -> 'a switch_state
+  shell -> 'a lock -> rw global_state -> ?rt:'b repos_state -> switch -> 'a switch_state
 
 (** Create the default global_config structure for a switch, including default
     prefix *)


### PR DESCRIPTION
This PR fixes the display of the `eval $(opam env)` messages. In particular:

 - #2925 converted the ``eval `opam config env` `` message to `eval $(opam config env)`. At this point, it was necessary to add a special case for `csh` which doesn't support that syntax.
 - `OpamEnv.eval_string` only ever guessed the shell from `$SHELL` even when `--shell` had been passed to opam.
 - `opam init` always displayed `eval $(opam env)` regardless of the shell, as did `--help` screens.

This PR:
 - Adds an extra case for `` `csh`` which uses backticks.
 - Extends `OpamEnv.eval_string` to have a `shell` parameter. This is quite an invasive change - in particular, it means that `switch`, `install`, `pin`, `remove` and `reinstall` commands now have a `--shell` parameter. I was quite haphazard about where `~shell` got put... if you're happy with the idea of this change, this should be rationalised (i.e. should the argument always be named and where should it go in argument listed).
 - `opam init` now displays the correct command for the given shell.
 - The `--help` screens for the `switch`, `config` and `env` commands now display the command based on `$SHELL` (i.e. `OpamStd.Sys.guess_shell_compat`). It's possible to peek the `--shell` argument here, but even I think that having `SHELL=bash opam config --shell=fish --help` work correctly is more effort than is necessary :wink: