### PR TITLE
Fix file locking on Windows

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -761,8 +761,10 @@ let init
          else OpamFile.InitConfig.default_compiler init_config), custom_scripts
       with e ->
         OpamStd.Exn.finalise e @@ fun () ->
-        if not (OpamConsole.debug ()) && root_empty then
-          OpamFilename.rmdir root)
+        if not (OpamConsole.debug ()) && root_empty then begin
+          OpamSystem.release_all_locks ();
+          OpamFilename.rmdir root
+        end)
   in
   OpamEnv.write_static_init_scripts root ~completion:true ~eval_env:false
     custom_scripts;

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -306,6 +306,7 @@ let install gt ?rt ?synopsis ?repos ~update_config ~packages switch =
          OpamStd.Option.iter
            (ignore @* OpamSwitchAction.set_current_switch `Lock_write gt)
            old_switch_opt);
+      ignore (OpamSwitchState.unlock st);
       ignore (clear_switch gt switch)
   in
   let gt = OpamGlobalState.unlock gt in
@@ -319,7 +320,10 @@ let install gt ?rt ?synopsis ?repos ~update_config ~packages switch =
            raise e);
        if OpamConsole.confirm "Switch initialisation failed: clean up? \
                                ('n' will leave the switch partially installed)"
-       then ignore (clear_switch gt switch));
+       then begin
+         ignore (OpamSwitchState.unlock st);
+         ignore (clear_switch gt switch)
+       end);
     raise e
 
 let switch lock gt switch =

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -717,6 +717,12 @@ let string_of_lock_kind = function
   | `Lock_read -> "read"
   | `Lock_write -> "write"
 
+let locks = Hashtbl.create 16
+
+let release_all_locks () =
+  Hashtbl.iter (fun fd _ -> Unix.close fd) locks;
+  Hashtbl.clear locks
+
 let rec flock_update
   : 'a. ([< lock_flag ] as 'a) -> ?dontblock:bool -> lock -> unit
   = fun flag ?(dontblock=OpamCoreConfig.(!r.safe_mode)) lock ->
@@ -727,6 +733,7 @@ let rec flock_update
   else
   match flag, lock with
   | `Lock_none, { fd = Some fd; kind = (`Lock_read | `Lock_write); _ } ->
+    Hashtbl.remove locks fd;
     Unix.close fd; (* implies Unix.lockf fd Unix.F_ULOCK 0 *)
     lock.kind <- (flag :> lock_flag);
     lock.fd <- None
@@ -763,6 +770,7 @@ and flock: 'a. ([< lock_flag ] as 'a) -> ?dontblock:bool -> string -> lock =
     mkdir (Filename.dirname file);
     let rdflag = if (flag :> lock_flag) = `Lock_write then Unix.O_RDWR else Unix.O_RDONLY in
     let fd = Unix.openfile file Unix.([O_CREAT; O_CLOEXEC; rdflag]) 0o666 in
+    Hashtbl.add locks fd ();
     let lock = { fd = Some fd; file; kind = `Lock_none } in
     flock_update flag ?dontblock lock;
     lock

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -220,6 +220,10 @@ val lock_none: lock
 (** Raised when locks can't be acquired and [dontblock] was specified) *)
 exception Locked
 
+(** Force releases all open locks in the process. Required for Windows if an exception
+    has been raised, since Windows doesn't permit unlinking while handles are open. *)
+val release_all_locks: unit -> unit
+
 (** Acquires a lock on the given file.
     Raises [Locked] if the lock can't be acquired and [dontblock] is set. Raises
     [OpamStd.Sys.Exit] if [safe_mode] is set and a write lock is required. Also


### PR DESCRIPTION
Another bit from #3260.

These three commits are worth looking at individually.

 - `Close all lock files on error`: this, as you noted in #3260, this shouldn't be necessary, but given that any coding error could result in this, I'd prefer to keep it. It could possibly be extended to display warnings if `OpamSystem.release_all_locks` actually has to release any locks? It would seem to be much better to have warnings displayed, which need fixing, than to get error messages about being unable to remove a directory (in this case `~/.opam`), as failing to delete the directory in this instance will probably result in worse error messages for the user on the next command they run.
 - `Fix file locking on Windows`: this is sound, though could potentially result in the loss of the lock to another opam process. This could be fixed by converting locks to be pairs of read and write locks if you want? A benefit of doing that is the code would cease to be Windows-specific (it would just retain a comment for why it can't be done the more obvious way).
 - `Fix reading/writing of OpamRepositoryState cache`: is a simple refactoring to prevent opening a file twice, since this doesn't work on Windows if it's locked for writing (even by the same process).