### PR TITLE
Updates for OCaml 4.07.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ src_ext/camlp4
 src_ext/findlib
 src_ext/ocamlbuild
 src_ext/topkg
+src_ext/seq
 src_ext/*.*stamp
 src_ext/*.tbz
 src_ext/*.tar.gz

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -106,7 +106,7 @@ EOF
         fi
         ./configure --prefix ~/local -no-graph -no-debugger ${CONFIGURE_SWITCHES:-}
         if [[ $OPAM_TEST -eq 1 ]] ; then
-          make -j world.opt
+          make -j 4 world.opt
         else
           make world.opt
         fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,17 +37,20 @@ matrix:
     - os: linux
       env: OCAML_VERSION=4.06.1
       stage: Build
+    - os: linux
+      env: OCAML_VERSION=4.07.1
+      stage: Build
     - os: osx
-      env: OCAML_VERSION=4.06.1 OPAM_TEST=1
+      env: OCAML_VERSION=4.07.1 OPAM_TEST=1
       stage: Test
     - os: osx
       env: OCAML_VERSION=4.03.0
       stage: Test
     - os: linux
-      env: OCAML_VERSION=4.06.1 OPAM_TEST=1
+      env: OCAML_VERSION=4.07.1 OPAM_TEST=1
       stage: Test
     - os: linux
-      env: OCAML_VERSION=4.06.1 OPAM_TEST=1 EXTERNAL_SOLVER=aspcud
+      env: OCAML_VERSION=4.07.1 OPAM_TEST=1 EXTERNAL_SOLVER=aspcud
       stage: Test
     - os: linux
       env: COLD=1

--- a/appveyor.patch
+++ b/appveyor.patch
@@ -14,8 +14,8 @@ index 1a350068..964a818c 100644
 --- a/src_ext/Makefile
 +++ b/src_ext/Makefile
 @@ -12,8 +12,8 @@ endif
- URL_ocaml = http://caml.inria.fr/pub/distrib/ocaml-4.06/ocaml-4.06.0.tar.gz
- MD5_ocaml = 66e5439eb63dbb8b8224cba5d1b20947
+ URL_ocaml = http://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.1.tar.gz
+ MD5_ocaml = 0b180b273ce5cc2ac68f347c9b06d06f
  
 -URL_flexdll = https://github.com/alainfrisch/flexdll/archive/0.37.tar.gz
 -MD5_flexdll = cc456a89382e60d84130cddd53977486

--- a/appveyor_build.cmd
+++ b/appveyor_build.cmd
@@ -119,11 +119,7 @@ if not exist bootstrap\nul (
   if exist bootstrap\ocaml-*.tar.gz del bootstrap\ocaml-*.tar.gz
   if "%OCAML_PORT%" neq "" if exist bootstrap\flexdll-*.tar.gz del bootstrap\flexdll-*.tar.gz
   del bootstrap\ocaml\bin\*.byte.exe
-  if "%OCAML_PORT%" equ "" (
-    del bootstrap\ocaml\lib\ocaml\expunge.exe
-  ) else (
-    del bootstrap\ocaml\lib\expunge.exe
-  )
+  del bootstrap\ocaml\lib\ocaml\expunge.exe
   for /f %%D in ('dir /b/ad bootstrap\ocaml-*') do (
     rd /s/q bootstrap\%%D
     rem Directory needs to exist, as the Cygwin bootstraps OCAMLLIB refers to it

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -30,7 +30,7 @@ URL_PKG_$(1) = $(URL_$(1))
 MD5_PKG_$(1) = $(MD5_$(1))
 endef
 
-SRC_EXTS = cppo extlib re cmdliner ocamlgraph cudf dose3 opam-file-format result
+SRC_EXTS = cppo extlib re cmdliner ocamlgraph cudf dose3 opam-file-format result seq
 PKG_EXTS = $(SRC_EXTS) jbuilder findlib ocamlbuild topkg mccs
 
 ifeq ($(MCCS_ENABLED),true)

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -9,8 +9,8 @@ else
 CAN_PKG=0
 endif
 
-URL_ocaml = http://caml.inria.fr/pub/distrib/ocaml-4.06/ocaml-4.06.0.tar.gz
-MD5_ocaml = 66e5439eb63dbb8b8224cba5d1b20947
+URL_ocaml = http://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.1.tar.gz
+MD5_ocaml = 0b180b273ce5cc2ac68f347c9b06d06f
 
 URL_flexdll = https://github.com/alainfrisch/flexdll/archive/0.37.tar.gz
 MD5_flexdll = cc456a89382e60d84130cddd53977486

--- a/src_ext/Makefile.packages
+++ b/src_ext/Makefile.packages
@@ -21,7 +21,9 @@ extlib.pkgbuild: findlib.pkgbuild cppo.pkgbuild
 
 ocamlbuild.pkgbuild: findlib.pkgbuild
 
-re.pkgbuild: jbuilder.pkgbuild findlib.pkgbuild
+re.pkgbuild: jbuilder.pkgbuild seq.pkgbuild findlib.pkgbuild
+
+seq.pkgbuild: findlib.pkgbuild ocamlbuild.pkgbuild
 
 ocamlgraph.pkgbuild: findlib.pkgbuild
 
@@ -99,3 +101,7 @@ mccs-pkg-build:
 	jbuilder build @install --root=.
 	ocamlfind install mccs $(addprefix _build/install/default/lib/,$(addprefix mccs/,META libmccs_stubs.$(EXT_LIB) mccs.*) stublibs/*.$(EXT_DLL))
 	cp -RL _build/install/default/lib/mccs/glpk $(SITELIB)/mccs/
+
+seq-pkg-build:
+	make all
+	make install

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -1,5 +1,5 @@
-URL_cppo = https://github.com/mjambon/cppo/archive/v1.6.4.tar.gz
-MD5_cppo = f7a4a6a0e83b76562b45db3a93ffd204
+URL_cppo = https://github.com/mjambon/cppo/archive/v1.6.5.tar.gz
+MD5_cppo = 1cd25741d31417995b0973fe0b6f6c82
 
 $(call PKG_SAME,cppo)
 
@@ -8,8 +8,8 @@ MD5_extlib = d989951536077563bf4c5e3479c3866f
 
 $(call PKG_SAME,extlib)
 
-URL_re = https://github.com/ocaml/ocaml-re/releases/download/1.7.3/re-1.7.3.tbz
-MD5_re = d2a74ca77216861bce4449600a132de9
+URL_re = https://github.com/ocaml/ocaml-re/releases/download/1.8.0/re-1.8.0.tbz
+MD5_re = 765f6f8d3e6ab200866e719ed7e5178d
 
 $(call PKG_SAME,re)
 
@@ -61,3 +61,8 @@ MD5_PKG_ocamlbuild = 442baa19470bd49150f153122e22907b
 
 URL_PKG_topkg = http://erratique.ch/software/topkg/releases/topkg-0.9.1.tbz
 MD5_PKG_topkg = 8978a0595db1a22e4251ec62735d4b84
+
+URL_seq = https://github.com/c-cube/seq/archive/0.1.tar.gz
+MD5_seq = 0e87f9709541ed46ecb6f414bc31458c
+
+$(call PKG_SAME,seq)

--- a/src_ext/jbuild-seq-src
+++ b/src_ext/jbuild-seq-src
@@ -1,0 +1,14 @@
+(jbuild_version 1)
+
+(library
+ ((name        seq)
+  (public_name seq)
+  (synopsis    seq)
+  (modules     (seq))))
+
+(rule
+ (with-stdout-to selected
+  (run ${OCAML} ${path:../select_version.ml} ${ocaml_version})))
+
+(rule (copy# ${read:selected} seq.ml))
+(rule (copy# "${read:selected}i" seq.mli))

--- a/src_ext/patches/seq.pkg/0001-switch-between-definition-alias-module-depending-on-.patch
+++ b/src_ext/patches/seq.pkg/0001-switch-between-definition-alias-module-depending-on-.patch
@@ -1,0 +1,125 @@
+From 2d608bd49647a4a6d0ec51c61cf63678212ea185 Mon Sep 17 00:00:00 2001
+From: Simon Cruanes <simon.cruanes.2007@m4x.org>
+Date: Thu, 19 Apr 2018 00:08:23 -0500
+Subject: [PATCH 1/3] switch between definition/alias module depending on
+ ocaml's version
+
+---
+ .gitignore                     |  2 ++
+ Makefile                       | 11 ++++++++++-
+ select_version.ml              | 14 ++++++++++++++
+ seq.opam                       |  3 ---
+ src/seq_alias.ml               |  1 +
+ src/seq_alias.mli              |  2 ++
+ src/{seq.ml => seq_redef.ml}   |  0
+ src/{seq.mli => seq_redef.mli} |  2 --
+ 8 files changed, 29 insertions(+), 6 deletions(-)
+ create mode 100644 select_version.ml
+ create mode 100644 src/seq_alias.ml
+ create mode 100644 src/seq_alias.mli
+ rename src/{seq.ml => seq_redef.ml} (100%)
+ rename src/{seq.mli => seq_redef.mli} (99%)
+
+diff --git a/.gitignore b/.gitignore
+index e35d885..487f91e 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -1 +1,3 @@
+ _build
++src/seq.ml
++src/seq.mli
+diff --git a/Makefile b/Makefile
+index fbf5dc9..c3048a5 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,9 +1,18 @@
+ 
++all: build
++
++OCAML_VERSION=$(shell ocaml -vnum)
++SELECT_CMD=$(shell ocaml select_version.ml $(OCAML_VERSION))
++
++select:
++	$(SELECT_CMD)
++
+ TARGETS=$(addprefix src/, seq.cma seq.cmxa seq.cmxs)
+-build:
++build: select
+ 	ocamlbuild $(TARGETS)
+ 
+ clean:
++	rm src/seq.ml src/seq.mli || true
+ 	ocamlbuild -clean
+ 
+ TOINSTALL=$(wildcard _build/src/*)
+diff --git a/select_version.ml b/select_version.ml
+new file mode 100644
+index 0000000..f92c665
+--- /dev/null
++++ b/select_version.ml
+@@ -0,0 +1,14 @@
++
++let () =
++  let version =
++    Scanf.sscanf Sys.argv.(1) "%d.%d" (fun major minor -> (major, minor))
++  in
++  let file =
++    if version < (4, 07) then
++      "cp src/seq_redef.ml src/seq.ml; cp src/seq_redef.mli src/seq.mli"
++    else
++      "cp src/seq_alias.ml src/seq.ml; cp src/seq_alias.mli src/seq.mli"
++  in
++  print_string file;
++  flush stdout
++
+diff --git a/seq.opam b/seq.opam
+index 8d3569c..b75ca84 100644
+--- a/seq.opam
++++ b/seq.opam
+@@ -21,8 +21,5 @@ tags: [ "iterator" "seq" "pure" "list" "compatibility" "cascade" ]
+ homepage: "https://github.com/c-cube/seq/"
+ bug-reports: "https://github.com/c-cube/seq/issues"
+ dev-repo: "https://github.com/c-cube/seq.git"
+-available: [
+-  ocaml-version < "4.07.0"
+-]
+ 
+ 
+diff --git a/src/seq_alias.ml b/src/seq_alias.ml
+new file mode 100644
+index 0000000..49d3313
+--- /dev/null
++++ b/src/seq_alias.ml
+@@ -0,0 +1 @@
++include Stdlib.Seq
+diff --git a/src/seq_alias.mli b/src/seq_alias.mli
+new file mode 100644
+index 0000000..8872dd5
+--- /dev/null
++++ b/src/seq_alias.mli
+@@ -0,0 +1,2 @@
++
++include module type of Stdlib.Seq
+diff --git a/src/seq.ml b/src/seq_redef.ml
+similarity index 100%
+rename from src/seq.ml
+rename to src/seq_redef.ml
+diff --git a/src/seq.mli b/src/seq_redef.mli
+similarity index 99%
+rename from src/seq.mli
+rename to src/seq_redef.mli
+index f33c19a..c22dff9 100644
+--- a/src/seq.mli
++++ b/src/seq_redef.mli
+@@ -23,8 +23,6 @@
+     them in a lazy fashion rather than upfront.
+ *)
+ 
+-(** @since 4.07 *)
+-
+ type 'a t = unit -> 'a node
+ (** The type of delayed lists containing elements of type ['a].
+     Note that the concrete list node ['a node] is delayed under a closure,
+-- 
+2.17.1
+

--- a/src_ext/patches/seq/0001-seq-0.2-for-jbuilder.patch
+++ b/src_ext/patches/seq/0001-seq-0.2-for-jbuilder.patch
@@ -1,0 +1,136 @@
+From 048e95da1f0899ce77b1f28c324b1a96fc1d5da5 Mon Sep 17 00:00:00 2001
+From: Simon Cruanes <simon.cruanes.2007@m4x.org>
+Date: Thu, 19 Apr 2018 00:08:23 -0500
+Subject: [PATCH] seq 0.2 for jbuilder
+
+---
+ .gitignore                     |  2 ++
+ Makefile                       | 11 ++++++++++-
+ select_version.ml              | 14 ++++++++++++++
+ seq.opam                       |  8 ++++----
+ src/seq_alias.ml               |  1 +
+ src/seq_alias.mli              |  2 ++
+ src/{seq.ml => seq_redef.ml}   |  0
+ src/{seq.mli => seq_redef.mli} |  2 --
+ 8 files changed, 33 insertions(+), 7 deletions(-)
+ create mode 100644 select_version.ml
+ create mode 100644 src/seq_alias.ml
+ create mode 100644 src/seq_alias.mli
+ rename src/{seq.ml => seq_redef.ml} (100%)
+ rename src/{seq.mli => seq_redef.mli} (99%)
+
+diff --git a/.gitignore b/.gitignore
+index e35d885..487f91e 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -1 +1,3 @@
+ _build
++src/seq.ml
++src/seq.mli
+diff --git a/Makefile b/Makefile
+index fbf5dc9..c3048a5 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,9 +1,18 @@
+ 
++all: build
++
++OCAML_VERSION=$(shell ocaml -vnum)
++SELECT_CMD=$(shell ocaml select_version.ml $(OCAML_VERSION))
++
++select:
++	$(SELECT_CMD)
++
+ TARGETS=$(addprefix src/, seq.cma seq.cmxa seq.cmxs)
+-build:
++build: select
+ 	ocamlbuild $(TARGETS)
+ 
+ clean:
++	rm src/seq.ml src/seq.mli || true
+ 	ocamlbuild -clean
+ 
+ TOINSTALL=$(wildcard _build/src/*)
+diff --git a/select_version.ml b/select_version.ml
+new file mode 100644
+index 0000000..a5c25ac
+--- /dev/null
++++ b/select_version.ml
+@@ -0,0 +1,14 @@
++
++let () =
++  let version =
++    Scanf.sscanf Sys.argv.(1) "%d.%d" (fun major minor -> (major, minor))
++  in
++  let file =
++    if version < (4, 07) then
++      "seq_redef.ml"
++    else
++      "seq_alias.ml"
++  in
++  print_string file;
++  flush stdout
++
+diff --git a/seq.opam b/seq.opam
+index 8d3569c..d8f19cf 100644
+--- a/seq.opam
++++ b/seq.opam
+@@ -3,7 +3,7 @@ name: "seq"
+ version: "0.1"
+ author: "Simon Cruanes"
+ maintainer: "simon.cruanes.2007@m4x.org"
+-license: "GPL"
++license: "LGPL2.1"
+ build: [
+   [make "build"]
+ ]
+@@ -21,8 +21,8 @@ tags: [ "iterator" "seq" "pure" "list" "compatibility" "cascade" ]
+ homepage: "https://github.com/c-cube/seq/"
+ bug-reports: "https://github.com/c-cube/seq/issues"
+ dev-repo: "https://github.com/c-cube/seq.git"
+-available: [
+-  ocaml-version < "4.07.0"
+-]
+ 
++# opam-repo contains a version for 4.07 and above that does nothing,
++# because OCaml starts having a `Seq` module in the stdlib
++available: [ocaml-version < "4.07.0"]
+ 
+diff --git a/src/seq_alias.ml b/src/seq_alias.ml
+new file mode 100644
+index 0000000..49d3313
+--- /dev/null
++++ b/src/seq_alias.ml
+@@ -0,0 +1 @@
++include Stdlib.Seq
+diff --git a/src/seq_alias.mli b/src/seq_alias.mli
+new file mode 100644
+index 0000000..8872dd5
+--- /dev/null
++++ b/src/seq_alias.mli
+@@ -0,0 +1,2 @@
++
++include module type of Stdlib.Seq
+diff --git a/src/seq.ml b/src/seq_redef.ml
+similarity index 100%
+rename from src/seq.ml
+rename to src/seq_redef.ml
+diff --git a/src/seq.mli b/src/seq_redef.mli
+similarity index 99%
+rename from src/seq.mli
+rename to src/seq_redef.mli
+index f33c19a..c22dff9 100644
+--- a/src/seq.mli
++++ b/src/seq_redef.mli
+@@ -23,8 +23,6 @@
+     them in a lazy fashion rather than upfront.
+ *)
+ 
+-(** @since 4.07 *)
+-
+ type 'a t = unit -> 'a node
+ (** The type of delayed lists containing elements of type ['a].
+     Note that the concrete list node ['a node] is delayed under a closure,
+-- 
+2.17.1
+

--- a/src_ext/update-sources.sh
+++ b/src_ext/update-sources.sh
@@ -32,7 +32,7 @@ while read name prefix version url; do
       fi
     fi
   fi
-done < <(fgrep URL_ Makefile.sources | sed -e "s/URL\(_\(PKG_\)\?\)\([^ =]*\) *= *\(.*\/\([^0-9][^-]*-\)\?v\?\)\([0-9.]\+\([-+.][^\/]*\)\?\)\(\.tbz\|\.tar\.gz\)/\3 \1 \6 \4\6\8/" | sort)
+done < <(fgrep URL_ Makefile.sources | fgrep -v "URL_jbuilder" | sed -e "s/URL\(_\(PKG_\)\?\)\([^ =]*\) *= *\(.*\/\([^0-9][^-]*-\)\?v\?\)\([0-9.]\+\([-+.][^\/]*\)\?\)\(\.tbz\|\.tar\.gz\)/\3 \1 \6 \4\6\8/" | sort)
 echo -e "\nComplete."
 if [[ ${#DISAGREEMENTS[@]} -gt 0 ]] ; then
   echo "Disagreements over version:${DISAGREEMENTS[@]}"

--- a/src_ext/update-sources.sh
+++ b/src_ext/update-sources.sh
@@ -8,7 +8,7 @@ while read name prefix version url; do
   if [[ $package = "findlib" ]] ; then package=ocamlfind ; fi
   latest=$(opam show $package -f all-versions)
   latest=${latest##* }
-  package_url=$(opam show $package.$latest -f url.src:)
+  package_url=$(opam show $package.$latest -f url.src: | sed -e 's/"//g')
   md5=$(sed -n -e "s/MD5$prefix$name *= *\(.*\)/\1/p" Makefile.sources)
   package_md5=$(opam show $package.$latest -f url.checksum: | sed -e "s/.*md5=\([a-fA-F0-9]\{32\}\).*/\1/")
   if [[ $package_url = $url ]] ; then

--- a/src_ext/update-sources.sh
+++ b/src_ext/update-sources.sh
@@ -10,7 +10,7 @@ while read name prefix version url; do
   latest=${latest##* }
   package_url=$(opam show $package.$latest -f url.src: | sed -e 's/"//g')
   md5=$(sed -n -e "s/MD5$prefix$name *= *\(.*\)/\1/p" Makefile.sources)
-  package_md5=$(opam show $package.$latest -f url.checksum: | sed -e "s/.*md5=\([a-fA-F0-9]\{32\}\).*/\1/")
+  package_md5=$(opam show $package.$latest -f url.checksum: | sed -n -e "/md5/s/.*md5=\([a-fA-F0-9]\{32\}\).*/\1/p")
   if [[ $package_url = $url ]] ; then
     if [[ $package_md5 = $md5 ]] ; then
       echo -ne "[\033[0;32m$name\033[m] "

--- a/src_ext/update-sources.sh
+++ b/src_ext/update-sources.sh
@@ -18,7 +18,7 @@ while read name prefix version url; do
         DISAGREEMENTS+=" $name ($version vs $latest in opam)"
       fi
     else
-      echo "\n$name: [\033[1;33mWARN\033[m] MD5 is wrong for (should be $package_md5 according to opam)"
+      echo -e "\n$name: [\033[1;33mWARN\033[m] MD5 is wrong for (should be $package_md5 according to opam)"
     fi
   else
     if [[ $package_md5 = $md5 ]] ; then


### PR DESCRIPTION
 - Three tweaks to the `src_ext` vendoring script.
 - Minor fix to AppVeyor bootstrap compaction
 - Shift the cold compiler to 4.07.~0~1 and include 4.07.~0~1 in the test matrix
 - ~Disable Cygwin64 testing - it's been only been enabled because the cached copy of OCaml 4.06.0 was still in place. flexdll needs patching, I've nagged the guy who wrote the patch to finish it...~ (cherry-picked in cac57424)