### PR TITLE
Missing case in Windows VT-100 translator

### DIFF
--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -373,6 +373,7 @@ let win32_print_message ch msg =
                 blend 0b011
             | "37" ->
                 blend 0b111
+            | "0"
             | "" ->
                 blend ~inheritbold:false 0b0111
             | _ -> assert false


### PR DESCRIPTION
The sequence `[m` was replaced with `[0m` in #3346 which required an additional case in the VT-100 translator in OpamConsole. Not quite sure how I missed this one, as `opam init` fails (I think it's because for ages now I've been using the testsuite, which of course pipes the output and so disables colour)...