### PR TITLE
Cache for pin download

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2263,7 +2263,7 @@ let pin ?(unpin_only=false) () =
     mk_flag ["dev-repo"] "Pin to the upstream package source for the latest \
                           development version"
   in
-  let guess_names url =
+  let guess_names url k =
     let from_opam_files dir =
       OpamStd.List.filter_map
         (fun (nameopt, f) -> match nameopt with
@@ -2279,36 +2279,41 @@ let pin ?(unpin_only=false) () =
           (OpamUrl.to_string url)
       | b::_ -> b
     in
-    let found =
+    let found, cleanup =
       match OpamUrl.local_dir url with
-      | Some d -> from_opam_files d
+      | Some d -> from_opam_files d, None
       | None ->
         let pin_cache_dir = OpamRepositoryPath.pin_cache url in
-        (* We will use pin cache directory from this point, it will be created
-           by the download job. To be sure that it will be cleaned, add an
-           `at_exit` handler. *)
-        OpamStd.Sys.at_exit
-          (fun () -> OpamFilename.rmdir @@ OpamRepositoryPath.pin_cache_dir ());
-        let open OpamProcess.Job.Op in
-        OpamProcess.Job.run @@
-        OpamRepository.pull_tree
-          ~cache_dir:(OpamRepositoryPath.download_cache
-                        OpamStateConfig.(!r.root_dir))
-          basename pin_cache_dir [] [url] @@| function
-        | Not_available u ->
-          OpamConsole.error_and_exit `Sync_error
-            "Could not retrieve %s" u
-        | Result _ | Up_to_date _ -> from_opam_files pin_cache_dir
+        let cleanup = fun () ->
+          OpamFilename.rmdir @@ OpamRepositoryPath.pin_cache_dir ()
+        in
+        try
+          let open OpamProcess.Job.Op in
+          OpamProcess.Job.run @@
+          OpamRepository.pull_tree
+            ~cache_dir:(OpamRepositoryPath.download_cache
+                          OpamStateConfig.(!r.root_dir))
+            basename pin_cache_dir [] [url] @@| function
+          | Not_available u ->
+            OpamConsole.error_and_exit `Sync_error
+              "Could not retrieve %s" u
+          | Result _ | Up_to_date _ -> from_opam_files pin_cache_dir, Some cleanup
+        with e -> OpamStd.Exn.finalise e cleanup
     in
-    match found with
-    | _::_ -> found
-    | [] ->
-      try [OpamPackage.Name.of_string basename] with
-      | Failure _ ->
-        OpamConsole.error_and_exit `Bad_arguments
-          "Could not infer a package name from %s, please specify it on the \
-           command-line, e.g. 'opam pin NAME TARGET'"
-          (OpamUrl.to_string url)
+    let finalise = OpamStd.Option.default (fun () -> ()) cleanup in
+    OpamStd.Exn.finally finalise @@ fun () ->
+    let names_found =
+      match found with
+      | _::_ -> found
+      | [] ->
+        try [OpamPackage.Name.of_string basename] with
+        | Failure _ ->
+          OpamConsole.error_and_exit `Bad_arguments
+            "Could not infer a package name from %s, please specify it on the \
+             command-line, e.g. 'opam pin NAME TARGET'"
+            (OpamUrl.to_string url)
+    in
+    k names_found
   in
   let pin_target kind target =
     let looks_like_version_re =
@@ -2412,7 +2417,7 @@ let pin ?(unpin_only=false) () =
          in
          `Error (true, msg)
        | `Source url ->
-         let names = guess_names url in
+         guess_names url @@ fun names ->
          let names = match names with
            | _::_::_ ->
              if OpamConsole.confirm

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1146,6 +1146,10 @@ module Exn = struct
     f ();
     Printexc.raise_with_backtrace e bt
 
+  let finally f k =
+    match k () with
+    | r -> f (); r
+    | exception e -> finalise e f
 end
 
 

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -309,6 +309,11 @@ module Exn : sig
       preserving backtraces (when the OCaml version permits, e.g. >= 4.05.0) *)
   val finalise: exn -> (unit -> unit) -> 'a
 
+  (** Execute the given continuation, then run the finaliser before returning
+      the result. If an exception is raised, call [finalise] with the given
+      finaliser. *)
+  val finally: (unit -> unit) -> (unit -> 'a) -> 'a
+
 end
 
 (** {2 Manipulation and query of environment variables} *)

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -39,6 +39,10 @@ val with_tmp_dir_job: (string -> 'a OpamProcess.job) -> 'a OpamProcess.job
     is reached *)
 val verbose_for_base_commands: unit -> bool
 
+(** Returns a directory name, in the temporary directory, composed by [prefix],
+    pid, and random number. *)
+val temp_basename: string -> string
+
 (** [copy_file src dst] copies [src] to [dst]. Remove [dst] before the copy
     if it is a link. *)
 val copy_file: string -> string -> unit

--- a/src/repository/opamRepositoryPath.ml
+++ b/src/repository/opamRepositoryPath.ml
@@ -15,6 +15,18 @@ let create root name = root / "repo" / OpamRepositoryName.to_string name
 
 let download_cache root = root / "download-cache"
 
+let pin_cache_dir =
+  let dir =
+    lazy (OpamFilename.Dir.of_string (OpamSystem.temp_basename "opam-pin-cache"))
+  in
+  fun () -> Lazy.force dir
+
+let pin_cache u =
+  pin_cache_dir () /
+  (OpamHash.contents @@
+   OpamHash.compute_from_string ~kind:`SHA512 @@
+   OpamUrl.to_string u)
+
 let repo repo_root = repo_root // "repo" |> OpamFile.make
 
 let packages_dir repo_root = repo_root / "packages"

--- a/src/repository/opamRepositoryPath.mli
+++ b/src/repository/opamRepositoryPath.mli
@@ -20,6 +20,12 @@ val create: dirname -> repository_name -> dirname
     Warning, this is relative to the opam root, not a repository root. *)
 val download_cache: dirname -> dirname
 
+(** Pin global cache, located in temporary directory, cleaned at end of process *)
+val pin_cache_dir: unit -> dirname
+
+(** Pin cache for a given download url. *)
+val pin_cache: OpamUrl.t -> dirname
+
 (** Return the repo file *)
 val repo: dirname -> OpamFile.Repo.t OpamFile.t
 


### PR DESCRIPTION
When running `opam pin distant_url`, there was a first download of the archive
or git repo to guess package name, and another ones for every package name
found. This PR adds a cache for these case of pin, in order to download
only once.