### PR TITLE
Update OpenBSD support, OpenBSD requires gtar

### DIFF
--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -44,6 +44,9 @@ let sandbox_filter = FOr (linux_filter, macos_filter)
 let gpatch_filter = FOr (openbsd_filter, freebsd_filter)
 let patch_filter = FNot gpatch_filter
 
+let gtar_filter = openbsd_filter
+let tar_filter = FNot gtar_filter
+
 let wrappers ~sandboxing () =
   let cmd t = [
     CString "%{hooks}%/sandbox.sh", None;
@@ -102,7 +105,8 @@ let required_tools ~sandboxing () =
     ["diff"], None, None;
     ["patch"], None, Some patch_filter;
     ["gpatch"], None, Some gpatch_filter;
-    ["tar"], None, None;
+    ["tar"], None, Some tar_filter;
+    ["gtar"], None, Some gtar_filter;
     ["unzip"], None, None;
   ] @
   if sandboxing then [

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -631,8 +631,13 @@ module Tar = struct
   let extract_command file =
     OpamStd.Option.Op.(
       get_type file >>| fun typ ->
+      let tar_cmd =
+        match OpamStd.Sys.os () with
+        | OpamStd.Sys.OpenBSD -> "gtar"
+        | _ -> "tar"
+      in
       let command c dir =
-        make_command "tar" [ Printf.sprintf "xf%c" c ; file; "-C" ; dir ]
+        make_command tar_cmd [ Printf.sprintf "xf%c" c ; file; "-C" ; dir ]
       in
       command (extract_option typ))
 end


### PR DESCRIPTION
OpenBSD tar does not support the ‘J’ flag