### PR TITLE
Recursive & subpath based pin

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -1104,7 +1104,9 @@ files.
 
 - <a id="opamfield-extra-fields">`x-*: <value>`</a>:
   extra fields prefixed with `x-` can be defined for use by external tools. <span class="opam">opam</span>
-  will ignore them except for some search operations.
+  will ignore them except for some search operations. _Note that_ on 2.1.0, the
+  field `x-subpath` is reserved to specify the subpath of the package (cf.
+  [install manpage](man/opam-install.html#lbAF)).
 
 #### descr
 

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -492,16 +492,19 @@ let make_command st opam ?dir ?text_command (cmd, args) =
          OpamPackage.Set.(elements @@
                           inter st.compiler_packages st.installed_roots));
       if OpamPackage.Set.mem nv st.pinned then
-        match OpamFile.OPAM.get_url opam with
+        match OpamFile.OPAM.url opam with
         | None -> "pinned"
-        | Some u ->
+        | Some url ->
+          let u = OpamFile.URL.url url in
           let src =
             OpamPath.Switch.pinned_package st.switch_global.root st.switch
               nv.name
           in
           let rev = OpamProcess.Job.run (OpamRepository.revision src u) in
-          Printf.sprintf "pinned(%s%s)"
+          Printf.sprintf "pinned(%s%s%s)"
             (OpamUrl.to_string u)
+            (OpamStd.Option.to_string (fun s -> "("^s^")")
+               (OpamFile.URL.subpath url))
             (OpamStd.Option.to_string
                (fun r -> "#"^OpamPackage.Version.to_string r) rev)
       else

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1167,6 +1167,12 @@ let assume_built =
      packages that are being worked on. Implies $(i,--inplace-build). \
      No locally-pinned packages will be skipped."
 
+(* Options common to all path based/related commands, e.g. (un)pin, upgrade,
+   remove, (re)install *)
+let recurse =
+  mk_flag ["recursive"]
+    "Allow recursive lookups of .opam files. Cf. $(i,--subpath) also."
+
 let subpath =
   mk_opt ["subpath"] "PATH"
     ".opam files are retrieved from the given subpath. It can be combined with \

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1167,6 +1167,12 @@ let assume_built =
      packages that are being worked on. Implies $(i,--inplace-build). \
      No locally-pinned packages will be skipped."
 
+let subpath =
+  mk_opt ["subpath"] "PATH"
+    ".opam files are retrieved from the given subpath. It can be combined with \
+    $(i,--recursive) to have a recursive lookup on the subpath."
+    Arg.(some string) None
+
 let package_selection_section = "PACKAGE SELECTION OPTIONS"
 
 let package_selection =

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1171,12 +1171,14 @@ let assume_built =
    remove, (re)install *)
 let recurse =
   mk_flag ["recursive"]
-    "Allow recursive lookups of .opam files. Cf. $(i,--subpath) also."
+    "Allow recursive lookups of (b,*.opam) files. Cf. $(i,--subpath) also."
 
 let subpath =
   mk_opt ["subpath"] "PATH"
-    ".opam files are retrieved from the given subpath. It can be combined with \
-    $(i,--recursive) to have a recursive lookup on the subpath."
+    "$(b,*.opam) files are retrieved from the given sub directory instead of \
+      top directory. Sources are then taken from the targeted sub directory, \
+      internally only this subdirectory is copied/fetched.  It can be combined \
+      with $(i,--recursive) to have a recursive lookup on the subpath."
     Arg.(some string) None
 
 let package_selection_section = "PACKAGE SELECTION OPTIONS"

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -455,6 +455,9 @@ let existing_filename_dirname_or_dash =
   in
   parse, print
 
+let subpath_conv =
+  (fun str -> `Ok (OpamStd.String.remove_prefix ~prefix:"./" str)), pr_str
+
 let package_name =
   let parse str =
     try `Ok (OpamPackage.Name.of_string str)
@@ -1179,7 +1182,7 @@ let subpath =
       top directory. Sources are then taken from the targeted sub directory, \
       internally only this subdirectory is copied/fetched.  It can be combined \
       with $(i,--recursive) to have a recursive lookup on the subpath."
-    Arg.(some string) None
+    Arg.(some subpath_conv) None
 
 let package_selection_section = "PACKAGE SELECTION OPTIONS"
 

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -117,6 +117,8 @@ val build_options: build_options Term.t
 (** Install and reinstall options *)
 val assume_built: bool Term.t
 
+val subpath: string option Term.t
+
 (** Applly build options *)
 val apply_build_options: build_options -> unit
 

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -117,6 +117,9 @@ val build_options: build_options Term.t
 (** Install and reinstall options *)
 val assume_built: bool Term.t
 
+(* Options common to all path based/related commands, e.g. (un)pin, upgrade,
+   remove, (re)install *)
+val recurse: bool Term.t
 val subpath: string option Term.t
 
 (** Applly build options *)

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -146,7 +146,7 @@ let resolve_locals_pinned st atom_or_local_list =
           if OpamPackage.Set.is_empty pkgs then
             OpamConsole.warning "No pinned packages found at %s"
               (OpamFilename.Dir.to_string d);
-          List.rev_append (OpamSolution.eq_atoms_of_packages pkgs) acc
+          List.rev_append (OpamSolution.atoms_of_packages pkgs) acc
         | `Filename f ->
           OpamConsole.error_and_exit `Bad_arguments
             "This command doesn't support specifying a file name (%S)"

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -88,8 +88,8 @@ let url_with_local_branch = function
      | None -> url)
   | url -> url
 
-let opams_of_dir ?recurse d =
-  let files = OpamPinned.files_in_source ?recurse d in
+let opams_of_dir ?recurse ?subpath d =
+  let files = OpamPinned.files_in_source ?recurse ?subpath d in
   List.fold_left (fun acc (n, f, base) ->
       let name =
         let open OpamStd.Option.Op in
@@ -168,7 +168,7 @@ let resolve_locals_pinned st ?(recurse=false) ?subpath atom_or_local_list =
   in
   List.rev atoms
 
-let resolve_locals ?(quiet=false) ?recurse atom_or_local_list =
+let resolve_locals ?(quiet=false) ?recurse ?subpath atom_or_local_list =
   let target_dir dir =
     let d = OpamFilename.Dir.to_string dir in
     let backend = OpamUrl.guess_version_control d in
@@ -179,7 +179,7 @@ let resolve_locals ?(quiet=false) ?recurse atom_or_local_list =
     List.fold_left (fun (to_pin, atoms) -> function
         | `Atom a -> to_pin, a :: atoms
         | `Dirname d ->
-          let names_files = opams_of_dir ?recurse d in
+          let names_files = opams_of_dir ?recurse ?subpath d in
           if names_files = [] && not quiet then
             OpamConsole.warning "No package definitions found at %s"
               (OpamFilename.Dir.to_string d);
@@ -221,8 +221,8 @@ let resolve_locals ?(quiet=false) ?recurse atom_or_local_list =
            (OpamUrl.to_string t))
           duplicates)
 
-let autopin_aux st ?quiet ?(for_view=false) ?recurse atom_or_local_list =
-  let to_pin, atoms = resolve_locals ?quiet ?recurse atom_or_local_list in
+let autopin_aux st ?quiet ?(for_view=false) ?recurse ?subpath atom_or_local_list =
+  let to_pin, atoms = resolve_locals ?quiet ?recurse ?subpath atom_or_local_list in
   if to_pin = [] then
     atoms, to_pin, OpamPackage.Set.empty, OpamPackage.Set.empty
   else
@@ -337,9 +337,9 @@ let simulate_local_pinnings ?quiet ?(for_view=false) st to_pin =
   } in
   st, local_packages
 
-let simulate_autopin st ?quiet ?(for_view=false) ?recurse atom_or_local_list =
+let simulate_autopin st ?quiet ?(for_view=false) ?recurse ?subpath atom_or_local_list =
   let atoms, to_pin, obsolete_pins, already_pinned_set =
-    autopin_aux st ?quiet ~for_view ?recurse atom_or_local_list
+    autopin_aux st ?quiet ~for_view ?recurse ?subpath atom_or_local_list
   in
   if to_pin = [] then st, atoms else
   let st =
@@ -369,12 +369,12 @@ let simulate_autopin st ?quiet ?(for_view=false) ?recurse atom_or_local_list =
         OpamConsole.msg "\n"));
   st, atoms
 
-let autopin st ?(simulate=false) ?quiet ?recurse atom_or_local_list =
+let autopin st ?(simulate=false) ?quiet ?recurse ?subpath atom_or_local_list =
   if OpamStateConfig.(!r.dryrun) || OpamClientConfig.(!r.show) then
     simulate_autopin st ?quiet atom_or_local_list
   else
   let atoms, to_pin, obsolete_pins, already_pinned_set =
-    autopin_aux st ?quiet ?recurse atom_or_local_list
+    autopin_aux st ?quiet ?recurse ?subpath atom_or_local_list
   in
   if to_pin = [] && OpamPackage.Set.is_empty obsolete_pins &&
      OpamPackage.Set.is_empty already_pinned_set

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -88,9 +88,9 @@ let url_with_local_branch = function
      | None -> url)
   | url -> url
 
-let opams_of_dir d =
-  let files = OpamPinned.files_in_source d in
-  List.fold_left (fun acc (n, f) ->
+let opams_of_dir ?recurse d =
+  let files = OpamPinned.files_in_source ?recurse d in
+  List.fold_left (fun acc (n, f, base) ->
       let name =
         let open OpamStd.Option.Op in
         n >>+ fun () ->
@@ -101,7 +101,7 @@ let opams_of_dir d =
         | [_] -> name_from_project_dirname d
       in
       match name with
-      | Some n -> (n, f) :: acc
+      | Some n -> (n, f, base) :: acc
       | None ->
         OpamConsole.warning
           "Ignoring file at %s: could not infer package name"
@@ -152,7 +152,7 @@ let resolve_locals_pinned st atom_or_local_list =
   in
   List.rev atoms
 
-let resolve_locals ?(quiet=false) atom_or_local_list =
+let resolve_locals ?(quiet=false) ?recurse atom_or_local_list =
   let target_dir dir =
     let d = OpamFilename.Dir.to_string dir in
     let backend = OpamUrl.guess_version_control d in
@@ -163,22 +163,22 @@ let resolve_locals ?(quiet=false) atom_or_local_list =
     List.fold_left (fun (to_pin, atoms) -> function
         | `Atom a -> to_pin, a :: atoms
         | `Dirname d ->
-          let names_files = opams_of_dir d in
+          let names_files = opams_of_dir ?recurse d in
           if names_files = [] && not quiet then
             OpamConsole.warning "No package definitions found at %s"
               (OpamFilename.Dir.to_string d);
           let target = target_dir d in
           let to_pin =
-            List.map (fun (n,f) -> n, target, f) names_files @ to_pin
+            List.map (fun (n,f,b) -> n, target, b, f) names_files @ to_pin
           in
           let atoms =
-            List.map (fun (n,_) -> n, None) names_files @ atoms
+            List.map (fun (n,_,_) -> n, None) names_files @ atoms
           in
           to_pin, atoms
         | `Filename f ->
           match name_and_dir_of_opam_file f with
           | Some n, srcdir ->
-            (n, target_dir srcdir, OpamFile.make f) :: to_pin,
+            (n, target_dir srcdir, None, OpamFile.make f) :: to_pin,
             (n, None) :: atoms
           | None, _ ->
             OpamConsole.error_and_exit `Not_found
@@ -188,8 +188,8 @@ let resolve_locals ?(quiet=false) atom_or_local_list =
       atom_or_local_list
   in
   let duplicates =
-    List.filter (fun (n, _, f) ->
-        List.exists (fun (n1, _, f1) -> n = n1 && f <> f1) to_pin)
+    List.filter (fun (n, _, _, f) ->
+        List.exists (fun (n1, _, _, f1) -> n = n1 && f <> f1) to_pin)
       to_pin
   in
   match duplicates with
@@ -197,7 +197,7 @@ let resolve_locals ?(quiet=false) atom_or_local_list =
   | _ ->
     OpamConsole.error_and_exit `Bad_arguments
       "Multiple files for the same package name were specified:\n%s"
-      (OpamStd.Format.itemize (fun (n, t, f) ->
+      (OpamStd.Format.itemize (fun (n, t, _, f) ->
          Printf.sprintf "Package %s with definition %s %s %s"
            (OpamConsole.colorise `bold @@ OpamPackage.Name.to_string n)
            (OpamFile.to_string f)
@@ -205,8 +205,8 @@ let resolve_locals ?(quiet=false) atom_or_local_list =
            (OpamUrl.to_string t))
           duplicates)
 
-let autopin_aux st ?quiet ?(for_view=false) atom_or_local_list =
-  let to_pin, atoms = resolve_locals ?quiet atom_or_local_list in
+let autopin_aux st ?quiet ?(for_view=false) ?recurse atom_or_local_list =
+  let to_pin, atoms = resolve_locals ?quiet ?recurse atom_or_local_list in
   if to_pin = [] then
     atoms, to_pin, OpamPackage.Set.empty, OpamPackage.Set.empty
   else
@@ -217,15 +217,16 @@ let autopin_aux st ?quiet ?(for_view=false) atom_or_local_list =
       atom_or_local_list
   in
   log "autopin: %a"
-    (slog @@ OpamStd.List.to_string (fun (name, target, _) ->
-         Printf.sprintf "%s => %s"
+    (slog @@ OpamStd.List.to_string (fun (name, target, subpath, _) ->
+         Printf.sprintf "%s => %s%s"
            (OpamPackage.Name.to_string name)
-           (OpamUrl.to_string target)))
+           (OpamUrl.to_string target)
+           (match subpath with None -> "" | Some s -> " ("^s^")")))
     to_pin;
   let obsolete_pins =
     (* Packages not current but pinned to the same dirs *)
     OpamPackage.Set.filter (fun nv ->
-        not (List.exists (fun (n,_,_) -> n = nv.name) to_pin) &&
+        not (List.exists (fun (n,_,_,_) -> n = nv.name) to_pin) &&
         match OpamStd.Option.Op.(OpamSwitchState.primary_url st nv >>=
                                  OpamUrl.local_dir)
         with
@@ -234,7 +235,7 @@ let autopin_aux st ?quiet ?(for_view=false) atom_or_local_list =
       st.pinned
   in
   let already_pinned, to_pin =
-    List.partition (fun (name, target, opam) ->
+    List.partition (fun (name, target, _,  opam) ->
         try
           (* check of the target to avoid repin of pin to update with `opam
              install .` and loose edited opams *)
@@ -253,7 +254,7 @@ let autopin_aux st ?quiet ?(for_view=false) atom_or_local_list =
       to_pin
   in
   let already_pinned_set =
-    List.fold_left (fun acc (name, _, _) ->
+    List.fold_left (fun acc (name, _, _, _) ->
         OpamPackage.Set.add (OpamPinned.package st name) acc)
       OpamPackage.Set.empty already_pinned
   in
@@ -263,12 +264,12 @@ let simulate_local_pinnings ?quiet ?(for_view=false) st to_pin =
   assert (not (for_view &&
                OpamSystem.get_lock_flag st.switch_lock = `Lock_write));
   let local_names =
-    List.fold_left (fun set (name, _, _) ->
+    List.fold_left (fun set (name, _, _, _) ->
         OpamPackage.Name.Set.add name set)
       OpamPackage.Name.Set.empty to_pin
   in
   let local_opams =
-    List.fold_left (fun map (name, target, file) ->
+    List.fold_left (fun map (name, target, subpath, file) ->
         match
           OpamPinCommand.read_opam_file_for_pinning ?quiet name file target
         with
@@ -277,7 +278,7 @@ let simulate_local_pinnings ?quiet ?(for_view=false) st to_pin =
           let opam = OpamFile.OPAM.with_name name opam in
           let opam =
             if for_view then opam
-            else OpamFile.OPAM.with_url (OpamFile.URL.create target) opam
+            else OpamFile.OPAM.with_url (OpamFile.URL.create ?subpath target) opam
           in
           let opam, version = match OpamFile.OPAM.version_opt opam with
             | Some v -> opam, v
@@ -320,9 +321,9 @@ let simulate_local_pinnings ?quiet ?(for_view=false) st to_pin =
   } in
   st, local_packages
 
-let simulate_autopin st ?quiet ?(for_view=false) atom_or_local_list =
+let simulate_autopin st ?quiet ?(for_view=false) ?recurse atom_or_local_list =
   let atoms, to_pin, obsolete_pins, already_pinned_set =
-    autopin_aux st ?quiet ~for_view atom_or_local_list
+    autopin_aux st ?quiet ~for_view ?recurse atom_or_local_list
   in
   if to_pin = [] then st, atoms else
   let st =
@@ -352,12 +353,12 @@ let simulate_autopin st ?quiet ?(for_view=false) atom_or_local_list =
         OpamConsole.msg "\n"));
   st, atoms
 
-let autopin st ?(simulate=false) ?quiet atom_or_local_list =
+let autopin st ?(simulate=false) ?quiet ?recurse atom_or_local_list =
   if OpamStateConfig.(!r.dryrun) || OpamClientConfig.(!r.show) then
     simulate_autopin st ?quiet atom_or_local_list
   else
   let atoms, to_pin, obsolete_pins, already_pinned_set =
-    autopin_aux st ?quiet atom_or_local_list
+    autopin_aux st ?quiet ?recurse atom_or_local_list
   in
   if to_pin = [] && OpamPackage.Set.is_empty obsolete_pins &&
      OpamPackage.Set.is_empty already_pinned_set
@@ -384,13 +385,13 @@ let autopin st ?(simulate=false) ?quiet atom_or_local_list =
   let st, pins =
     if simulate then simulate_local_pinnings ?quiet st to_pin else
     try
-      List.fold_left (fun (st, pins) (name, target, file) ->
+      List.fold_left (fun (st, pins) (name, target, subpath, file) ->
           match OpamPinCommand.read_opam_file_for_pinning ?quiet name file target with
           | None -> st, pins
           | Some opam ->
             let st =
               try
-                OpamPinCommand.source_pin st name ~quiet:true ~opam
+                OpamPinCommand.source_pin st name ~quiet:true ~opam ?subpath
                   (Some target)
               with OpamPinCommand.Nothing_to_do -> st
             in
@@ -407,14 +408,14 @@ let autopin st ?(simulate=false) ?quiet atom_or_local_list =
   in
   st, atoms
 
-let get_compatible_compiler ?repos rt dir =
+let get_compatible_compiler ?repos ?recurse rt dir =
   let gt = rt.repos_global in
   let virt_st =
     OpamSwitchState.load_virtual ?repos_list:repos gt rt
   in
-  let local_files = opams_of_dir dir in
+  let local_files = opams_of_dir ?recurse dir in
   let local_opams =
-    List.fold_left (fun acc (name, f) ->
+    List.fold_left (fun acc (name, f, _) ->
         let opam = OpamFile.OPAM.safe_read f in
         let opam = OpamFormatUpgrade.opam_file ~filename:f opam in
         let nv, opam =

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -130,9 +130,12 @@ let resolve_locals_pinned st atom_or_local_list =
   let pinned_packages_of_dir st dir =
     OpamPackage.Set.filter
       (fun nv ->
-         OpamStd.Option.Op.(OpamSwitchState.primary_url st nv >>=
-                            OpamUrl.local_dir)
-         = Some dir)
+         match
+           OpamStd.Option.Op.(OpamSwitchState.primary_url_with_subpath st nv >>=
+                              OpamUrl.local_dir)
+         with
+         | None -> false
+         | Some suburl -> OpamFilename.dir_starts_with dir suburl)
       st.pinned
   in
   let atoms =

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -326,8 +326,9 @@ let simulate_local_pinnings ?quiet ?(for_view=false) st to_pin =
         | Some opam ->
           let opam = OpamFile.OPAM.with_name name opam in
           let opam =
-            if for_view then opam
-            else OpamFile.OPAM.with_url (OpamFile.URL.create ?subpath target) opam
+            if for_view then opam else
+              OpamFile.OPAM.with_url (OpamFile.URL.create ?subpath target) opam
+            |> OpamFile.OPAM.with_opam2_1_restriction
           in
           let opam, version = match OpamFile.OPAM.version_opt opam with
             | Some v -> opam, v

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -328,7 +328,6 @@ let simulate_local_pinnings ?quiet ?(for_view=false) st to_pin =
           let opam =
             if for_view then opam else
               OpamFile.OPAM.with_url (OpamFile.URL.create ?subpath target) opam
-            |> OpamFile.OPAM.with_opam2_1_restriction
           in
           let opam, version = match OpamFile.OPAM.version_opt opam with
             | Some v -> opam, v

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -109,6 +109,39 @@ let opams_of_dir ?recurse ?subpath d =
         acc)
     [] files
 
+let opams_of_dir_w_target ?(recurse=false) ?subpath
+    ?(same_kind=fun _ -> OpamClientConfig.(!r.pin_kind_auto)) url dir =
+  OpamStd.List.filter_map (fun (name, file, base) ->
+      let url =
+        match url.OpamUrl.backend with
+        | #OpamUrl.version_control as vc ->
+          let module VCS =
+            (val match vc with
+               | `git -> (module OpamGit.VCS: OpamVCS.VCS)
+               | `hg -> (module OpamHg.VCS: OpamVCS.VCS)
+               | `darcs -> (module OpamDarcs.VCS: OpamVCS.VCS)
+               : OpamVCS.VCS)
+          in
+          let open OpamProcess.Job.Op in
+          let files =
+            OpamProcess.Job.run @@
+            VCS.versioned_files dir @@| fun files -> files
+          in
+          let versioned =
+            OpamFilename.remove_prefix dir (OpamFile.filename file)
+          in
+          if List.mem versioned files then url else
+            { url with
+              transport = "file";
+              hash = None;
+              backend = `rsync }
+        | _ -> url
+      in
+      if same_kind url then
+        Some (name, file, url, base)
+      else None)
+    (opams_of_dir ~recurse ?subpath dir)
+
 let name_and_dir_of_opam_file f =
   let srcdir = OpamFilename.dirname f in
   let srcdir =
@@ -179,16 +212,16 @@ let resolve_locals ?(quiet=false) ?recurse ?subpath atom_or_local_list =
     List.fold_left (fun (to_pin, atoms) -> function
         | `Atom a -> to_pin, a :: atoms
         | `Dirname d ->
-          let names_files = opams_of_dir ?recurse ?subpath d in
+          let target = target_dir d in
+          let names_files = opams_of_dir_w_target ?recurse ?subpath target d in
           if names_files = [] && not quiet then
             OpamConsole.warning "No package definitions found at %s"
               (OpamFilename.Dir.to_string d);
-          let target = target_dir d in
           let to_pin =
-            List.map (fun (n,f,b) -> n, target, b, f) names_files @ to_pin
+            List.map (fun (n,f,u,b) -> n, u, b, f) names_files @ to_pin
           in
           let atoms =
-            List.map (fun (n,_,_) -> n, None) names_files @ atoms
+            List.map (fun (n,_,_,_) -> n, None) names_files @ atoms
           in
           to_pin, atoms
         | `Filename f ->

--- a/src/client/opamAuxCommands.mli
+++ b/src/client/opamAuxCommands.mli
@@ -33,6 +33,22 @@ val url_with_local_branch: url -> url
     be found, and the corresponding source directory *)
 val name_and_dir_of_opam_file: filename -> name option * dirname
 
+(** From a directory, retrieve its opam files and returns packages name, opam
+    file and subpath option *)
+val opams_of_dir:
+  ?recurse:bool -> ?subpath:string ->
+  OpamFilename.Dir.t -> (name * OpamFile.OPAM.t OpamFile.t * string option) list
+
+(** Like [opam_of_dirs], but changes the pinning_url if needed. If given [url]
+    is local dir with vcs backend, and opam files not versioned, its pinning url
+    is changed to rsync path-pin. If [ame_kind the_new_url] returns true,
+    package information (name, opam file, new_url, subpath) are added to the
+    returned list, otherwise it is discarded. *)
+val opams_of_dir_w_target:
+  ?recurse:bool -> ?subpath:string ->
+  ?same_kind:(OpamUrl.t -> bool) -> OpamUrl.t -> OpamFilename.Dir.t ->
+  (name * OpamFile.OPAM.t OpamFile.t * OpamUrl.t * string option) list
+
 (** Resolves the opam files and directories in the list to package name and
     location, and returns the corresponding pinnings and atoms. May fail and
     exit if package names for provided [`Filename] could not be inferred, or if

--- a/src/client/opamAuxCommands.mli
+++ b/src/client/opamAuxCommands.mli
@@ -49,7 +49,7 @@ val resolve_locals:
     is pinned, or opam files corresponding to no pinned package.
 *)
 val resolve_locals_pinned:
-  'a switch_state ->
+  'a switch_state -> ?recurse:bool -> ?subpath:string ->
   [ `Atom of atom | `Dirname of dirname ] list ->
   atom list
 

--- a/src/client/opamAuxCommands.mli
+++ b/src/client/opamAuxCommands.mli
@@ -39,7 +39,7 @@ val name_and_dir_of_opam_file: filename -> name option * dirname
     the same package name appears multiple times.
 *)
 val resolve_locals:
-  ?quiet:bool -> ?recurse:bool ->
+  ?quiet:bool -> ?recurse:bool -> ?subpath:string ->
   [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
   (name * OpamUrl.t * string option * OpamFile.OPAM.t OpamFile.t) list * atom list
 
@@ -69,6 +69,7 @@ val autopin:
   ?simulate:bool ->
   ?quiet:bool ->
   ?recurse:bool ->
+  ?subpath:string ->
   [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
   rw switch_state * atom list
 
@@ -83,6 +84,7 @@ val simulate_autopin:
   ?quiet:bool ->
   ?for_view:bool ->
   ?recurse:bool ->
+  ?subpath:string ->
   [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
   'a switch_state * atom list
 

--- a/src/client/opamAuxCommands.mli
+++ b/src/client/opamAuxCommands.mli
@@ -39,9 +39,9 @@ val name_and_dir_of_opam_file: filename -> name option * dirname
     the same package name appears multiple times.
 *)
 val resolve_locals:
-  ?quiet:bool ->
+  ?quiet:bool -> ?recurse:bool ->
   [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
-  (name * OpamUrl.t * OpamFile.OPAM.t OpamFile.t) list * atom list
+  (name * OpamUrl.t * string option * OpamFile.OPAM.t OpamFile.t) list * atom list
 
 (** Resolves the opam files and directories in the list to package name and
     location, according to what is currently pinned, and returns the
@@ -68,6 +68,7 @@ val autopin:
   rw switch_state ->
   ?simulate:bool ->
   ?quiet:bool ->
+  ?recurse:bool ->
   [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
   rw switch_state * atom list
 
@@ -81,6 +82,7 @@ val simulate_autopin:
   'a switch_state ->
   ?quiet:bool ->
   ?for_view:bool ->
+  ?recurse:bool ->
   [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
   'a switch_state * atom list
 
@@ -92,4 +94,5 @@ val simulate_autopin:
     the empty list after user confirmation. *)
 val get_compatible_compiler:
   ?repos:repository_name list ->
+  ?recurse:bool ->
   'a repos_state -> dirname -> atom option * bool

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1392,12 +1392,12 @@ module PIN = struct
         "No package named %S found"
         (OpamPackage.Name.to_string name)
 
-  let pin st name ?(edit=false) ?version ?(action=true) target =
+  let pin st name ?(edit=false) ?version ?(action=true) ?subpath target =
     try
       let pinned = st.pinned in
       let st =
         match target with
-        | `Source url -> source_pin st name ?version ~edit (Some url)
+        | `Source url -> source_pin st name ?version ~edit ?subpath (Some url)
         | `Version v ->
           let st = version_pin st name v in
           if edit then OpamPinCommand.edit st name else st

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -117,7 +117,7 @@ module PIN: sig
   val pin:
     rw switch_state ->
     OpamPackage.Name.t ->
-    ?edit:bool -> ?version:version -> ?action:bool ->
+    ?edit:bool -> ?version:version -> ?action:bool -> ?subpath:string ->
     [< `Source of url | `Version of version | `Dev_upstream | `None ] ->
     rw switch_state
 

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -89,7 +89,9 @@ val update:
     versions. The specified atoms are kept installed (or newly installed after a
     confirmation). The upgrade concerns them only unless [all] is specified. *)
 val upgrade:
-  rw switch_state -> ?check:bool -> all:bool -> atom list -> rw switch_state
+  rw switch_state ->
+  ?check:bool -> ?only_installed:bool ->
+  all:bool -> atom list -> rw switch_state
 
 (** Low-level version of [upgrade], bypassing the package name sanitization and
    dev package update, and offering more control. [terse] avoids the verbose
@@ -97,6 +99,7 @@ val upgrade:
 val upgrade_t:
   ?strict_upgrade:bool -> ?auto_install:bool -> ?ask:bool -> ?check:bool ->
   ?terse:bool ->
+  ?only_installed:bool ->
   all:bool -> atom list -> rw switch_state -> rw switch_state
 
 (** Recovers from an inconsistent universe *)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1352,9 +1352,12 @@ let install =
        it will ask if you want them installed and launch install of \
        $(i,PACKAGES) with option $(b,deps-only) enabled."
   in
+  let recurse =
+    mk_flag ["r";"rec"]
+      "Allow recursive lookups of .opam files." in
   let install
       global_options build_options add_to_roots deps_only ignore_conflicts
-      restore destdir assume_built check atoms_or_locals =
+      restore destdir assume_built check recurse atoms_or_locals =
     apply_global_options global_options;
     apply_build_options build_options;
     if atoms_or_locals = [] && not restore then
@@ -1382,8 +1385,8 @@ let install =
     in
     if atoms_or_locals = [] then `Ok () else
     let st, atoms =
-      OpamAuxCommands.autopin st ~quiet:check ~simulate:(deps_only||check)
-        atoms_or_locals
+      OpamAuxCommands.autopin
+        st ~recurse ~quiet:check ~simulate:(deps_only||check) atoms_or_locals
     in
     if atoms = [] then
       (OpamConsole.msg "Nothing to do\n";
@@ -1418,7 +1421,7 @@ let install =
   Term.ret
     Term.(const install $global_options $build_options
           $add_to_roots $deps_only $ignore_conflicts $restore $destdir
-          $assume_built $check $atom_or_local_list),
+          $assume_built $check $recurse $atom_or_local_list),
   term_info "install" ~doc ~man
 
 (* REMOVE *)
@@ -2539,6 +2542,9 @@ let pin ?(unpin_only=false) () =
     mk_flag ["e";"edit"]
       "With $(i,opam pin add), edit the opam file as with `opam pin edit' \
        after pinning." in
+  let recurse =
+    mk_flag ["r";"rec"]
+      "Allow recursive lookups of .opam files." in
   let kind =
     let main_kinds = [
       "version", `version;
@@ -2575,18 +2581,18 @@ let pin ?(unpin_only=false) () =
     mk_flag ["dev-repo"] "Pin to the upstream package source for the latest \
                           development version"
   in
-  let guess_names url k =
+  let guess_names ~recurse url k =
     let from_opam_files dir =
       OpamStd.List.filter_map
-        (fun (nameopt, f) ->
+        (fun (nameopt, f, subpath) ->
            let opam_opt = OpamFile.OPAM.read_opt f in
            let name =
              match nameopt with
              | None -> OpamStd.Option.replace OpamFile.OPAM.name_opt opam_opt
              | some -> some
            in
-           OpamStd.Option.map (fun n -> n, opam_opt) name)
-        (OpamPinned.files_in_source dir)
+           OpamStd.Option.map (fun n -> n, opam_opt, subpath) name)
+        (OpamPinned.files_in_source ~recurse dir)
     in
     let basename =
       match OpamStd.String.split (OpamUrl.basename url) '.' with
@@ -2623,7 +2629,7 @@ let pin ?(unpin_only=false) () =
       match found with
       | _::_ -> found
       | [] ->
-        try [OpamPackage.Name.of_string basename, None] with
+        try [OpamPackage.Name.of_string basename, None, None] with
         | Failure _ ->
           OpamConsole.error_and_exit `Bad_arguments
             "Could not infer a package name from %s, please specify it on the \
@@ -2673,7 +2679,7 @@ let pin ?(unpin_only=false) () =
   in
   let pin
       global_options build_options
-      kind edit no_act dev_repo print_short command params =
+      kind edit no_act dev_repo print_short recurse command params =
     apply_global_options global_options;
     apply_build_options build_options;
     let action = not no_act in
@@ -2748,12 +2754,14 @@ let pin ?(unpin_only=false) () =
          in
          `Error (true, msg)
        | `Source url ->
-         guess_names url @@ fun names ->
+         guess_names ~recurse url @@ fun names ->
          let names = match names with
            | _::_::_ ->
              if OpamConsole.confirm
                  "This will pin the following packages: %s. Continue?"
-                 (OpamStd.List.concat_map ", " (fst @> OpamPackage.Name.to_string) names)
+                 (OpamStd.List.concat_map ", "
+                    (fun (n, _, _) -> OpamPackage.Name.to_string n)
+                    names)
              then names
              else OpamStd.Sys.exit_because `Aborted
            | _ -> names
@@ -2762,7 +2770,7 @@ let pin ?(unpin_only=false) () =
          OpamSwitchState.with_ `Lock_write gt @@ fun st ->
          let pinned = st.pinned in
          let st =
-           List.fold_left (fun st (name, opam_opt) ->
+           List.fold_left (fun st (name, opam_opt, subpath) ->
                OpamStd.Option.iter (fun opam ->
                    let opam_localf =
                      OpamPath.Switch.Overlay.tmp_opam
@@ -2771,14 +2779,15 @@ let pin ?(unpin_only=false) () =
                    if not (OpamFilename.exists (OpamFile.filename opam_localf))
                    then OpamFile.OPAM.write opam_localf opam)
                  opam_opt;
-               try OpamPinCommand.source_pin st name ~edit (Some url) with
+               try OpamPinCommand.source_pin st name ~edit ?subpath (Some url) with
                | OpamPinCommand.Aborted -> OpamStd.Sys.exit_because `Aborted
                | OpamPinCommand.Nothing_to_do -> st)
              st names
          in
          if action then
            (OpamSwitchState.drop @@
-            OpamClient.PIN.post_pin_action st pinned (List.map fst names);
+            OpamClient.PIN.post_pin_action st pinned
+              (List.map (fun (n,_,_) -> n) names);
             `Ok ())
          else `Ok ())
     | Some `add, [n; target] | Some `default n, [target] ->
@@ -2796,7 +2805,7 @@ let pin ?(unpin_only=false) () =
   Term.ret
     Term.(const pin
           $global_options $build_options
-          $kind $edit $no_act $dev_repo $print_short_flag
+          $kind $edit $no_act $dev_repo $print_short_flag $recurse
           $command $params),
   term_info "pin" ~doc ~man
 
@@ -2975,17 +2984,21 @@ let lint =
     mk_flag ["check-upstream"]
       "Check upstream, archive availability and checksum(s)"
   in
+  let recurse =
+    mk_flag ["r";"rec"]
+      "Allow recursive lookups of .opam files."
+  in
   let lint global_options files package normalise short warnings_sel
-      check_upstream =
+      check_upstream recurse =
     apply_global_options global_options;
     let opam_files_in_dir d =
-      match OpamPinned.files_in_source d with
+      match OpamPinned.files_in_source ~recurse d with
       | [] ->
         OpamConsole.warning "No opam files found in %s"
           (OpamFilename.Dir.to_string d);
         []
       | l ->
-        List.map (fun (_name,f) -> Some f) l
+        List.map (fun (_name,f,_) -> Some f) l
     in
     let files = match files, package with
       | [], None -> (* Lookup in cwd if nothing was specified *)
@@ -3093,8 +3106,8 @@ let lint =
     OpamStd.Option.iter (fun json -> OpamJson.append "lint" (`A json)) json;
     if err then OpamStd.Sys.exit_because `False
   in
-  Term.(const lint $global_options $files $package $normalise $short $warnings
-        $check_upstream),
+  Term.(const lint $global_options $files $package $normalise $short
+        $warnings $check_upstream $recurse),
   term_info "lint" ~doc ~man
 
 (* CLEAN *)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -722,7 +722,7 @@ let show =
       OpamConsole.warning "No opam files found in %s"
         (OpamFilename.Dir.to_string d);
       []
-    | l -> List.map (fun (_,f) -> Some f) l
+    | l -> List.map (fun (_,f,_) -> Some f) l
   in
   let pkg_info global_options fields show_empty raw where
       list_files file normalise no_lint just_file all_versions sort atom_locs =

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1687,7 +1687,11 @@ let upgrade =
        $(i,PACKAGES) was not specified, and can be useful with $(i,PACKAGES) \
        to upgrade while ensuring that some packages get or remain installed."
   in
-  let upgrade global_options build_options fixup check all atom_locs =
+  let installed =
+    mk_flag ["installed"]
+      "When a directory is provided as argument, do not install pinned package \
+       that are not yet installed." in
+  let upgrade global_options build_options fixup check only_installed all atom_locs =
     apply_global_options global_options;
     apply_build_options build_options;
     let all = all || atom_locs = [] in
@@ -1702,11 +1706,11 @@ let upgrade =
     else
       OpamSwitchState.with_ `Lock_write gt @@ fun st ->
       let atoms = OpamAuxCommands.resolve_locals_pinned st atom_locs in
-      OpamSwitchState.drop @@ OpamClient.upgrade st ~check ~all atoms;
+      OpamSwitchState.drop @@ OpamClient.upgrade st ~check ~only_installed ~all atoms;
       `Ok ()
   in
-  Term.(ret (const upgrade $global_options $build_options $fixup $check $all
-             $atom_or_dir_list)),
+  Term.(ret (const upgrade $global_options $build_options $fixup $check
+             $installed $all $atom_or_dir_list)),
   term_info "upgrade" ~doc ~man
 
 (* REPOSITORY *)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3011,10 +3011,10 @@ let lint =
       "Check upstream, archive availability and checksum(s)"
   in
   let lint global_options files package normalise short warnings_sel
-      check_upstream recurse =
+      check_upstream recurse subpath =
     apply_global_options global_options;
     let opam_files_in_dir d =
-      match OpamPinned.files_in_source ~recurse d with
+      match OpamPinned.files_in_source ~recurse ?subpath d with
       | [] ->
         OpamConsole.warning "No opam files found in %s"
           (OpamFilename.Dir.to_string d);
@@ -3129,7 +3129,7 @@ let lint =
     if err then OpamStd.Sys.exit_because `False
   in
   Term.(const lint $global_options $files $package $normalise $short
-        $warnings $check_upstream $recurse),
+        $warnings $check_upstream $recurse $subpath),
   term_info "lint" ~doc ~man
 
 (* CLEAN *)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2579,7 +2579,7 @@ let pin ?(unpin_only=false) () =
     mk_flag ["dev-repo"] "Pin to the upstream package source for the latest \
                           development version"
   in
-  let guess_names ~recurse url k =
+  let guess_names ~recurse ?subpath url k =
     let from_opam_files dir =
       OpamStd.List.filter_map
         (fun (nameopt, f, subpath) ->
@@ -2590,7 +2590,7 @@ let pin ?(unpin_only=false) () =
              | some -> some
            in
            OpamStd.Option.map (fun n -> n, opam_opt, subpath) name)
-        (OpamPinned.files_in_source ~recurse dir)
+        (OpamPinned.files_in_source ~recurse ?subpath dir)
     in
     let basename =
       match OpamStd.String.split (OpamUrl.basename url) '.' with
@@ -2752,7 +2752,7 @@ let pin ?(unpin_only=false) () =
          in
          `Error (true, msg)
        | `Source url ->
-         guess_names ~recurse url @@ fun names ->
+         guess_names ~recurse ?subpath url @@ fun names ->
          let names = match names with
            | _::_::_ ->
              if OpamConsole.confirm

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2861,6 +2861,10 @@ let source =
          (see option `--dir')"
         (Dir.to_string dir);
     let opam = OpamSwitchState.opam t nv in
+    let subpath =
+      OpamStd.Option.map_default OpamFile.URL.subpath
+        None (OpamFile.OPAM.url opam)
+    in
     if dev_repo then (
       match OpamFile.OPAM.dev_repo opam with
       | None ->
@@ -2875,6 +2879,7 @@ let source =
             (OpamRepository.pull_tree
                ~cache_dir:(OpamRepositoryPath.download_cache
                              OpamStateConfig.(!r.root_dir))
+               ?subpath
                (OpamPackage.to_string nv) dir []
                [url])
         with
@@ -2900,7 +2905,9 @@ let source =
               (Dir.to_string dir) (Printexc.to_string e)
       in
       OpamProcess.Job.run job;
-      if OpamPinned.find_opam_file_in_source nv.name dir = None
+      if OpamPinned.find_opam_file_in_source nv.name
+          (OpamStd.Option.map_default (fun sp -> Op.(dir / sp)) dir subpath)
+         = None
       then
         let f =
           if OpamFilename.exists_dir Op.(dir / "opam")

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1352,9 +1352,6 @@ let install =
        it will ask if you want them installed and launch install of \
        $(i,PACKAGES) with option $(b,deps-only) enabled."
   in
-  let recurse =
-    mk_flag ["r";"rec"]
-      "Allow recursive lookups of .opam files." in
   let install
       global_options build_options add_to_roots deps_only ignore_conflicts
       restore destdir assume_built check recurse atoms_or_locals =
@@ -2546,9 +2543,6 @@ let pin ?(unpin_only=false) () =
     mk_flag ["e";"edit"]
       "With $(i,opam pin add), edit the opam file as with `opam pin edit' \
        after pinning." in
-  let recurse =
-    mk_flag ["r";"rec"]
-      "Allow recursive lookups of .opam files." in
   let kind =
     let main_kinds = [
       "version", `version;
@@ -2987,10 +2981,6 @@ let lint =
   let check_upstream =
     mk_flag ["check-upstream"]
       "Check upstream, archive availability and checksum(s)"
-  in
-  let recurse =
-    mk_flag ["r";"rec"]
-      "Allow recursive lookups of .opam files."
   in
   let lint global_options files package normalise short warnings_sel
       check_upstream recurse =

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2586,74 +2586,36 @@ let pin ?(unpin_only=false) () =
                           development version"
   in
   let guess_names kind ~recurse ?subpath url k =
-    let keep_opam url =
-      match kind, url.OpamUrl.backend with
-      | (None | Some `auto), _
-      | Some `rsync, `rsync
-      | Some `http, `http -> true
-      | Some (#OpamUrl.version_control as vc1), (#OpamUrl.version_control as vc2) ->
-        vc1 = vc2
-      | Some (`none | `version), _ -> assert false
-      | _ -> false
-    in
-    let from_opam_files ?(local=false) dir =
-      OpamStd.List.filter_map
-        (fun (nameopt, f, subpath) ->
-           let opam_opt = OpamFile.OPAM.read_opt f in
-           let name =
-             match nameopt with
-             | None -> OpamStd.Option.replace OpamFile.OPAM.name_opt opam_opt
-             | some -> some
-           in
-           let url =
-             if local then
-               match url.OpamUrl.backend with
-               | #OpamUrl.version_control as vc ->
-                 let module VCS =
-                   (val match vc with
-                      | `git -> (module OpamGit.VCS: OpamVCS.VCS)
-                      | `hg -> (module OpamHg.VCS: OpamVCS.VCS)
-                      | `darcs -> (module OpamDarcs.VCS: OpamVCS.VCS)
-                      : OpamVCS.VCS)
-                 in
-                 let open OpamProcess.Job.Op in
-                 let files =
-                   OpamProcess.Job.run @@
-                   VCS.versioned_files dir @@| fun files -> files
-                 in
-                 let versioned =
-                   OpamFilename.remove_prefix dir (OpamFile.filename f)
-                 in
-                 if List.mem versioned files then url
-                 else
-                   { url with
-                     transport = "file";
-                     hash = None;
-                     backend = `rsync}
-               | _ -> url
-             else url
-           in
-           if keep_opam url then
-             OpamStd.Option.map (fun n -> n, opam_opt, subpath, url) name
-           else None
-        )
-        (OpamPinned.files_in_source ~recurse ?subpath dir)
-    in
-    let basename =
-      match OpamStd.String.split (OpamUrl.basename url) '.' with
-      | [] ->
-        OpamConsole.error_and_exit `Bad_arguments
-          "Can not retrieve a path from '%s'"
-          (OpamUrl.to_string url)
-      | b::_ -> b
-    in
     let found, cleanup =
       match OpamUrl.local_dir url with
-      | Some d -> from_opam_files ~local:true d, None
+      | Some d ->
+        let same_kind url =
+          match kind, url.OpamUrl.backend with
+          | (None | Some `auto), _
+          | Some `rsync, `rsync
+          | Some `http, `http -> true
+          | Some (#OpamUrl.version_control as vc1), (#OpamUrl.version_control as vc2) ->
+            vc1 = vc2
+          | Some (`none | `version), _ -> assert false
+          | _ -> false
+        in
+        let pkgs =
+          OpamAuxCommands.opams_of_dir_w_target ~recurse ?subpath ~same_kind url d
+          |> List.map (fun (n,o,u,b) -> (n, OpamFile.OPAM.read_opt o, b, u))
+        in
+        pkgs, None
       | None ->
         let pin_cache_dir = OpamRepositoryPath.pin_cache url in
         let cleanup = fun () ->
           OpamFilename.rmdir @@ OpamRepositoryPath.pin_cache_dir ()
+        in
+        let basename =
+          match OpamStd.String.split (OpamUrl.basename url) '.' with
+          | [] ->
+            OpamConsole.error_and_exit `Bad_arguments
+              "Can not retrieve a path from '%s'"
+              (OpamUrl.to_string url)
+          | b::_ -> b
         in
         try
           let open OpamProcess.Job.Op in
@@ -2665,23 +2627,16 @@ let pin ?(unpin_only=false) () =
           | Not_available (_,u) ->
             OpamConsole.error_and_exit `Sync_error
               "Could not retrieve %s" u
-          | Result _ | Up_to_date _ -> from_opam_files pin_cache_dir, Some cleanup
+          | Result _ | Up_to_date _ ->
+            let pkgs =
+              OpamAuxCommands.opams_of_dir ~recurse ?subpath pin_cache_dir
+              |> List.map (fun (n,o,b) -> (n, OpamFile.OPAM.read_opt o, b, url))
+            in
+            pkgs, Some cleanup
         with e -> OpamStd.Exn.finalise e cleanup
     in
     let finalise = OpamStd.Option.default (fun () -> ()) cleanup in
-    OpamStd.Exn.finally finalise @@ fun () ->
-    let names_found =
-      match found with
-      | _::_ -> found
-      | [] ->
-        try [OpamPackage.Name.of_string basename, None, None, url] with
-        | Failure _ ->
-          OpamConsole.error_and_exit `Bad_arguments
-            "Could not infer a package name from %s, please specify it on the \
-             command-line, e.g. 'opam pin NAME TARGET'"
-            (OpamUrl.to_string url)
-    in
-    k names_found
+    OpamStd.Exn.finally finalise @@ fun () -> k found
   in
   let pin_target kind target =
     let looks_like_version_re =

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2683,7 +2683,7 @@ let pin ?(unpin_only=false) () =
   in
   let pin
       global_options build_options
-      kind edit no_act dev_repo print_short recurse command params =
+      kind edit no_act dev_repo print_short recurse subpath command params =
     apply_global_options global_options;
     apply_build_options build_options;
     let action = not no_act in
@@ -2801,7 +2801,7 @@ let pin ?(unpin_only=false) () =
          OpamGlobalState.with_ `Lock_none @@ fun gt ->
          OpamSwitchState.with_ `Lock_write gt @@ fun st ->
          OpamSwitchState.drop @@
-         OpamClient.PIN.pin st name ?version ~edit ~action pin;
+         OpamClient.PIN.pin st name ?version ~edit ~action ?subpath pin;
          `Ok ()
        | `Error e -> `Error (false, e))
     | command, params -> bad_subcommand commands ("pin", command, params)
@@ -2809,7 +2809,7 @@ let pin ?(unpin_only=false) () =
   Term.ret
     Term.(const pin
           $global_options $build_options
-          $kind $edit $no_act $dev_repo $print_short_flag $recurse
+          $kind $edit $no_act $dev_repo $print_short_flag $recurse $subpath
           $command $params),
   term_info "pin" ~doc ~man
 

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -20,7 +20,10 @@ let string_of_pinned opam =
   let bold = OpamConsole.colorise `bold in
   Printf.sprintf "pinned %s (version %s)"
     (OpamStd.Option.to_string ~none:(bold "locally")
-       (fun u -> "to " ^ (bold (OpamUrl.to_string (OpamFile.URL.url u))))
+       (fun u -> Printf.sprintf "to %s%s"
+           (bold (OpamUrl.to_string (OpamFile.URL.url u)))
+           (OpamStd.Option.map_default (fun s -> bold (" ("^s^")"))
+              "" (OpamFile.URL.subpath u)))
        (OpamFile.OPAM.url opam))
     (bold (OpamPackage.Version.to_string (OpamFile.OPAM.version opam)))
 

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -556,7 +556,11 @@ and source_pin
     let opam =
       match OpamFile.OPAM.get_url opam with
       | Some _ -> opam
-      | None -> OpamFile.OPAM.with_url_opt urlf opam
+      | None ->
+        (let opam = OpamFile.OPAM.with_url_opt urlf opam in
+         match subpath with
+         | None -> opam
+         | Some _ -> OpamFile.OPAM.with_opam2_1_restriction opam)
     in
     let version =
       OpamStd.Option.Op.(OpamFile.OPAM.version_opt opam +! nv.version)

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -637,14 +637,20 @@ let list st ~short =
   let lines nv =
     try
       let opam = OpamSwitchState.opam st nv in
-      let url = OpamFile.OPAM.get_url opam in
+      let url = OpamFile.OPAM.url opam in
       let kind, target =
         if OpamSwitchState.is_version_pinned st nv.name then
           "version", OpamPackage.Version.to_string nv.version
         else
         match url with
-        | Some u ->
-          OpamUrl.string_of_backend u.OpamUrl.backend, OpamUrl.to_string u
+        | Some url ->
+          let u = OpamFile.URL.url url in
+          let subpath =
+            match OpamFile.URL.subpath url with
+            | None -> ""
+            | Some s -> " ("^s^")" in
+          OpamUrl.string_of_backend u.OpamUrl.backend,
+          OpamUrl.to_string u ^ subpath
         | None -> "local definition", ""
       in
       let state, extra =

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -556,11 +556,7 @@ and source_pin
     let opam =
       match OpamFile.OPAM.get_url opam with
       | Some _ -> opam
-      | None ->
-        (let opam = OpamFile.OPAM.with_url_opt urlf opam in
-         match subpath with
-         | None -> opam
-         | Some _ -> OpamFile.OPAM.with_opam2_1_restriction opam)
+      | None -> OpamFile.OPAM.with_url_opt urlf opam
     in
     let version =
       OpamStd.Option.Op.(OpamFile.OPAM.version_opt opam +! nv.version)

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -54,7 +54,7 @@ let read_opam_file_for_pinning ?(quiet=false) name f url =
 
 exception Fetch_Fail of string
 
-let get_source_definition ?version st nv url =
+let get_source_definition ?version ?subpath st nv url =
   let root = st.switch_global.root in
   let srcdir = OpamPath.Switch.pinned_package root st.switch nv.name in
   let fix opam =
@@ -65,7 +65,7 @@ let get_source_definition ?version st nv url =
     opam
   in
   let open OpamProcess.Job.Op in
-  OpamUpdate.fetch_dev_package url srcdir nv @@| function
+  OpamUpdate.fetch_dev_package url srcdir ?subpath nv @@| function
   | Not_available (_,s) -> raise (Fetch_Fail s)
   | Up_to_date _ | Result _ ->
     let subsrcdir =
@@ -473,7 +473,7 @@ and source_pin
       OpamStd.Option.Op.(
         opam_opt >>+ fun () ->
         urlf >>= fun url ->
-        OpamProcess.Job.run @@ get_source_definition ?version st nv url
+        OpamProcess.Job.run @@ get_source_definition ?version ?subpath st nv url
       )
     with Fetch_Fail err ->
       if force then None else

--- a/src/client/opamPinCommand.mli
+++ b/src/client/opamPinCommand.mli
@@ -35,7 +35,7 @@ exception Nothing_to_do
 val source_pin:
   rw switch_state -> name ->
   ?version:version -> ?edit:bool -> ?opam:OpamFile.OPAM.t -> ?quiet:bool ->
-  ?force:bool -> ?ignore_extra_pins:bool ->
+  ?force:bool -> ?ignore_extra_pins:bool -> ?subpath: string ->
   url option ->
   rw switch_state
 

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -404,7 +404,15 @@ let parallel_apply t ~requested ?add_roots ~assume_built ?(force_remove=false)
             !t_ref.conf_files; }
     in
     let nv = action_contents action in
-    let source_dir = OpamSwitchState.source_dir t nv in
+    let opam = OpamSwitchState.opam t nv in
+    let source_dir =
+      let raw = OpamSwitchState.source_dir t nv in
+      match OpamFile.OPAM.url opam with
+      | None -> raw
+      | Some url ->
+        match OpamFile.URL.subpath url with
+        | None -> raw
+        | Some subpath -> OpamFilename.Op.(raw / subpath) in
     if OpamClientConfig.(!r.fake) then
       match action with
       | `Build _ | `Fetch _ -> Done (`Successful (installed, removed))

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1945,9 +1945,11 @@ module URLSyntax = struct
            (Pp.V.string -| Pp.of_module "checksum" (module OpamHash)));
       "mirrors", Pp.ppacc with_mirrors mirrors
         (Pp.V.map_list ~depth:1 Pp.V.url);
+      (* Disable for 2.1.0
       "subpath", Pp.ppacc_opt
         with_subpath subpath
         Pp.V.string;
+      *)
     ]
 
   let pp_contents =
@@ -2303,6 +2305,28 @@ module OPAMSyntax = struct
   let with_ocaml_version ocaml_version t =
     { t with ocaml_version = Some ocaml_version }
   let with_os os t = { t with os }
+
+  let with_opam2_1_restriction t =
+    let opam_version = OpamVariable.of_string "opam-version" in
+    let available =
+      let opam_restricted =
+        OpamFilter.fold_down_left (fun acc filter ->
+            if acc then acc else
+            match filter with
+            | FOp (FIdent (_, var, _), (`Eq|`Geq), FString version) ->
+              var = opam_version &&
+              OpamVersion.(compare (of_string version) (of_string "2.1")) >= 0
+            | _ -> false) false t.available
+      in
+      if opam_restricted then t.available else
+      let opam_restriction =
+        FOp (FIdent ([], opam_version, None), `Geq, FString "2.1")
+      in
+      match t.available with
+      | FBool true -> opam_restriction
+      | available -> FAnd (available, opam_restriction)
+    in
+    { t with available }
 
   (* Post-processing functions used for some fields (optional, because we
      don't want them when linting). It's better to do them in the same pass
@@ -2673,6 +2697,42 @@ module OPAMSyntax = struct
     in
     Pp.pp parse (fun x -> x)
 
+  let handle_subpath_2_0 =
+    let subpath_xfield = "x-subpath" in
+    let parse ~pos:_ t =
+      match OpamStd.String.Map.find_opt subpath_xfield t.extensions with
+      | Some (_, String (pos,subpath)) ->
+        let extensions =
+          OpamStd.String.Map.remove subpath_xfield t.extensions
+        in
+        let url =
+          OpamStd.Option.Op.(t.url >>| (fun u ->
+              (match u.subpath with
+               | Some sb ->
+                 Pp.warn ~pos "%s already defined (%s) in the opam file, \
+                               it is replaced by %s."
+                   (OpamConsole.colorise `underline "subpath") sb subpath
+               | None -> ());
+              URL.with_subpath subpath u))
+        in
+        with_opam2_1_restriction { t with url; extensions }
+      | Some (pos, _) ->
+        Pp.warn ~pos ~strict:true "%s field contains a non string value"
+          (OpamConsole.colorise `underline subpath_xfield);
+        t
+      | None -> t
+
+    in
+    let print t =
+      match t.url with
+      | Some ({ URL.subpath = Some sb ; _ } as url) ->
+        add_extension t subpath_xfield (String (pos_null, sb))
+        |> with_url (URL.with_subpath_opt None url)
+        |> with_opam2_1_restriction
+      | _ -> t
+    in
+    Pp.pp parse print
+
   (* Doesn't handle package name encoded in directory name *)
   let pp_raw_fields =
     Pp.I.check_opam_version ~format_version () -|
@@ -2685,7 +2745,8 @@ module OPAMSyntax = struct
        OpamStd.String.Map.(Pp.pp (fun ~pos:_ -> of_list) bindings)) -|
     Pp.pp
       (fun ~pos:_ (t, extensions) -> with_extensions extensions t)
-      (fun t -> t, extensions t)
+      (fun t -> t, extensions t) -|
+    handle_subpath_2_0
 
   let pp_raw = Pp.I.map_file @@ pp_raw_fields
 
@@ -2725,7 +2786,8 @@ module OPAMSyntax = struct
                   (OpamStd.Option.default (nv.OpamPackage.name) t.name)
                   (OpamStd.Option.default (nv.OpamPackage.version) t.version))
                (OpamFilename.prettify filename);
-           {t with name = None; version = None})
+           {t with name = None; version = None}
+      )
 
   let to_string_with_preserved_format
       ?format_from ?format_from_string filename t =

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1918,6 +1918,7 @@ module URLSyntax = struct
   let with_mirrors mirrors t = { t with mirrors }
   let with_checksum checksum t = { t with checksum = checksum }
   let with_subpath subpath t = { t with subpath = Some subpath }
+  let with_subpath_opt subpath t = { t with subpath = subpath }
 
   let fields =
     let with_url url t =

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1893,11 +1893,12 @@ module URLSyntax = struct
     mirrors : url list;
     checksum: OpamHash.t list;
     errors  : (string * Pp.bad_format) list;
+    subpath : string option;
   }
 
-  let create ?(mirrors=[]) ?(checksum=[]) url =
+  let create ?(mirrors=[]) ?(checksum=[]) ?subpath url =
     {
-      url; mirrors; checksum; errors = [];
+      url; mirrors; checksum; errors = []; subpath;
     }
 
   let empty = {
@@ -1905,15 +1906,18 @@ module URLSyntax = struct
     mirrors = [];
     checksum= [];
     errors  = [];
+    subpath = None;
   }
 
   let url t = t.url
   let mirrors t = t.mirrors
   let checksum t = t.checksum
+  let subpath t = t.subpath
 
   let with_url url t = { t with url }
   let with_mirrors mirrors t = { t with mirrors }
   let with_checksum checksum t = { t with checksum = checksum }
+  let with_subpath subpath t = { t with subpath = Some subpath }
 
   let fields =
     let with_url url t =
@@ -1940,6 +1944,9 @@ module URLSyntax = struct
            (Pp.V.string -| Pp.of_module "checksum" (module OpamHash)));
       "mirrors", Pp.ppacc with_mirrors mirrors
         (Pp.V.map_list ~depth:1 Pp.V.url);
+      "subpath", Pp.ppacc_opt
+        with_subpath subpath
+        Pp.V.string;
     ]
 
   let pp_contents =

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -273,6 +273,8 @@ module URL: sig
 
   (** Constructor *)
   val with_checksum: OpamHash.t list -> t -> t
+  val with_subpath: string -> t -> t
+  val with_subpath_opt: string option -> t -> t
 
   val subpath: t -> string option
 

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -640,10 +640,6 @@ module OPAM: sig
 
   val with_format_errors: (string * OpamPp.bad_format) list -> t -> t
 
-  (** `x-subpath` restriction: add 2.1 (or further) opam version restriction on
-      file when `x-subpath` field is used *)
-  val with_opam2_1_restriction: t -> t (*  *)
-
   (** Prints to a string, while keeping the format of the original file as much
       as possible. The original format is read from the given
       [format_from_string], the file [format_from], or the output file if

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -640,6 +640,8 @@ module OPAM: sig
 
   val with_format_errors: (string * OpamPp.bad_format) list -> t -> t
 
+  val with_opam2_1_restriction: t -> t (* x-subpath 2.1 restriction *)
+
   (** Prints to a string, while keeping the format of the original file as much
       as possible. The original format is read from the given
       [format_from_string], the file [format_from], or the output file if

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -640,7 +640,9 @@ module OPAM: sig
 
   val with_format_errors: (string * OpamPp.bad_format) list -> t -> t
 
-  val with_opam2_1_restriction: t -> t (* x-subpath 2.1 restriction *)
+  (** `x-subpath` restriction: add 2.1 (or further) opam version restriction on
+      file when `x-subpath` field is used *)
+  val with_opam2_1_restriction: t -> t (*  *)
 
   (** Prints to a string, while keeping the format of the original file as much
       as possible. The original format is read from the given

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -259,7 +259,9 @@ module URL: sig
 
   include IO_FILE
 
-  val create: ?mirrors:url list -> ?checksum:OpamHash.t list -> url -> t
+  val create:
+    ?mirrors:url list -> ?checksum:OpamHash.t list -> ?subpath:string ->
+    url -> t
 
   (** URL address *)
   val url: t -> url
@@ -271,6 +273,8 @@ module URL: sig
 
   (** Constructor *)
   val with_checksum: OpamHash.t list -> t -> t
+
+  val subpath: t -> string option
 
 end
 

--- a/src/repository/opamDarcs.ml
+++ b/src/repository/opamDarcs.ml
@@ -157,7 +157,7 @@ module VCS = struct
 
   let current_branch _dir = Done None (* No branches in Darcs *)
 
-  let is_dirty dir =
+  let is_dirty ?subpath:_ dir =
     darcs dir [ "whatsnew"; "--quiet"; "--summary" ]
     @@> fun r -> Done (OpamProcess.check_success_and_cleanup r)
 

--- a/src/repository/opamDarcs.ml
+++ b/src/repository/opamDarcs.ml
@@ -48,7 +48,7 @@ module VCS = struct
   (* Marks the current state, in the form of a reversing patch on top of the
      fetched state *)
 
-  let fetch ?cache_dir:_ repo_root repo_url =
+  let fetch ?cache_dir:_ ?subpath:_ repo_root repo_url =
     (* Just do a fresh pull into a temp directory, and replace _darcs/
        There is no easy way to diff or make sure darcs forgets about local
        patches otherwise. *)

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -214,8 +214,12 @@ module VCS : OpamVCS.VCS = struct
     | _ ->
       Done (Some "HEAD")
 
-  let is_dirty dir =
-    git dir [ "diff" ; "--no-ext-diff" ; "--quiet" ]
+  let is_dirty ?subpath dir =
+    let subpath =
+      match subpath with
+      | None -> []
+      | Some dir -> ["--" ; dir] in
+    git dir ([ "diff"; "--no-ext-diff"; "--quiet" ; "HEAD" ] @ subpath)
     @@> function
     | { OpamProcess.r_code = 0; _ } ->
       (git dir ["ls-files"; "--others"; "--exclude-standard"]

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -61,7 +61,15 @@ module VCS : OpamVCS.VCS = struct
     | Some h -> "refs/remotes/opam-ref-"^h
     | None -> "refs/remotes/opam-ref"
 
-  let fetch ?cache_dir repo_root repo_url =
+  let fetch ?cache_dir ?subpath repo_root repo_url =
+    (match subpath with
+     | Some sp ->
+       git repo_root [ "config"; "--local"; "core.sparseCheckout"; "true" ]
+       @@> fun r -> OpamSystem.raise_on_process_error r;
+       OpamFilename.write (repo_root / ".git" / "info" // "sparse-checkout") sp;
+       Done()
+     | None -> Done())
+    @@+ fun _ ->
     (match cache_dir with
      | Some c when OpamUrl.local_dir repo_url = None ->
        let dir = c / "git" in

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -89,7 +89,8 @@ module B = struct
   let revision _ =
     Done None
 
-  let sync_dirty dir url = pull_url dir None url
+  let sync_dirty ?subpath:_ dir url = pull_url dir None url
+  (* do not propagate *)
 
   let get_remote_url ?hash:_ _ =
     Done None

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -68,7 +68,7 @@ module B = struct
 
   let repo_update_complete _ _ = Done ()
 
-  let pull_url ?cache_dir:_ dirname checksum remote_url =
+  let pull_url ?cache_dir:_ ?subpath:_ dirname checksum remote_url =
     log "pull-file into %a: %a"
       (slog OpamFilename.Dir.to_string) dirname
       (slog OpamUrl.to_string) remote_url;

--- a/src/repository/opamHg.ml
+++ b/src/repository/opamHg.ml
@@ -111,7 +111,7 @@ module VCS = struct
             | branch::_ when branch <> "default" -> Done (Some branch)
             | _ -> Done None
 
-  let is_dirty repo_root =
+  let is_dirty ?subpath:_ repo_root =
     hg repo_root [ "status"; "--subrepos" ] @@> fun r ->
     OpamSystem.raise_on_process_error r;
     Done (r.OpamProcess.r_stdout = [])

--- a/src/repository/opamHg.ml
+++ b/src/repository/opamHg.ml
@@ -37,7 +37,7 @@ module VCS = struct
     | None -> mark_prefix
     | Some fragment -> mark_prefix ^ "-" ^ fragment
 
-  let fetch ?cache_dir:_ repo_root repo_url =
+  let fetch ?cache_dir:_ ?subpath:_ repo_root repo_url =
     let src = OpamUrl.base_url repo_url in
     let rev = OpamStd.Option.default "default" repo_url.OpamUrl.hash in
     let mark = mark_from_url repo_url in

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -238,7 +238,7 @@ module B = struct
   let revision _ =
     Done None
 
-  let sync_dirty dir url = pull_url dir None url
+  let sync_dirty ?subpath dir url = pull_url ?subpath dir None url
 
   let get_remote_url ?hash:_ _ =
     Done None

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -192,9 +192,17 @@ module B = struct
 
   let repo_update_complete _ _ = Done ()
 
-  let pull_url ?cache_dir:_ local_dirname _checksum remote_url =
+  let pull_url ?cache_dir:_ ?subpath local_dirname _checksum remote_url =
+    let local_dirname =
+      OpamStd.Option.map_default (fun x -> OpamFilename.Op.(local_dirname / x))
+        local_dirname subpath
+    in
     OpamFilename.mkdir local_dirname;
     let dir = OpamFilename.Dir.to_string local_dirname in
+    let remote_url =
+      OpamStd.Option.map_default (fun x -> OpamUrl.Op.(remote_url / x))
+        remote_url subpath
+    in
     let remote_url =
       match OpamUrl.local_dir remote_url with
       | Some _ ->

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -62,9 +62,7 @@ let rsync ?(args=[]) ?(exclude_vcdirs=true) src dst =
   let overlap src dst =
     let norm d = Filename.concat d "" in
     OpamStd.String.starts_with ~prefix:(norm src) (norm dst) &&
-    not (OpamStd.String.starts_with
-           ~prefix:(norm (Filename.concat src OpamSwitch.external_dirname))
-           (norm dst)) ||
+    not (OpamStd.String.contains ~sub:OpamSwitch.external_dirname (norm dst)) ||
     OpamStd.String.starts_with ~prefix:(norm dst) (norm src)
   in
   (* See also OpamVCS.sync_dirty *)

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -463,9 +463,9 @@ let current_branch url =
   on_local_version_control url ~default:(Done None) @@
   fun dir (module VCS) -> VCS.current_branch dir
 
-let is_dirty url =
+let is_dirty ?subpath url =
   on_local_version_control url ~default:(Done false) @@
-  fun dir (module VCS) -> VCS.is_dirty dir
+  fun dir (module VCS) -> VCS.is_dirty ?subpath dir
 
 let report_fetch_result pkg = function
   | Result msg ->

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -178,6 +178,20 @@ let pull_from_upstream
         in
         rsync, pull
        )
+     else if OpamUrl.(match url.backend with | `git -> true | _ -> false)
+          && OpamFilename.exists_dir pin_cache_dir then
+       (log "Pin cache (git) existing for %s : %s\n"
+          (OpamUrl.to_string url) @@ OpamFilename.Dir.to_string pin_cache_dir;
+        let git_cached =
+          OpamUrl.parse ~backend:`git
+          @@ OpamFilename.Dir.to_string pin_cache_dir
+        in
+        let pull =
+          let module BR = (val url_backend git_cached: OpamRepositoryBackend.S) in
+          BR.pull_url
+        in
+        git_cached, pull
+       )
      else url, B.pull_url
    in
    pull ?cache_dir ?subpath destdir cksum url

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -160,7 +160,7 @@ let pull_from_upstream
       (OpamUrl.string_of_backend url.OpamUrl.backend)
   in
   OpamProcess.Job.with_text text @@
-  (if working_dir then B.sync_dirty destdir url
+  (if working_dir then B.sync_dirty ?subpath destdir url
    else
    let pin_cache_dir = OpamRepositoryPath.pin_cache url in
    let url, pull =

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -152,7 +152,7 @@ let validate_and_add_to_cache label url cache_dir file checksums =
 
 (* [cache_dir] used to add to cache only *)
 let pull_from_upstream
-    label ?(working_dir=false) cache_dir destdir checksums url =
+    label ?(working_dir=false) ?subpath cache_dir destdir checksums url =
   let module B = (val url_backend url: OpamRepositoryBackend.S) in
   let cksum = match checksums with [] -> None | c::_ -> Some c in
   let text =
@@ -180,7 +180,7 @@ let pull_from_upstream
        )
      else url, B.pull_url
    in
-   pull ?cache_dir destdir cksum url
+   pull ?cache_dir ?subpath destdir cksum url
   )
   @@| function
   | (Result (Some file) | Up_to_date (Some file)) as ret ->
@@ -193,14 +193,14 @@ let pull_from_upstream
   | (Result None | Up_to_date None) as ret -> ret
   | Not_available _ as na -> na
 
-let pull_from_mirrors label ?working_dir cache_dir destdir checksums urls =
+let pull_from_mirrors label ?working_dir ?subpath cache_dir destdir checksums urls =
   let rec aux = function
     | [] -> invalid_arg "pull_from_mirrors: empty mirror list"
     | [url] ->
-      pull_from_upstream label ?working_dir cache_dir destdir checksums url
+      pull_from_upstream label ?working_dir ?subpath cache_dir destdir checksums url
       @@| fun r -> url, r
     | url::mirrors ->
-      pull_from_upstream label ?working_dir cache_dir destdir checksums url
+      pull_from_upstream label ?working_dir ?subpath cache_dir destdir checksums url
       @@+ function
       | Not_available (_,s) ->
         OpamConsole.warning "%s: download of %s failed (%s), trying mirror"
@@ -219,7 +219,7 @@ let pull_from_mirrors label ?working_dir cache_dir destdir checksums urls =
   | ret -> ret
 
 let pull_tree
-    label ?cache_dir ?(cache_urls=[]) ?working_dir
+    label ?cache_dir ?(cache_urls=[]) ?working_dir ?subpath
     local_dirname checksums remote_urls =
   let extract_archive f s =
     OpamFilename.cleandir local_dirname;
@@ -258,7 +258,7 @@ let pull_tree
           Some ("missing checksum"),
           label ^ ": Missing checksum, and `--require-checksums` was set."))
     else
-      pull_from_mirrors label ?working_dir cache_dir local_dirname checksums
+      pull_from_mirrors label ?working_dir ?subpath cache_dir local_dirname checksums
         remote_urls
       @@+ function
       | _, Up_to_date None -> Done (Up_to_date "no changes")

--- a/src/repository/opamRepository.mli
+++ b/src/repository/opamRepository.mli
@@ -61,7 +61,7 @@ val current_branch: url -> string option OpamProcess.job
 
 (** Returns true if the url points to a local, version-controlled directory that
     has uncommitted changes *)
-val is_dirty: url -> bool OpamProcess.job
+val is_dirty: ?subpath:string -> url -> bool OpamProcess.job
 
 (** Find a backend *)
 val find_backend: repository -> (module OpamRepositoryBackend.S)

--- a/src/repository/opamRepository.mli
+++ b/src/repository/opamRepository.mli
@@ -33,7 +33,7 @@ val update: repository -> dirname -> unit OpamProcess.job
     or synchronised directly if local and [working_dir] was set. *)
 val pull_tree:
   string -> ?cache_dir:dirname -> ?cache_urls:url list -> ?working_dir:bool ->
-  dirname -> OpamHash.t list -> url list ->
+  ?subpath:string -> dirname -> OpamHash.t list -> url list ->
   string download OpamProcess.job
 
 (** Same as [pull_tree], but for fetching a single file. *)

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -22,7 +22,7 @@ type update =
 module type S = sig
   val name: OpamUrl.backend
   val pull_url:
-    ?cache_dir:dirname -> dirname -> OpamHash.t option -> url ->
+    ?cache_dir:dirname -> ?subpath:string -> dirname -> OpamHash.t option -> url ->
     filename option download OpamProcess.job
   val fetch_repo_update:
     repository_name -> ?cache_dir:dirname -> dirname -> url ->

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -29,7 +29,8 @@ module type S = sig
     update OpamProcess.job
   val repo_update_complete: dirname -> url -> unit OpamProcess.job
   val revision: dirname -> version option OpamProcess.job
-  val sync_dirty: dirname -> url -> filename option download OpamProcess.job
+  val sync_dirty:
+    ?subpath:string -> dirname -> url -> filename option download OpamProcess.job
   val get_remote_url:
     ?hash:string -> dirname ->
     url option OpamProcess.job

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -45,7 +45,7 @@ module type S = sig
       [checksum] can be used for retrieval but is NOT checked by this
       function. *)
   val pull_url:
-    ?cache_dir:dirname -> dirname -> OpamHash.t option -> url ->
+    ?cache_dir:dirname -> ?subpath:string -> dirname -> OpamHash.t option -> url ->
     filename option download OpamProcess.job
 
   (** [pull_repo_update] fetches the remote update from [url] to the local

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -73,7 +73,7 @@ module type S = sig
       [pull_url], then remove deleted files, and finally copy via rsync
       unversioned & modified-uncommitted files. *)
   val sync_dirty:
-    dirname -> url -> filename option download OpamProcess.job
+    ?subpath:string -> dirname -> url -> filename option download OpamProcess.job
 
   (** [get_remote_url ?hash dirname] return the distant url of repo [dirname], \
       if found. When [hash] is specified, it checks that this hash (branch or \

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -26,7 +26,7 @@ module type VCS = sig
   val versioned_files: dirname -> string list OpamProcess.job
   val vc_dir: dirname -> dirname
   val current_branch: dirname -> string option OpamProcess.job
-  val is_dirty: dirname -> bool OpamProcess.job
+  val is_dirty: ?subpath:string -> dirname -> bool OpamProcess.job
   val modified_files: dirname -> string list OpamProcess.job
   val get_remote_url: ?hash:string -> dirname -> url option OpamProcess.job
 end

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -100,16 +100,27 @@ module Make (VCS: VCS) = struct
     VCS.revision repo_root @@+ fun r ->
     Done (OpamStd.Option.map OpamPackage.Version.of_string r)
 
-  let sync_dirty repo_root repo_url =
-    pull_url repo_root None repo_url @@+ fun result ->
+  let sync_dirty ?subpath repo_root repo_url =
+    let filter_subpath files =
+      match subpath with
+      | None -> files
+      | Some sp ->
+        OpamStd.List.filter_map
+          (fun f ->
+             if OpamStd.String.remove_prefix ~prefix:(sp ^ Filename.dir_sep) f
+                <> f then Some f else None)
+          files
+    in
+    pull_url ?subpath repo_root None repo_url @@+ fun result ->
     match OpamUrl.local_dir repo_url with
     | None -> Done (result)
     | Some dir ->
       VCS.versioned_files dir @@+ fun vc_files ->
       VCS.modified_files dir @@+ fun vc_dirty_files ->
       let files =
-        List.map OpamFilename.(remove_prefix dir)
-          (OpamFilename.rec_files dir)
+        filter_subpath
+          (List.map OpamFilename.(remove_prefix dir)
+             (OpamFilename.rec_files dir))
       in
       (* Remove non-listed files from destination *)
       (* fixme: doesn't clean directories *)
@@ -135,8 +146,8 @@ module Make (VCS: VCS) = struct
               exc)
           fset
       in
-      let vcset = OpamStd.String.Set.of_list vc_files in
-      let vc_dirty_set = OpamStd.String.Set.of_list vc_dirty_files in
+      let vcset = OpamStd.String.Set.of_list (filter_subpath vc_files) in
+      let vc_dirty_set = OpamStd.String.Set.of_list (filter_subpath vc_dirty_files) in
       let final_set =
         OpamStd.String.Set.Op.(fset -- vcset ++ vc_dirty_set -- excluded)
       in

--- a/src/repository/opamVCS.mli
+++ b/src/repository/opamVCS.mli
@@ -28,7 +28,7 @@ module type VCS = sig
       in a staging area.
       Be aware that the remote URL might have been changed, so make sure
       to update accordingly. *)
-  val fetch: ?cache_dir:dirname -> dirname -> url -> unit OpamProcess.job
+  val fetch: ?cache_dir:dirname -> ?subpath:string -> dirname -> url -> unit OpamProcess.job
 
   (** Reset the master branch of the repository to match the remote repository
       state. This might still fetch more data (git submodules...), so is

--- a/src/repository/opamVCS.mli
+++ b/src/repository/opamVCS.mli
@@ -65,7 +65,7 @@ module type VCS = sig
       recorded in the VCS as current. This differs from [is_up_to_date], which
       compares specifically to the last fetched state. This should always be
       [false] after [reset] has been called. *)
-  val is_dirty: dirname -> bool OpamProcess.job
+  val is_dirty: ?subpath:string -> dirname -> bool OpamProcess.job
 
   (** Returns the list of files under version control, modified in the working
       tree but not comitted *)

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -682,8 +682,8 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
             else
             let msg =
               let is_singular = function [_] -> true | _ -> false in
-              Printf.sprintf "Checksum%s match the archive: %s."
-                (if is_singular not_corresponding then " doesn't" else "s don't")
+              Printf.sprintf "The archive doesn't match checksum%s: %s."
+                (if is_singular not_corresponding then "" else "s")
                 (OpamStd.List.to_string OpamHash.to_string not_corresponding)
             in
             Some msg)

--- a/src/state/opamPinned.ml
+++ b/src/state/opamPinned.ml
@@ -191,8 +191,13 @@ let files_in_source ?(recurse=false) ?subpath d =
              match OpamFilename.opt_file OpamFilename.Op.(d//"opam") with
              | None -> acc
              | Some f -> (f, base) :: acc
-           else if recurse then
-             let basename = OpamFilename.(Base.to_string (basename_dir d)) in
+           else
+           let base_dir = OpamFilename.basename_dir d in
+           let basename = OpamFilename.Base.to_string base_dir in
+           if recurse &&
+              base_dir <> OpamFilename.Base.of_string OpamSwitch.external_dirname &&
+              not (OpamStd.String.starts_with ~prefix:"." basename)
+           then
              let base = match base with
                | None -> Some basename
                | Some base -> Some (Filename.concat base basename) in

--- a/src/state/opamPinned.mli
+++ b/src/state/opamPinned.mli
@@ -38,6 +38,7 @@ val find_opam_file_in_source: name -> dirname -> OpamFile.OPAM.t OpamFile.t opti
     [OpamStateConfig.(!r.locked)] *)
 val files_in_source:
   ?recurse:bool ->
+  ?subpath:string ->
   dirname -> (name option * OpamFile.OPAM.t OpamFile.t * string option) list
 
 (** From an opam file location, sitting below the given project directory, find

--- a/src/state/opamPinned.mli
+++ b/src/state/opamPinned.mli
@@ -37,7 +37,8 @@ val find_opam_file_in_source: name -> dirname -> OpamFile.OPAM.t OpamFile.t opti
     [pkgname.opam/opam], etc. This is affected by
     [OpamStateConfig.(!r.locked)] *)
 val files_in_source:
-  dirname -> (name option * OpamFile.OPAM.t OpamFile.t) list
+  ?recurse:bool ->
+  dirname -> (name option * OpamFile.OPAM.t OpamFile.t * string option) list
 
 (** From an opam file location, sitting below the given project directory, find
     the corresponding package name if specified ([<name>.opam] or

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -375,6 +375,15 @@ let url st nv =
 let primary_url st nv =
   OpamStd.Option.Op.(url st nv >>| OpamFile.URL.url)
 
+let primary_url_with_subpath st nv =
+  match url st nv with
+  | None -> None
+  | Some urlf ->
+    let url = OpamFile.URL.url urlf in
+    match OpamFile.URL.subpath urlf with
+    | None -> Some url
+    | Some subpath -> Some (OpamUrl.Op.(url / subpath))
+
 let files st nv =
   match opam_opt st nv with
   | None -> []

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -95,6 +95,8 @@ val url: 'a switch_state -> package -> OpamFile.URL.t option
 (** Returns the primary URL from the URL field of the given package *)
 val primary_url: 'a switch_state -> package -> url option
 
+val primary_url_with_subpath: 'a switch_state -> package -> url option
+
 (** Return the descr field for the given package (or an empty descr if none) *)
 val descr: 'a switch_state -> package -> OpamFile.Descr.t
 

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -173,16 +173,15 @@ let repositories rt repos =
   OpamRepositoryState.Cache.save rt;
   failed, rt
 
-let fetch_dev_package url srcdir ?(working_dir=false) nv =
+let fetch_dev_package url srcdir ?(working_dir=false) ?subpath nv =
   let remote_url = OpamFile.URL.url url in
   let mirrors = remote_url :: OpamFile.URL.mirrors url in
   let checksum = OpamFile.URL.checksum url in
   log "updating %a" (slog OpamUrl.to_string) remote_url;
   OpamRepository.pull_tree
     ~cache_dir:(OpamRepositoryPath.download_cache OpamStateConfig.(!r.root_dir))
-    (OpamPackage.to_string nv) srcdir checksum ~working_dir mirrors
+    (OpamPackage.to_string nv) srcdir checksum ~working_dir ?subpath mirrors
   @@| OpamRepository.report_fetch_result nv
-
 
 let pinned_package st ?version ?(working_dir=false) name =
   log "update-pinned-package %s%a" (OpamPackage.Name.to_string name)

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -520,7 +520,7 @@ let download_package_source st nv dirname =
     | None   -> Done None
     | Some u ->
       (OpamRepository.pull_tree (OpamPackage.to_string nv)
-        ~cache_dir ~cache_urls
+        ~cache_dir ~cache_urls ?subpath:(OpamFile.URL.subpath u)
         dirname
         (OpamFile.URL.checksum u)
         (OpamFile.URL.url u :: OpamFile.URL.mirrors u))

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -177,7 +177,8 @@ let fetch_dev_package url srcdir ?(working_dir=false) ?subpath nv =
   let remote_url = OpamFile.URL.url url in
   let mirrors = remote_url :: OpamFile.URL.mirrors url in
   let checksum = OpamFile.URL.checksum url in
-  log "updating %a" (slog OpamUrl.to_string) remote_url;
+  log "updating %a%a" (slog OpamUrl.to_string) remote_url
+    (slog (OpamStd.Option.map_default (fun s -> " ("^s^")") "")) subpath;
   OpamRepository.pull_tree
     ~cache_dir:(OpamRepositoryPath.download_cache OpamStateConfig.(!r.root_dir))
     (OpamPackage.to_string nv) srcdir checksum ~working_dir ?subpath mirrors

--- a/src/state/opamUpdate.mli
+++ b/src/state/opamUpdate.mli
@@ -91,5 +91,5 @@ val cleanup_source:
 
 (** Low-level function to retrieve the package source into its local cache *)
 val fetch_dev_package:
-  OpamFile.URL.t -> dirname -> ?working_dir:bool -> package ->
+  OpamFile.URL.t -> dirname -> ?working_dir:bool -> ?subpath:string -> package ->
   unit download OpamProcess.job


### PR DESCRIPTION
This PR is the continuation of #3174, started by @hnrgrgr.

It introduces recursive, subpath based, and subpath recursive pin, with options `--recursive` and `--subpath PATH`.

On recursive mode, opam goes throught subdirectories to find opam files & pin them to their subdirectories.
On subpath based mode, opam goes to the given subdirectory to find opam file & pin it to this subdrectory.

Mixed pins are not allowed, pin kind is the top directory kind. If git repos are subdirectory of a local directory, thoses packages will be pinned as path based. If a subdirectory is not versionned of a top git directory, it is ignored (as it is git-based copy).

Internally, opam doesn't copy the whole top directories (except for `hg` & `darcs`), only the content of subdirectory of each subpath based package and its full directory structure from the top directory. Also, for `git+http` backend, git repository is downloaded only once, sub pins are retrieved from pin cache.

These options are available for: `pin`, `unpin`, `remove`, `install`, `reinstall`, `upgrade`, and `lint`. `opam source` also handles it, it copies the sources of the subdirectory content only.

A pin example can be found [in this gist](https://gist.github.com/rjbou/d634da7333ac0bbe40c9dfb75c4e5c6e).

~*Note: This PR is a **WIP**, it needs to be **tested**, and at the end git tree need to be cleaned before merge.*~
Closes #3174
Closes #3477