### PR TITLE
Make '--locked' a full-fledged build option

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1068,7 +1068,8 @@ let build_options =
        and reproduce similar build contexts, hence the name. The $(i,opam \
        lock) plugin can be used to generate such files, based on the versions \
        of the dependencies currently installed on the host. This is equivalent \
-       to setting the $(b,\\$OPAMLOCK) environment variable."
+       to setting the $(b,\\$OPAMLOCK) environment variable. Note that this \
+       option doesn't generally affect already pinned packages."
   in
   Term.(const create_build_options
     $keep_build_dir $reuse_build_dir $inplace_build $make

--- a/src/client/opamAuxCommands.mli
+++ b/src/client/opamAuxCommands.mli
@@ -37,10 +37,9 @@ val name_and_dir_of_opam_file: filename -> name option * dirname
     location, and returns the corresponding pinnings and atoms. May fail and
     exit if package names for provided [`Filename] could not be inferred, or if
     the same package name appears multiple times.
-    If [locked], the [*.locked] counterparts of opam files are used if present.
 *)
 val resolve_locals:
-  ?quiet:bool -> ?locked:bool ->
+  ?quiet:bool ->
   [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
   (name * OpamUrl.t * OpamFile.OPAM.t OpamFile.t) list * atom list
 
@@ -64,14 +63,11 @@ val resolve_locals_pinned:
 
     This also handles [pin-depends:] of the local packages. That part is done
     even if [simulate] is [true].
-
-    If [locked], the [*.locked] counterparts of opam files are used if present.
 *)
 val autopin:
   rw switch_state ->
   ?simulate:bool ->
   ?quiet:bool ->
-  ?locked:bool ->
   [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
   rw switch_state * atom list
 
@@ -85,7 +81,6 @@ val simulate_autopin:
   'a switch_state ->
   ?quiet:bool ->
   ?for_view:bool ->
-  ?locked:bool ->
   [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
   'a switch_state * atom list
 
@@ -96,5 +91,4 @@ val simulate_autopin:
     warning, and returns the empty list after user confirmation. *)
 val get_compatible_compiler:
   ?repos:repository_name list ->
-  ?locked:bool ->
   'a repos_state -> dirname -> atom list

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -90,6 +90,7 @@ val opam_init:
   ?ignore_constraints_on:OpamPackage.Name.Set.t ->
   ?unlock_base:bool ->
   ?no_env_notice:bool ->
+  ?locked:string option ->
   ?cudf_file:string option ->
   ?solver:(module OpamCudfSolver.S) Lazy.t ->
   ?best_effort:bool ->

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1183,16 +1183,8 @@ let install =
        --destdir) to revert."
       Arg.(some dirname) None
   in
-  let locked =
-    mk_flag ["locked"]
-      "With a directory as argument, when a package definition file is found, \
-       if a file by the same name with a $(i,.locked) extension is present \
-       beside it, use the latter. This allows alternate local package \
-       definitions, and is typically useful to provide more constrained \
-       dependencies that describe a precise development environment."
-  in
   let install
-      global_options build_options add_to_roots deps_only restore destdir locked
+      global_options build_options add_to_roots deps_only restore destdir
       assume_built atoms_or_locals =
     apply_global_options global_options;
     apply_build_options build_options;
@@ -1221,7 +1213,7 @@ let install =
     in
     if atoms_or_locals = [] then `Ok () else
     let st, atoms =
-      OpamAuxCommands.autopin st ~simulate:deps_only ~locked atoms_or_locals
+      OpamAuxCommands.autopin st ~simulate:deps_only atoms_or_locals
     in
     if atoms = [] then
       (OpamConsole.msg "Nothing to do\n";
@@ -1239,7 +1231,7 @@ let install =
   in
   Term.ret
     Term.(const install $global_options $build_options
-          $add_to_roots $deps_only $restore $destdir $locked $assume_built
+          $add_to_roots $deps_only $restore $destdir $assume_built
           $atom_or_local_list),
   term_info "install" ~doc ~man
 
@@ -1997,17 +1989,9 @@ let switch =
        containing opam package definitions), install the dependencies of the \
        project but not the project itself."
   in
-  let locked =
-    mk_flag ["locked"]
-      "With a directory as argument, when a package definition file is found, \
-       if a file by the same name with a $(i,.locked) extension is present \
-       beside it, use the latter. This allows alternate local package \
-       definitions, and is typically useful to provide more constrained \
-       dependencies that describe a precise development environment."
-  in
   let switch
       global_options build_options command print_short
-      no_switch packages empty descr full no_install deps_only locked repos
+      no_switch packages empty descr full no_install deps_only repos
       params =
     apply_global_options global_options;
     apply_build_options build_options;
@@ -2025,7 +2009,7 @@ let switch =
         OpamSwitchCommand.guess_compiler_package ?repos rt
           (OpamSwitch.to_string switch)
       | None, None, true ->
-        OpamAuxCommands.get_compatible_compiler ?repos ~locked rt
+        OpamAuxCommands.get_compatible_compiler ?repos rt
           (OpamFilename.dirname_dir
              (OpamSwitch.get_root rt.repos_global.root switch))
       | _ ->
@@ -2105,7 +2089,7 @@ let switch =
       let st =
         if not no_install && not empty && OpamSwitch.is_external switch then
           let st, atoms =
-            OpamAuxCommands.autopin st ~simulate:deps_only ~locked ~quiet:true
+            OpamAuxCommands.autopin st ~simulate:deps_only ~quiet:true
               [`Dirname (OpamFilename.Dir.of_string switch_arg)]
           in
           OpamClient.install st atoms
@@ -2254,7 +2238,7 @@ let switch =
              $global_options $build_options $command
              $print_short_flag
              $no_switch
-             $packages $empty $descr $full $no_install $deps_only $locked
+             $packages $empty $descr $full $no_install $deps_only
              $repos $params)),
   term_info "switch" ~doc ~man
 
@@ -2576,7 +2560,8 @@ let pin ?(unpin_only=false) () =
   Term.ret
     Term.(const pin
           $global_options $build_options
-          $kind $edit $no_act $dev_repo $print_short_flag $command $params),
+          $kind $edit $no_act $dev_repo $print_short_flag
+          $command $params),
   term_info "pin" ~doc ~man
 
 (* SOURCE *)

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -490,7 +490,7 @@ and source_pin
                         (OPAM.with_url URL.empty local)
                         (OPAM.with_url URL.empty vers)) ->
       OpamConsole.warning
-        "%s opam file have non-trivial uncommitted changes, using the versioned one"
+        "%s's opam file has uncommitted changes, using the versioned one"
         (OpamPackage.Name.to_string name);
       opam_opt
     | _ -> opam_opt

--- a/src/state/opamPinned.mli
+++ b/src/state/opamPinned.mli
@@ -29,12 +29,15 @@ val package_opt: 'a switch_state -> name -> package option
 (** The set of all pinned packages with their pinning versions *)
 val packages: 'a switch_state -> package_set
 
-(** Looks up an 'opam' file for the given named package in a source directory *)
+(** Looks up an 'opam' file for the given named package in a source directory.
+    This is affected by [OpamStateConfig.(!r.locked)]. *)
 val find_opam_file_in_source: name -> dirname -> OpamFile.OPAM.t OpamFile.t option
 
 (** Finds all package definition files in a given source dir [opam],
-    [pkgname.opam/opam], etc. *)
-val files_in_source: dirname -> (name option * OpamFile.OPAM.t OpamFile.t) list
+    [pkgname.opam/opam], etc. This is affected by
+    [OpamStateConfig.(!r.locked)] *)
+val files_in_source:
+  dirname -> (name option * OpamFile.OPAM.t OpamFile.t) list
 
 (** From an opam file location, sitting below the given project directory, find
     the corresponding package name if specified ([<name>.opam] or

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -23,6 +23,7 @@ type t = {
   ignore_constraints_on: name_set;
   unlock_base: bool;
   no_env_notice: bool;
+  locked: string option;
 }
 
 let default = {
@@ -44,6 +45,7 @@ let default = {
   ignore_constraints_on = OpamPackage.Name.Set.empty;
   unlock_base = false;
   no_env_notice = false;
+  locked = None;
 }
 
 type 'a options_fun =
@@ -59,6 +61,7 @@ type 'a options_fun =
   ?ignore_constraints_on:name_set ->
   ?unlock_base:bool ->
   ?no_env_notice:bool ->
+  ?locked:string option ->
   'a
 
 let setk k t
@@ -74,6 +77,7 @@ let setk k t
     ?ignore_constraints_on
     ?unlock_base
     ?no_env_notice
+    ?locked
   =
   let (+) x opt = match opt with Some x -> x | None -> x in
   k {
@@ -89,7 +93,8 @@ let setk k t
     makecmd = t.makecmd + makecmd;
     ignore_constraints_on = t.ignore_constraints_on + ignore_constraints_on;
     unlock_base = t.unlock_base + unlock_base;
-    no_env_notice = t.no_env_notice + no_env_notice
+    no_env_notice = t.no_env_notice + no_env_notice;
+    locked = t.locked + locked;
   }
 
 let set t = setk (fun x () -> x) t
@@ -123,6 +128,7 @@ let initk k =
        OpamPackage.Name.Set.of_list)
     ?unlock_base:(env_bool "UNLOCKBASE")
     ?no_env_notice:(env_bool "NOENVNOTICE")
+    ?locked:(env_string "LOCKED" >>| function "" -> None | s -> Some s)
 
 let init ?noop:_ = initk (fun () -> ())
 

--- a/src/state/opamStateConfig.mli
+++ b/src/state/opamStateConfig.mli
@@ -26,6 +26,7 @@ type t = private {
   ignore_constraints_on: name_set;
   unlock_base: bool;
   no_env_notice: bool;
+  locked: string option;
 }
 
 type 'a options_fun =
@@ -41,6 +42,7 @@ type 'a options_fun =
   ?ignore_constraints_on:name_set ->
   ?unlock_base:bool ->
   ?no_env_notice:bool ->
+  ?locked:string option ->
   'a
 
 include OpamStd.Config.Sig


### PR DESCRIPTION
there is no reason it should be available in 'opam install' and not
'opam pin'; this also avoids the issue that 'opam update PKG' would not
accept the --locked option and detect a changed opam file.

There is still a few corner-cases, the combination with the
pinned-package-update can sometimes be a bit strange.