### PR TITLE
Remove link only if it exists

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -500,7 +500,7 @@ let remove_package_aux
         (OpamPath.Switch.bin root t.switch t.switch_config)
         (OpamFilename.basename link)
     in
-    if OpamFilename.readlink link = bin then
+    if OpamFilename.exists link && OpamFilename.readlink link = bin then
       OpamFilename.remove link
   );
 


### PR DESCRIPTION
This PR is related to https://github.com/ocaml/opam-depext/issues/104.
If a plugin fails to install, it is silently removed, which leads to a missing link error, hiding the real one.