### PR TITLE
Make it so that 'make tests' can pass from within opam

### DIFF
--- a/src/client/opamAdminRepoUpgrade.ml
+++ b/src/client/opamAdminRepoUpgrade.ml
@@ -195,8 +195,13 @@ let do_upgrade repo_root =
     (fun () ->
        Hashtbl.fold
          (fun url hash l -> [OpamUrl.to_string url; OpamHash.to_string hash]::l)
-         url_md5 [] |>
-       OpamFile.Lines.write cache_file)
+         url_md5 [] |> fun lines ->
+       try OpamFile.Lines.write cache_file lines with e ->
+         OpamStd.Exn.fatal e;
+         OpamConsole.log "REPO_UPGRADE"
+           "Could not write archive hash cache to %s, skipping (%s)"
+           (OpamFile.to_string cache_file)
+           (Printexc.to_string e))
   in
   let ocaml_versions =
     OpamStd.String.Map.fold (fun c comp_file ocaml_versions ->

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -103,7 +103,7 @@ init:
 ifeq ($(REPOKIND), git)
 	cd $(OPAM_REPO) && $(call GIT_INIT,README)
 endif
-	$(OPAMBIN) init --bare --no-setup $(REPO) $(OPAM_REPO) -k $(REPOKIND)
+	$(OPAMBIN) init --bare --no-setup --disable-sandboxing $(REPO) $(OPAM_REPO) -k $(REPOKIND)
 
 define mkurl
   echo 'src: "http://dev.null" checksum: "'`openssl md5 packages/$(2) |cut -d' ' -f2`'"' \


### PR DESCRIPTION
This fixes `opam install -t opam-devel` by:
- ignoring the archive hash cache update when the file can't be written to
- disabling sandboxing within `make tests`