### PR TITLE
Locked state and signals, avoid 

### DIFF
--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -816,7 +816,10 @@ let rec flock_update
            Unix.(lockf fd F_ULOCK 0);
          Unix.lockf fd (unix_lock_op ~dontblock:true flag) 0
        with Unix.Unix_error (Unix.EAGAIN,_,_) ->
-         if dontblock then raise Locked;
+         if dontblock then
+           OpamConsole.error_and_exit `Locked
+             "Another process has locked %s and non blocking mode enabled"
+             file;
          OpamConsole.formatted_msg
            "Another process has locked %s, waiting (%s to abort)... "
            file (if Sys.win32 then "CTRL+C" else "C-c");


### PR DESCRIPTION
When opam is blocked (waiting for a lock to be released) signals abort this blocking state, like SIGWINCH wich is launched when a window is resized. This PR catch interruption caused by signals in order to ignore them.
Terminal signals still terminates the program.