### PR TITLE
Redirect shell hook stderr to /dev/null

### DIFF
--- a/src/state/shellscripts/env_hook.fish
+++ b/src/state/shellscripts/env_hook.fish
@@ -1,3 +1,3 @@
 function __opam_env_export_eval --on-event fish_prompt;
-    eval (opam env --shell=fish --readonly);
+    eval (opam env --shell=fish --readonly ^ /dev/null);
 end

--- a/src/state/shellscripts/env_hook.sh
+++ b/src/state/shellscripts/env_hook.sh
@@ -1,6 +1,6 @@
 _opam_env_hook() {
  local previous_exit_status=$?;
- eval $(opam env --shell=bash --readonly);
+ eval $(opam env --shell=bash --readonly 2> /dev/null);
  return $previous_exit_status;
 };
 if ! [[ "$PROMPT_COMMAND" =~ _opam_env_hook ]]; then

--- a/src/state/shellscripts/env_hook.zsh
+++ b/src/state/shellscripts/env_hook.zsh
@@ -1,5 +1,5 @@
 _opam_env_hook() {
-    eval $(opam env --shell=zsh --readonly);
+    eval $(opam env --shell=zsh --readonly 2> /dev/null);
 }
 typeset -ag precmd_functions;
 if [[ -z ${precmd_functions[(r)_opam_env_hook]} ]]; then


### PR DESCRIPTION
This PR fixes #3431, stderr is dropped in order to not pollute user shell in case of inconsistent opam state or uninstalled opam.
- Working on bash, sh, zsh, and fish (csh do not permit redirecting only stderr)
- With fish, do not handle inexistant opam binary, the error is raised at fish level
