### PR TITLE
doc: update readme, remove cygwin64 install

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,8 @@ If you are developing OPAM, you may enable developer features by including the
 BUILDING ON WINDOWS IS A WORK-IN-PROGRESS AND THESE INSTRUCTIONS WILL EVOLVE!
 ```
 
-Cygwin (https://www.cygwin.com/setup-x86_64.exe) is always required to build opam on
-Windows. Both the 64-bit and 32-bit versions of Cygwin may be used (you can build
-32-bit opam using 64-bit Cygwin and vice versa though note that you must be running
-64-bit Windows in order to build the 64-bit version).
+Cygwin (https://www.cygwin.com/setup-x86.exe) is always required to build opam on
+Windows. Only 32-bit versions of Cygwin can be used.
 
 The following Cygwin packages are required:
 * From Devel - `make`
@@ -75,7 +73,7 @@ The following Cygwin packages are required:
 Alternatively, having downloaded Cygwin's setup program, Cygwin can be installed
 using the following command line:
 
-`setup-x86_64 --root=C:\cygwin64 --quiet-mode --no-desktop --no-startmenu --packages=make,mingw64-i686-gcc-core,mingw64-x86_64-gcc-core,m4,patch`
+`setup-x86 --root=C:\cygwin32 --quiet-mode --no-desktop --no-startmenu --packages=make,mingw64-i686-gcc-core,mingw64-x86_64-gcc-core,m4,patch`
 
 The `--no-desktop` and `--no-startmenu` switches may be omitted in order to create
 shortcuts on the Desktop and Start Menu respectively. Executed this way, setup will


### PR DESCRIPTION
This PR is related to #3503.
It updates the readme as opam does not compile with cygwin64.
/cc @dra27