### PR TITLE
install.sh: xsudo when creating bin dir

### DIFF
--- a/shell/install.sh
+++ b/shell/install.sh
@@ -211,7 +211,7 @@ while true; do
         read R
         case "$R" in
             ""|"y"|"Y"|"yes")
-            mkdir -p $BINDIR
+            xsudo mkdir -p $BINDIR
             break;;
         esac
     fi


### PR DESCRIPTION
```sh
## Downloading opam 2.0.0~rc4 for darwin on x86_64...
## Downloaded.
## Where should it be installed ? [/usr/local/bin] 
## /usr/local/bin does not exist. Create ? [Y/n] 
mkdir: /usr/local/bin: Permission denied
```