### PR TITLE
Recompile ocaml-system on (dis)appearance of graphics.cmi

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -1225,6 +1225,8 @@ source tree after its installation instructions have been run.
   consistency of packages that rely on system-wide files or system packages when
   those are changed, _e.g._ by `apt-get upgrade`. The user will be warned if the
   file was removed, and the package marked for reinstallation if it was changed.
+  If the checksum is zero, then the file is assumed not to exist and opam will
+  detect its appearance as requiring the package to be marked for reinstallation.
 - <a id="dotconfigsection-variables">`variables: "{" { <ident>: ( <string> | [ <string> ... ] | <bool> ) ... }
   "}"`</a>: allows the definition of package variables, that will be available
   as `<pkgname>:<varname>` to dependent packages.


### PR DESCRIPTION
This builds on the feature added in #3343 and enables the following user experience:

```
dra@bionic:~$ opam install graphics
The following actions will be performed:
  ∗ install graphics 1.0 

<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[ERROR] The compilation of graphics failed at "/home/dra/.opam/opam-init/hooks/sandbox.sh build ocamlc -custom graphics.cma -o test".

#=== ERROR while compiling graphics.1.0 =======================================#
# context      2.0.0~rc | linux/x86_64 | ocaml-system.4.05.0 | file:///home/dra/opam-repository
# path         ~/.opam/test/.opam-switch/build/graphics.1.0
# command      ~/.opam/opam-init/hooks/sandbox.sh build ocamlc -custom graphics.cma -o test
# exit-code    2
# env-file     ~/.opam/log/graphics-7451-4bcc67.env
# output-file  ~/.opam/log/graphics-7451-4bcc67.out
### output ###
# /usr/bin/x86_64-linux-gnu-ld: cannot find -lgraphics
# collect2: error: ld returned 1 exit status
# File "_none_", line 1:
# Error: Error while building custom runtime system



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
┌─ The following actions failed
│ λ build graphics 1.0
└─ 
╶─ No changes have been performed

<><> graphics.1.0 troubleshooting <><><><><><><><><><><><><><><><><><><><><><><>
=> This package checks whether the Graphics library was compiled.
dra@bionic:~$ sudo apt install ocaml
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following NEW packages will be installed
  ocaml
0 to upgrade, 1 to newly install, 0 to remove and 0 not to upgrade.
Need to get 45.6 kB of archives.
After this operation, 265 kB of additional disk space will be used.
Get:1 http://gb.archive.ubuntu.com/ubuntu bionic/universe amd64 ocaml amd64 4.05.0-10ubuntu1 [45.6 kB]
Fetched 45.6 kB in 1s (75.7 kB/s)
Selecting previously unselected package ocaml.
(Reading database ... 130904 files and directories currently installed.)
Preparing to unpack .../ocaml_4.05.0-10ubuntu1_amd64.deb ...
Unpacking ocaml (4.05.0-10ubuntu1) ...
Setting up ocaml (4.05.0-10ubuntu1) ...
dra@bionic:~$ opam install graphics
[WARNING] File /usr/lib/ocaml/graphics.cmi, which package ocaml-system.4.05.0 depends upon, was changed on your system. ocaml-system has been
          marked as removed, and will be reinstalled if necessary.
The following actions will be performed:
  ∗ install   ocaml-system 4.05.0 
  ↻ recompile ocaml        4.05.0 
  ∗ install   graphics     1.0    
===== ∗ 2   ↻ 1 =====
Do you want to continue? [Y/n] y

<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
⊘ removed   ocaml.4.05.0
∗ installed ocaml-system.4.05.0
∗ installed ocaml.4.05.0
∗ installed graphics.1.0
Done.
```