### PR TITLE
Fix #3659: Sandboxing on MacOS is too strict

### DIFF
--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -2,7 +2,8 @@
 set -ue
 
 POL='(version 1)(allow default)(deny network*)(deny file-write*)'
-POL="$POL"'(allow file-write* (literal "/dev/null"))'
+POL="$POL"'(allow network* (remote unix))'
+POL="$POL"'(allow file-write* (literal "/dev/null") (literal "/dev/dtracehelper"))'
 
 add_mounts() {
     local DIR="$(cd "$2" && pwd -P)"


### PR DESCRIPTION
This commit allows applications to use unix sockets.

It also allows them to write to /dev/dtracehelper. This permission is
not strictly needed, as no program is broken by a denied access. However,
MacOS' dynamic loader (hence almost all the applications) wants to access
it, so the system logs are flooded by messages such as "SandboxViolation:
sh(49331) deny(1) file-write-data /dev/dtracehelper" when using opam.