### PR TITLE
Update installation instructions for opam

### DIFF
--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -162,11 +162,16 @@ for Opam usage.
 
 #### Ubuntu
 
-Ubuntu has native packages for opam:
-
+##### Versions 18.04 and newer
+There is a [ppa](https://launchpad.net/~avsm/+archive/ubuntu/ppa) available that contains the current stable version of `opam`.
 ```
+add-apt-repository ppa:avsm/ppa
+apt update
 apt install opam
 ```
+
+##### Versions older than 18.04
+Use the binary distribution. Instructions provided at https://opam.ocaml.org/doc/Install.html#Binary-distribution
 
 ## From Sources
 


### PR DESCRIPTION
Point out Anil's ppa that packages the current stable `opam`.
The version packaged in Ubuntu versions older than 19.04 is opam 1.2