### PR TITLE
opam clean: Ignore errors trying to remove directories

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2930,14 +2930,16 @@ let clean =
         OpamConsole.msg "rm -rf \"%s\"/*\n"
           (OpamFilename.Dir.to_string d)
       else
-        OpamFilename.cleandir d
+      try OpamFilename.cleandir d
+      with OpamSystem.Internal_error msg -> OpamConsole.warning "Error ignored: %s" msg
     in
     let rmdir d =
       if dry_run then
         OpamConsole.msg "rm -rf \"%s\"\n"
           (OpamFilename.Dir.to_string d)
       else
-        OpamFilename.rmdir d
+      try OpamFilename.rmdir d
+      with OpamSystem.Internal_error msg -> OpamConsole.warning "Error ignored: %s" msg
     in
     let switches =
       if all_switches then OpamGlobalState.switches gt


### PR DESCRIPTION
The `opam clean` command seems slightly too strict when it comes to errors in subcommands.
My use-case here is that I have mounted `~/.opam/4.07.1/.opam-switch/build` into tmpfs to avoid unnecessary write and disk space taken on my SSD but when I try to execute `opam clean` to remove the archive cache for example, it fails trying to remove this directory.

My proposal here is to ignore all failures to when trying to remove directories during `opam clean` and instead display a note to the user telling this command failed and has been ignored.