### PR TITLE
Respect user's TMPDIR when invoking bwrap

### DIFF
--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -ue
+#!/usr/bin/env bash
+
+set -ue
 
 if ! command -v bwrap >/dev/null; then
     echo "The 'bwrap' command was not found. Install 'bubblewrap' on your system, or" >&2

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -11,9 +11,9 @@ fi
 
 ARGS=(--unshare-net --new-session)
 ARGS=("${ARGS[@]}" --proc /proc --dev /dev)
-ARGS=("${ARGS[@]}" --bind "$TMPDIR" /tmp \
-                   --setenv TMPDIR /tmp --setenv TMP /tmp --setenv TEMPDIR /tmp --setenv TEMP /tmp \
-                   --tmpfs /run --tmpfs /var)
+ARGS=("${ARGS[@]}" --bind "${TMPDIR:-/tmp}" /tmp)
+ARGS=("${ARGS[@]}" --setenv TMPDIR /tmp --setenv TMP /tmp --setenv TEMPDIR /tmp --setenv TEMP /tmp)
+ARGS=("${ARGS[@]}" --tmpfs /run --tmpfs /var)
 
 add_mounts() {
     case "$1" in

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -11,7 +11,9 @@ fi
 
 ARGS=(--unshare-net --new-session)
 ARGS=("${ARGS[@]}" --proc /proc --dev /dev)
-ARGS=("${ARGS[@]}" --bind /tmp /tmp --tmpfs /run --tmpfs /var)
+ARGS=("${ARGS[@]}" --bind "$TMPDIR" /tmp \
+                   --setenv TMPDIR /tmp --setenv TMP /tmp --setenv TEMPDIR /tmp --setenv TEMP /tmp \
+                   --tmpfs /run --tmpfs /var)
 
 add_mounts() {
     case "$1" in


### PR DESCRIPTION
Before this change, the invocation to `bwrap` assumed `TMPDIR=/tmp` and/or that scripts hardcode `/tmp`. This binds `/tmp` in the bubblewrap to the host `TMPDIR` and then points all tmp-related env vars to `/tmp`. Notably, this makes `opam` work better on NixOS. It may also affect which temp dir gets used on other systems.