### PR TITLE
LF/CRLF-agnostic hashing take 2

### DIFF
--- a/src/core/opamHash.ml
+++ b/src/core/opamHash.ml
@@ -103,10 +103,11 @@ let compute ?target ?(kind=default_kind) file =
   let probably_binary name =
     List.mem (Filename.extension name) [".zip"; ".tar"; ".xz"; ".lz"; ".gz"; ".tgz"; ".tbz"; ".txz"; ".tlz"]
   in
-  if target = None || target = Some primary || probably_binary file then
+  let size = Unix.((stat file).st_size) in
+  if target = None || target = Some primary || size = 0 || probably_binary file then
     primary
   else
-    let buffer = Buffer.create (Unix.((stat file).st_size)) in
+    let buffer = Buffer.create size in
     let ch = open_in_bin file in
     let no_eol_at_eof ch =
       seek_in ch (in_channel_length ch - 1);

--- a/src/core/opamHash.ml
+++ b/src/core/opamHash.ml
@@ -101,7 +101,7 @@ let compute ?target ?(kind=default_kind) file =
         make kind (OpamSHA.hash kind file)
   in
   let probably_binary name =
-    List.mem (Filename.extension name) [".zip"; ".tar"; ".gz"; ".tgz"; ".tbz"; ".txz"; ".tlz"]
+    List.mem (Filename.extension name) [".zip"; ".tar"; ".xz"; ".lz"; ".gz"; ".tgz"; ".tbz"; ".txz"; ".tlz"]
   in
   if target = None || target = Some primary || probably_binary file then
     primary


### PR DESCRIPTION
While going through points made subsequent to merging #3407, I noticed that the hashing code I'd written was not doing precisely what I'd originally intended it to do. This PR:

 - Adds a few extra binary file extensions to the weak heuristic which aborts this scan, as suggested by @cfcs
 - Adds a missing check for hashing empty files
 - Most importantly, switches the logic for allowing an alternate hash to be considered. Based on the first line read from the file, the function will remove `\r` from the end of **every** line (or ~abort~ otherwise *try adding `\r` to every line*) or add `\r` to the end of every line ~**only** if none of the lines already had `\r` at the end~. In the previous implementation, the detection of the former was faulty and the detection of the latter was missing.

As regards the memory "problems" (which is why the weak heuristic for "this is probably a binary file" is there in the first place), there are several options:
 - Separate implementation of MD5 which exposes the state (i.e. as @AltGr's SHA implementations already do) - it's only done this way because OCaml's `Digest` module doesn't expose its workings.
 - Size restriction on the availability of the transform. That said, I suppose a 16MB script is not inconceivable.

My RTT will be slower for the rest of the evening, as I'm not supposed to respond to GitHub PRs while driving... I haven't yet tested this patch, but wanted to get the points from it up for further discussion before leaving.