### PR TITLE
Don't continue with checksum check if openssl sha512 is unavailable

### DIFF
--- a/shell/install.sh
+++ b/shell/install.sh
@@ -158,7 +158,7 @@ bin_sha512() {
 }
 
 check_sha512() {
-  if command -v openssl > /dev/null && ! openssl sha512 2>&1 < /dev/null | grep Error > /dev/null; then
+  if command -v openssl > /dev/null && [ "$(openssl sha512 2>&1 < /dev/null)" = "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e" ]; then
     sha512=`openssl sha512 "$TMP/$OPAM_BIN" 2> /dev/null | cut -f 2 -d ' '`
     check=`bin_sha512`
     test "x$sha512" = "x$check"

--- a/shell/install.sh
+++ b/shell/install.sh
@@ -158,7 +158,7 @@ bin_sha512() {
 }
 
 check_sha512() {
-  if command -v openssl > /dev/null; then
+  if command -v openssl > /dev/null && ! openssl sha512 2>&1 < /dev/null | grep Error > /dev/null; then
     sha512=`openssl sha512 "$TMP/$OPAM_BIN" 2> /dev/null | cut -f 2 -d ' '`
     check=`bin_sha512`
     test "x$sha512" = "x$check"


### PR DESCRIPTION
On some macOS versions openssl doesn't come with sha256 support by default:
```
[~] openssl sha512 < /dev/null
openssl:Error: 'sha512' is an invalid command.
```

If that's the case the installation script currently fails with a checksum mismatch, which is not desiderable