### PR TITLE
Fix #3627: use `git -c diff.noprefix=false diff`

### DIFF
--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -33,6 +33,8 @@ module VCS : OpamVCS.VCS = struct
       git repo_root [ "init" ];
       (* Enforce this option, it can break our use of git if set *)
       git repo_root [ "config" ; "--local" ; "fetch.prune"; "false"];
+      (* We reset diff.noprefix to ensure we get a `-p1` patch and avoid <https://github.com/ocaml/opam/issues/3627>. *)
+      git repo_root [ "config" ; "--local" ; "diff.noprefix"; "false"];
       (* Document the remote for user-friendliness (we don't use it) *)
       git repo_root [ "remote"; "add"; "origin"; OpamUrl.base_url repo_url ];
     ] @@+ function
@@ -156,8 +158,7 @@ module VCS : OpamVCS.VCS = struct
     (* Git diff is to the working dir, but doesn't work properly for
        unregistered directories. *)
     OpamSystem.raise_on_process_error r;
-    (* We reset diff.noprefix to ensure we get a `-p1` patch and avoid <https://github.com/ocaml/opam/issues/3627>. *)
-    git repo_root ~stdout:patch_file [ "-c" ; "diff.noprefix=false" ; "diff" ; "--no-ext-diff" ; "-R" ; "-p" ; rref; "--" ]
+    git repo_root ~stdout:patch_file [ "diff" ; "--no-ext-diff" ; "-R" ; "-p" ; rref; "--" ]
     @@> fun r ->
     if not (OpamProcess.check_success_and_cleanup r) then
       (finalise ();

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -158,7 +158,8 @@ module VCS : OpamVCS.VCS = struct
     (* Git diff is to the working dir, but doesn't work properly for
        unregistered directories. *)
     OpamSystem.raise_on_process_error r;
-    git repo_root ~stdout:patch_file [ "diff" ; "--no-ext-diff" ; "-R" ; "-p" ; rref; "--" ]
+    (* We also reset diff.noprefix here to handle already existing repo. *)
+    git repo_root ~stdout:patch_file [ "-c" ; "diff.noprefix=false" ; "diff" ; "--no-ext-diff" ; "-R" ; "-p" ; rref; "--" ]
     @@> fun r ->
     if not (OpamProcess.check_success_and_cleanup r) then
       (finalise ();

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -156,7 +156,8 @@ module VCS : OpamVCS.VCS = struct
     (* Git diff is to the working dir, but doesn't work properly for
        unregistered directories. *)
     OpamSystem.raise_on_process_error r;
-    git repo_root ~stdout:patch_file [ "diff" ; "--no-ext-diff" ; "-R" ; "-p" ; rref; "--" ]
+    (* We reset diff.noprefix to ensure we get a `-p1` patch and avoid <https://github.com/ocaml/opam/issues/3627>. *)
+    git repo_root ~stdout:patch_file [ "-c" ; "diff.noprefix=false" ; "diff" ; "--no-ext-diff" ; "-R" ; "-p" ; rref; "--" ]
     @@> fun r ->
     if not (OpamProcess.check_success_and_cleanup r) then
       (finalise ();


### PR DESCRIPTION
Fix #3627 by ensuring `git` produces a `-p1` diff. This is a very limited
fix but appears to work in my usecase. I have reviewed the other uses of
`git diff` in the same file, but it appears their output is not passed
to `patch` hence this change is unnecessary.