### PR TITLE
Fix variable display

### DIFF
--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -315,32 +315,35 @@ let set_global var value =
   OpamGlobalState.write { gt with config }
 
 let variable gt v =
-  match OpamPackageVar.resolve_global gt v with
-  | Some c ->
-    OpamConsole.msg "%s\n" (OpamVariable.string_of_variable_contents c)
-  | None ->
+  let raw_switch_content =
     match OpamStateConfig.get_switch_opt () with
-    | None ->
-      OpamConsole.error_and_exit `Not_found
-        "Variable %s not found"
-        (OpamVariable.Full.to_string v)
     | Some switch ->
       let switch_config =
         OpamFile.Switch_config.safe_read
           (OpamPath.Switch.switch_config gt.root switch)
       in
-      match OpamPackageVar.resolve_switch_raw gt switch switch_config v with
-      | Some c ->
-        OpamConsole.msg "%s\n" (OpamVariable.string_of_variable_contents c)
-      | None ->
-        OpamSwitchState.with_ `Lock_none gt @@ fun st ->
-        match OpamPackageVar.resolve st v with
-        | Some c ->
-          OpamConsole.msg "%s\n" (OpamVariable.string_of_variable_contents c)
-        | None ->
-          OpamConsole.error_and_exit `Not_found
-            "Variable %s not found"
-            (OpamVariable.Full.to_string v)
+      OpamPackageVar.resolve_switch_raw gt switch switch_config v
+    | None -> None
+  in
+  let switch_content =
+    match raw_switch_content with
+    | None when not (OpamVariable.Full.is_global v) ->
+      OpamSwitchState.with_ `Lock_none gt @@ fun st ->
+      OpamPackageVar.resolve st v
+    | rsc -> rsc
+  in
+  let content =
+    match switch_content with
+    | Some _ as some -> some
+    | None -> OpamPackageVar.resolve_global gt v
+  in
+  match content with
+  | Some c -> OpamConsole.msg "%s\n" (OpamVariable.string_of_variable_contents c)
+  | None ->
+    OpamConsole.error_and_exit `Not_found
+      "Variable %s not found"
+      (OpamVariable.Full.to_string v)
+
 
 let exec gt ?set_opamroot ?set_opamswitch ~inplace_path command =
   log "config-exec command=%a" (slog (String.concat " ")) command;

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -34,6 +34,8 @@ let load_config global_lock root =
   OpamFormatUpgrade.as_necessary global_lock root config;
   config
 
+let inferred_from_system = "Inferred from system"
+
 let load lock_kind =
   let root = OpamStateConfig.(!r.root_dir) in
   log "LOAD-GLOBAL-STATE @ %a" (slog OpamFilename.Dir.to_string) root;
@@ -64,7 +66,9 @@ let load lock_kind =
     List.fold_left (fun acc (v,value) ->
         OpamVariable.Map.add v
           (lazy (Some (OpamStd.Option.default (S "unknown") (Lazy.force value))),
-           "Inferred from system")
+          (* Careful on changing it, it is used to determine user defined
+             variables on `config report`. See [OpamConfigCommand.help]. *)
+           inferred_from_system)
           acc)
       OpamVariable.Map.empty
       (OpamSysPoll.variables)

--- a/src/state/opamGlobalState.mli
+++ b/src/state/opamGlobalState.mli
@@ -60,3 +60,6 @@ val write: rw global_state -> unit
     registered if it is set and exists, and removing any non-existing switches.
     Writes back to disk if possible (ie lock is available) *)
 val fix_switch_list: 'a global_state -> 'a global_state
+
+(** Description used for system inferred variables *)
+val inferred_from_system: string


### PR DESCRIPTION
`opam config list` and `opam config var <var>` don't give the same result, as the first one look first at switch modified variables (e.g. with `opam config set`) while the second does the opposite.

Fixed to the same behavior: resolving it first with switch state (loading it only for package defined variables), otherwise, global state.

Confusing pointed in #3717.