### PR TITLE
Travis: opam boostrap version

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xue
 
-OPAMBSVERSION=2.0.0-rc
+OPAMBSVERSION=2.0.0-rc2
 OPAMBSROOT=$HOME/.opam.cached
 OPAMBSSWITCH=opam-build
 PATH=~/local/bin:$PATH; export PATH


### PR DESCRIPTION
Fix Travis jobs with test, with no cache, there is an error on init, which results to an invalid opam root.