### PR TITLE
Tar extract fail error message

### DIFF
--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -237,10 +237,8 @@ let pull_tree
     OpamFilename.cleandir local_dirname;
     OpamFilename.extract_job f local_dirname @@+ function
     | None -> Done (Up_to_date ())
-    | Some (Failure _) ->
-      Done (Not_available (Some "Could not extract archive",
-                           OpamFilename.(Base.to_string (basename f))^
-                            " (could not extract archive)"))
+    | Some (Failure s) ->
+      Done (Not_available (Some "Could not extract archive", s))
     | Some e -> Done (Not_available (None, Printexc.to_string e))
   in
   (match cache_dir with


### PR DESCRIPTION
This PR closes #3497.
If a `tar` extract fails, it checks the presence of underlying command (`bzip2`, `xz`, `lzma`, `gzip`) to display the error message in verbose mode.