### PR TITLE
Add `--assume-built` option

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1059,6 +1059,16 @@ let build_options =
     $skip_update $fake $jobs_flag $ignore_constraints_on
     $unlock_base)
 
+(* Option common to install commands *)
+let assume_built =
+  Arg.(value & flag & info ["assume-built"]
+         ~doc:"For use on locally-pinned packages: assume they have already \
+               been correctly built, and only run their installation \
+               instructions, directly from their source directory. This \
+               skips the build instructions and can be useful to install \
+               packages that are being worked on. Implies $(i,--inplace-build). \
+               No locally-pinned packages will be skipped.")
+
 let package_selection_section = "PACKAGE SELECTION OPTIONS"
 
 let package_selection =

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -114,6 +114,9 @@ val build_option_section: string
 (** Build options *)
 val build_options: build_options Term.t
 
+(** Instal and reinstall options *)
+val assume_built: bool Term.t
+
 (** Applly build options *)
 val apply_build_options: build_options -> unit
 

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -903,27 +903,85 @@ let check_conflicts t atoms =
     full_orphans,
     orphan_versions
 
-let install_t t ?ask atoms add_to_roots ~deps_only =
+let assume_built_restrictions t atoms =
+  let installed_fixed, not_installed_fixed =
+    let rec all_deps set pkgs =
+      let universe =
+        OpamSwitchState.universe t
+          ~requested:(OpamPackage.names_of_packages pkgs)
+          Install
+      in
+      let deps =
+        OpamPackage.Set.of_list
+          (OpamSolver.dependencies ~build:false ~post:true
+             ~depopts:false ~installed:false ~unavailable:true universe pkgs)
+      in
+      let deps = deps -- pkgs in
+      if OpamPackage.Set.is_empty deps then set
+      else all_deps (set ++ deps) deps
+    in
+    let pkg_of_atoms =
+      OpamPackage.Set.filter
+        (fun p -> List.exists (fun a -> OpamFormula.check a p) atoms)
+        t.packages
+    in
+    let all_fixed = all_deps OpamPackage.Set.empty pkg_of_atoms in
+    OpamSolution.eq_atoms_of_packages all_fixed |> get_installed_atoms t
+  in
+  let atoms =
+      atoms @ OpamSolution.eq_atoms_of_packages
+        (OpamPackage.Set.of_list installed_fixed)
+  in
+  let t =
+      let avp =
+        OpamPackage.Set.filter
+          (fun p -> not (List.exists (fun a -> OpamFormula.check a p)
+                           not_installed_fixed))
+          (Lazy.force t.available_packages)
+      in
+      { t with available_packages = lazy avp}
+  in
+  t, atoms
+
+let filter_unpinned_locally t atoms f =
+  OpamStd.List.filter_map (fun at ->
+      let n,_ = at in
+      if OpamSwitchState.is_pinned t n &&
+         OpamStd.Option.Op.(OpamPinned.package_opt t n >>=
+                            OpamSwitchState.primary_url t >>=
+                            OpamUrl.local_dir) <> None
+      then
+        Some (f at)
+      else
+        (log "Package %a is not pinned locally and assume built \
+              option is set, skipping"
+           (slog OpamPackage.Name.to_string) n;
+         None))
+    atoms
+
+let install_t t ?ask atoms add_to_roots ~deps_only ~assume_built =
   log "INSTALL %a" (slog OpamFormula.string_of_atoms) atoms;
   let names = OpamPackage.Name.Set.of_list (List.rev_map fst atoms) in
 
   let t, full_orphans, orphan_versions = check_conflicts t atoms in
 
   let atoms =
-    List.map (function
-        | (_, Some _) as at -> at
-        | (name, None) as at ->
-          match OpamPinned.package_opt t name with
-          | Some nv -> OpamSolution.eq_atom_of_package nv
-          | None -> at)
-      atoms
+    let compl = function
+      | (_, Some _) as at -> at
+      | (name, None) as at ->
+        match OpamPinned.package_opt t name with
+        | Some nv -> OpamSolution.eq_atom_of_package nv
+        | None -> at
+    in
+    if assume_built then filter_unpinned_locally t atoms compl
+    else List.map compl atoms
   in
   let pkg_skip, pkg_new =
     get_installed_atoms t atoms in
   let pkg_reinstall =
-    t.reinstall %% OpamPackage.Set.of_list pkg_skip
+    if assume_built then OpamPackage.Set.of_list pkg_skip
+    else t.reinstall %% OpamPackage.Set.of_list pkg_skip
   in
-
   (* Add the packages to the list of package roots and display a
      warning for already installed package roots. *)
   let current_roots = t.installed_roots in
@@ -1001,12 +1059,18 @@ let install_t t ?ask atoms add_to_roots ~deps_only =
   let t = {t with available_packages = lazy available_packages} in
 
   if pkg_new = [] && OpamPackage.Set.is_empty pkg_reinstall then t else
-
+  let t, atoms =
+    if assume_built then
+      assume_built_restrictions t atoms
+    else t, atoms
+  in
   let request = OpamSolver.request ~install:atoms () in
   let solution =
+    let reinstall = if assume_built then Some pkg_reinstall else None in
     OpamSolution.resolve t Install
       ~orphans:(full_orphans ++ orphan_versions)
       ~requested:names
+      ?reinstall
       request in
   let t, solution = match solution with
     | Conflicts cs ->
@@ -1028,19 +1092,21 @@ let install_t t ?ask atoms add_to_roots ~deps_only =
             | false -> OpamPackage.Name.Set.empty)
           add_to_roots
       in
-      OpamSolution.apply ?ask t Install ~requested:names ?add_roots solution
+      OpamSolution.apply ?ask t Install ~requested:names ?add_roots
+        ~assume_built solution
   in
   OpamSolution.check_solution t solution;
   t
 
-let install t ?autoupdate ?add_to_roots ?(deps_only=false) names =
+let install t ?autoupdate ?add_to_roots
+    ?(deps_only=false) ?(assume_built=false) names =
   let atoms = OpamSolution.sanitize_atom_list ~permissive:true t names in
   let autoupdate_atoms = match autoupdate with
     | None -> atoms
     | Some a -> OpamSolution.sanitize_atom_list ~permissive:true t a
   in
   let t = update_dev_packages_t autoupdate_atoms t in
-  install_t t atoms add_to_roots ~deps_only
+  install_t t atoms add_to_roots ~deps_only ~assume_built
 
 let remove_t ?ask ~autoremove ~force atoms t =
   log "REMOVE autoremove:%b %a" autoremove

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -50,13 +50,13 @@ val reinit:
 val install:
   rw switch_state ->
   ?autoupdate:atom list -> ?add_to_roots:bool -> ?deps_only:bool ->
-  atom list -> rw switch_state
+  ?assume_built:bool -> atom list -> rw switch_state
 
 (** Low-level version of [reinstall], bypassing the package name sanitization
     and dev package update, and offering more control *)
 val install_t:
   rw switch_state -> ?ask:bool ->
-  atom list -> bool option -> deps_only:bool ->
+  atom list -> bool option -> deps_only:bool -> assume_built:bool ->
   rw switch_state
 
 (** Reinstall the given set of packages. *)

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -61,12 +61,13 @@ val install_t:
 
 (** Reinstall the given set of packages. *)
 val reinstall:
-  rw switch_state -> atom list -> rw switch_state
+  rw switch_state -> ?assume_built:bool -> atom list -> rw switch_state
 
 (** Low-level version of [reinstall], bypassing the package name sanitization
     and dev package update, and offering more control *)
 val reinstall_t:
-  rw switch_state -> ?ask:bool -> ?force:bool -> atom list -> rw switch_state
+  rw switch_state -> ?ask:bool -> ?force:bool -> assume_built:bool -> atom list
+  -> rw switch_state
 
 (** Update the local mirrors for the repositories and/or development packages.
     Returns [(success, changes, rt)], where [success] is [true] only if all

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1340,14 +1340,14 @@ let reinstall =
                 overriding."
       ])
   in
-  let reinstall global_options build_options atoms_locs cmd =
+  let reinstall global_options build_options assume_built atoms_locs cmd =
     apply_global_options global_options;
     apply_build_options build_options;
     OpamGlobalState.with_ `Lock_none @@ fun gt ->
     match cmd, atoms_locs with
     | `Default, (_::_ as atom_locs) ->
       OpamSwitchState.with_ `Lock_write gt @@ fun st ->
-      ignore @@ OpamClient.reinstall st
+      ignore @@ OpamClient.reinstall st ~assume_built
         (OpamAuxCommands.resolve_locals_pinned st atom_locs);
       `Ok ()
     | `Pending, [] | `Default, [] ->
@@ -1391,8 +1391,8 @@ let reinstall =
     | _, _::_ ->
       `Error (true, "Package arguments not allowed with this option")
   in
-  Term.(ret (const reinstall $global_options $build_options $atom_or_dir_list
-             $cmd)),
+  Term.(ret (const reinstall $global_options $build_options $assume_built
+             $atom_or_dir_list $cmd)),
   term_info "reinstall" ~doc ~man
 
 (* UPDATE *)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1182,7 +1182,7 @@ let install =
   in
   let install
       global_options build_options add_to_roots deps_only restore destdir locked
-      atoms_or_locals =
+      assume_built atoms_or_locals =
     apply_global_options global_options;
     apply_build_options build_options;
     if atoms_or_locals = [] && not restore then
@@ -1217,7 +1217,7 @@ let install =
        OpamStd.Sys.exit_because `Success);
     let st =
       OpamClient.install st atoms
-        ~autoupdate:pure_atoms ?add_to_roots ~deps_only
+        ~autoupdate:pure_atoms ?add_to_roots ~deps_only ~assume_built
     in
     match destdir with
     | None -> `Ok ()
@@ -1228,7 +1228,7 @@ let install =
   in
   Term.ret
     Term.(const install $global_options $build_options
-          $add_to_roots $deps_only $restore $destdir $locked
+          $add_to_roots $deps_only $restore $destdir $locked $assume_built
           $atom_or_local_list),
   term_info "install" ~doc ~man
 

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -908,7 +908,8 @@ let resolve t action ~orphans ?reinstall ~requested request =
   Json.output_solution t r;
   r
 
-let resolve_and_apply ?ask t action ~orphans ?reinstall ~requested ?add_roots request =
+let resolve_and_apply ?ask t action ~orphans ?reinstall ~requested ?add_roots
+    ?(assume_built=false) request =
   match resolve t action ~orphans ?reinstall ~requested request with
   | Conflicts cs ->
     log "conflict!";
@@ -916,4 +917,4 @@ let resolve_and_apply ?ask t action ~orphans ?reinstall ~requested ?add_roots re
       (OpamCudf.string_of_conflict t.packages
          (OpamSwitchState.unavailable_reason t) cs);
     t, No_solution
-  | Success solution -> apply ?ask t action ~requested ?add_roots solution
+  | Success solution -> apply ?ask t action ~requested ?add_roots ~assume_built solution

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -260,7 +260,7 @@ end
 
 (* Process the atomic actions in a graph in parallel, respecting graph order,
    and report to user. Takes a graph of atomic actions *)
-let parallel_apply t _action ~requested ?add_roots action_graph =
+let parallel_apply t _action ~requested ?add_roots ~assume_built action_graph =
   log "parallel_apply";
 
   let remove_action_packages =
@@ -313,7 +313,7 @@ let parallel_apply t _action ~requested ?add_roots action_graph =
   in
 
   let inplace =
-    if OpamClientConfig.(!r.inplace_build) then
+    if OpamClientConfig.(!r.inplace_build) || assume_built then
       OpamPackage.Set.fold (fun nv acc ->
           match
             OpamStd.Option.Op.(OpamSwitchState.url t nv >>| OpamFile.URL.url >>=
@@ -450,6 +450,14 @@ let parallel_apply t _action ~requested ?add_roots action_graph =
     else
     match action with
     | `Build nv ->
+      if assume_built && OpamPackage.Set.mem nv requested then
+        (log "Skipping build for %s, just install%s"
+           (OpamPackage.to_string nv)
+           (OpamStd.Option.map_default
+              (fun p -> " from " ^ OpamFilename.Dir.to_string p)
+              "" (OpamPackage.Map.find_opt nv inplace));
+         Done (`Successful (installed, removed)))
+      else
       let is_inplace, build_dir =
         try true, OpamPackage.Map.find nv inplace
         with Not_found ->
@@ -772,7 +780,7 @@ let run_hook_job t name ?(local=[]) w =
     Done true
 
 (* Apply a solution *)
-let apply ?ask t action ~requested ?add_roots solution =
+let apply ?ask t action ~requested ?add_roots ?(assume_built=false) solution =
   log "apply";
   if OpamSolver.solution_is_empty solution then
     (* The current state satisfies the request contraints *)
@@ -859,7 +867,9 @@ let apply ?ask t action ~requested ?add_roots solution =
       if not pre_session then
         OpamStd.Sys.exit_because `Configuration_error;
       let t0 = t in
-      let t, r = parallel_apply t action ~requested ?add_roots action_graph in
+      let t, r =
+        parallel_apply t action ~requested ?add_roots ~assume_built action_graph
+      in
       let success = match r with | OK _ -> true | _ -> false in
       let post_session =
         let open OpamPackage.Set.Op in

--- a/src/client/opamSolution.mli
+++ b/src/client/opamSolution.mli
@@ -34,6 +34,7 @@ val apply:
   user_action ->
   requested:OpamPackage.Name.Set.t ->
   ?add_roots:OpamPackage.Name.Set.t ->
+  ?assume_built:bool ->
   OpamSolver.solution ->
   rw switch_state * solver_result
 

--- a/src/client/opamSolution.mli
+++ b/src/client/opamSolution.mli
@@ -50,6 +50,7 @@ val resolve_and_apply:
   ?reinstall:package_set ->
   requested:OpamPackage.Name.Set.t ->
   ?add_roots:OpamPackage.Name.Set.t ->
+  ?assume_built:bool ->
   atom request ->
   rw switch_state * solver_result
 


### PR DESCRIPTION
This PR is related to this issue #3380.
If a package `foo` is locally pinned, option `--assume-built` can be set to skip build steps and perform only install commands. 
If a package is not locally pinned and the option is set, it will be skipped.
Packages dependencies are *locked* on their current version: if a dependency `bar` of the package `foo` needs an upgrade, and a `foo` install with `--assume-built` is launched, opam won't propose to upgrade the dependency  `bar` and reinstall `foo`. 

EDIT:
- Add the option to `reinstall`
- Always reinstall `foo` with the option (even if no changes detected)
- if a package `baz` depends on `foo`, on `foo` reinstall `baz` will be recompiled/reinstalled (even if non-locally pinned).