### PR TITLE
[Sandbox] make /var readonly instead of empty and rw

### DIFF
--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -15,7 +15,7 @@ ARGS=(--unshare-net --new-session)
 ARGS=("${ARGS[@]}" --proc /proc --dev /dev)
 ARGS=("${ARGS[@]}" --bind "${TMPDIR:-/tmp}" /tmp)
 ARGS=("${ARGS[@]}" --setenv TMPDIR /tmp --setenv TMP /tmp --setenv TEMPDIR /tmp --setenv TEMP /tmp)
-ARGS=("${ARGS[@]}" --tmpfs /run --tmpfs /var)
+ARGS=("${ARGS[@]}" --tmpfs /run)
 
 add_mounts() {
     case "$1" in
@@ -31,7 +31,7 @@ add_mounts() {
 # use OPAM_USER_PATH_RO variable to add them
 # the OPAM_USER_PATH_RO format is the same as PATH
 # ie: export OPAM_USER_PATH_RO=/nix/store:/rw/usrlocal
-add_mounts ro /usr /bin /lib /lib32 /lib64 /etc /opt /home
+add_mounts ro /usr /bin /lib /lib32 /lib64 /etc /opt /home /var
 
 # C compilers using `ccache` will write to a shared cache directory
 # that remain writeable. ccache seems widespread in some Fedora systems.


### PR DESCRIPTION
Should fix #3604 

What is the security logic of this file? Why not all `/` ro , instead of sherry picking? It should be stated in the file at least.