### PR TITLE
linter checks spaces and empty string on 'depexts' field

### DIFF
--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -579,7 +579,14 @@ let lint ?check_extra_files t =
      cond 53 `Error
        "Mismatching 'extra-files:' field"
        ~detail:(List.map OpamFilename.Base.to_string mismatching_extra_files)
-       (mismatching_extra_files <> []))
+       (mismatching_extra_files <> []));
+    (let spaced_depexts = List.concat (List.map (fun (dl,_) ->
+         List.filter (fun d -> String.contains d ' ' || String.length d = 0) dl)
+         t.depexts) in
+     cond 54 `Warning
+       "External dependencies should not contain spaces nor empty string"
+       ~detail:spaced_depexts
+       (spaced_depexts <> []))
   ]
   in
   format_errors @

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -559,7 +559,7 @@ let lint ?check_extra_files t =
              false f)
           false
           (OpamFormula.ands [t.depends; t.depopts]));
-    cond 46 `Error
+    cond 52 `Error
       "Package is needlessly flagged \"light-uninstall\", since it has no \
        remove instructions"
       (has_flag Pkgflag_Conf t && t.remove = []);
@@ -576,7 +576,7 @@ let lint ?check_extra_files t =
              with Not_found -> Some n)
            ffiles
      in
-     cond 52 `Error
+     cond 53 `Error
        "Mismatching 'extra-files:' field"
        ~detail:(List.map OpamFilename.Base.to_string mismatching_extra_files)
        (mismatching_extra_files <> []))


### PR DESCRIPTION
This PR fixes the issue https://github.com/ocaml/opam/issues/3208. 
It adds a warning in case of space character or an empty string in `depexts` field.
And a tiny fix on linter error/warning numbering.