### PR TITLE
Docs: Add install instructions when using Fedora

### DIFF
--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -103,8 +103,14 @@ cave resolve -x repository/ocaml-unofficial
 
 #### [Fedora](http://fedoraproject.org), [CentOS](http://centos.org) and RHEL
 
-No native packages at the moment, you will need to use our pre-built binaries,
-or build from sources.
+The opam package for Fedora can be installed with the command:
+
+```
+dnf install opam
+```
+
+There is not currently a package for CentOS/RHEL. You will need to use our
+pre-built binaries, or build from sources.
 
 #### Mageia
 


### PR DESCRIPTION
I'm the Fedora packager for opam. There was a discussion in #2953 about the lack of install instructions for Fedora-- now that there is an opam package available in the Fedora repositories, the documentation should be updated to reflect that.

This will resolve #2953.

(There's still no CentOS/RHEL package. When I first started packaging opam, the version of ocaml available in RHEL 7 was too old. But it's since been updated, so when I get a chance I might try to build one. If I do, I'll open another pull request).