### PR TITLE
Posix shebangs

### DIFF
--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -ue
+#!/usr/bin/env bash
+set -ue
 
 POL='(version 1)(allow default)(deny network*)(deny file-write*)'
 POL="$POL"'(allow file-write* (literal "/dev/null"))'


### PR DESCRIPTION
This PR, on top of #3399 (which switched sanbbox_exec.sh to `bash` instead of `sh`), use POSIX-friendly shebangs `/usr/bin/env bash -ue` instead of `/bin/bash -ue` as suggested by @hannesm. I don't know enough about the porability issues underhand to decide whether that's a good move, but the PR is here for consideration.