### PR TITLE
Fix typo in install script

### DIFF
--- a/shell/install.sh
+++ b/shell/install.sh
@@ -227,7 +227,7 @@ echo "## opam $VERSION installed to $BINDIR"
 
 if [ ! "$FRESH" = 1 ]; then
     echo "## Converting the opam root format & updating"
-    "$BINDIR/opam" init --reinit -nc
+    "$BINDIR/opam" init --reinit -ni
 fi
 
 WHICH=$(command -v opam || echo notfound)


### PR DESCRIPTION
Looks like `-nc` was meant to be `-ni` like the command suggested in https://opam.ocaml.org/2.0-preview/blog/opam-2-0-0-rc2/.

Fix #3371 