### PR TITLE
add an explicit warning about the single-switch behavior of `repo add` (#3292)

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1477,6 +1477,14 @@ let repository =
      address. The quorum is a positive integer that determines the validation \
      threshold for signed repositories, with fingerprints the trust anchors \
      for said validation.";
+    " ", `add, [],
+    (* using an unbreakable space here will indent the text paragraph at the level
+       of the previous labelled paragraph, which is what we want for our note. *)
+    "$(b,Note:) By default, the repository is only be added to the current switch. \
+     To add a switch to other repositories, you need to use the $(b,--all) or \
+     $(b,--set-default) options (see below). If you want to enable a repository \
+     only to install of of its switches, you may be looking for \
+     $(b,opam switch create --repositories=REPOS).";
     "remove", `remove, ["NAME..."],
     "Unselects the given repositories so that they will not be used to get \
      package definitions anymore. With $(b,--all), makes opam forget about \


### PR DESCRIPTION
The output looks roughly like this (plus emphasis).

```
   add NAME [ADDRESS] [QUORUM] [FINGERPRINTS]
       Adds under NAME the repository at address ADDRESS to the list of
       configured repositories, if not already registered, and sets this
       repository for use in the current switch (or the specified scope).
       ADDRESS is required if the repository name is not already
       registered, and is otherwise an error if different from the
       registered address. The quorum is a positive integer that
       determines the validation threshold for signed repositories, with
       fingerprints the trust anchors for said validation.

       Note: By default, the repository is only be added to the current
       switch. To add a switch to other repositories, you need to use the
       --all or --set-default options (see below). If you want to enable a
       repository only to install of of its switches, you may be looking
       for opam switch create --repositories=REPOS.
```