### PR TITLE
if 'ccache' is installed, add its cache directory to the sandbox (rw)

### DIFF
--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ue
+#!/bin/bash -ue
 
 POL='(version 1)(allow default)(deny network*)(deny file-write*)'
 POL="$POL"'(allow file-write* (literal "/dev/null"))'

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -13,12 +13,29 @@ add_mounts() {
 
 add_mounts rw "${TMPDIR:-/tmp}"
 
+# C compilers using `ccache` will write to a shared cache directory
+# that remain writeable. ccache seems widespread in some Fedora systems.
+add_ccache_mount() {
+  if command -v ccache > /dev/null; then
+      CCACHE_DIR=$HOME/.ccache
+      ccache_dir_regex='cache_dir = (.*)$'
+      local IFS=$'\n'
+      for f in $(ccache --print-config); do
+        if [[ $f =~ $ccache_dir_regex ]]; then
+          CCACHE_DIR=${BASH_REMATCH[1]}
+        fi
+      done
+      add_mounts rw $CCACHE_DIR
+  fi
+}
+
 # This case-switch should remain identical between the different sandbox implems
 COMMAND="$1"; shift
 case "$COMMAND" in
     build)
         add_mounts ro "$OPAM_SWITCH_PREFIX"
         add_mounts rw "$PWD"
+        add_ccache_mount
         ;;
     install)
         add_mounts rw "$OPAM_SWITCH_PREFIX"


### PR DESCRIPTION
fixes #3395 

cc @AltGr, @avsm 

I have tested the patchset on my machine (Linux, ccache installed). I have not tested it on macos (so the `sandbox_exec.sh` change is untested), or on a machine without ccache.

@AltGr is there a way to factorize common code between the two files?

This implementation ignores the CCACHE_DISABLED setting: it will add the cache directory (rw) even if ccache is available but disabled in the system. I could take this into account (there is a line of the `--print-config` output that tells whether ccache is currently disabled), but I thought it wasn't worth the trouble and extra script complexity.