### PR TITLE
Allow build to specify GNU sed executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ else
 endif
 
 OPAMINSTALLER = ./opam-installer$(EXE)
+SED ?= sed
 
 ALWAYS:
 	@
@@ -95,7 +96,7 @@ endif
 
 opam-devel.install: $(JBUILDER_DEP)
 	$(JBUILDER) build $(JBUILDER_ARGS) -p opam opam.install
-	sed -e "s/bin:/libexec:/" opam.install > $@
+	$(SED) -e "s/bin:/libexec:/" opam.install > $@
 
 opam-%.install: $(JBUILDER_DEP)
 	$(JBUILDER) build $(JBUILDER_ARGS) -p opam-$* $@

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Either from an existing opam installation, use `opam pin add opam-devel
 * Run `make lib-ext` as advertised by `./configure` if you don't have the
   dependencies installed. This will locally take care of all OCaml dependencies
   for you (downloading them, unless you used the inclusive archive we provide
-  for each release).
+  for each release). This step requires GNU 'sed' and assumes it's named 'sed'.
+  To specify a different path or name, define the variable 'SED'.
 * Run `make`
 * Run `make install`
 

--- a/admin-scripts/Makefile
+++ b/admin-scripts/Makefile
@@ -4,8 +4,10 @@ INCLUDE = $(patsubst %,-I ../src/%,$(DEPS)) -I ../src/tools
 
 LIBS = $(patsubst %,../src/opam-%.cma,$(DEPS))
 
+SED ?= sed
+
 %: %.ml
-	sed 's/^#.*//' $< >$*-tmp.ml
+	$(SED) 's/^#.*//' $< >$*-tmp.ml
 	ocamlfind ocamlc -package unix,re.glob,ocamlgraph -linkpkg $(INCLUDE) $(LIBS) ../src/tools/opam_admin_top.ml $*-tmp.ml -o $@
 	rm $*-tmp.ml
 
@@ -13,6 +15,6 @@ LIBS = $(patsubst %,../src/opam-%.cma,$(DEPS))
 	cp $< $@
 
 couverture: couverture.ml
-	sed 's/^#.*//' $< >couverture-tmp.ml
+	$(SED) 's/^#.*//' $< >couverture-tmp.ml
 	ocamlfind ocamlopt -package re.glob,opam-lib.state -linkpkg ../src/tools/opam_admin_top.ml couverture-tmp.ml -o $@
 	rm couverture-tmp.ml

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -16,6 +16,8 @@ ifndef OPAM
   OPAM_DEP := $(shell $(JBUILDER) exec -- which opam)
 endif
 
+SED ?= sed
+
 TOPICS  = $(shell $(OPAM) help topics)
 TOPICS_ADMIN = cache filter index lint list upgrade
 
@@ -56,7 +58,7 @@ man-html: man
 	echo '<h1>Opam $(version) man-pages index</h1>' >>$@/index.html
 	echo '<ul>' >>$@/index.html
 	for f in man/*; do\
-	  man2html -r $$f | sed 1,2d > $@/$$(basename $$f .1).html;\
+	  man2html -r $$f | $(SED) 1,2d > $@/$$(basename $$f .1).html;\
 	  echo "  <li><a href=\"$$(basename $$f .1).html\">$$(basename $$f .1)</a></li>" >>$@/index.html;\
 	done
 	echo '</ul>' >>$@/index.html
@@ -69,7 +71,7 @@ html:
 	rm -rf html
 	cd .. && $(JBUILDER) build @doc
 	cp -r ../_build/default/_doc/_html html
-	sed 's/%{OPAMVERSION}%/'$(version)'/g' index.html > html/index.html
+	$(SED) 's/%{OPAMVERSION}%/'$(version)'/g' index.html > html/index.html
 # Not to break older links, add manpages to the `ocamldoc` dir
 	mkdir -p html/ocamldoc
 	cd html/ocamldoc && for f in ../*/*/index.html; do\

--- a/release/Makefile
+++ b/release/Makefile
@@ -8,12 +8,14 @@ FULL_ARCHIVE_URL = https://github.com/ocaml/opam/releases/download/$(VERSION)/op
 TARGETS = x86_64-linux i686-linux armhf-linux arm64-linux
 # todo: x86_64-darwin
 
+SED ?= sed
+
 OCAMLV = 4.04.2
 # currently hardcoded in Dockerfile.in
 OCAML_URL = https://caml.inria.fr/pub/distrib/ocaml-$(basename $(OCAMLV))/ocaml-$(OCAMLV).tar.gz
 
 HOST_OS = $(shell uname -s | tr A-Z a-z)
-HOST = $(shell uname -m | sed 's/amd64/x86_64/')-$(HOST_OS)
+HOST = $(shell uname -m | $(SED) 's/amd64/x86_64/')-$(HOST_OS)
 
 all: $(patsubst %,out/opam-$(VERSION)-%,$(TARGETS))
 
@@ -21,7 +23,7 @@ out/opam-full-$(VERSION).tar.gz:
 	mkdir -p out
 	cd out && curl -OfL $(FULL_ARCHIVE_URL) || { \
 	  git clone $(GIT_URL) -b $(TAG) --depth 1 opam-full-$(VERSION); \
-	  sed -i 's/^AC_INIT(opam,.*)/AC_INIT(opam,$(OPAM_VERSION))/' \
+	  $(SED) -i 's/^AC_INIT(opam,.*)/AC_INIT(opam,$(OPAM_VERSION))/' \
 	    opam-full-$(VERSION)/configure.ac; \
 	  $(MAKE) -C opam-full-$(VERSION) configure download-ext; \
 	  tar cz --exclude-vcs opam-full-$(VERSION) -f $(notdir $@); \
@@ -29,13 +31,13 @@ out/opam-full-$(VERSION).tar.gz:
 	}
 
 build/Dockerfile.x86_64-linux: Dockerfile.in
-	mkdir -p build && sed 's/%TARGET_TAG%/amd64-jessie/g' $^ | sed 's/%CONF%//g' >$@
+	mkdir -p build && $(SED) 's/%TARGET_TAG%/amd64-jessie/g' $^ | $(SED) 's/%CONF%//g' >$@
 build/Dockerfile.i686-linux: Dockerfile.in
-	mkdir -p build && sed 's/%TARGET_TAG%/i386-jessie/g' $^ | sed 's/%CONF%/-host i686-linux/g' >$@
+	mkdir -p build && $(SED) 's/%TARGET_TAG%/i386-jessie/g' $^ | $(SED) 's/%CONF%/-host i686-linux/g' >$@
 build/Dockerfile.armhf-linux: Dockerfile.in
-	mkdir -p build && sed 's/%TARGET_TAG%/armhf-jessie/g' $^ | sed 's/%CONF%//g' >$@
+	mkdir -p build && $(SED) 's/%TARGET_TAG%/armhf-jessie/g' $^ | $(SED) 's/%CONF%//g' >$@
 build/Dockerfile.arm64-linux: Dockerfile.in
-	mkdir -p build && sed 's/%TARGET_TAG%/arm64-jessie/g' $^ | sed 's/%CONF%//g' >$@
+	mkdir -p build && $(SED) 's/%TARGET_TAG%/arm64-jessie/g' $^ | $(SED) 's/%CONF%//g' >$@
 
 
 build/%.image: build/Dockerfile.%

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -2,6 +2,8 @@ ifneq ($(filter-out archives cache-archives lib-pkg,$(MAKECMDGOALS)),)
 -include ../Makefile.config
 endif
 
+SED ?= sed
+
 ifneq ($(wildcard Makefile.config),)
 include Makefile.config
 CAN_PKG=1
@@ -54,7 +56,7 @@ ifdef OCAML
 # Portable md5check
 MD5CHECK = $(OCAML) ../shell/md5check.ml $(1) $(2)
 else
-MD5CHECK = test "`md5sum $(1) | sed -e 's/^[^a-f0-9]*\([a-f0-9]*\).*/\1/'`" = "$(2)" || (rm $(1) && false)
+MD5CHECK = test "`md5sum $(1) | $(SED) -e 's/^[^a-f0-9]*\([a-f0-9]*\).*/\1/'`" = "$(2)" || (rm $(1) && false)
 endif
 
 lib-ext: clone
@@ -181,11 +183,11 @@ endef
 	  done; \
         fi
 	@for j in $(wildcard jbuild-$* jbuild-$*-*); do \
-     cp $$j $*$$(echo "$$j" | sed -e "s/jbuild-$*//" -e "s|-|/|g")/jbuild; \
+     cp $$j $*$$(echo "$$j" | $(SED) -e "s/jbuild-$*//" -e "s|-|/|g")/jbuild; \
    done
 	@touch $*/$*.opam
 	@for i in `find $* -name jbuild`; do \
-     sed -i -e "s/name \+runtest/name disabled-runtest/g" $$i; \
+     $(SED) -i -e "s/name \+runtest/name disabled-runtest/g" $$i; \
    done
 	@touch $@ && rm -f $*.pkgstamp $*.pkgbuild
 

--- a/src_ext/Makefile.packages
+++ b/src_ext/Makefile.packages
@@ -1,5 +1,6 @@
-EXT_LIB:=$(shell PATH="$(PATH)" ocamlc -config | tr -d '\r' | sed -ne "s/ext_lib: \.//p")
-EXT_DLL:=$(shell PATH="$(PATH)" ocamlc -config | tr -d '\r' | sed -ne "s/ext_dll: \.//p")
+SED ?= sed
+EXT_LIB:=$(shell PATH="$(PATH)" ocamlc -config | tr -d '\r' | $(SED) -ne "s/ext_lib: \.//p")
+EXT_DLL:=$(shell PATH="$(PATH)" ocamlc -config | tr -d '\r' | $(SED) -ne "s/ext_dll: \.//p")
 EXT_EXE:=$(if $(filter Win32,$(shell PATH="$(PATH)" ocamlc -config | fgrep os_type)),.exe)
 OCAMLBIN:=$(dir $(shell PATH="$(PATH)" command -v ocamlc))
 # SITELIB must *not* be evaluated with := (because it must be evaluated *after*


### PR DESCRIPTION
Some uses of `sed` in the `Makefiles` specify the `-i` option which is only found in GNU `sed`. On my BSD system, GNU `sed` gets installed as `gsed`. This pull request still defaults to using `sed`, but allows the user to specify a different executable by defining the `SED` variable.