### PR TITLE
Update download error message

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -154,7 +154,13 @@ let download_package st nv =
     (OpamUpdate.cleanup_source st
        (OpamPackage.Map.find_opt nv st.installed_opams)
        (OpamSwitchState.opam st nv);
-     OpamProcess.Job.catch (fun e -> Done (Some (None, Printexc.to_string e)))
+     OpamProcess.Job.catch (fun e ->
+         let na =
+           match e with
+           | OpamDownload.Download_fail (s,l) -> (s,l)
+           | e -> (None, Printexc.to_string e)
+         in
+         Done (Some na))
      @@ fun () ->
      OpamUpdate.download_package_source st nv dir @@| function
      | Some (Not_available (s,l)) -> Some (s,l)

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -372,7 +372,7 @@ let parallel_apply t _action ~requested ?add_roots ~assume_built action_graph =
          (fun (p, (s,l)) ->
             Printf.sprintf "%s:%s" (OpamPackage.to_string p)
               (if OpamConsole.verbose () then "\n" ^ l
-               else " " ^  OpamStd.Option.default l s))
+               else  OpamStd.Option.map_default (fun x -> " " ^ x) "" s))
          (OpamPackage.Map.bindings failed_downloads))
   else if not (OpamPackage.Map.is_empty failed_downloads) then
     OpamConsole.warning

--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -137,7 +137,8 @@ let really_download
   download_command ~compress ?checksum ~url ~dst:tmp_dst
   @@+ fun () ->
   if not (Sys.file_exists tmp_dst) then
-    fail (None, "Download command succeeded, but resulting file not found")
+    fail (Some "Downloaded file not found",
+          "Download command succeeded, but resulting file not found")
   else if Sys.file_exists dst && not overwrite then
     OpamSystem.internal_error "The downloaded file will overwrite %s." dst;
   if validate &&

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -77,7 +77,8 @@ let fetch_from_cache =
            else OpamConsole.colorise `red " (MISMATCH)")
           checksums);
     OpamFilename.remove file;
-    Done (Not_available (None, "cache CONFLICT"))
+    let m = "cache CONFLICT" in
+    Done (Not_available (Some m, m))
   in
   let dl_from_cache_job root_cache_url checksum file =
     let url = cache_url root_cache_url checksum in
@@ -107,13 +108,13 @@ let fetch_from_cache =
     then Done (Up_to_date (hit_file, OpamUrl.empty))
     else mismatch hit_file
   with Not_found -> match checksums with
-    | [] -> Done (Not_available (None, "cache miss"))
+    | [] -> let m = "cache miss" in Done (Not_available (Some m, m))
     | checksum::_ ->
       (* Try all cache urls in order, but only the first checksum *)
       let local_file = cache_file cache_dir checksum in
       let tmpfile = OpamFilename.add_extension local_file "tmp" in
       let rec try_cache_dl = function
-        | [] -> Done (Not_available (None, "cache miss"))
+        | [] -> let m = "cache miss" in Done (Not_available (Some m, m))
         | root_cache_url::other_caches ->
           OpamProcess.Job.catch
             (function Failure _ -> try_cache_dl other_caches
@@ -195,7 +196,8 @@ let pull_from_upstream
          (OpamUrl.to_string url);
        ret)
     else
-      Not_available (None, "Checksum mismatch")
+    let m = "Checksum mismatch" in
+    Not_available (Some m, m)
   | (Result None | Up_to_date None) as ret ->
     if checksums = [] then
       (OpamConsole.msg "[%s] %s from %s\n"
@@ -208,7 +210,8 @@ let pull_from_upstream
                           retrieved from %s"
          label (OpamUrl.to_string url);
        OpamFilename.rmdir destdir;
-       Not_available (None, "can't check directory checksum"))
+       let m = "can't check directory checksum" in
+       Not_available (Some m, m))
   | Not_available _ as na -> na
 
 let rec pull_from_mirrors label ?working_dir cache_dir destdir checksums = function
@@ -244,7 +247,8 @@ let pull_tree
      fetch_from_cache cache_dir cache_urls checksums
    | None ->
      assert (cache_urls = []);
-     Done (Not_available (None, "no cache")))
+     let m = "no cache" in
+     Done (Not_available (Some m, m)))
   @@+ function
   | Up_to_date (archive, _) ->
     OpamConsole.msg "[%s] found in cache\n"
@@ -290,7 +294,8 @@ let pull_file label ?cache_dir ?(cache_urls=[])  ?(silent_hits=false)
      fetch_from_cache cache_dir cache_urls checksums
    | None ->
      assert (cache_urls = []);
-     Done (Not_available (None, "no cache")))
+     let m = "no cache" in
+     Done (Not_available (Some m, m)))
   @@+ function
   | Up_to_date (f, _) ->
     if not silent_hits then
@@ -315,7 +320,7 @@ let pull_file label ?cache_dir ?(cache_urls=[])  ?(silent_hits=false)
         @@| function
         | Up_to_date _ -> assert false
         | Result (Some f) -> OpamFilename.move ~src:f ~dst:file; Result ()
-        | Result None -> Not_available (None, "is a directory")
+        | Result None -> let m = "is a directory" in Not_available (Some m, m)
         | Not_available _ as na -> na)
 
 let pull_file_to_cache label ~cache_dir ?(cache_urls=[]) checksums remote_urls =
@@ -334,7 +339,7 @@ let pull_file_to_cache label ~cache_dir ?(cache_urls=[]) checksums remote_urls =
         @@| function
         | Up_to_date _ -> assert false
         | Result (Some _) -> Result ()
-        | Result None -> Not_available (None, "is a directory")
+        | Result None -> let m = "is a directory" in Not_available (Some m, m)
         | Not_available _ as na -> na)
 
 let packages r =

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -89,7 +89,7 @@ let fetch_from_cache =
     | `rsync ->
       (OpamLocal.rsync_file url file @@| function
         | Result _ | Up_to_date _-> ()
-        | Not_available (_,m) -> failwith m)
+        | Not_available (s,l) -> raise (OpamDownload.Download_fail (s,l)))
     | #OpamUrl.version_control ->
       failwith "Version control not allowed as cache URL"
   in


### PR DESCRIPTION
This PR update the download error message display: 
- Fix a lost short message propagation
- by default always show the short one, and the long one in verbose mode