### PR TITLE
Big optimisation pass on universe loading

### DIFF
--- a/src/client/opamAdminCheck.ml
+++ b/src/client/opamAdminCheck.ml
@@ -67,7 +67,7 @@ let installability_check univ =
   let graph =
     OpamCudf.Graph.of_universe @@
     OpamSolver.load_cudf_universe
-      ~depopts:false ~build:true ~post:true univ packages
+      ~depopts:false ~build:true ~post:true univ packages ()
   in
   let filter_roots g packages =
     let has_pkg p = OpamPackage.Set.mem (OpamCudf.cudf2opam p) packages in
@@ -101,7 +101,7 @@ let formula_of_pkglist packages = function
 let cycle_check univ =
   let cudf_univ =
     OpamSolver.load_cudf_universe
-      ~depopts:true ~build:true ~post:false univ univ.u_packages
+      ~depopts:true ~build:true ~post:false univ univ.u_packages ()
   in
   let graph =
     OpamCudf.Graph.of_universe cudf_univ |>

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -37,6 +37,7 @@ module type MAP = sig
   val values: 'a t -> 'a list
   val find_opt: key -> 'a t -> 'a option
   val union: ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+  val is_singleton: 'a t -> bool
   val of_list: (key * 'a) list -> 'a t
   val safe_add: key -> 'a -> 'a t -> 'a t
   val update: key -> ('a -> 'a) -> 'a -> 'a t -> 'a t
@@ -257,6 +258,10 @@ module Map = struct
           | Some v1, Some v2 -> Some (f v1 v2)
           | None, None -> assert false)
         m1 m2
+
+    let is_singleton s =
+      not (is_empty s) &&
+      fst (min_binding s) == fst (max_binding s)
 
     let to_string string_of_value m =
       if M.cardinal m > max_print then

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -62,6 +62,8 @@ module type MAP = sig
       using the function given as argument. *)
   val union: ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
 
+  val is_singleton: 'a t -> bool
+
   val of_list: (key * 'a) list -> 'a t
 
   (** Raises Failure in case the element is already present *)

--- a/src/format/opamFilter.mli
+++ b/src/format/opamFilter.mli
@@ -154,6 +154,14 @@ val filter_formula:
     formula *)
 val partial_filter_formula: env -> filtered_formula -> filtered_formula
 
+(** A more generic formula reduction function, that takes a "partial resolver"
+    as argument *)
+val gen_filter_formula:
+  ('a -> [< `True | `False | `Formula of 'b OpamTypes.generic_formula ]) ->
+  ('c * 'a) OpamFormula.formula ->
+  ('c * 'b OpamTypes.generic_formula) OpamFormula.formula
+
+
 val string_of_filtered_formula: filtered_formula -> string
 
 val variables_of_filtered_formula: filtered_formula -> full_variable list
@@ -170,9 +178,18 @@ val filter_deps:
   ?default_version:version -> ?default:bool ->
   filtered_formula -> formula
 
+(** The environment used in resolving the dependency filters, as per
+    [filter_deps]. *)
+val deps_var_env:
+  build:bool -> post:bool -> ?test:bool -> ?doc:bool -> ?dev:bool -> env
 
 (** Like [OpamFormula.simplify_version_formula], but on filtered formulas
     (filters are kept unchanged, but put in front) *)
 val simplify_extended_version_formula:
   filter filter_or_constraint OpamFormula.formula ->
   filter filter_or_constraint OpamFormula.formula option
+
+val atomise_extended:
+  filtered_formula ->
+  (OpamPackage.Name.t * (filter * (relop * filter) option))
+    OpamFormula.formula

--- a/src/format/opamFormula.ml
+++ b/src/format/opamFormula.ml
@@ -60,15 +60,19 @@ type 'a cnf = 'a list list
 
 let string_of_cnf string_of_atom cnf =
   let string_of_clause c =
-    Printf.sprintf "(%s)" (OpamStd.List.concat_map " | " string_of_atom c) in
-  Printf.sprintf "(%s)" (OpamStd.List.concat_map " & " string_of_clause cnf)
+    let left, right = match c with [_] -> "", "" | _ -> "(", ")" in
+    OpamStd.List.concat_map ~left ~right " | " string_of_atom c
+  in
+  OpamStd.List.concat_map " & " string_of_clause cnf
 
 type 'a dnf = 'a list list
 
 let string_of_dnf string_of_atom cnf =
   let string_of_clause c =
-    Printf.sprintf "(%s)" (OpamStd.List.concat_map " & " string_of_atom c) in
-  Printf.sprintf "(%s)" (OpamStd.List.concat_map " | " string_of_clause cnf)
+    let left, right = match c with [_] -> "", "" | _ -> "(", ")" in
+    OpamStd.List.concat_map ~left ~right " & " string_of_atom c
+  in
+  OpamStd.List.concat_map " | " string_of_clause cnf
 
 type 'a formula =
   | Empty
@@ -321,76 +325,88 @@ let of_atom_formula (a:atom formula): t =
     | Some (r,v) -> Atom (n, Atom (r,v)) in
   map atom a
 
-(* Convert a formula to CNF *)
-let to_cnf (t : t) =
-  let rec or_formula = function
-    | Atom (x,None)      -> [x, None]
-    | Atom (x,Some(r,v)) -> [x, Some(r,v)]
-    | Or(x,y)            -> or_formula x @ or_formula y
-    | Empty
-    | Block _
-    | And _      -> assert false in
-  let rec aux t = match t with
-    | Empty    -> []
-    | Block _  -> assert false
-    | Atom _
-    | Or _     -> [or_formula t]
-    | And(x,y) -> aux x @ aux y in
-  aux (cnf_of_formula (to_atom_formula t))
-
-(* Convert a formula to DNF *)
-let to_dnf t =
-  let rec and_formula = function
-    | Atom (x,None)      -> [x, None]
-    | Atom (x,Some(r,v)) -> [x, Some(r,v)]
-    | And(x,y)           -> and_formula x @ and_formula y
-    | Empty
-    | Block _
-    | Or _      -> assert false in
-  let rec aux t = match t with
-    | Empty   -> []
-    | Block _ -> assert false
-    | Atom _
-    | And _   -> [and_formula t]
-    | Or(x,y) -> aux x @ aux y in
-  aux (dnf_of_formula (to_atom_formula t))
-
-let to_conjunction t =
-  match to_dnf t with
-  | []  -> []
-  | [x] -> x
-  | _   ->
-    failwith (Printf.sprintf "%s is not a valid conjunction" (to_string t))
-
 let ands l = List.fold_left make_and Empty l
 
 let rec ands_to_list = function
   | Empty -> []
-  | And (e,f) | Block (And (e,f)) -> ands_to_list e @ ands_to_list f
+  | And (e,f) ->
+    List.rev_append (rev_ands_to_list e) (ands_to_list f)
+  | Block f -> ands_to_list f
+  | x -> [x]
+and rev_ands_to_list = function
+  | Empty -> []
+  | Block f -> rev_ands_to_list f
+  | And (e,f) ->
+    List.rev_append (ands_to_list f) (rev_ands_to_list e)
   | x -> [x]
 
 let of_conjunction c =
   of_atom_formula (ands (List.rev_map (fun x -> Atom x) c))
 
-let to_disjunction t =
-  match to_cnf t with
-  | []  -> []
-  | [x] -> x
-  | _   ->
-    failwith (Printf.sprintf "%s is not a valid disjunction" (to_string t))
-
 let ors l = List.fold_left make_or Empty l
 
 let rec ors_to_list = function
   | Empty -> []
-  | Or (e,f) | Block (Or (e,f)) -> ors_to_list e @ ors_to_list f
+  | Or (e,f) ->
+    List.rev_append (rev_ors_to_list e) (ors_to_list f)
+  | Block f -> ors_to_list f
   | x -> [x]
+and rev_ors_to_list = function
+  | Empty -> []
+  | Or (e,f) ->
+    List.rev_append (ors_to_list f) (rev_ors_to_list e)
+  | Block f -> rev_ors_to_list f
+  | x -> [x]
+
+let is_conjunction t =
+  let rec aux = function
+    | Or _ -> false
+    | And (a,b) -> aux a && aux b
+    | Block a -> aux a
+    | _ -> true
+  in
+  aux t
+
+let is_disjunction t =
+  let rec aux = function
+    | And _ -> false
+    | Or (a,b) -> aux a && aux b
+    | Block a -> aux a
+    | _ -> true
+  in
+  aux t
+
+let atoms t =
+  fold_right (fun accu x -> x::accu) [] (to_atom_formula t)
+
+let to_cnf t =
+  let atf = to_atom_formula t in
+  let atoms = fold_right (fun acc a -> a::acc) [] in
+  let conj = rev_ands_to_list atf in
+  if List.for_all is_disjunction conj then
+    List.rev_map atoms conj (* this gives a nice speedup *)
+  else
+    List.rev_map atoms @@ rev_ands_to_list @@ cnf_of_formula atf
+
+let to_dnf t =
+  let atf = to_atom_formula t in
+  let atoms = fold_right (fun acc a -> a::acc) [] in
+  let disj = rev_ors_to_list atf in
+  if List.for_all is_conjunction disj then
+    List.rev_map atoms disj
+  else
+    List.rev_map atoms @@ rev_ors_to_list @@ dnf_of_formula atf
+
+let to_conjunction t =
+  if is_conjunction t then atoms t
+  else failwith (Printf.sprintf "%s is not a valid conjunction" (to_string t))
+
+let to_disjunction t =
+  if is_disjunction t then atoms t
+  else failwith (Printf.sprintf "%s is not a valid disjunction" (to_string t))
 
 let of_disjunction d =
   of_atom_formula (ors (List.rev_map (fun x -> Atom x) d))
-
-let atoms t =
-  fold_left (fun accu x -> x::accu) [] (to_atom_formula t)
 
 let get_disjunction_formula version_set cstr =
   List.map (fun ff ->
@@ -410,6 +426,7 @@ let set_to_disjunction set t =
         failwith (Printf.sprintf "%s is not a valid disjunction" (to_string t))
       | Or _ | Block _ | Empty -> assert false
       | Atom (name, Empty) -> [name, None]
+      | Atom (name, Atom a) -> [name, Some a]
       | Atom (name, cstr) ->
         get_disjunction_formula
           (OpamPackage.versions_of_name set name)

--- a/src/format/opamFormula.mli
+++ b/src/format/opamFormula.mli
@@ -123,6 +123,9 @@ val iter: ('a -> unit) -> 'a formula -> unit
 (** Fold function (bottom-up, left-to-right) *)
 val fold_left: ('a -> 'b -> 'a) -> 'a -> 'b formula -> 'a
 
+(** Fold function (bottom-up, right-to-left) *)
+val fold_right: ('a -> 'b -> 'a) -> 'a -> 'b formula -> 'a
+
 (** Expressions composed entirely of version constraints *)
 type version_formula = version_constraint formula
 

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -188,3 +188,7 @@ let string_of_cause to_string =
 let map_success f = function
   | Success x -> Success (f x)
   | Conflicts c -> Conflicts c
+
+let iter_success f = function
+  | Success x -> f x
+  | Conflicts _ -> ()

--- a/src/format/opamTypesBase.mli
+++ b/src/format/opamTypesBase.mli
@@ -74,3 +74,4 @@ val all_package_flags: package_flag list
 
 (** Map on a solver result *)
 val map_success: ('a -> 'b) -> ('a,'fail) result -> ('b,'fail) result
+val iter_success: ('a -> unit) -> ('a, 'b) result -> unit

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -109,7 +109,62 @@ module Graph = struct
   module Topo = Graph.Topological.Make (PG)
 
   let of_universe u =
-    Algo.Defaultgraphs.PackageGraph.dependency_graph u
+    (* {[Algo.Defaultgraphs.PackageGraph.dependency_graph u]}
+       -> doesn't handle conjunctive dependencies correctly
+       (e.g. (a>3 & a<=4) is considered as (a>3 | a<=4) and results in extra
+       edges).
+       Here we handle the fact that a conjunction with the same pkgname is an
+       intersection, while a conjunction between different names is an union *)
+    let t = OpamConsole.timer () in
+    let g = PG.create ~size:(Cudf.universe_size u) () in
+    let iter_deps f deps =
+      (* List.iter (fun d -> List.iter f (Common.CudfAdd.resolve_deps u d)) deps *)
+      let strong_deps, weak_deps =
+        (* strong deps are mandatory (constraint appearing in the top
+           conjunction)
+           weak deps correspond to optional occurences of a package, as part of
+           a disjunction: e.g. in (A>=4 & (B | A<5)), A>=4 is strong, and the
+           other two are weak. In the end we want to retain B and A>=4. *)
+        List.fold_left (fun (strong_deps, weak_deps) l ->
+            let names =
+              List.fold_left (fun acc (n, _) ->
+                  OpamStd.String.Map.add n Set.empty acc)
+                OpamStd.String.Map.empty l
+            in
+            let set =
+              List.fold_left (fun acc (n, cstr) ->
+                  List.fold_left (fun s x -> Set.add x s)
+                    acc (Cudf.lookup_packages ~filter:cstr u n))
+                Set.empty l
+            in
+            let by_name =
+              Set.fold (fun p ->
+                  OpamStd.String.Map.update
+                    p.Cudf.package (Set.add p) Set.empty)
+                set names
+            in
+            if OpamStd.String.Map.is_singleton by_name then
+              let name, versions = OpamStd.String.Map.choose by_name in
+              OpamStd.String.Map.update name (Set.inter versions) versions
+                strong_deps,
+              OpamStd.String.Map.remove name weak_deps
+            else
+              strong_deps, OpamStd.String.Map.union Set.union weak_deps by_name)
+          (OpamStd.String.Map.empty, OpamStd.String.Map.empty) deps
+      in
+      OpamStd.String.Map.iter (fun _ p -> Set.iter f p) strong_deps;
+      OpamStd.String.Map.iter (fun name p ->
+          if not (OpamStd.String.Map.mem name strong_deps)
+          then Set.iter f p)
+        weak_deps
+    in
+    Cudf.iter_packages
+      (fun p ->
+         PG.add_vertex g p;
+         iter_deps (PG.add_edge g p) p.Cudf.depends)
+      u;
+    log ~level:3 "Graph generation: %.3f" (t ());
+    g
 
   let output g filename =
     let fd = open_out (filename ^ ".dot") in
@@ -151,8 +206,11 @@ let filter_dependencies f_direction universe packages =
   r
 
 let dependencies = filter_dependencies (fun x -> x)
+(* similar to Algo.Depsolver.dependency_closure but with finer results on
+   version sets *)
 
 let reverse_dependencies = filter_dependencies Graph.mirror
+(* similar to Algo.Depsolver.reverse_dependency_closure but more reliable *)
 
 let string_of_atom (p, c) =
   let const = function

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -266,7 +266,7 @@ let opam2cudf universe version_map packages =
         OpamPackage.Map.merge (fun _ d dopts ->
             let d = OpamStd.Option.default Empty d in
             let dopts = OpamStd.Option.default Empty dopts in
-            Some OpamFormula.(ands [d; ors [d; dopts]]))
+            Some OpamFormula.(ands [d; dopts]))
           depends_map depopts_map
       else depends_map
     in

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -141,110 +141,149 @@ let lag_function =
   let rec power n x = if n <= 0 then 1 else x * power (n-1) x in
   power exp
 
-let opam2cudf universe ?(depopts=false) ~build ~post version_map package =
-  let name = OpamPackage.name package in
-  let version = OpamPackage.version package in
-  let depends =
-    try
-      OpamFilter.filter_deps ~build ~post ~default:false
-        (OpamPackage.Map.find package universe.u_depends)
-    with Not_found -> Empty in
-(*
-  let base_depends =
-    if OpamPackage.has_name universe.u_base name then Empty else
-      OpamFormula.ands
-        (OpamPackage.Name.Set.fold (fun name acc -> Atom (name, Empty) :: acc)
-           (OpamPackage.names_of_packages universe.u_base) [])
+let formula_to_cudf universe version_map f =
+  List.map (List.map (atom2cudf universe version_map))
+    (OpamFormula.to_cnf f)
+
+let opam2cudf universe version_map packages =
+  let set_to_bool_map set =
+    OpamPackage.Set.fold (fun nv -> OpamPackage.Map.add nv true)
+      (packages %% set) OpamPackage.Map.empty
   in
-  let depends = OpamFormula.ands [base_depends; depends] in
-*)
-  let depends =
-    let opts = depopts_of_package ~build universe package in
-    if depopts then
-      let opts = List.rev_map OpamFormula.of_conjunction opts in
-      And (depends, Or(depends, OpamFormula.ors opts))
-    else depends
+  let base_map =
+    OpamPackage.Set.fold (fun nv ->
+        OpamPackage.Map.add nv
+          { Cudf.default_package with
+            Cudf.package = name_to_cudf nv.name;
+            pkg_extra = [
+              OpamCudf.s_source, `String(OpamPackage.name_to_string nv);
+              OpamCudf.s_source_number, `String(OpamPackage.version_to_string nv);
+            ];
+          })
+      packages OpamPackage.Map.empty
   in
-  let conflicts =
-    try OpamPackage.Map.find package universe.u_conflicts
-    with Not_found -> Empty in
-  let conflicts =
-    (name, None) :: (* prevents install of multiple versions of the same pkg *)
-    OpamFormula.set_to_disjunction universe.u_packages conflicts in
-  let installed = OpamPackage.Set.mem package universe.u_installed in
-  let keep =
-    if OpamPackage.Set.mem package universe.u_base then
-      if OpamPackage.Set.mem package universe.u_available
-      then `Keep_version
-      else if OpamPackage.has_name universe.u_available package.name
-      then `Keep_package
-      else `Keep_none
-    else `Keep_none
+  let only_packages m =
+    OpamPackage.Map.merge
+      (fun _ -> function None -> fun _ -> None | Some _ -> fun x -> x)
+      base_map m
   in
-  let reinstall = OpamPackage.Set.mem package universe.u_reinstall in
-  let installed_root = OpamPackage.Set.mem package universe.u_installed_roots in
-  let pinned_to_current_version =
-    OpamPackage.Set.mem package universe.u_pinned in
-  let version_lag =
-    let all_versions = OpamPackage.versions_of_name universe.u_available name in
-    let count,i =
-      OpamPackage.Version.Set.fold
-        (fun v (i,r) -> if v = version then i,i else i+1, r)
-        all_versions (0,0)
+  let installed_map = set_to_bool_map universe.u_installed in
+  let keep_map =
+    OpamPackage.Set.fold (fun nv acc ->
+        if OpamPackage.Set.mem nv universe.u_available
+        then OpamPackage.Map.add nv `Keep_version acc
+        else if OpamPackage.has_name universe.u_available nv.name
+        then OpamPackage.Map.add nv `Keep_package acc
+        else acc)
+      (packages %% universe.u_base) OpamPackage.Map.empty
+  in
+  let reinstall_map = set_to_bool_map universe.u_reinstall in
+  let installed_root_map = set_to_bool_map universe.u_installed_roots in
+  let pinned_to_current_version_map = set_to_bool_map universe.u_pinned in
+  let version_lag_map =
+    OpamPackage.Name.Map.fold (fun name version_set acc ->
+        let nvers, vs =
+          OpamPackage.Version.Set.fold (fun v (i,acc) ->
+              i+1, OpamPackage.Version.Map.add v i acc)
+            version_set (0, OpamPackage.Version.Map.empty)
+        in
+        OpamPackage.Version.Map.fold (fun v i ->
+            let lag = lag_function (nvers - i - 1) in
+            if lag > 0 then
+              OpamPackage.Map.add (OpamPackage.create name v) lag
+            else fun acc -> acc)
+          vs acc)
+      (OpamPackage.to_map packages)
+      OpamPackage.Map.empty
+  in
+  let extras_maps =
+    List.map (fun (label, set) ->
+        OpamPackage.Set.fold (fun nv ->
+            OpamPackage.Map.add nv (label, `Int 1))
+          (packages %% set) OpamPackage.Map.empty)
+      universe.u_attrs
+  in
+  let add elts f map =
+    OpamPackage.Map.merge (fun nv a b ->
+        match a, b with
+        | Some cp, None -> Some cp
+        | Some cp, Some x -> Some (f nv x cp)
+        | None, _ -> None)
+      map elts
+  in
+  let univ0 =
+    base_map
+    |> add version_map (fun _ version cp -> {cp with Cudf.version})
+    |> add installed_map (fun _ installed cp -> {cp with Cudf.installed})
+    |> add keep_map (fun _ keep cp -> {cp with Cudf.keep})
+    |> add reinstall_map (fun _ x cp ->
+        {cp with Cudf.pkg_extra =
+                   (OpamCudf.s_reinstall, `Bool x) :: cp.Cudf.pkg_extra})
+    |> add installed_root_map (fun _ x cp ->
+        {cp with Cudf.pkg_extra =
+                   (OpamCudf.s_installed_root, `Bool x) :: cp.Cudf.pkg_extra})
+    |> add pinned_to_current_version_map (fun _ x cp ->
+        {cp with Cudf.pkg_extra =
+                   (OpamCudf.s_pinned, `Bool x) :: cp.Cudf.pkg_extra})
+    |> add version_lag_map (fun _ x cp ->
+        {cp with Cudf.pkg_extra =
+                   (OpamCudf.s_version_lag, `Int x) :: cp.Cudf.pkg_extra})
+    |> List.fold_right (fun m ->
+        add m (fun _ x cp -> {cp with Cudf.pkg_extra = x :: cp.Cudf.pkg_extra}))
+      extras_maps
+  in
+  fun ~depopts ~build ~post ->
+    let depends_map =
+      OpamPackage.Map.map (fun f ->
+          OpamFilter.filter_deps ~build ~post ~default:false f)
+        (only_packages universe.u_depends)
     in
-    lag_function (count - i)
-  in
-  let extras =
-    let e = [
-      OpamCudf.s_source, `String (OpamPackage.Name.to_string name);
-      OpamCudf.s_source_number, `String (OpamPackage.Version.to_string version);
-    ] in
-    let e = if installed && reinstall
-      then (OpamCudf.s_reinstall, `Bool true)::e else e in
-    let e = if installed_root
-      then (OpamCudf.s_installed_root, `Bool true)::e else e in
-    let e =
-      if pinned_to_current_version then (OpamCudf.s_pinned, `Bool true)::e
-      else if version_lag = 0 then e
-      else (OpamCudf.s_version_lag, `Int version_lag)::e
+    let depopts_map =
+      OpamPackage.Map.map (fun f ->
+          OpamFilter.filter_deps ~build ~post:false ~default:false f)
+        (only_packages universe.u_depopts)
     in
-    e
-  in
-  let extras =
-    List.fold_left (fun extras (label,set) ->
-        if OpamPackage.Set.mem package set then (label, `Int 1)::extras
-        else extras)
-      extras universe.u_attrs
-  in
-  { Cudf.default_package with
-    Cudf.
-    package = name_to_cudf (OpamPackage.name package);
-    version = OpamPackage.Map.find package version_map;
-    depends = List.rev_map (List.rev_map (atom2cudf universe version_map))
-        (OpamFormula.to_cnf depends);
-    conflicts = List.rev_map (atom2cudf universe version_map) conflicts;
-    installed;
-    keep;
-    (* was_installed: reserved for the solver; *)
-    (* provides: unused atm *)
-    pkg_extra = extras;
-  }
+    let all_depends_map =
+      if depopts then
+        OpamPackage.Map.merge (fun _ d dopts ->
+            let d = OpamStd.Option.default Empty d in
+            let dopts = OpamStd.Option.default Empty dopts in
+            Some OpamFormula.(ands [d; ors [d; dopts]]))
+          depends_map depopts_map
+      else depends_map
+    in
+    let conflicts_map =
+      OpamPackage.Map.mapi
+        (fun nv conflicts ->
+           (nv.name, None) ::
+           (* prevents install of multiple versions of the same pkg *)
+           OpamFormula.set_to_disjunction universe.u_packages
+             (* OpamFormula.to_disjunction *) conflicts)
+        (only_packages universe.u_conflicts)
+    in
+    let depends_map_resolved =
+      OpamPackage.Map.map (formula_to_cudf universe version_map)
+        all_depends_map
+    in
+    let conflicts_map_resolved =
+      OpamPackage.Map.map (List.rev_map (atom2cudf universe version_map))
+        conflicts_map
+    in
+    univ0
+    |> add depends_map_resolved (fun _ depends cp -> {cp with Cudf.depends})
+    |> add conflicts_map_resolved (fun _ conflicts cp -> {cp with Cudf.conflicts})
+    |> OpamPackage.Map.values
 
 (* load a cudf universe from an opam one *)
-let load_cudf_universe ?depopts ~build ~post
+let load_cudf_universe
     opam_universe ?version_map opam_packages =
-  log "Load cudf universe (depopts:%a, build:%b, post:%b)"
-    (slog @@ OpamStd.Option.to_string ~none:"false" string_of_bool) depopts
-    build
-    post;
   let chrono = OpamConsole.timer () in
   let version_map = match version_map with
     | Some vm -> vm
     | None -> cudf_versions_map opam_universe opam_packages in
   log ~level:3 "Load cudf universe: opam2cudf";
   let opam_packages =
-    if OpamPackage.Set.is_empty
-        (opam_universe.u_base -- opam_universe.u_available)
+    if OpamPackage.Set.subset opam_universe.u_base opam_universe.u_available
     then
       (* Filter out extra compiler versions, they add too much cost to the
          solver and are not needed *)
@@ -256,23 +295,26 @@ let load_cudf_universe ?depopts ~build ~post
        -- opam_universe.u_base)
     else opam_packages
   in
+  let univ_gen =
+    opam2cudf opam_universe version_map opam_packages
+  in
+  log ~level:3 "Preload of cudf universe: done in %.3fs" (chrono ());
+  fun ?(depopts=false) ~build ~post () ->
+  log "Load cudf universe (depopts:%a, build:%b, post:%b)"
+    (slog string_of_bool) depopts
+    build
+    post;
+  let chrono = OpamConsole.timer () in
   let cudf_universe =
     let cudf_packages =
-      (* TODO:
-         Doing opam2cudf for every package is inefficient (lots of Set.mem to
-         check if it is installed, etc. Optimise by gathering all info first *)
-      OpamPackage.Set.fold
-        (fun nv list ->
-           opam2cudf opam_universe ?depopts ~build ~post version_map nv
-           :: list)
-        opam_packages [] in
+      univ_gen ~depopts ~build ~post
+    in
+    log ~level:3 "opam2cudf: done in %.3fs" (chrono ());
     try Cudf.load_universe cudf_packages
     with Cudf.Constraint_violation s ->
       OpamConsole.error_and_exit `Solver_failure "Malformed CUDF universe (%s)" s
   in
-  log ~level:3 "Load cudf universe: done in %.3fs" (chrono ());
-  (* We can trim the universe here to get faster results, but we
-     choose to keep it bigger to get more precise conflict messages. *)
+  log ~level:3 "Secondary load of cudf universe: done in %.3fs" (chrono ());
   (* let universe = Algo.Depsolver.trim universe in *)
   cudf_universe
 
@@ -345,12 +387,24 @@ let cycle_conflict ~version_map univ cycles =
 
 let resolve universe ~orphans request =
   log "resolve request=%a" (slog string_of_request) request;
-  let version_map =
-    cudf_versions_map universe
-      (universe.u_available ++ universe.u_installed ++ orphans) in
-  let simple_universe =
-    load_cudf_universe universe ~version_map ~build:true ~post:true
-      (universe.u_available ++ universe.u_installed -- orphans) in
+  let all_packages = universe.u_available ++ universe.u_installed ++ orphans in
+  let version_map = cudf_versions_map universe all_packages in
+  let univ_gen = load_cudf_universe universe ~version_map all_packages in
+  let simple_universe, cudf_orphans =
+    let u = univ_gen ~build:true ~post:true () in
+    let cudf_orphans =
+      OpamPackage.Set.fold (fun nv acc ->
+          let cnv = name_to_cudf nv.name, OpamPackage.Map.find nv version_map in
+          let cp = Cudf.lookup_package u cnv in
+          Cudf.remove_package u cnv;
+          cp :: acc)
+        orphans []
+    in
+    u, cudf_orphans
+  in
+  let add_orphan_packages u =
+    Cudf.load_universe (List.rev_append cudf_orphans (Cudf.get_packages u))
+  in
   let request =
     let extra_attributes =
       OpamStd.List.sort_nodup compare
@@ -360,11 +414,6 @@ let resolve universe ~orphans request =
   in
   let request = cleanup_request universe request in
   let cudf_request = map_request (atom2cudf universe version_map) request in
-  let add_orphan_packages u =
-    load_cudf_universe universe ~version_map ~build:true ~post:true
-      (orphans ++
-         (OpamPackage.Set.of_list
-            (List.map OpamCudf.cudf2opam (Cudf.get_packages u)))) in
   let resolve u req =
     try
       let resp = OpamCudf.resolve ~extern:true ~version_map u req in
@@ -375,14 +424,8 @@ let resolve universe ~orphans request =
   match resolve simple_universe cudf_request with
   | Conflicts _ as c -> c
   | Success actions ->
-    let all_packages =
-      universe.u_available ++ orphans in
-    let simple_universe =
-      load_cudf_universe universe ~depopts:true ~build:false ~post:false
-        ~version_map all_packages in
-    let complete_universe =
-      load_cudf_universe universe ~depopts:true ~build:true ~post:false
-        ~version_map all_packages in
+    let simple_universe = univ_gen ~depopts:true ~build:false ~post:false () in
+    let complete_universe = univ_gen ~depopts:true ~build:true ~post:false () in
     try
       let atomic_actions =
         OpamCudf.atomic_actions
@@ -397,7 +440,7 @@ let get_atomic_action_graph t =
 let installable universe =
   log "trim";
   let simple_universe =
-    load_cudf_universe universe universe.u_available ~build:true ~post:true
+    load_cudf_universe universe universe.u_available ~build:true ~post:true ()
   in
   let trimmed_universe =
     (* Algo.Depsolver.trim simple_universe => this can explode memory, we need
@@ -424,11 +467,11 @@ let installable_subset universe packages =
   let version_map = cudf_versions_map universe universe.u_available in
   let simple_universe =
     load_cudf_universe ~build:true ~post:true universe ~version_map
-      universe.u_available
+      universe.u_available ()
   in
   let cudf_packages =
-    List.map (opam2cudf universe ~build:true ~post:true version_map)
-      (OpamPackage.Set.elements packages)
+    opam2cudf universe ~depopts:false ~build:true ~post:true
+      version_map packages
   in
   let trimmed_universe =
     (* Algo.Depsolver.trimlist simple_universe with [~explain:false] *)
@@ -463,10 +506,10 @@ let filter_dependencies
   let version_map = cudf_versions_map universe u_packages in
   let cudf_universe =
     load_cudf_universe ~depopts ~build ~post universe ~version_map
-      u_packages in
+      u_packages () in
   let cudf_packages =
-    List.rev_map (opam2cudf universe ~depopts ~build ~post version_map)
-      (OpamPackage.Set.elements packages) in
+    opam2cudf universe ~depopts ~build ~post version_map packages
+  in
   log ~level:3 "filter_dependencies: dependency";
   let topo_packages = f_direction cudf_universe cudf_packages in
   let result = List.rev_map OpamCudf.cudf2opam topo_packages in
@@ -482,11 +525,11 @@ let coinstallability_check universe packages =
   let version_map = cudf_versions_map universe universe.u_packages in
   let cudf_universe =
     load_cudf_universe ~build:true ~post:true ~version_map
-      universe universe.u_packages
+      universe universe.u_packages ()
   in
   let cudf_packages =
-    List.map (opam2cudf universe ~build:true ~post:true version_map)
-      (OpamPackage.Set.elements packages)
+    opam2cudf universe ~depopts:false ~build:true ~post:true
+      version_map packages
   in
   match Algo.Depsolver.edos_coinstall cudf_universe cudf_packages with
   | { Algo.Diagnostic.result = Algo.Diagnostic.Success _; _ } ->
@@ -503,21 +546,23 @@ let atom_coinstallability_check universe atoms =
   let packages = OpamFormula.packages_of_atoms universe.u_available atoms in
   let map = OpamPackage.to_map packages in
   List.for_all (fun (n, _) -> OpamPackage.Name.Map.mem n map) atoms &&
-  let ll =
-    List.map (fun (n, versions) ->
-        List.map (fun v -> OpamPackage.create n v)
-          (OpamPackage.Version.Set.elements versions))
-      (OpamPackage.Name.Map.bindings map)
-  in
   let version_map = cudf_versions_map universe universe.u_packages in
   let cudf_universe =
     load_cudf_universe ~build:true ~post:true ~version_map
-      universe universe.u_packages
+      universe universe.u_packages ()
   in
   let cudf_ll =
-    List.map
-      (List.map (opam2cudf universe ~build:true ~post:true version_map))
-      ll
+    OpamPackage.Name.Map.fold (fun n versions acc ->
+        let packages =
+          OpamPackage.Version.Set.fold
+            (fun v -> OpamPackage.(Set.add (create n v)))
+            versions OpamPackage.Set.empty
+        in
+        opam2cudf
+          universe ~depopts:false ~build:true ~post:true version_map
+          packages
+        :: acc)
+      map []
   in
   let result = Algo.Depsolver.edos_coinstall_prod cudf_universe cudf_ll in
   List.exists Algo.Diagnostic.is_solution result
@@ -631,7 +676,7 @@ let dump_universe universe oc =
   let version_map = cudf_versions_map universe universe.u_packages in
   let cudf_univ =
     load_cudf_universe ~depopts:false ~build:true ~post:true ~version_map
-      universe universe.u_available in
+      universe universe.u_available () in
   OpamCudf.dump_universe oc cudf_univ;
   (* Add explicit bindings to retrieve original versions of non-available and
      non-existing (but referred to) packages *)

--- a/src/solver/opamSolver.mli
+++ b/src/solver/opamSolver.mli
@@ -51,8 +51,9 @@ val print_solution:
 (** Computes an opam->cudf version map from a set of package *)
 val cudf_versions_map: universe -> package_set -> int OpamPackage.Map.t
 
-(** Creates a CUDF universe from an OPAM universe, including the given
-    packages. Evaluation of the first 3 arguments is staged *)
+(** Creates a CUDF universe from an OPAM universe, including the given packages.
+    Evaluation of the first 3 arguments is staged. Warning: when [depopts] is
+    [true], the optional dependencies may become strong dependencies. *)
 val load_cudf_universe:
   universe -> ?version_map:int package_map -> package_set ->
   ?depopts:bool -> build:bool -> post:bool -> unit ->

--- a/src/solver/opamSolver.mli
+++ b/src/solver/opamSolver.mli
@@ -52,10 +52,11 @@ val print_solution:
 val cudf_versions_map: universe -> package_set -> int OpamPackage.Map.t
 
 (** Creates a CUDF universe from an OPAM universe, including the given
-    packages *)
+    packages. Evaluation of the first 3 arguments is staged *)
 val load_cudf_universe:
-  ?depopts:bool -> build:bool -> post:bool ->
-  universe -> ?version_map:int package_map -> package_set -> Cudf.universe
+  universe -> ?version_map:int package_map -> package_set ->
+  ?depopts:bool -> build:bool -> post:bool -> unit ->
+  Cudf.universe
 
 (**  Build a request *)
 val request:


### PR DESCRIPTION
by reviewing the whole loading process, this achieves x2 speedup on a basic `opam install` run.
Involved changes:
- optimise and make tail-rec some functions on the manipulation of formulas (e.g. add cases for CNF conversion when trivial, which is thankfully most of the time)
- review opam to cudf conversion to be based on computing maps from the universe and running `Map.merge` (rather than converting packages one by one)
- simplify handling of optional dependencies when activated, since these are only used to build the dependency graph
- factorise as much as possible the loading between runs with different flags (build, post, opt), including CNF conversion

This also includes a fix in computing the dependency graph, which was
over-approximating dependencies in some cases with conjunctions of
version constraints (e.g. `a>=3 & a<4`.