### PR TITLE
pin: fix update source of version-pinned package

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -148,8 +148,14 @@ let download_package st nv =
   else
   let dir = OpamSwitchState.source_dir st nv in
   if OpamPackage.Set.mem nv st.pinned &&
-     OpamFilename.exists_dir dir
-  then Done None
+     OpamFilename.exists_dir dir &&
+     OpamStd.Option.Op.(
+       OpamPinned.find_opam_file_in_source nv.name dir >>=
+       OpamFile.OPAM.read_opt >>=
+       OpamFile.OPAM.version_opt)
+     = Some nv.version
+  then
+    Done None
   else
     (OpamUpdate.cleanup_source st
        (OpamPackage.Map.find_opt nv st.installed_opams)


### PR DESCRIPTION
On version pinning, source directory isn't automatically updated with the new archive.
Fixes #3651.