### PR TITLE
Better shell detection

### DIFF
--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -720,6 +720,7 @@ module OpamSys = struct
 
   let shell_of_string = function
     | "tcsh"
+    | "bsd-csh"
     | "csh"  -> Some `csh
     | "zsh"  -> Some `zsh
     | "bash" -> Some `bash

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -125,6 +125,8 @@ module Option: sig
 
   val default_map: 'a option -> 'a option -> 'a option
 
+  val replace : ('a -> 'b option) -> 'a option -> 'b option
+
   val compare: ('a -> 'a -> int) -> 'a option -> 'a option -> int
 
   val to_string: ?none:string -> ('a -> string) -> 'a option -> string


### PR DESCRIPTION
At present, opam bases shell detection entirely on `$SHELL`. This is fine for the default shell, but doesn't cope with a shell launched from another shell.

This PR adds various mechanisms based on `/proc` and `ps` which I believe should work for both Linux and the BSDs. If all three mechanisms fail, it falls back to $SHELL. Note that in this context, "fail" means "doesn't identify a shell" (so, for example, if for some strange reason you start `fish` using a symlink called `fishy`, then opam will continue to inspect `$SHELL`).