### PR TITLE
Erroneous report of mismatching extra-files

### DIFF
--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -845,7 +845,8 @@ let add_aux_files ?dir ~files_subdir_hashes opam =
           (OpamFilename.Dir.to_string dir);
         opam
       | Some oef, Some ef ->
-        if oef <> ef then
+        let sort = List.sort (fun (b, _) (b', _) -> compare b b') in
+        if sort oef <> sort ef then
           log "Mismatching extra-files at %s"
             (OpamFilename.Dir.to_string dir);
         opam


### PR DESCRIPTION
When adding auxiliary files, sometimes opam report erroneously mismatching extra files:
```
00:00.248  opam-file   Mismatching extra-files at .opam/repo/default/packages/ocb-stubblr/ocb-stubblr.0.1.1-1
00:00.290  opam-file   Mismatching extra-files at .opam/repo/default/packages/conf-dbm/conf-dbm.1.0.0
00:00.440  opam-file   Mismatching extra-files at .opam/repo/default/packages/ocaml-config/ocaml-config.1
00:00.485  opam-file   Mismatching extra-files at .opam/repo/default/packages/zarith-freestanding/zarith-freestanding.1.7-1
```