### PR TITLE
Fix configure tests

### DIFF
--- a/configure
+++ b/configure
@@ -5112,7 +5112,7 @@ $as_echo "not found" >&6; }
 
 
 if test "x${with_mccs}" = "xno" && test "x$OCAML_PKG_mccs" != "xno"; then :
-  as_fn_error $? "Option --without-mccs is not supported. You need to uninstall the 'mccs' package" "$LINENO" 5
+  as_fn_error $? "Option --without-mccs is not available without uninstalling the 'mccs' package" "$LINENO" 5
 fi
 
 

--- a/configure
+++ b/configure
@@ -6637,11 +6637,14 @@ bindir="`eval echo ${bindir}`"
 mandir="`eval echo ${mandir}`"
 mandir="`eval echo ${mandir}`"
 
-if { test "x$MCCS_ENABLED" = "xfalse" && test "x${hasalldeps}" = "x"; } ||
-       { test "x$OCAML_PKG_mccs" = "xno" && test "x${hasalldeps}" = "xtrue"; }; then :
+if test "x$MCCS_ENABLED" = "xfalse"; then :
+
   echo "Opam will be built WITHOUT a built-in solver"
+
 else
+
   echo "Opam will be built WITH a built-in solver"
+
 fi
 echo
 echo Executables will be installed in ${bindir}

--- a/configure
+++ b/configure
@@ -5116,22 +5116,9 @@ if test "x${with_mccs}" = "xno" && test "x$OCAML_PKG_mccs" != "xno"; then :
 fi
 
 
+if test "x$MCCS_ENABLED" = "xtrue"; then :
 
-echo
-
-
-if test "x${enable_checks}" != "xno" && {
-       test "x$OCAML_PKG_extlib" = "xno" ||
-       test "x$OCAML_PKG_re" = "xno" ||
-       test "x$OCAML_PKG_cmdliner" = "xno" ||
-       test "x$OCAML_PKG_ocamlgraph" = "xno" ||
-       test "x$OCAML_PKG_cudf" = "xno" ||
-       test "x$OCAML_PKG_dose3_common" = "xno" ||
-       test "x$OCAML_PKG_opam_file_format" = "xno" ||
-       test "x$OCAML_PKG_cppo" = "xno" ||
-       test "x$OCAML_PKG_mccs$MCCS_ENABLED$MCCS_DEFAULT" = "xnotrue"; }; then :
-
-  if test "x$MCCS_ENABLED" = "xtrue" -a "x${CCOMP_TYPE}" != "xmsvc"; then :
+  if test "x${CCOMP_TYPE}" != "xmsvc"; then :
 
     ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
@@ -5401,13 +5388,34 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 else
 
-        as_fn_error $? "A C++ compiler is required to build mccs" "$LINENO" 5
+        if test "x${enable_checks}" != "xno"; then :
+
+          as_fn_error $? "A C++ compiler is required to build mccs" "$LINENO" 5
 
 fi
 
 fi
 
 fi
+
+fi
+
+fi
+
+
+echo
+
+
+if test "x${enable_checks}" != "xno" && {
+       test "x$OCAML_PKG_extlib" = "xno" ||
+       test "x$OCAML_PKG_re" = "xno" ||
+       test "x$OCAML_PKG_cmdliner" = "xno" ||
+       test "x$OCAML_PKG_ocamlgraph" = "xno" ||
+       test "x$OCAML_PKG_cudf" = "xno" ||
+       test "x$OCAML_PKG_dose3_common" = "xno" ||
+       test "x$OCAML_PKG_opam_file_format" = "xno" ||
+       test "x$OCAML_PKG_cppo" = "xno" ||
+       test "x$OCAML_PKG_mccs$MCCS_ENABLED" = "xnotrue";}; then :
 
   echo "============================================================================"
   echo "Some dependencies are missing. If you are just interested in the stand-alone"

--- a/configure
+++ b/configure
@@ -4753,7 +4753,9 @@ elif test x"$FETCH" = x"wget" ; then
   fetch="wget $wget_certificate_check -O \$(2) \$(1)"
 
 elif test x"${enable_checks}" != x"no" ; then
-  as_fn_error $? "You must have either curl or wget installed." "$LINENO" 5
+  if ! ${MAKE:-make} -q -C src_ext has-archives 2>/dev/null ; then
+    as_fn_error $? "You must have either curl or wget installed." "$LINENO" 5
+  fi
 fi
 
 if test "x${with_private_runtime}" != "xno"; then :

--- a/configure.ac
+++ b/configure.ac
@@ -371,10 +371,11 @@ bindir="`eval echo ${bindir}`"
 mandir="`eval echo ${mandir}`"
 mandir="`eval echo ${mandir}`"
 
-AS_IF([{ test "x$MCCS_ENABLED" = "xfalse" && test "x${hasalldeps}" = "x"; } ||
-       { test "x$OCAML_PKG_mccs" = "xno" && test "x${hasalldeps}" = "xtrue"; }],
-      [echo "Opam will be built WITHOUT a built-in solver"],
-      [echo "Opam will be built WITH a built-in solver"])
+AS_IF([test "x$MCCS_ENABLED" = "xfalse"],[
+  echo "Opam will be built WITHOUT a built-in solver"
+],[
+  echo "Opam will be built WITH a built-in solver"
+])
 echo
 echo Executables will be installed in ${bindir}
 echo Manual pages will be installed in ${mandir}

--- a/configure.ac
+++ b/configure.ac
@@ -288,6 +288,23 @@ dnl      AC_CHECK_OCAML_PKG([mccs]),
 dnl      [echo "checking for OCaml findlib package mccs... disabled"
 dnl       AC_SUBST(OCAML_PKG_mccs,"no")])
 
+AS_IF([test "x$MCCS_ENABLED" = "xtrue"],[
+  AS_IF([test "x${CCOMP_TYPE}" != "xmsvc"],[
+    AC_PROG_CXX
+    # Curiously, CXX=g++ && GXX= seems to be how autoconf "signals" that no C++
+    # compiler was found.
+    AS_IF([test "x$CXX" = "xg++" -a "x$GXX" != "xyes"],[
+      AS_IF([test "x$MCCS_DEFAULT" = "xyes"],[
+        AC_SUBST(MCCS_ENABLED,false)
+      ],[
+        AS_IF([test "x${enable_checks}" != "xno"],[
+          AC_MSG_ERROR([A C++ compiler is required to build mccs])
+        ])
+      ])
+    ])
+  ])
+])
+
 
 dnl echo
 dnl echo "extlib........................ ${OCAML_PKG_extlib}"
@@ -308,20 +325,7 @@ AS_IF([test "x${enable_checks}" != "xno" && {
        test "x$OCAML_PKG_dose3_common" = "xno" ||
        test "x$OCAML_PKG_opam_file_format" = "xno" ||
        test "x$OCAML_PKG_cppo" = "xno" ||
-       test "x$OCAML_PKG_mccs$MCCS_ENABLED$MCCS_DEFAULT" = "xnotrue"; }],[
-  AS_IF([test "x$MCCS_ENABLED" = "xtrue" -a "x${CCOMP_TYPE}" != "xmsvc"],[
-    AC_PROG_CXX
-    # Curiously, CXX=g++ && GXX= seems to be how autoconf "signals" that no C++
-    # compiler was found.
-    AS_IF([test "x$CXX" = "xg++" -a "x$GXX" != "xyes"],[
-      AS_IF([test "x$MCCS_DEFAULT" = "xyes"],[
-        AC_SUBST(MCCS_ENABLED,false)
-      ],[
-        AC_MSG_ERROR([A C++ compiler is required to build mccs])
-      ])
-    ])
-  ])
-
+       test "x$OCAML_PKG_mccs$MCCS_ENABLED" = "xnotrue";}],[
   echo "============================================================================"
   echo "Some dependencies are missing. If you are just interested in the stand-alone"
   echo "'opam' binary, run 'make lib-ext' to download and include them."

--- a/configure.ac
+++ b/configure.ac
@@ -232,7 +232,9 @@ if test x"$FETCH" = x"curl" ; then
 elif test x"$FETCH" = x"wget" ; then
   AC_SUBST(fetch, "wget $wget_certificate_check -O \$(2) \$(1)")
 elif test x"${enable_checks}" != x"no" ; then
-  AC_MSG_ERROR([You must have either curl or wget installed.])
+  if ! ${MAKE:-make} -q -C src_ext has-archives 2>/dev/null ; then
+    AC_MSG_ERROR([You must have either curl or wget installed.])
+  fi
 fi
 
 AS_IF([test "x${with_private_runtime}" != "xno"],[

--- a/configure.ac
+++ b/configure.ac
@@ -279,7 +279,7 @@ AC_CHECK_OCAML_PKG([mccs])
 AC_CHECK_OCAML_PKG([cppo])
 
 AS_IF([test "x${with_mccs}" = "xno" && test "x$OCAML_PKG_mccs" != "xno"],
-      [AC_MSG_ERROR([Option --without-mccs is not supported. You need to uninstall the 'mccs' package])])
+      [AC_MSG_ERROR([Option --without-mccs is not available without uninstalling the 'mccs' package])])
 
 dnl -- that's what we would like to do, but no way to disable mccs in jbuilder
 dnl -- if it's installed, at the moment

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -128,6 +128,9 @@ archives-pkg: $(PKG_EXTS:=.pkgdownload)
 cache-archives: $(SRC_EXTS:=.cache) $(PKG_EXTS:=.pkgcache) ocaml.cache flexdll.cache
 	@
 
+has-archives: $(addprefix archives/, $(notdir $(URL_ocaml)) $(notdir $(URL_flexdll)) $(ARCHIVES) $(filter-out $(ARCHIVES), $(foreach pkg,$(PKG_EXTS), $(notdir $(URL_PKG_$(pkg))))))
+	@
+
 %.cache:
 	@mkdir -p archives
 	@[ -e archives/$(notdir $(URL_$*)) ] || \


### PR DESCRIPTION
Addresses two shortcomings of the configure script:

 - not having wget or curl is now only a hard-error if `src_ext/archives` doesn't contain the archives (i.e. if `make -C src_ext cache-archives` has not been run) which means that this should no longer be a requirement for building with the "full" tarball
 - the C++ test for MCCS is now moved to the correct place and the message as to whether the solver will be built should work correctly with `--disable-checks`. Note that not having a C++ compiler is not considered an error if `--disable-checks` is specified because `configure` is permitted to believe that the mccs library exists even if it couldn't detect it.

cc @hannesm, @pmetzger

Fixes #3551 