### PR TITLE
No CRLF translation for opam generated patches

### DIFF
--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -359,8 +359,8 @@ let link ?(relative=false) ~target ~link =
   in
   OpamSystem.link target (to_string link)
 
-let patch filename dirname =
-  OpamSystem.patch ~dir:(Dir.to_string dirname) (to_string filename)
+let patch ?preprocess filename dirname =
+  OpamSystem.patch ?preprocess ~dir:(Dir.to_string dirname) (to_string filename)
 
 let flock flag ?dontblock file = OpamSystem.flock flag ?dontblock (to_string file)
 

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -229,9 +229,9 @@ val remove_prefix_dir: Dir.t -> Dir.t -> string
 (** Remove a suffix from a filename *)
 val remove_suffix: Base.t -> t -> string
 
-(** Apply a patch in a directory. Returns [None] on success, the process error
-    otherwise *)
-val patch: t -> Dir.t -> exn option OpamProcess.job
+(** Apply a patch in a directory. If [preprocess] is set to false, there is no
+    CRLF translation. Returns [None] on success, the process error otherwise *)
+val patch: ?preprocess:bool -> t -> Dir.t -> exn option OpamProcess.job
 
 (** Create an empty file *)
 val touch: t -> unit

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -1125,12 +1125,18 @@ let translate_patch ~dir orig corrected =
     |> ignore;
   close_out ch
 
-let patch ~dir p =
+let patch ?(preprocess=true) ~dir p =
   if not (Sys.file_exists p) then
     (OpamConsole.error "Patch file %S not found." p;
      raise Not_found);
-  let p' = temp_file ~auto_clean:false "processed-patch" in
-  translate_patch ~dir p p';
+  let p' =
+    if preprocess then
+      let p' = temp_file ~auto_clean:false "processed-patch" in
+      translate_patch ~dir p p';
+      p'
+    else
+      p
+  in
   make_command ~name:"patch" ~dir "patch" ["-p1"; "-i"; p'] @@> fun r ->
     if not (OpamConsole.debug ()) then Sys.remove p';
     if OpamProcess.is_success r then Done None

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -252,9 +252,10 @@ val get_lock_fd: lock -> Unix.file_descr
 
 (** {2 Misc} *)
 
-(** Apply a patch file in the current directory. Returns the error if the patch
-    didn't apply. *)
-val patch: dir:string -> string -> exn option OpamProcess.job
+(** Apply a patch file in the current directory. If [preprocess] is set to
+    false, there is no CRLF translation. Returns the error if the patch didn't
+    apply. *)
+val patch: ?preprocess:bool -> dir:string -> string -> exn option OpamProcess.job
 
 (** Create a tempory file in {i ~/.opam/logs/<name>XXX}. ?auto_clean controls
     whether the file is automatically deleted when opam terminates

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -414,7 +414,12 @@ let apply_repo_update repo = function
     log "%a: applying patch update at %a"
       (slog OpamRepositoryName.to_string) repo.repo_name
       (slog OpamFilename.to_string) f;
-    (OpamFilename.patch f repo.repo_root @@+ function
+    let preprocess =
+      match repo.repo_url.OpamUrl.backend with
+      | `http | `rsync -> false
+      | _ -> true
+    in
+    (OpamFilename.patch ~preprocess f repo.repo_root @@+ function
       | Some e ->
         if not (OpamConsole.debug ()) then OpamFilename.remove f;
         raise e


### PR DESCRIPTION
This PR is a partial fix for #3433. For patches generated by opam (http & local backends), CRLF translation is not performed.