### PR TITLE
bwrap: add opam switch prefix bind for build

### DIFF
--- a/src/state/bwrap.sh
+++ b/src/state/bwrap.sh
@@ -32,6 +32,7 @@ add_mounts ro /usr /bin /lib /lib32 /lib64 /etc /opt /nix/store /home
 COMMAND="$1"; shift
 case "$COMMAND" in
     build)
+        add_mounts ro "$OPAM_SWITCH_PREFIX"
         add_mounts rw "$PWD"
         ;;
     install)


### PR DESCRIPTION
The `OPAM_SWITCH_PREFIX` was not bind on build with bwrap, causing some `opam-rt` test failure.