### PR TITLE
switch: allow local compiler switch creation

### DIFF
--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -491,13 +491,13 @@ let get_compatible_compiler ?repos rt dir =
        (OpamStd.Format.itemize OpamPackage.to_string
           (OpamPackage.Set.elements local_packages));
      if OpamConsole.confirm "Do you want to create an empty switch regardless?"
-     then []
+     then [], false
      else OpamStd.Sys.exit_because `Aborted)
   else
   let compilers = OpamPackage.Set.inter compilers installable in
   try
     [OpamSolution.eq_atom_of_package
-       (OpamPackage.Set.choose_one compilers)]
+       (OpamPackage.Set.choose_one compilers)], true
   with
   | Not_found when not (OpamPackage.Set.is_empty local_packages) ->
     OpamConsole.warning
@@ -507,7 +507,7 @@ let get_compatible_compiler ?repos rt dir =
        OpamConsole.confirm
          "Create the switch with no specific compiler selected, and attempt to \
           continue?"
-    then []
+    then [], false
     else OpamStd.Sys.exit_because `Aborted
  | Failure _ | Not_found ->
    (* Find a matching compiler from the default selection *)
@@ -515,7 +515,7 @@ let get_compatible_compiler ?repos rt dir =
      OpamFile.Config.default_compiler gt.config
    in
    if default_compiler = Empty then
-     (OpamConsole.warning "No compiler selected"; [])
+     (OpamConsole.warning "No compiler selected"; [], false)
    else
    let candidates = OpamFormula.to_dnf default_compiler in
    try
@@ -545,7 +545,7 @@ let get_compatible_compiler ?repos rt dir =
             Some (OpamSolution.eq_atoms_of_packages compiler)
           else None
        )
-       candidates
+       candidates, false
    with Not_found ->
       OpamConsole.warning
         "The default compiler selection: %s\n\
@@ -557,5 +557,5 @@ let get_compatible_compiler ?repos rt dir =
       if OpamConsole.confirm
           "You may also proceed, with no specific compiler selected. \
            Do you want to?"
-      then []
+      then [], false
       else OpamStd.Sys.exit_because `Aborted

--- a/src/client/opamAuxCommands.mli
+++ b/src/client/opamAuxCommands.mli
@@ -91,4 +91,4 @@ val simulate_autopin:
     warning, and returns the empty list after user confirmation. *)
 val get_compatible_compiler:
   ?repos:repository_name list ->
-  'a repos_state -> dirname -> atom list
+  'a repos_state -> dirname -> atom list * bool

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -269,7 +269,7 @@ let install_compiler_packages t atoms =
   OpamSolution.check_solution ~quiet:OpamClientConfig.(not !r.show) t result;
   t
 
-let install gt ?rt ?synopsis ?repos ~update_config ~packages switch =
+let install gt ?rt ?synopsis ?repos ~update_config ~packages ?(local_compiler=false) switch =
   let update_config = update_config && not (OpamSwitch.is_external switch) in
   let old_switch_opt = OpamFile.Config.switch gt.config in
   let comp_dir = OpamPath.Switch.root gt.root switch in
@@ -310,6 +310,13 @@ let install gt ?rt ?synopsis ?repos ~update_config ~packages switch =
                 ~opams:st.opams)
       in
       { st with switch; available_packages }
+  in
+  let st =
+    if OpamSwitch.is_external switch && local_compiler then
+      OpamAuxCommands.autopin st ~quiet:true
+        [`Dirname (OpamFilename.Dir.of_string (OpamSwitch.to_string switch))]
+      |> fst
+    else st
   in
   let packages =
     try OpamSolution.sanitize_atom_list st packages

--- a/src/client/opamSwitchCommand.mli
+++ b/src/client/opamSwitchCommand.mli
@@ -24,7 +24,9 @@ val install:
   ?synopsis:string ->
   ?repos:repository_name list ->
   update_config:bool ->
-  packages:atom conjunction -> switch ->
+  packages:atom conjunction -> 
+  ?local_compiler:bool ->
+  switch ->
   unlocked global_state * rw switch_state
 
 (** Install a compiler's base packages *)


### PR DESCRIPTION
Allow creation of local switch with unknown compiler directory.
Fixes #3713