### PR TITLE
pin edit: fix editing an opam file whithout a name field

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2769,7 +2769,7 @@ let lint =
              | name, None -> OpamSwitchState.get_package st name
            in
            let opam = OpamSwitchState.opam st nv in
-           match OpamPinned.orig_opam_file opam with
+           match OpamPinned.orig_opam_file (OpamPackage.name nv) opam with
            | None -> raise Not_found
            | some -> [some]
          with Not_found ->

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -223,7 +223,7 @@ let edit st ?version name =
         | Some o -> OpamFile.OPAM.with_version new_nv.version o
      in
      OpamFile.OPAM.write_with_preserved_format
-       ?format_from:(OpamPinned.orig_opam_file base_opam)
+       ?format_from:(OpamPinned.orig_opam_file name base_opam)
        temp_file base_opam);
   match edit_raw name temp_file with
   | None -> st
@@ -514,7 +514,7 @@ and source_pin
     if need_edit then
       (if not (OpamFile.exists temp_file) then
          OpamFile.OPAM.write_with_preserved_format
-           ?format_from:(OpamPinned.orig_opam_file opam_base)
+           ?format_from:(OpamPinned.orig_opam_file name opam_base)
            temp_file opam_base;
        OpamStd.Option.Op.(
          edit_raw name temp_file >>|
@@ -553,7 +553,7 @@ and source_pin
     let opam = copy_files st opam in
 
     OpamFile.OPAM.write_with_preserved_format
-      ?format_from:(OpamPinned.orig_opam_file opam)
+      ?format_from:(OpamPinned.orig_opam_file name opam)
       (OpamPath.Switch.Overlay.opam st.switch_global.root st.switch nv.name)
       opam;
 

--- a/src/state/opamPinned.ml
+++ b/src/state/opamPinned.ml
@@ -99,11 +99,11 @@ let files_in_source d =
            (OpamFilename.to_string f);
          None)
 
-let orig_opam_file opam =
+let orig_opam_file name opam =
   let open OpamStd.Option.Op in
   OpamFile.OPAM.metadata_dir opam >>= fun dir ->
   OpamStd.List.find_opt OpamFilename.exists [
-    dir // (OpamPackage.Name.to_string (OpamFile.OPAM.name opam) ^ ".opam");
+    dir // (OpamPackage.Name.to_string name ^ ".opam");
     dir // "opam"
   ] >>|
   OpamFile.make

--- a/src/state/opamPinned.mli
+++ b/src/state/opamPinned.mli
@@ -47,4 +47,5 @@ val name_of_opam_filename: dirname -> filename -> name option
 
 (** Finds back the location of the opam file this package definition was loaded
     from *)
-val orig_opam_file: OpamFile.OPAM.t -> OpamFile.OPAM.t OpamFile.t option
+val orig_opam_file:
+  OpamPackage.Name.t -> OpamFile.OPAM.t -> OpamFile.OPAM.t OpamFile.t option


### PR DESCRIPTION
If an `opam pin --edit` concerns an opam file not defining the field `name`, an error is raised
```
$ opam pin --edit opam-core --dev -n
Fatal error:
Field 'name:' is required
```