### PR TITLE
Issue #3281: Improve 'opam update' with repositories of kind 'hg'.

### DIFF
--- a/src/repository/opamDarcs.ml
+++ b/src/repository/opamDarcs.ml
@@ -76,7 +76,7 @@ module VCS = struct
     OpamSystem.raise_on_process_error r;
     Done ()
 
-  let reset repo_root _repo_url =
+  let reset_tree repo_root _repo_url =
     darcs repo_root [ "obliterate"; "--all"; "-t"; opam_local_tag ]
     @@> fun r ->
     OpamSystem.raise_on_process_error r;
@@ -85,6 +85,8 @@ module VCS = struct
     (* returns 0 even if patch doesn't exist *)
     OpamSystem.raise_on_process_error r;
     Done ()
+
+  let patch_applied _ _ = Done ()
 
   let revision repo_root =
     (* 'Weak hash' is only supported from 2.10.3, so provide a fallback *)
@@ -142,7 +144,7 @@ module VCS = struct
       else
         Done (Some (OpamFilename.of_string patch_file))
 
-  let versionned_files repo_root =
+  let versioned_files repo_root =
     darcs repo_root [ "show" ; "files" ]
     @@> fun r ->
     OpamSystem.raise_on_process_error r;

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -126,7 +126,7 @@ module VCS : OpamVCS.VCS = struct
          else
            Done (Some full))
 
-  let reset repo_root repo_url =
+  let reset_tree repo_root repo_url =
     let rref = remote_ref repo_url in
     git repo_root [ "reset" ; "--hard"; rref; "--" ]
     @@> fun r ->
@@ -141,6 +141,11 @@ module VCS : OpamVCS.VCS = struct
             (OpamFilename.Dir.to_string repo_root);
         Done ()
       else Done ()
+
+  let patch_applied _ _ =
+    (* This might be a good place to do 'git reset --soft' and check for
+       unstaged changes. See <https://github.com/ocaml/opam/pull/3283>. *)
+    Done ()
 
   let diff repo_root repo_url =
     let rref = remote_ref repo_url in
@@ -170,7 +175,7 @@ module VCS : OpamVCS.VCS = struct
       OpamProcess.cleanup ~force:true r; Done false
     | r -> OpamSystem.process_error r
 
-  let versionned_files repo_root =
+  let versioned_files repo_root =
     git repo_root ~verbose:false [ "ls-files" ] @@> fun r ->
     OpamSystem.raise_on_process_error r;
     Done r.OpamProcess.r_stdout

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -66,6 +66,7 @@ module B = struct
       | None -> OpamRepositoryBackend.Update_empty
       | Some patch -> OpamRepositoryBackend.Update_patch patch
 
+  let repo_update_complete _ _ = Done ()
 
   let pull_url ?cache_dir:_ dirname checksum remote_url =
     log "pull-file into %a: %a"

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -179,6 +179,8 @@ module B = struct
         | None -> OpamRepositoryBackend.Update_empty
         | Some p -> OpamRepositoryBackend.Update_patch p
 
+  let repo_update_complete _ _ = Done ()
+
   let pull_url ?cache_dir:_ local_dirname _checksum remote_url =
     OpamFilename.mkdir local_dirname;
     let dir = OpamFilename.Dir.to_string local_dirname in

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -420,10 +420,12 @@ let update repo =
         raise exn)
     @@ fun () ->
     validate_repo_update repo upd @@+ function
-    | true -> apply_repo_update repo upd
     | false ->
       cleanup_repo_update upd;
       failwith "Invalid repository signatures, update aborted"
+    | true ->
+      apply_repo_update repo upd @@+ fun () ->
+      B.repo_update_complete repo.repo_root repo.repo_url
 
 let on_local_version_control url ~default f =
   match url.OpamUrl.backend with

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -27,6 +27,7 @@ module type S = sig
   val fetch_repo_update:
     repository_name -> ?cache_dir:dirname -> dirname -> url ->
     update OpamProcess.job
+  val repo_update_complete: dirname -> url -> unit OpamProcess.job
   val revision: dirname -> version option OpamProcess.job
   val sync_dirty: dirname -> url -> filename option download OpamProcess.job
 end

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -56,6 +56,13 @@ module type S = sig
     repository_name -> ?cache_dir:dirname -> dirname -> url ->
     update OpamProcess.job
 
+  (** [repo_update_complete dirname url] finalizes the update of the repository
+      after verification of the patch returned from [pull_repo_update] with
+      [Update_patch file] is applied. Version control systems, e.g. Mercurial,
+      that track the state of the working directory automatically use this to
+      update internal caches. *)
+  val repo_update_complete: dirname -> url -> unit OpamProcess.job
+
   (** Return the (optional) revision of a given repository. Only useful for VCS
       backends. Is not expected to work with [pull_repo_update], which doesn't
       update the VCS commit information. *)

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -63,6 +63,10 @@ module Make (VCS: VCS) = struct
       VCS.reset tmpdir repo_url @@| fun () ->
       OpamRepositoryBackend.Update_full tmpdir
 
+  let repo_update_complete dirname url =
+    VCS.reset dirname url @@+ fun () ->
+    Done ()
+
   let pull_url ?cache_dir dirname checksum url =
     if checksum <> None then invalid_arg "VC pull_url doesn't allow checksums";
     OpamProcess.Job.catch

--- a/src/repository/opamVCS.mli
+++ b/src/repository/opamVCS.mli
@@ -33,7 +33,11 @@ module type VCS = sig
   (** Reset the master branch of the repository to match the remote repository
       state. This might still fetch more data (git submodules...), so is
       unsuitable for running after validation. *)
-  val reset: dirname -> url -> unit OpamProcess.job
+  val reset_tree: dirname -> url -> unit OpamProcess.job
+
+  (** Confirm that applying the patch results in a clean synchronization of
+      the working tree with its repository state. *)
+  val patch_applied: dirname -> url -> unit OpamProcess.job
 
   (** Returns the pending modifications in the form of a patch file, or None if
       [dirname] is up to date with what was last fetched. *)
@@ -47,7 +51,7 @@ module type VCS = sig
   val revision: dirname -> string option OpamProcess.job
 
   (** Returns the list of files under version control *)
-  val versionned_files: dirname -> string list OpamProcess.job
+  val versioned_files: dirname -> string list OpamProcess.job
 
   (** Returns the absolute directory name for vc data (e.g.
       [.../project/.git]) *)


### PR DESCRIPTION
* Adds [repo_update_complete] to the signature of {OpamRepositoryBackend.S}
  and calls it after an update is validated to provide the VCS backend with
  the opportunity to reset the working set explicitly. Mercurial requires
  this after the patch is applied to update its internal state tracking the
  identity of the changeset. Also, the Mercurial handler has various updates
  to improve correctness in the presence of a) subrepositories, b) multiple
  heads on the same branch, and c) bookmarks on the server.