### PR TITLE
travis: restrain cudf to 0.9

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -29,7 +29,7 @@ init-bootstrap () {
     eval $(opam env)
     # extlib is installed, since UChar.cmi causes problems with the search
     # order. See also the removal of uChar and uTF8 in src_ext/jbuild-extlib-src
-    opam install cohttp-lwt-unix ssl cmdliner dose3 opam-file-format re extlib 'jbuilder>=1.0+beta19' 'mccs>=1.1+5' --yes
+    opam install cohttp-lwt-unix ssl cmdliner dose3 cudf.0.9 opam-file-format re extlib 'jbuilder>=1.0+beta19' 'mccs>=1.1+5' --yes
   fi
   rm -f "$OPAMBSROOT"/log/*
 }


### PR DESCRIPTION
In travis build, opam automatically install (dependence) cudf.0.8, which broke the build because of camlp4 system package (success even if campl4 is not installed).