### PR TITLE
Fixes: Env var & delimiters, unversionned opam file pin, doc

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -187,6 +187,12 @@ pinning a package, the source is searched for metadata in an `opam` or
 directory. You can also replace that file by a directory containing an `opam`
 file and optionally other metadata, like a `files/` subdirectory.
 
+As the `package` argument is optional, `opam` guesses package name from the
+`<URL>` or the `opam` file found. Note that for local VCS pinning, when given
+without package name, `opam` retrieves the locally found `opam` file, even if not
+versioned. If this file is versioned, `opam` relies on the versioned
+version.
+
 Whenever an install, reinstall or upgrade command-line refers to a pinned
 package, <span class="opam">opam</span> first fetches its latest source. `opam
 update [--development]` is otherwise the standard way to update the sources of

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -151,7 +151,7 @@ let print_sexp_env env =
 
 let rec print_fish_env env =
   let set_arr_cmd k v =
-    let v = OpamStd.String.split_delim v ':' in
+    let v = OpamStd.String.split v ':' in
     OpamConsole.msg "set -gx %s %s;\n" k
       (OpamStd.List.concat_map " "
          (fun v ->

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -593,7 +593,7 @@ module OpamSys = struct
 
   let path_sep = if Sys.win32 then ';' else ':'
 
-  let split_path_variable =
+  let split_path_variable ?(clean=true) =
     if Sys.win32 then fun path ->
       let length = String.length path in
       let rec f acc index current last normal =
@@ -613,7 +613,8 @@ module OpamSys = struct
             f acc next current last normal in
       f [] 0 "" 0 true
     else fun path ->
-      OpamString.split_delim path path_sep
+      let split = if clean then OpamString.split else OpamString.split_delim in
+      split path path_sep
 
   let with_process_in cmd args f =
     if Sys.win32 then

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -508,12 +508,18 @@ module OpamString = struct
     Re.(split (compile (rep1 (char c)))) s
 
   let split_delim s c =
-    (* old compat version (Re 1.2.0)
-       {[Re_str.split_delim (Re_str.regexp (Printf.sprintf "[%c]" c)) s]} *)
-    let s = if String.length s <> 0
-      then Printf.sprintf "%c%s%c" c s c
-      else s in
-    Re.(split (compile (rep1 (char c))) s)
+    let tokens = Re.(split_full (compile (char c)) s) in
+    let rec aux acc = function
+      | [] -> acc
+      | (`Delim _)::[] -> ""::acc
+      | (`Text s)::tl -> aux (s::acc) tl
+      | (`Delim _)::tl -> aux acc tl
+    in
+    let acc0 =
+      match tokens with
+      | (`Delim _)::_ -> [""]
+      |_ -> []
+    in List.rev (aux acc0 tokens)
 
   let fold_left f acc s =
     let acc = ref acc in
@@ -531,14 +537,14 @@ module Env = struct
 
   (* Remove from a c-separated list of string the one with the given prefix *)
   let reset_value ~prefix c v =
-    let v = OpamString.split_delim v c in
+    let v = OpamString.split v c in
     List.filter (fun v -> not (OpamString.starts_with ~prefix v)) v
 
   (* Split the list in two according to the first occurrence of the string
      starting with the given prefix.
   *)
   let cut_value ~prefix c v =
-    let v = OpamString.split_delim v c in
+    let v = OpamString.split v c in
     let rec aux before =
       function
       | [] -> [], List.rev before
@@ -1059,7 +1065,7 @@ module OpamFormat = struct
       else s ^ (String.make (n - sn) ' ')
     in
     let pad_multi n s =
-      match OpamString.split_delim s '\n' with
+      match OpamString.split s '\n' with
       | [] | [_] -> pad n s ^"\n"
       | ls -> String.concat "\n" (List.map (pad n) ls)
     in

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -402,8 +402,10 @@ module Sys : sig
   val path_sep: char
 
   (** Splits a PATH-like variable separated with [path_sep]. More involved than
-      it seems, because there may be quoting on Windows. *)
-  val split_path_variable: string -> string list
+      it seems, because there may be quoting on Windows. By default, it returns
+      the path cleaned (remove trailing, leading, contiguous delimiters).
+      Optional argument [clean] permits to keep those empty strings. *)
+  val split_path_variable: ?clean:bool -> string -> string list
 
   (** {3 Exit handling} *)
 

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -20,7 +20,7 @@ let slog = OpamConsole.slog
 
 (* - Environment and updates handling - *)
 
-let split_var v = OpamStd.Sys.split_path_variable v
+let split_var v = OpamStd.Sys.split_path_variable ~clean:false v
 
 let join_var l =
   String.concat (String.make 1 OpamStd.Sys.path_sep) l

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -44,9 +44,11 @@ let rezip_to_string ?insert z =
   join_var (rezip ?insert z)
 
 let apply_op_zip op arg (rl1,l2 as zip) =
-  let colon_eq = function (* prepend a, but keep ":"s *)
+  let colon_eq ?(eqcol=false) = function (* prepend a, but keep ":"s *)
     | [] | [""] -> [], [arg; ""]
-    | "" :: l -> l, [""; arg] (* keep leading colon *)
+    | "" :: l ->
+      (* keep surrounding colons *)
+      if eqcol then l@[""], [arg] else l, [""; arg]
     | l -> l, [arg]
   in
   match op with
@@ -57,7 +59,7 @@ let apply_op_zip op arg (rl1,l2 as zip) =
   | ColonEq ->
     let l, add = colon_eq (rezip zip) in [], add @ l
   | EqColon ->
-    let l, add = colon_eq (List.rev_append l2 rl1) in
+    let l, add = colon_eq ~eqcol:true (List.rev_append l2 rl1) in
     l, List.rev add
 
 (** Undoes previous updates done by opam, useful for not duplicating already

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -422,7 +422,7 @@ let export_in_shell shell =
            if v = Printf.sprintf "\"$%s\"" k then
              "$"^k (* remove quotes *)
            else v)
-        (OpamStd.String.split_delim v ':')
+        (OpamStd.String.split v ':')
     in
     match k with
     | "PATH" ->


### PR DESCRIPTION
This PR closes #3391.
- It fixes `OpamStd.split_delim` implementation which had the same behaviour than `OpamStd.split`. Now they respectively keep & clean empty strings from the returned list.
- An option is added to `OpamStd.Sys.split_path_variable`, permiiting to retrieve a cleaned path or no.
- A fix on environment variables construction, in order to keep the trailing delimiter when it should be.

edit:
- Fix #3403: on local pin, versionned directory, if opam file is not versionned retrieve the one found locally in source directory
- ~Fix # 3398: Escape json extended ascii characters~
- Update pinning doc