### PR TITLE
Allow native Windows to use Cygwin tools

### DIFF
--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -92,7 +92,10 @@ let cygwin_create_process_env prog args env fd1 fd2 fd3 =
           f 0
       in
       log ~level:3 "result: %S" r; r in
-    if List.exists (fun s -> try String.index s '"' >= 0 with Not_found -> false) argv then
+    (* Setting noglob is causing some problems for ocamlbuild invoking Cygwin's
+       find. The reason for using it is to try to keep command line lengths
+       below the maximum, but for now disable the use of noglob. *)
+    if true || List.exists (fun s -> try String.index s '"' >= 0 with Not_found -> false) argv then
       ("\"" ^ String.concat "\" \"" (List.map (gen_quote ~quote:"\"" ~pre:"\"'" ~post:"'\"") argv) ^ "\"", false)
     else
       (String.concat " " (List.map (gen_quote ~quote:"\b\r\n " ~pre:"\"") argv), true) in

--- a/src/core/opamProcess.mli
+++ b/src/core/opamProcess.mli
@@ -210,3 +210,7 @@ module Job: sig
 end
 
 type 'a job = 'a Job.Op.job
+
+(**/**)
+val set_resolve_command :
+  (?env:string array -> ?dir:string -> string -> string option) -> unit

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -435,6 +435,21 @@ module OpamString = struct
     with Not_found ->
       false
 
+  let find_from f s i =
+    let l = String.length s in
+    if i < 0 || i > l then
+      invalid_arg "find_from"
+    else
+      let rec g i =
+        if i < l then
+          if f s.[i] then
+            i
+          else
+            g (succ i)
+        else
+          raise Not_found in
+      g i
+
   let map f s =
     let len = String.length s in
     let b = Bytes.create len in
@@ -597,9 +612,9 @@ module OpamSys = struct
     if Sys.win32 then fun path ->
       let length = String.length path in
       let rec f acc index current last normal =
-        if index = length
-        then let current = current ^ String.sub path last (index - last) in
-          if current <> "" then current::acc else acc
+        if index = length then
+          let current = current ^ String.sub path last (index - last) in
+          List.rev (if current <> "" then current::acc else acc)
         else let c = path.[index]
           and next = succ index in
           if c = ';' && normal || c = '"' then
@@ -707,6 +722,10 @@ module OpamSys = struct
         in
         Hashtbl.add memo arg r;
         r
+
+  let system () =
+    (* CSIDL_SYSTEM = 0x25 *)
+    OpamStubs.(shGetFolderPath 0x25 SHGFP_TYPE_CURRENT)
 
   type os =
     | Darwin

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -407,6 +407,12 @@ module Sys : sig
       Optional argument [clean] permits to keep those empty strings. *)
   val split_path_variable: ?clean:bool -> string -> string list
 
+  (** For native Windows builds, returns [`Cygwin] if the command is a Cygwin-
+      compiled executable, [`CygLinked] if the command links to a library which is
+      itself Cygwin-compiled or [`Native] otherwise.
+      Note that this returns [`Native] on a Cygwin-build of opam! *)
+  val is_cygwin_variant: string -> [ `Native | `Cygwin | `CygLinked ]
+
   (** {3 Exit handling} *)
 
   (** Like Pervasives.at_exit but with the possibility to call manually

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -224,6 +224,7 @@ module String : sig
   val contains_char: string -> char -> bool
   val contains: sub:string -> string -> bool
   val exact_match: Re.re -> string -> bool
+  val find_from: (char -> bool) -> string -> int -> int
 
   (** {3 Manipulation} *)
 
@@ -367,6 +368,9 @@ module Sys : sig
 
   (** The /etc directory *)
   val etc: unit -> string
+
+  (** The system directory (Windows only) *)
+  val system: unit -> string
 
   type os = Darwin
           | Linux

--- a/src/core/opamStubs.ml.dummy
+++ b/src/core/opamStubs.ml.dummy
@@ -35,3 +35,4 @@ let shGetFolderPath _ = that's_a_no_no
 let sendMessageTimeout _ _ _ _ _ = that's_a_no_no
 let getParentProcessID = that's_a_no_no
 let getConsoleAlias _ = that's_a_no_no
+let win_create_process _ _ _ _ _ = that's_a_no_no

--- a/src/core/opamStubs.ml.win32
+++ b/src/core/opamStubs.ml.win32
@@ -11,3 +11,7 @@
 include OpamStubsTypes
 include OpamWin32Stubs
 let getpid () = Int32.to_int (getCurrentProcessID ())
+
+external win_create_process : string -> string -> string option ->
+                              Unix.file_descr -> Unix.file_descr -> Unix.file_descr -> int
+                            = "win_create_process" "win_create_process_native"

--- a/src/core/opamStubs.mli
+++ b/src/core/opamStubs.mli
@@ -128,3 +128,7 @@ val getConsoleAlias : string -> string -> string
 (** Windows only. [getConsoleAlias alias exeName] retrieves the value for a
     given executable or [""] if the alias is not defined. See
     https://docs.microsoft.com/en-us/windows/console/getconsolealias *)
+
+val win_create_process : string -> string -> string option -> Unix.file_descr ->
+                         Unix.file_descr -> Unix.file_descr -> int
+(** Windows only. Provided by OCaml's win32unix library. *)

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -1292,3 +1292,6 @@ let init () =
   Sys.catch_break true;
   try Sys.set_signal Sys.sigpipe (Sys.Signal_handle (fun _ -> ()))
   with Invalid_argument _ -> ()
+
+let () =
+  OpamProcess.set_resolve_command resolve_command

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -650,18 +650,21 @@ module Tar = struct
         Some (Printf.sprintf "Tar needs %s to extract the archive" cmd)
       else None)
 
-  let extract_command file =
-    OpamStd.Option.Op.(
-      get_type file >>| fun typ ->
-      let tar_cmd =
-        match OpamStd.Sys.os () with
-        | OpamStd.Sys.OpenBSD -> "gtar"
-        | _ -> "tar"
-      in
-      let command c dir =
-        make_command tar_cmd [ Printf.sprintf "xf%c" c ; file; "-C" ; dir ]
-      in
-      command (extract_option typ))
+  let extract_command =
+    let tar_cmd =
+      match OpamStd.Sys.os () with
+      | OpamStd.Sys.OpenBSD -> "gtar"
+      | _ -> "tar"
+    in
+    let f = get_cygpath_function ~command:tar_cmd in
+    fun file ->
+      OpamStd.Option.Op.(
+        get_type file >>| fun typ ->
+        let f = Lazy.force f in
+        let command c dir =
+          make_command tar_cmd [ Printf.sprintf "xf%c" c ; f file; "-C" ; f dir ]
+        in
+        command (extract_option typ))
 end
 
 module Zip = struct

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -157,6 +157,11 @@ type command = string list
     if found in PATH) *)
 val resolve_command: ?env:string array -> ?dir:string -> string -> string option
 
+(** Returns a function which should be applied to arguments for a given command
+    by determining if the command is the Cygwin variant of the command. Returns
+    the identity function otherwise. *)
+val get_cygpath_function: command:string -> (string -> string) lazy_t
+
 (** [command cmd] executes the command [cmd] in the correct OPAM
     environment. *)
 val command: ?verbose:bool -> ?env:string array -> ?name:string ->

--- a/src/core/opamUrl.ml
+++ b/src/core/opamUrl.ml
@@ -238,6 +238,12 @@ let to_json url = `String (to_string url)
 
 type url = t
 
+let map_file_url f url =
+  if url.transport = "file" then
+    {url with path = f url.path}
+  else
+    url
+
 module O = struct
   type t = url
   let to_string = to_string

--- a/src/core/opamUrl.mli
+++ b/src/core/opamUrl.mli
@@ -66,6 +66,10 @@ val local_file: t -> OpamFilename.t option
     to an existing local path, check for version-control clues at that path *)
 val guess_version_control: string -> [> version_control ] option
 
+(** [map_file_url f url] applies [f] to the [path] portion of [url] if
+    [transport] is ["file"]. *)
+val map_file_url : (string -> string) -> t -> t
+
 module Op: sig
 
   (** Appends at the end of an URL path with '/' separator. Gets back to the

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -29,6 +29,8 @@ module type VCS = sig
   val is_dirty: dirname -> bool OpamProcess.job
 end
 
+let convert_path =
+  OpamSystem.get_cygpath_function ~command:"rsync"
 
 module Make (VCS: VCS) = struct
 
@@ -123,7 +125,7 @@ module Make (VCS: VCS) = struct
                   OpamStd.String.Set.mem basename fset)
           then OpamFilename.remove f)
         (OpamFilename.rec_files repo_root);
-      OpamLocal.rsync_dirs ~args:["--files-from"; stdout_file]
+      OpamLocal.rsync_dirs ~args:["--files-from"; (Lazy.force convert_path) stdout_file]
         ~exclude_vcdirs:false
         repo_url repo_root
       @@+ fun result ->


### PR DESCRIPTION
Yet another bit from #3260.

~This also borrows a commit from #3346, so it will need rebasing before merge.~

This set of patches address two fundamental issues:
 - It allows native Windows opam to call Cygwin tools correctly, by converting their arguments to Cygwin-style paths when necessary.
 - It allows native Windows opam to appear to be able to execute shell scripts directly (by interpreting `#!` comments) and also ensures that command line arguments passed to Cygwin executables are correctly encoded/escaped, since they don't follow the same rules as native Windows executables. Note that this has **nothing** to do with shell escaping: this is dealing with the conversion of arguments as a string list to a single string (which is how Windows passes the command line) by the calling process being recovered as the *same* string array by the invoked process.