### PR TITLE
Update FAQ URIs for bubblewrap

### DIFF
--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -66,7 +66,7 @@ let bwrap_cmd = "bwrap"
 let bwrap_filter = linux_filter
 let bwrap_string () = Printf.sprintf
     "Sandboxing tool %s was not found. You should install 'bubblewrap'. \
-     See http://opam.ocaml.org/doc/2.0/FAQ.html#Why-opam-asks-me-to-install-bwrap."
+     See https://opam.ocaml.org/doc/FAQ.html#Why-does-opam-require-bwrap."
     bwrap_cmd
 
 let fetch_cmd_user () =

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -7,7 +7,7 @@ if ! command -v bwrap >/dev/null; then
     echo "disable sandboxing in ${OPAMROOT:-~/.opam}/config at your own risk." >&2
     echo "See https://github.com/projectatomic/bubblewrap for bwrap details." >&2
     echo "For 'bwrap' use in opam, see the FAQ:" >&2
-    echo "  https://opam.ocaml.org/doc/2.0/FAQ.html#Why-does-opam-require-bwrap" >&2
+    echo "  https://opam.ocaml.org/doc/FAQ.html#Why-does-opam-require-bwrap" >&2
     exit 10
 fi
 


### PR DESCRIPTION
This PR updates URIs in error messages for bwrap. The new URI is <http://opam.ocaml.org/doc/FAQ.html#Why-does-opam-require-bwrap>.