### PR TITLE
Steps towards sudo-enabled make install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,5 @@ doc/tutorials/opam.wiki
 doc/dev-manual/*.out
 doc/man
 doc/pages/*.html
+doc/*.build
 src/x_build_libs.ocp

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ OPAMINSTALLER = ./opam-installer$(EXE)
 ALWAYS:
 	@
 
-JBUILDER_DEP = ALWAYS $(JBUILDER_FILE)
+JBUILDER_DEP = $(JBUILDER_FILE)
 
 src_ext/jbuilder/_build/install/default/bin/jbuilder$(EXE): src_ext/jbuilder.stamp
 	cd src_ext/jbuilder && ocaml bootstrap.ml && ./boot.exe

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,6 +13,7 @@ endif
 
 ifndef OPAM
   OPAM = $(JBUILDER) exec -- opam
+  OPAM_DEP := $(shell $(JBUILDER) exec -- which opam)
 endif
 
 TOPICS  = $(shell $(OPAM) help topics)
@@ -22,12 +23,16 @@ HELPFMT = --help=groff
 
 ifndef OPAM_INSTALLER
   OPAM_INSTALLER = $(JBUILDER) exec -- opam-installer
+  OPAM_INSTALLER_DEP := $(shell $(JBUILDER) exec -- which opam-installer)
 endif
 
 .PHONY: man html dev-manual pages
 all: man dev html pages
 
-man:
+man: man.build
+	@
+
+man.build: $(OPAM_DEP) $(OPAM_INSTALLER_DEP)
 	rm -rf man
 	mkdir -p man
 	$(OPAM) $(HELPFMT) > man/opam.1
@@ -39,6 +44,7 @@ man:
 	  $(OPAM) admin $$i $(HELPFMT) > man/opam-admin-$$i.1;\
 	done
 	$(OPAM_INSTALLER) $(HELPFMT) > man/opam-installer.1
+	touch $@
 
 man-html: man
 	rm -rf man-html
@@ -78,5 +84,5 @@ PAGES=$(wildcard pages/*.md)
 pages: $(PAGES:.md=.html)
 
 clean:
-	rm -rf dependencies.dot man html/ocamldoc man-html pages/*.html html/index.html
+	rm -rf dependencies.dot man html/ocamldoc man-html pages/*.html html/index.html man.build
 	$(MAKE) -C dev-manual clean


### PR DESCRIPTION
At the moment a jbuilder-less installation cannot do `sudo make install` because opam attempts to build things. I believe the GNU standards recommend that `make` should do everything necessary so that `make install` doesn't have to build anything. This PR attempts to move towards that. You can now run:
 - `./configure`
 - `make lib-ext`
 - `make opam-actual.install`
 - `sudo make install`

in an environment which *only* has OCaml installed.