### PR TITLE
Upgrade to opan2.0 format overlay opam files of pinned packages

### DIFF
--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -877,6 +877,20 @@ let from_2_0_alpha_to_2_0_alpha2 root conf =
       in
       OpamFile.SwitchSelections.write selections_file selections;
 
+      (* Update pinned overlay opam files *)
+      OpamPackage.Set.iter (fun nv ->
+          let pkg_dir =
+            meta_dir / "overlay" / OpamPackage.Name.to_string nv.name
+          in
+          let opamf = pkg_dir // "opam" in
+          let opam0 = OpamFile.make opamf in
+          OpamStd.Option.iter (fun opam ->
+              opam_file_from_1_2_to_2_0 ~filename:opam0 opam
+              |> OpamFile.OPAM.write_with_preserved_format opam0;
+              OpamFilename.remove (pkg_dir // "descr");
+              OpamFilename.remove (pkg_dir // "url")
+            ) (OpamFileTools.read_opam pkg_dir)
+        ) selections.sel_pinned;
     )
     (OpamFile.Config.installed_switches conf);
   OpamFile.Config.with_eval_variables [


### PR DESCRIPTION
This PR fixes #3515.
_During  upgrade process, opam repo files are upgrades to 2.0, but not remaining switch opam files [in the overlay directory]._
More details in [this comment](https://github.com/ocaml/opam/issues/3515#issuecomment-417745153).