### PR TITLE
Upgrade pin source

### DIFF
--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -291,6 +291,9 @@ let process_in ?root fn src dst =
 
 let copy_in ?root = process_in ?root copy
 
+let is_archive filename =
+  OpamSystem.is_archive (to_string filename)
+
 let extract filename dirname =
   OpamSystem.extract (to_string filename) ~dir:(Dir.to_string dirname)
 

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -194,6 +194,9 @@ val install: ?exec:bool -> src:t -> dst:t -> unit -> unit
     directory if possible. Otherwise, the symlink is absolute. *)
 val link: ?relative:bool -> target:t -> link:t -> unit
 
+(** Returns true if the given file is an archive (zip or tar) *)
+val is_archive: t -> bool
+
 (** Extract an archive in a given directory (it rewrites the root to
     match [Dir.t] dir if needed) *)
 val extract: t -> Dir.t -> unit

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -685,7 +685,8 @@ module Zip = struct
     Some (fun dir -> make_command "unzip" [ file; "-d"; dir ])
 end
 
-let is_tar_archive = Tar.is_archive
+let is_archive file =
+  Tar.is_archive file || Zip.is_archive file
 
 let extract_command file =
   if Zip.is_archive file then Zip.extract_command file

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -185,7 +185,7 @@ val read_command_output: ?verbose:bool -> ?env:string array ->
 (** END *)
 
 (** Test whether the file is an archive, by looking as its extension *)
-val is_tar_archive: string -> bool
+val is_archive: string -> bool
 
 (** [extract ~dir:dirname filename] extracts the archive [filename] into
     [dirname]. [dirname] should not exists and [filename] should


### PR DESCRIPTION
This PR contains a fix for format upgrade, it add extraction of archived source files of version-pinned packages. opam1.2 stores the archive file while opam2 the extract.
Related to #3600.