### PR TITLE
Shell config update

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -669,7 +669,8 @@ let reinit ?(init_config=OpamInitDefaults.init_config()) config =
         | Some flt -> if OpamFilter.eval_to_bool env flt then
             Some (nam,scr) else None) (OpamFile.Config.init_scripts config)
   in
-  OpamEnv.write_static_init_scripts root ~completion:true init_scripts;
+  OpamEnv.write_static_init_scripts root ~completion:true ~eval_env:false
+    init_scripts;
   let gt = OpamGlobalState.load `Lock_write in
   let rt = OpamRepositoryState.load `Lock_write gt in
   OpamConsole.header_msg "Updating repositories";
@@ -766,7 +767,8 @@ let init
         if not (OpamConsole.debug ()) && root_empty then
           OpamFilename.rmdir root)
   in
-  OpamEnv.write_static_init_scripts root ~completion:true custom_scripts;
+  OpamEnv.write_static_init_scripts root ~completion:true ~eval_env:false
+    custom_scripts;
   let _updated = match update_config with
     | `no  -> false
     | `ask -> OpamEnv.setup_interactive root ~dot_profile shell

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -89,6 +89,7 @@ val opam_init:
   ?makecmd:string Lazy.t ->
   ?ignore_constraints_on:OpamPackage.Name.Set.t ->
   ?unlock_base:bool ->
+  ?noeval_env:bool ->
   ?cudf_file:string option ->
   ?solver:(module OpamCudfSolver.S) Lazy.t ->
   ?best_effort:bool ->

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -687,11 +687,12 @@ let config =
      configuration options. You can use this command to automatically update: \
      (i) user-configuration files such as ~/.profile; and (ii) \
      global-configuration files controlling which shell scripts are loaded on \
-     startup, such as auto-completion. These configuration options can be \
-     updated using $(b,opam config setup --global) to setup the global \
-     configuration files stored in $(b,~/.opam/opam-init/) and $(b,opam config \
-     setup --user) to setup the user ones. To modify both the global and user \
-     configuration, use $(b,opam config setup --all).";
+     startup, such as auto-completion and automatic evaluation of $(b,opam env). \
+     These configuration options can be updated using $(b,opam config setup \
+     --global) to setup the global configuration files stored in \
+     $(b,~/.opam/opam-init/) and $(b,opam config setup --user) to setup the user \
+     ones. To modify both the global and user configuration, use $(b,opam config \
+     setup --all).";
     "exec", `exec, ["[--] COMMAND"; "[ARG]..."],
     "Execute $(i,COMMAND) with the correct environment variables. This command \
      can be used to cross-compile between switches using $(b,opam config exec \
@@ -750,10 +751,13 @@ let config =
   let profile_doc     = "Modify ~/.profile (or ~/.zshrc, etc., depending on your shell) to \
                          setup an opam-friendly environment when starting a new shell." in
   let no_complete_doc = "Do not load the auto-completion scripts in the environment." in
+  let eval_env_doc    = "Add to your shell a hook to ensure that the opam \
+                         environement remains in sync." in
   let dot_profile_doc = "Select which configuration file to update (default is ~/.profile)." in
   let list_doc        = "List the current configuration." in
   let profile         = mk_flag ["profile"]        profile_doc in
   let no_complete     = mk_flag ["no-complete"]    no_complete_doc in
+  let eval_env        = mk_flag ["eval-env"]       eval_env_doc in
   let all             = mk_flag ["a";"all"]        all_doc in
   let user            = mk_flag ["u";"user"]       user_doc in
   let global          = mk_flag ["g";"global"]     global_doc in
@@ -763,7 +767,7 @@ let config =
   let config global_options
       command shell sexp inplace_path
       dot_profile_o list all global user
-      profile no_complete set_opamroot set_opamswitch params =
+      profile no_complete eval_env set_opamroot set_opamswitch params =
     apply_global_options global_options;
     match command, params with
     | Some `env, [] ->
@@ -955,7 +959,7 @@ let config =
           $global_options $command $shell_opt $sexp
           $inplace_path
           $dot_profile_flag $list $all $global $user
-          $profile $no_complete
+          $profile $no_complete $eval_env
           $set_opamroot $set_opamswitch
           $params)
   ),

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -786,7 +786,8 @@ let config =
       let user        = all || user in
       let global      = all || global in
       let profile     = user  || profile in
-      let completion    = global && not no_complete in
+      let completion  = global && not no_complete in
+      let eval_env    = global && eval_env in
       let dot_profile = init_dot_profile shell dot_profile_o in
       if list then
         `Ok (OpamConfigCommand.setup_list shell dot_profile)
@@ -794,7 +795,7 @@ let config =
         let dot_profile = if profile then Some dot_profile else None in
         OpamGlobalState.with_ `Lock_write @@ fun gt ->
         `Ok (OpamConfigCommand.setup gt
-               ?dot_profile ~completion ~shell
+               ?dot_profile ~completion ~eval_env ~shell
                ~user ~global)
       else
         `Ok (OpamConsole.msg

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -330,7 +330,7 @@ let setup gt ?dot_profile ~completion ~eval_env ~shell
   if user then
     OpamEnv.update_user_setup gt.root ?dot_profile shell;
   if global then (
-    OpamEnv.write_static_init_shell_scripts gt.root ~completion ~eval_env;
+    OpamEnv.write_init_shell_scripts gt.root ~completion ~eval_env;
     match OpamFile.Config.switch gt.config with
     | Some sw ->
       OpamSwitchState.with_ `Lock_none gt ~switch:sw @@ fun st ->

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -324,13 +324,13 @@ let variable gt v =
             "Variable %s not found"
             (OpamVariable.Full.to_string v)
 
-let setup gt ?dot_profile ~completion ~shell
-  ~user ~global =
+let setup gt ?dot_profile ~completion ~eval_env ~shell
+    ~user ~global =
   log "config-setup";
   if user then
     OpamEnv.update_user_setup gt.root ?dot_profile shell;
   if global then (
-    OpamEnv.write_static_init_scripts gt.root ~completion [];
+    OpamEnv.write_static_init_scripts gt.root ~completion ~eval_env [];
     match OpamFile.Config.switch gt.config with
     | Some sw ->
       OpamSwitchState.with_ `Lock_none gt ~switch:sw @@ fun st ->

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -330,7 +330,7 @@ let setup gt ?dot_profile ~completion ~eval_env ~shell
   if user then
     OpamEnv.update_user_setup gt.root ?dot_profile shell;
   if global then (
-    OpamEnv.write_static_init_scripts gt.root ~completion ~eval_env [];
+    OpamEnv.write_static_init_shell_scripts gt.root ~completion ~eval_env;
     match OpamFile.Config.switch gt.config with
     | Some sw ->
       OpamSwitchState.with_ `Lock_none gt ~switch:sw @@ fun st ->

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -53,6 +53,7 @@ val setup:
   rw global_state ->
   ?dot_profile:OpamTypes.filename ->
   completion:bool ->
+  eval_env:bool ->
   shell:OpamTypes.shell ->
   user:bool -> global:bool -> unit
 

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -650,7 +650,11 @@ let display_setup root ~dot_profile shell =
 let check_and_print_env_warning st =
   if (OpamFile.Config.switch st.switch_global.config = Some st.switch ||
       OpamStateConfig.(!r.switch_from <> `Command_line)) &&
-     not (is_up_to_date st) then
+     (not (is_up_to_date st) &&
+      (dot_profile_needs_update OpamStateConfig.(!r.root_dir)
+         (OpamFilename.of_string @@
+          OpamStd.Sys.(guess_dot_profile @@ guess_shell_compat ()))) = `yes)
+  then
     OpamConsole.formatted_msg
       "# Run %s to update the current shell environment\n"
       (OpamConsole.colorise `bold (eval_string st.switch_global

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -585,8 +585,14 @@ let dot_profile_needs_update root dot_profile =
 
 let update_dot_profile root dot_profile shell =
   let pretty_dot_profile = OpamFilename.prettify dot_profile in
+  let bash_src () =
+    if shell = `bash || shell = `sh then
+      OpamConsole.note "Make sure that %s is well %s in your ~/.bashrc.\n"
+        pretty_dot_profile
+        (OpamConsole.colorise `underline "sourced")
+  in
   match dot_profile_needs_update root dot_profile with
-  | `no        -> OpamConsole.msg "  %s is already up-to-date.\n" pretty_dot_profile
+  | `no        -> OpamConsole.msg "  %s is already up-to-date.\n" pretty_dot_profile; bash_src()
   | `otherroot ->
     OpamConsole.msg
       "  %s is already configured for another opam root.\n"
@@ -599,6 +605,7 @@ let update_dot_profile root dot_profile shell =
       else
         "" in
     OpamConsole.msg "  Updating %s.\n" pretty_dot_profile;
+    bash_src();
     let body =
       Printf.sprintf
         "%s\n\n\

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -355,6 +355,8 @@ let eval_string gt ?(set_opamswitch=false) switch =
   match OpamStd.Sys.guess_shell_compat () with
   | `fish ->
     Printf.sprintf "eval (opam env%s%s%s)" root switch setswitch
+  | `csh ->
+    Printf.sprintf "eval `opam env%s%s%s`" root switch setswitch
   | _ ->
     Printf.sprintf "eval $(opam env%s%s%s)" root switch setswitch
 

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -656,8 +656,14 @@ let display_setup root ~dot_profile shell =
         && not complete_zsh then
           not_set
         else ok in
-      [ ("init-script"     , Printf.sprintf "%s" pretty_init_file);
-        ("auto-completion" , completion);
+      let eval_env =
+        try
+          if bool_of_string @@ OpamStd.Config.env_bool "NOEVALENV" then ok else not_set
+        with Not_found -> not_set
+      in
+      [ ("init-script"         , Printf.sprintf "%s" pretty_init_file);
+        ("auto-completion"     , completion);
+        ("opam env evalutation", eval_env);
       ]
   in
   OpamConsole.msg "User configuration:\n";

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -659,9 +659,7 @@ let display_setup root ~dot_profile shell =
           not_set
         else ok in
       let eval_env =
-        try
-          if bool_of_string @@ OpamStd.Config.env_bool "NOEVALENV" then ok else not_set
-        with Not_found -> not_set
+        if OpamStateConfig.(!r.noeval_env) then ok else not_set
       in
       [ ("init-script"         , Printf.sprintf "%s" pretty_init_file);
         ("auto-completion"     , completion);
@@ -680,10 +678,7 @@ let check_and_print_env_warning st =
        (OpamFilename.of_string @@
         OpamStd.Sys.(guess_dot_profile @@ guess_shell_compat ()))) = `yes
   in
-  let opam_noeval_env =
-    try bool_of_string @@ OpamStd.Config.env_bool "NOEVALENV"
-    with Not_found -> false
-  in
+  let opam_noeval_env = OpamStateConfig.(!r.noeval_env) in
   if (OpamFile.Config.switch st.switch_global.config = Some st.switch ||
       OpamStateConfig.(!r.switch_from <> `Command_line)) &&
      (outdated_env && (dot_profile_not_configured || opam_noeval_env))

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -373,31 +373,31 @@ let init_csh       = "init.csh"
 let init_fish      = "init.fish"
 let opam_env_sh    =
   "\
-\  _opam_env_hook() {\n\
-\    local previous_exit_status=$?;\n\
-\    eval \"$(opam env --shell=bash)\";\n\
-\    return $previous_exit_status;\n\
-\  };\n\
-\  if ! [[ \"$PROMPT_COMMAND\" =~ _opam_env_hook ]]; then\n\
-\    PROMPT_COMMAND=\"_opam_env_hook;$PROMPT_COMMAND\";\n\
-\  fi\n\
-"
+  \  _opam_env_hook() {\n\
+  \    local previous_exit_status=$?;\n\
+  \    eval \"$(opam env --shell=bash)\";\n\
+  \    return $previous_exit_status;\n\
+  \  };\n\
+  \  if ! [[ \"$PROMPT_COMMAND\" =~ _opam_env_hook ]]; then\n\
+  \    PROMPT_COMMAND=\"_opam_env_hook;$PROMPT_COMMAND\";\n\
+  \  fi\n\
+  "
 let opam_env_zsh   =
   "\
-\  _opam_env_hook() {\n\
-\    eval \"$(opam env --shell=zsh)\";\n\
-\  }\n\
-\  typeset -ag precmd_functions;\n\
-\  if [[ -z ${precmd_functions[(r)_opam_env_hook]} ]]; then\n\
-\    precmd_functions+=_opam_env_hook;\n\
-\  fi\n\
-"
+  \  _opam_env_hook() {\n\
+  \    eval \"$(opam env --shell=zsh)\";\n\
+  \  }\n\
+  \  typeset -ag precmd_functions;\n\
+  \  if [[ -z ${precmd_functions[(r)_opam_env_hook]} ]]; then\n\
+  \    precmd_functions+=_opam_env_hook;\n\
+  \  fi\n\
+  "
 let opam_env_fish  =
   "\
-\  function __opam_env_export_eval --on-event fish_prompt;\n\
-\    eval (opam env --shell=fish);\n\
-\  end\n\
-"
+  \  function __opam_env_export_eval --on-event fish_prompt;\n\
+  \    eval (opam env --shell=fish);\n\
+  \  end\n\
+  "
 let opam_env_csh   = "  alias precmd 'eval `opam env --shell=csh`'\n"
 
 let init_file = function
@@ -419,8 +419,8 @@ let source root ~shell f =
       (file f) (file f)
 
 let get_shell_content root ~shell fvar fcomplete =
-  let if_csh t e  = Printf.sprintf "if ( { [ -t 0 ] } ) then\n%selse\n  %sendif\n" t e in
-  let if_fish t e = Printf.sprintf "if [ -t 0 ]\n%selse\n  %send\n" t e in
+  let if_csh t e  = Printf.sprintf "if ( $?prompt ) then\n%selse\n  %sendif\n" t e in
+  let if_fish t e = Printf.sprintf "if isatty\n%selse\n  %send\n" t e in
   let if_sh t e   = Printf.sprintf "if [ -t 0 ]; then\n%selse\n  %sfi\n" t e in
   let variables = source root ~shell fvar in
   let if_st, opam_env = match shell with

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -87,7 +87,7 @@ val update_user_setup:
 
 (** Write the generic scripts in ~/.opam/opam-init needed to import state for
     various shells. *)
-val write_static_init_shell_scripts:
+val write_init_shell_scripts:
   dirname -> completion:bool -> eval_env:bool -> unit
 
 (** Write the generic scripts in ~/.opam/opam-init needed to import state for

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -86,6 +86,11 @@ val update_user_setup:
   dirname -> ?dot_profile:filename -> shell -> unit
 
 (** Write the generic scripts in ~/.opam/opam-init needed to import state for
+    various shells. *)
+val write_static_init_shell_scripts:
+  dirname -> completion:bool -> eval_env:bool -> unit
+
+(** Write the generic scripts in ~/.opam/opam-init needed to import state for
     various shells, and custom scripts defined in the built-in configuration or
     `opamrc` file. The last argument is a list of (name, script content). *)
 val write_static_init_scripts:

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -88,7 +88,8 @@ val update_user_setup:
 (** Write the generic scripts in ~/.opam/opam-init needed to import state for
     various shells, and custom scripts defined in the built-in configuration or
     `opamrc` file. The last argument is a list of (name, script content). *)
-val write_static_init_scripts: dirname -> completion:bool -> (string * string) list -> unit
+val write_static_init_scripts:
+  dirname -> completion:bool -> eval_env:bool -> (string * string) list -> unit
 
 (** Update the shell scripts containing the current switch configuration in
     ~/.opam/opam-init ; prints a warning and skips if a write lock on the global

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -22,6 +22,7 @@ type t = {
   makecmd: string Lazy.t;
   ignore_constraints_on: name_set;
   unlock_base: bool;
+  noeval_env: bool;
 }
 
 let default = {
@@ -42,6 +43,7 @@ let default = {
     );
   ignore_constraints_on = OpamPackage.Name.Set.empty;
   unlock_base = false;
+  noeval_env = false;
 }
 
 type 'a options_fun =
@@ -56,6 +58,7 @@ type 'a options_fun =
   ?makecmd:string Lazy.t ->
   ?ignore_constraints_on:name_set ->
   ?unlock_base:bool ->
+  ?noeval_env:bool ->
   'a
 
 let setk k t
@@ -70,6 +73,7 @@ let setk k t
     ?makecmd
     ?ignore_constraints_on
     ?unlock_base
+    ?noeval_env
   =
   let (+) x opt = match opt with Some x -> x | None -> x in
   k {
@@ -85,6 +89,7 @@ let setk k t
     makecmd = t.makecmd + makecmd;
     ignore_constraints_on = t.ignore_constraints_on + ignore_constraints_on;
     unlock_base = t.unlock_base + unlock_base;
+    noeval_env = t.noeval_env + noeval_env
   }
 
 let set t = setk (fun x () -> x) t
@@ -117,6 +122,7 @@ let initk k =
        List.map OpamPackage.Name.of_string |>
        OpamPackage.Name.Set.of_list)
     ?unlock_base:(env_bool "UNLOCKBASE")
+    ?noeval_env:(env_bool "NOEVALENV")
 
 let init ?noop:_ = initk (fun () -> ())
 

--- a/src/state/opamStateConfig.mli
+++ b/src/state/opamStateConfig.mli
@@ -25,6 +25,7 @@ type t = private {
   makecmd: string Lazy.t;
   ignore_constraints_on: name_set;
   unlock_base: bool;
+  noeval_env: bool;
 }
 
 type 'a options_fun =
@@ -39,6 +40,7 @@ type 'a options_fun =
   ?makecmd:string Lazy.t ->
   ?ignore_constraints_on:name_set ->
   ?unlock_base:bool ->
+  ?noeval_env:bool ->
   'a
 
 include OpamStd.Config.Sig


### PR DESCRIPTION
This PR contains an update of shell configuration scripts to have always opam variables set (evaluation at each command). It was inspired from [direnv](https://github.com/direnv/direnv) (thanks @samoht). Available for all opam handled shells.
For `bash`, I kept sourcing scripts on profile config files (cf. #1447), assuming that profile files are sourced in `.bashrc`. Added a message for the user in this case. 