### PR TITLE
pinning: don't vcs-pin unversionned opam files

### DIFF
--- a/src/client/opamAuxCommands.mli
+++ b/src/client/opamAuxCommands.mli
@@ -33,6 +33,20 @@ val url_with_local_branch: url -> url
     be found, and the corresponding source directory *)
 val name_and_dir_of_opam_file: filename -> name option * dirname
 
+(** From a directory, retrieve its opam files and returns packages name and
+    opam file *)
+val opams_of_dir:
+  OpamFilename.Dir.t -> (name * OpamFile.OPAM.t OpamFile.t) list
+
+(** Like [opam_of_dirs], but changes the pinning_url if needed. If given [url]
+    is local dir with vcs backend, and opam files not versioned, its pinning url
+    is changed to rsync path-pin. If [same_kind the_new_url] returns true,
+    package information (name, opam file, new url) are added to the returned
+    list, otherwise it is discarded. *)
+val opams_of_dir_w_target:
+  ?same_kind:(OpamUrl.t -> bool) -> OpamUrl.t ->
+  OpamFilename.Dir.t -> (name * OpamFile.OPAM.t OpamFile.t * OpamUrl.t) list
+
 (** Resolves the opam files and directories in the list to package name and
     location, and returns the corresponding pinnings and atoms. May fail and
     exit if package names for provided [`Filename] could not be inferred, or if


### PR DESCRIPTION
At the moment, when pinning a local package in a  vcs folder, opam automatically vcs-pin it, and takes into account unversioned opam files.
This PR changes this behavior by changing the pinning url: if the opam file is versioned, it is kept as a vcs-pin, otherwise it is transformed into a path-pin.
To restrict opam to pin only versioned opam files, the option `-k git` (or other vcs) can be used.

The main usefulness of this behavior is with recursive pinning, where it is applied to folders not just opam files.