### PR TITLE
Add /rw/usrlocal to bwrap.sh

### DIFF
--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -23,7 +23,7 @@ add_mounts() {
     done
 }
 
-add_mounts ro /usr /bin /lib /lib32 /lib64 /etc /opt /nix/store /home
+add_mounts ro /usr /bin /lib /lib32 /lib64 /etc /opt /nix/store /rw/usrlocal /home
 
 # C compilers using `ccache` will write to a shared cache directory
 # that remain writeable. ccache seems widespread in some Fedora systems.


### PR DESCRIPTION
On Qubes `/usr/local/` is usually a symlink to `/rw/usrlocal/`.

I had trouble installing `cpuid` because it calls out to `opam`, but since `/usr/local/` is a symlink to the unmounted path `/rw/usrlocal/` the `opam` binary in `/usr/bin/` got precedence.