### PR TITLE
Download error message

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -154,10 +154,10 @@ let download_package st nv =
     (OpamUpdate.cleanup_source st
        (OpamPackage.Map.find_opt nv st.installed_opams)
        (OpamSwitchState.opam st nv);
-     OpamProcess.Job.catch (fun e -> Done (Some (Printexc.to_string e)))
+     OpamProcess.Job.catch (fun e -> Done (Some (None, Printexc.to_string e)))
      @@ fun () ->
      OpamUpdate.download_package_source st nv dir @@| function
-     | Some (Not_available s) -> Some s
+     | Some (Not_available (s,l)) -> Some (s,l)
      | None | Some (Up_to_date () | Result ()) -> None)
 
 (* Prepare the package build:
@@ -279,7 +279,7 @@ let prepare_package_source st nv dir =
         (OpamFile.URL.url urlf :: OpamFile.URL.mirrors urlf)
       @@| function
       | Result () | Up_to_date () -> None
-      | Not_available msg -> Some (Failure msg)
+      | Not_available (_,msg) -> Some (Failure msg)
     in
     List.fold_left (fun job dl ->
         job @@+ function

--- a/src/client/opamAction.mli
+++ b/src/client/opamAction.mli
@@ -15,12 +15,13 @@ open OpamTypes
 open OpamStateTypes
 
 (** [download t pkg] downloads the source of the package [pkg] into its locally
-    cached source dir. Returns [Some errmsg] on error, [None] on success.
+    cached source dir. Returns [Some (short_errmsg option, long_errmsg)] on error,
+    [None] on success. See {!OpamTypes.Not_available}.
 
     This doesn't update dev packages that already have a locally cached
     source. *)
 val download_package:
-  rw switch_state -> package -> string option OpamProcess.job
+  rw switch_state -> package -> (string option * string) option OpamProcess.job
 
 (** [prepare_package_source t pkg dir] updates the given source [dir] with the
     extra downloads, overlays and patches from the package's metadata

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -137,7 +137,7 @@ let package_files_to_cache repo_root cache_dir ?link (nv, prefix) =
           checksums
           (OpamFile.URL.url urlf :: OpamFile.URL.mirrors urlf)
         @@| function
-        | Not_available m ->
+        | Not_available (_,m) ->
           OpamPackage.Map.update nv (fun l -> m::l) [] errors
         | Up_to_date () | Result () ->
           OpamStd.Option.iter (fun link_dir ->

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2332,7 +2332,7 @@ let pin ?(unpin_only=false) () =
             ~cache_dir:(OpamRepositoryPath.download_cache
                           OpamStateConfig.(!r.root_dir))
             basename pin_cache_dir [] [url] @@| function
-          | Not_available u ->
+          | Not_available (_,u) ->
             OpamConsole.error_and_exit `Sync_error
               "Could not retrieve %s" u
           | Result _ | Up_to_date _ -> from_opam_files pin_cache_dir, Some cleanup
@@ -2571,7 +2571,7 @@ let source =
                (OpamPackage.to_string nv) dir []
                [url])
         with
-        | Not_available u ->
+        | Not_available (_,u) ->
           OpamConsole.error_and_exit `Sync_error "%s is not available" u
         | Result _ | Up_to_date _ ->
           OpamConsole.formatted_msg
@@ -2581,7 +2581,7 @@ let source =
       let job =
         let open OpamProcess.Job.Op in
         OpamUpdate.download_package_source t nv dir @@+ function
-        | Some (Not_available s) ->
+        | Some (Not_available (_,s)) ->
           OpamConsole.error_and_exit `Sync_error "Download failed: %s" s
         | None | Some (Result () | Up_to_date ()) ->
           OpamAction.prepare_package_source t nv dir @@| function

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -64,7 +64,7 @@ let get_source_definition ?version st nv url =
   in
   let open OpamProcess.Job.Op in
   OpamUpdate.fetch_dev_package url srcdir nv @@| function
-  | Not_available s -> raise (Fetch_Fail s)
+  | Not_available (_,s) -> raise (Fetch_Fail s)
   | Up_to_date _ | Result _ ->
     match OpamPinned.find_opam_file_in_source nv.name srcdir with
     | None -> None

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -368,8 +368,9 @@ let parallel_apply t _action ~requested ?add_roots action_graph =
   if fatal_dl_error then
     OpamConsole.error_and_exit `Sync_error
       "The sources of the following couldn't be obtained, aborting:\n%s"
-      (OpamStd.Format.itemize OpamPackage.to_string
-         (OpamPackage.Map.keys failed_downloads))
+      (OpamStd.Format.itemize
+      (fun (p,s) -> Printf.sprintf "%s:\n%s" (OpamPackage.to_string p) s)
+         (OpamPackage.Map.bindings failed_downloads))
   else if not (OpamPackage.Map.is_empty failed_downloads) then
     OpamConsole.warning
       "The sources of the following couldn't be obtained, they may be \

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -348,14 +348,14 @@ let parallel_apply t _action ~requested ?add_roots action_graph =
     in
     List.fold_left2 (fun failed nv -> function
         | None -> failed
-        | Some e -> OpamPackage.Map.add nv e failed)
+        | Some (s,l) -> OpamPackage.Map.add nv (s,l) failed)
       OpamPackage.Map.empty sources_list results
   in
 
   if OpamClientConfig.(!r.json_out <> None) &&
      not (OpamPackage.Map.is_empty failed_downloads) then
     OpamJson.append "download-failures"
-      (`O (List.map (fun (nv,err) -> OpamPackage.to_string nv, `String err)
+      (`O (List.map (fun (nv,(_,err)) -> OpamPackage.to_string nv, `String err)
              (OpamPackage.Map.bindings failed_downloads)));
 
   let fatal_dl_error =
@@ -369,7 +369,10 @@ let parallel_apply t _action ~requested ?add_roots action_graph =
     OpamConsole.error_and_exit `Sync_error
       "The sources of the following couldn't be obtained, aborting:\n%s"
       (OpamStd.Format.itemize
-      (fun (p,s) -> Printf.sprintf "%s:\n%s" (OpamPackage.to_string p) s)
+         (fun (p, (s,l)) ->
+            Printf.sprintf "%s:%s" (OpamPackage.to_string p)
+              (if OpamConsole.verbose () then "\n" ^ l
+               else " " ^  OpamStd.Option.default l s))
          (OpamPackage.Map.bindings failed_downloads))
   else if not (OpamPackage.Map.is_empty failed_downloads) then
     OpamConsole.warning

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -49,7 +49,9 @@ type std_path =
 (** Download result *)
 type 'a download =
   | Up_to_date of 'a
-  | Not_available of string
+  | Not_available of string option * string
+  (** Arguments are respectively the short (if relevant) and long error message.
+      The usage is: the second argument is the default one when the first one is [None] *)
   | Result of 'a
 
 (** {2 Packages} *)

--- a/src/repository/opamDownload.mli
+++ b/src/repository/opamDownload.mli
@@ -11,6 +11,8 @@
 
 (** Configuration init and handling of downloading commands *)
 
+exception Download_fail of string option * string
+
 (** downloads a file from an URL, using Curl, Wget, or a custom configured
     tool, to the given directory. Returns the downloaded filename.
     @raise Failure if the download failed or if the checksum is specified and

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -75,13 +75,13 @@ module B = struct
     OpamProcess.Job.catch
       (fun e ->
          OpamStd.Exn.fatal e;
-         let msg =
-           Printf.sprintf "%s (%s)" (OpamUrl.to_string remote_url)
-             (match e with
-              | Failure msg -> msg
-              | _ -> "download failed")
+         let s,l =
+           let str = Printf.sprintf "%s (%s)" (OpamUrl.to_string remote_url) in
+           match e with
+           | OpamDownload.Download_fail (s,l) -> s, str l
+           | _ -> Some "Download failed", str "download failed"
          in
-         Done (Not_available msg))
+         Done (Not_available (s,l)))
     @@ fun () ->
     OpamDownload.download ~quiet:true ~overwrite:true ?checksum remote_url dirname
     @@+ fun local_file -> Done (Result (Some local_file))

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -76,7 +76,7 @@ module Make (VCS: VCS) = struct
            (OpamFilename.Dir.to_string dirname)
            (OpamUrl.to_string url)
            (match e with Failure fw -> fw | _ -> Printexc.to_string e);
-         Done (Not_available (OpamUrl.to_string url)))
+         Done (Not_available (None, OpamUrl.to_string url)))
     @@ fun () ->
     if VCS.exists dirname then
       VCS.fetch ?cache_dir dirname url @@+ fun () ->


### PR DESCRIPTION
This PR closes #3393.
It adds two levels of download error message: a short one to be displayed on normal mode and a more complete one on verbose mode (when it is needed, when the message itself is short, it is the same on both modes). For the moment, no specific error download message is displayed to user, it is only filled on json file output when option is set.