### PR TITLE
bwrap script: allow writes to /tmp

### DIFF
--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -11,7 +11,7 @@ fi
 
 ARGS=(--unshare-net --new-session)
 ARGS=("${ARGS[@]}" --proc /proc --dev /dev)
-ARGS=("${ARGS[@]}" --tmpfs /tmp --tmpfs /run --tmpfs /var)
+ARGS=("${ARGS[@]}" --bind /tmp /tmp --tmpfs /run --tmpfs /var)
 
 add_mounts() {
     case "$1" in


### PR DESCRIPTION
Previously, `/tmp` was made a dedicated tmpfs; but that completely
breaks running from an opam root within /tmp.