### PR TITLE
Resolve opam root path

### DIFF
--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -129,6 +129,10 @@ let (/) d1 s2 =
   let s1 = Dir.to_string d1 in
   raw_dir (Filename.concat s1 s2)
 
+let concat_and_resolve d1 s2 =
+  let s1 = Dir.to_string d1 in
+  Dir.of_string (Filename.concat s1 s2)
+
 type t = {
   dirname:  Dir.t;
   basename: Base.t;

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -93,6 +93,9 @@ val with_tmp_dir: (Dir.t -> 'a) -> 'a
 (** Provide an automatically cleaned up temp directory to a job *)
 val with_tmp_dir_job: (Dir.t -> 'a OpamProcess.job) -> 'a OpamProcess.job
 
+(** Create a new Dir.t and resolve symlinks *)
+val concat_and_resolve: Dir.t -> string -> Dir.t
+
 include OpamStd.ABSTRACT
 
 (** Generic filename *)

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -27,8 +27,8 @@ type t = {
 }
 
 let default = {
-  root_dir = OpamFilename.Op.(
-      OpamFilename.Dir.of_string (OpamStd.Sys.home ()) / ".opam"
+  root_dir = OpamFilename.(
+      concat_and_resolve (Dir.of_string (OpamStd.Sys.home ())) ".opam"
     );
   current_switch = None;
   switch_from = `Default;


### PR DESCRIPTION
Default opam root is resolved at creation, in order to have the correct linked path.
fixes #3622