### PR TITLE
Regenerate missing environment file

### DIFF
--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -234,7 +234,7 @@ let updates_common ~set_opamroot ~set_opamswitch root switch =
     else [] in
   root @ switch
 
-let updates ~set_opamroot ~set_opamswitch ?force_path st =
+let updates ?(set_opamroot=false) ?(set_opamswitch=false) ?force_path st =
   updates_common ~set_opamroot ~set_opamswitch st.switch_global.root st.switch @
   compute_updates ?force_path st
 

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -46,6 +46,12 @@ val get_pure: ?updates:env_update list -> unit -> env
     returned by e.g. [get_full]!) *)
 val add: env -> env_update list -> env
 
+(** Like [get_opam] computes environment modification by OPAM , but returns
+    these [updates] instead of the new environment. *)
+val updates:
+  ?set_opamroot:bool -> ?set_opamswitch:bool -> ?force_path:bool ->
+  'a switch_state -> env_update list
+
 (** Check if the shell environment is in sync with the current OPAM switch (or
     if OPAMNOENVNOTICE has been set, in which case we just assume it's up to
     date) *)


### PR DESCRIPTION
Regenerate missing environment file. In order to do that, switch is loaded, which can sometimes slow `opam env`, but only in this case.
Fixes #3690  #3594.