### PR TITLE
improve the formatting of docstrings with odoc master

### DIFF
--- a/src/format/opamFilter.mli
+++ b/src/format/opamFilter.mli
@@ -9,9 +9,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Formulas on variables, as used in opam files build scripts *)
+(** Formulas on variables, as used in opam files build scripts
 
-(** Filters are a small language of formulas over strings and booleans used for
+    Filters are a small language of formulas over strings and booleans used for
     conditions and text replacements. It has relational operators over strings
     (using version-number comparison), And, Or and Not boolean operations,
     dynamic casting (using strings "true" and "false"), and string
@@ -20,7 +20,9 @@
 
     String interpolation uses the syntax [%{identifier}%]
 
-    Identifiers have the form {v[package:]var[?str_if_true:str_if_false_or_undef]v}.
+    Identifiers have the form
+    {v [package:]var[?str_if_true:str_if_false_or_undef] v}
+
     The last optional part specifies a conversion from boolean to static strings.
 
     The syntax [pkg1+pkg2+pkgn:var] is allowed as a shortcut to

--- a/src/format/opamFormat.mli
+++ b/src/format/opamFormat.mli
@@ -72,8 +72,7 @@ module V : sig
   val group : (value, value list) t
 
   (** Options in the [value] type sense, i.e. a value with an optional list
-      of parameters in braces:
-      "value {op1 op2}" *)
+      of parameters in braces: ["value {op1 op2}"] *)
   val option :
     (value, value * value list) t
 


### PR DESCRIPTION
When generating the docs with `dune build @doc` and odoc master,
the new parser emits some warnings. This fixes some of the markup
to be more compliant.