### PR TITLE
fish unconditionally display manpath when fish version is 2.7 or later

### DIFF
--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -177,9 +177,9 @@ let rec print_fish_env env =
   (* set manpath if and only if fish version >= 2.6 *)
   let manpath_cmd v =
     OpamConsole.msg "%s" (
-      "awk -v f=$FISH_VERSION " ^
-      "'BEGIN { split(f, fs, \".\"); goodfish = fs[1] > 2 || (fs[1] == 2 && fs[2] >= 6); if (goodfish) { exit 0 } else { exit 1 } }' " ^
-      "; and "
+      (* test for existence of disown builtin, introduced in fish 2.7 *)
+      (* depends on `string' builtin, introduced in fish 2.3 *)
+      "builtin string match -q disown (builtin -n); and "
     ) ;
     set_arr_cmd "MANPATH" v in
   match env with

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -174,6 +174,14 @@ let rec print_fish_env env =
               (OpamStd.Env.escape_single_quotes ~using_backslashes:true v))
          v)
   in
+  (* set manpath if and only if fish version >= 2.6 *)
+  let manpath_cmd v =
+    OpamConsole.msg "%s" (
+      "awk -v f=$FISH_VERSION " ^
+      "'BEGIN { split(f, fs, \".\"); goodfish = fs[1] > 2 || (fs[1] == 2 && fs[2] >= 6); if (goodfish) { exit 0 } else { exit 1 } }' " ^
+      "; and "
+    ) ;
+    set_arr_cmd "MANPATH" v in
   match env with
   | [] -> ()
   | (k, v, _) :: r ->
@@ -185,8 +193,7 @@ let rec print_fish_env env =
           * opamState.ml for details *)
          set_arr_cmd k v
        | "MANPATH" ->
-         if OpamStd.Env.getopt k <> None then
-           set_arr_cmd k v
+         manpath_cmd v
        | _ ->
          OpamConsole.msg "set -gx %s '%s';\n"
            k (OpamStd.Env.escape_single_quotes ~using_backslashes:true v));

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -174,12 +174,15 @@ let rec print_fish_env env =
               (OpamStd.Env.escape_single_quotes ~using_backslashes:true v))
          v)
   in
-  (* set manpath if and only if fish version >= 2.6 *)
+  (* set manpath if and only if fish version >= 2.7 *)
   let manpath_cmd v =
     OpamConsole.msg "%s" (
-      (* test for existence of disown builtin, introduced in fish 2.7 *)
-      (* depends on `string' builtin, introduced in fish 2.3 *)
-      "builtin string match -q disown (builtin -n); and "
+      (* test for existence of `argparse` builtin, introduced in fish 2.7 .
+       * use `grep' instead of `builtin string match' so that old fish versions do not
+       *     produce unwanted error messages on stderr.
+       * use `grep' inside a `/bin/sh' fragment so that nothing is written to stdout or
+       *     stderr if `grep' does not exist. *)
+      "builtin -n | /bin/sh -c 'grep -q \\'^argparse$\\'' 1>/dev/null 2>/dev/null; and "
     ) ;
     set_arr_cmd "MANPATH" v in
   match env with


### PR DESCRIPTION
Hello, I would like feedback on this change and advice on how to write a test for it. I briefly looked through the test directory and saw some scaffolding for "fake packages", but could not figure out what the right way to set up a "fake switch" is for testing purposes.

My system opam packaged by Manjaro (version `2.0.1`, sha256sum `2b76b39ed8d53923b81985b618d4ef13fca1eabb7110bb477c7f9a3e4ae01767`) does not produce a fish shell fragment for the `MANPATH` environment variable, causing `opam` to erroneously report that the environment is out of sync.

As a workaround, I have been using the following `fish` function. `setenv` is a valid fish command and the quoting strategy used by `OpamConfigEnv.print_csh_env` seems to work for fish if the paths contain sensible characters.

    function opam_env
      eval (opam config env --shell=csh)
    end

I removed a conditional and changed it so that `OpamConfigEnv.print_fish_env` always prints the `MANPATH`, since none of the other `print_*_env` functions appear to have dedicated logic for the `MANPATH` environment variable.

I tested it by `evaling` fragments generated by the development version of `opam` and checking for the presence or absence of warnings.

    ~/.../opam> setenv MANPATH '/'
    Exit 1

    ~/.../opam> opam switch
    #   switch   compiler                    description
        4.05.0   ocaml-base-compiler.4.05.0  4.05.0
    ->  default  ocaml-system.4.07.1         default

    [WARNING] The environment is not in sync with the current switch.
              You should run: eval (opam env)

    ~/.../opam> eval (~/.../opam/opam/_build/install/default/bin/opam config env --shell=fish)

    ~/.../opam  > opam switch
    #   switch   compiler                    description
        4.05.0   ocaml-base-compiler.4.05.0  4.05.0
    ->  default  ocaml-system.4.07.1         default

No tests failed as a result of this change. At least one test probably should have failed, though.

Thanks in advance,
Greg