### PR TITLE
Fix opam installer

### DIFF
--- a/shell/install.sh
+++ b/shell/install.sh
@@ -5,7 +5,7 @@ set -ue
 # (c) Copyright Fabrice Le Fessant INRIA/OCamlPro 2013
 # (c) Copyright Louis Gesbert OCamlPro 2014-2017
 
-VERSION='2.0.1'
+VERSION='2.0.2'
 TAG=$(echo "$VERSION" | tr '~' '-')
 DEFAULT_BINDIR=/usr/local/bin
 

--- a/shell/install.sh
+++ b/shell/install.sh
@@ -130,7 +130,7 @@ case "$ARCH" in
     *) ARCH=$(echo "$ARCH" | awk '{print tolower($0)}')
 esac
 
-OS=$(uname -s || echo unknown)
+OS=$(uname -s | awk '{print tolower($0)}' || echo unknown)
 case "$OS" in
     darwin|macos) OS=macos;;
     *) OS=$(echo "$OS" | awk '{print tolower($0)}')


### PR DESCRIPTION
- the SHAs have been updated for 2.0.2 but version has been kept at 2.0.1, meaning the wrong release is being downloaded and the checksum fails
- on my system `uname -s` comes back as `Darwin`, not `darwin`