### PR TITLE
Try to improve opam init message about configuration files

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -226,9 +226,15 @@ let init =
     in
     let init_config =
       try
-        OpamConsole.note "Will configure from built-in defaults%s."
-          (OpamStd.List.concat_map ~nil:"" ~left:", " ~last_sep:" and " ", "
-             OpamFile.to_string config_files);
+        let others =
+          match config_files with
+          | [] -> ""
+          | [file] -> OpamFile.to_string file ^ " and then from "
+          | _ ->
+              (OpamStd.List.concat_map ~nil:"" ~right:", and finally from " ", then "
+               OpamFile.to_string (List.rev config_files))
+        in
+        OpamConsole.note "Will configure from %sbuilt-in defaults." others;
         List.fold_left (fun acc f ->
             OpamFile.InitConfig.add acc (OpamFile.InitConfig.read f))
           OpamInitDefaults.init_config

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -227,7 +227,7 @@ let init =
     let init_config =
       try
         OpamConsole.note "Will configure from built-in defaults%s."
-          (OpamStd.List.concat_map ~nil:"" ~left:", " ", "
+          (OpamStd.List.concat_map ~nil:"" ~left:", " ~last_sep:" and " ", "
              OpamFile.to_string config_files);
         List.fold_left (fun acc f ->
             OpamFile.InitConfig.add acc (OpamFile.InitConfig.read f))

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -152,7 +152,7 @@ module List : sig
   (** Convert list items to string and concat. [sconcat_map sep f x] is equivalent
       to String.concat sep (List.map f x) but tail-rec. *)
   val concat_map:
-    ?left:string -> ?right:string -> ?nil:string ->
+    ?left:string -> ?right:string -> ?nil:string -> ?last_sep:string ->
     string -> ('a -> string) -> 'a list -> string
 
   (** Like [List.find], but returning option instead of raising *)


### PR DESCRIPTION
The list of configuration files being consulted (the first "NOTE" from `opam init`) displays the files in ascending order of priority which is not wholly intuitive. I've tweaked the wording so that the note now appears as:
```
[NOTE] Will configure from /home/dra/.opamrc, then /etc/opamrc, and finally from built-in defaults.
```
or
```
[NOTE] Will configure from /home/dra/.opamrc and then from built-in defaults.
```

I've also added, but then not used, a `?last_sep` parameter to `OpamStd.List.concat_map` which allows you to have lists written `x and y` or `x, y and z` (or even `x, y, and z` if you are so inclined). There are definitely other places in the client where the messages could be augmented by use of that parameter.