### PR TITLE
upgrade: handle non http backend on repo upgrade

### DIFF
--- a/src/client/opamAdminRepoUpgrade.ml
+++ b/src/client/opamAdminRepoUpgrade.ml
@@ -237,12 +237,17 @@ let do_upgrade repo_root =
       let opam =
         match OpamFile.OPAM.url opam with
         | Some urlf when OpamFile.URL.checksum urlf = [] ->
-          (match OpamProcess.Job.run (get_url_md5 (OpamFile.URL.url urlf)) with
-           | None -> None
-           | Some hash ->
-             Some
-               (OpamFile.OPAM.with_url (OpamFile.URL.with_checksum [hash] urlf)
-                  opam))
+          let url = OpamFile.URL.url urlf in
+          (match url.OpamUrl.backend with
+           | #OpamUrl.version_control -> Some opam
+           | `rsync when OpamUrl.local_dir url <> None -> Some opam
+           | _ ->
+             (match OpamProcess.Job.run (get_url_md5 url) with
+              | None -> None
+              | Some hash ->
+                Some
+                  (OpamFile.OPAM.with_url (OpamFile.URL.with_checksum [hash] urlf)
+                     opam)))
         | _ -> Some opam
       in
       match opam with


### PR DESCRIPTION
When upgrading a repo, if a compiler file contains a source git defined url, it results to an assert failure. Opam tries to download the archive to get its md5 (if missing from file or from cache), and assuming its a single file uses direct download (http or rsync backend).

Fix #3590.