### PR TITLE
Don't raise error when retrieving mirror cache fails

### DIFF
--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -370,9 +370,9 @@ let parallel_apply t _action ~requested ?add_roots ~assume_built action_graph =
       "The sources of the following couldn't be obtained, aborting:\n%s"
       (OpamStd.Format.itemize
          (fun (p, (s,l)) ->
-            Printf.sprintf "%s:%s" (OpamPackage.to_string p)
-              (if OpamConsole.verbose () then "\n" ^ l
-               else  OpamStd.Option.map_default (fun x -> " " ^ x) "" s))
+            Printf.sprintf "%s%s" (OpamPackage.to_string p)
+              (if OpamConsole.verbose () then ":\n" ^ l
+               else OpamStd.Option.map_default (fun x -> ": " ^ x) "" s))
          (OpamPackage.Map.bindings failed_downloads))
   else if not (OpamPackage.Map.is_empty failed_downloads) then
     OpamConsole.warning

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -50,8 +50,9 @@ type std_path =
 type 'a download =
   | Up_to_date of 'a
   | Not_available of string option * string
-  (** Arguments are respectively the short (if relevant) and long error message.
-      The usage is: the second argument is the default one when the first one is [None] *)
+  (** Arguments are respectively the short and long version of an error message.
+      The usage is: the first argument is displayed on normal mode (nothing
+      if [None]), and the second one on verbose mode. *)
   | Result of 'a
 
 (** {2 Packages} *)

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -117,7 +117,9 @@ let fetch_from_cache =
         | [] -> let m = "cache miss" in Done (Not_available (Some m, m))
         | root_cache_url::other_caches ->
           OpamProcess.Job.catch
-            (function Failure _ -> try_cache_dl other_caches
+            (function Failure _
+                    | OpamDownload.Download_fail _ ->
+                      try_cache_dl other_caches
                     | e -> raise e)
           @@ fun () ->
           dl_from_cache_job root_cache_url checksum tmpfile


### PR DESCRIPTION
This PR completes commit 5ec161401d51c2e153e5467bead902fcab21bc4b (https://github.com/ocaml/opam/pull/3428#issuecomment-401756482), that introduced an error raised on the first mirror cache fail, and some typos.