### PR TITLE
Doc fix, formula printer & upgrade message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,9 @@ opam-%.install: $(JBUILDER_DEP)
 opam.install: $(JBUILDER_DEP)
 	$(JBUILDER) build $(JBUILDER_ARGS) opam-installer.install opam.install
 
-opam-actual.install: opam.install
+opam-actual.install: opam.install man
 	@echo 'bin: [' > $@
-	@grep -h 'bin/[^/]*' $^ >> $@
+	@grep -h 'bin/[^/]*' $< >> $@
 	@echo ']' >> $@
 	@echo 'man: [' >>$@
 	@$(patsubst %,echo '  "'%'"' >>$@;,$(wildcard doc/man/*.1))

--- a/README.md
+++ b/README.md
@@ -37,9 +37,14 @@ it as a second step.
 
 * Make sure to have ocamlfind, ocamlgraph, cmdliner >= 0.9.8, cudf >= 0.7,
   dose3 >= 5, re >= 1.5.0, opam-file-format installed. Or run `opam install
-  opam-lib --deps-only` if you already have a working instance. Re-run
+  . --deps-only` if you already have a working instance. Re-run
   `./configure` once done
 * Run `make libinstall` at the end
+
+_Note_: If you install on your system (without changeing the prefix), you will
+need to install as root (`sudo`). As sudo do not propagate environment
+variables, there wil be some errors. You can use `sudo -E "PATH=$PATH" in order
+to be sure to have the good environment for install.
 
 ## Developer mode
 

--- a/doc/pages/FAQ.md
+++ b/doc/pages/FAQ.md
@@ -87,8 +87,9 @@ You can manually disable package build sandboxing and remove bwrap from
 the required dependencies (at your own risk). You can use the built-in
 configuration as a template to create or update an `opamrc` file: run `opam
 init --show-default-opamrc >~/.opamrc`, then edit that file and remove or
-modify the `init-scripts:` and `wrap-*:` fields as well as the `bwrap` line
-from the `required-tools:` field, and finally retry `opam init`.
+modify the [`init-scripts:`](Manual.html#opamrcfield-init-scripts) and
+`wrap-*:` fields as well as the `bwrap` line from the `required-tools:` field,
+and finally retry `opam init`.
 
 See also the [wrap entry](Manual.html#configfield-wrap-build-commands) section
 in the manual.

--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -721,7 +721,7 @@ The default, built-in initial config of <span class="opam">opam</span> can be se
   of alternative commands to look for in the `PATH`, optionally a specific error
   message to display if none of them is found, and a filter that can make the
   check conditional.
-- <a id="configfield-init-scripts">`init-scripts: [ [ <string> <string> ] { <filter> } ... ]`</a>:
+- <a id="opamrcfield-init-scripts">`init-scripts: [ [ <string> <string> ] { <filter> } ... ]`</a>:
   These scripts will be written verbatim into the hook directory
   (`~/.opam/opam-init/hooks`) upon initialisation. The first string is the file
   name of the script, the second its raw contents, and the filter allows to
@@ -1331,12 +1331,14 @@ for <span class="opam">opam</span>.
   specify wrappers around every command executed during the corresponding action
   of any package. The command-line elements will be prefixed to the package
   command, so for example command `[ make "install" ]` with wrapper
-  `[ "time" "-o" "/tmp/timings" "-a" ]` will result in the command
-  `[ "time" "-o" "/tmp/timings" "-a" make "install" ]`.
-  As `init-scripts:` are stored in the hook directory, when using a wrapper
-  script defined by `init-scripts:`, use the variable `%{hook}%` as prefix for
-  you script filename.
-  The filters are evaluated in the same scope as the package commands.
+  `[ "time" "-o" "/tmp/timings" "-a" ]` will result in the command `[ "time"
+  "-o" "/tmp/timings" "-a" make "install" ]`. The filters are evaluated in the
+  same scope as the package commands.
+
+    As [`init-scripts:`](#opamrcfield-init-scripts) are stored in the hook
+    directory, when using a wrapper script defined by
+    [`init-scripts:`](#opamrcfield-init-scripts), use the variable `%{hook}%` as
+    prefix for you script filename.
 - <a id="configfield-post-build-commands">`post-build-commands: [ [ <term> { <filter> } ... ] { <filter> } ... ]`</a>,
   <a id="configfield-post-install-commands">`post-install-commands: [ [ <term> { <filter> } ... ] { <filter> } ... ]`</a>,
   <a id="configfield-post-remove-commands">`post-remove-commands: [ [ <term> { <filter> } ... ] { <filter> } ... ]`</a>:


### PR DESCRIPTION
This PR contains:
- Some documentation fixes
- Formula printer: print inner parenthesis, even if it is in a `Block`, to avoid conflicts on regenerated `opam` files 
- Improve upgrade message in case of conflict (related to #3334)
- Fix manpage installation: they need to be generated before `opam-actual.install` generation, in order to be installed by `opam-installer` (close #3318)