### PR TITLE
install.sh: use `-g 0` instead of `-g root`

### DIFF
--- a/shell/install.sh
+++ b/shell/install.sh
@@ -78,7 +78,7 @@ xsudo() {
         echo "Write access to $DSTDIR required, using 'sudo'."
         echo "Command: $CMD $@"
         if [ "$CMD" = "install" ]; then
-            sudo "$CMD" -g root -o root "$@"
+            sudo "$CMD" -g 0 -o root "$@"
         else
             sudo "$CMD" "$@"
         fi


### PR DESCRIPTION
In some OSX installations there is no `root` group so this command fails, if we instead default to `-g 0`, it will install correctly using the `wheel` group