### PR TITLE
opam show with local opam file returns local file information

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -695,14 +695,26 @@ let show =
           show_empty
         else fields, show_empty || fields <> []
       in
+      let atom_locs, locals =
+        List.partition (fun al -> match al with
+            | `Filename _ -> false
+            | _ -> true) atom_locs
+      in
+      let locals, _ = OpamAuxCommands.resolve_locals locals in
+      let mlocals =
+        List.fold_left (fun map (n, _, o) ->
+            OpamPackage.Name.Map.add n (OpamFile.OPAM.read o) map)
+          OpamPackage.Name.Map.empty locals
+      in
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
       let st = OpamListCommand.get_switch_state gt in
       let st, atoms =
-        OpamAuxCommands.simulate_autopin ~quiet:no_lint ~for_view:true st
-          atom_locs
+        if atom_locs = [] then st, [] else
+          OpamAuxCommands.simulate_autopin ~quiet:no_lint ~for_view:true st
+            atom_locs
       in
       OpamListCommand.info st
-        ~fields ~raw_opam:raw ~where ~normalise ~show_empty atoms;
+        ~fields ~raw_opam:raw ~where ~normalise ~show_empty atoms mlocals;
       `Ok ()
     | Some f, [] ->
       let opam = match f with

--- a/src/client/opamListCommand.mli
+++ b/src/client/opamListCommand.mli
@@ -138,7 +138,7 @@ val info:
   'a switch_state ->
   fields:string list -> raw_opam:bool -> where:bool ->
   ?normalise:bool -> ?show_empty:bool ->
-  atom list -> unit
+  atom list -> OpamFile.OPAM.t OpamPackage.Name.Map.t -> unit
 
 (** Prints the value of an opam field in a shortened way (with [prettify] -- the
     default -- puts lists of strings in a format that is easier to read *)


### PR DESCRIPTION
Currently, if a package is pinned, opam retrieves package information from the switch.
This PR fixes #3423.