### PR TITLE
WIP Dirty optimisation to repository loading

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -365,8 +365,9 @@ let init =
       OpamStd.Option.map (fun url ->
           let repo_url = OpamUrl.parse ?backend:repo_kind url in
           let repo_root =
-            OpamRepositoryPath.create (OpamStateConfig.(!r.root_dir))
-              repo_name
+            let d = OpamSystem.mk_temp_dir () in
+            OpamStd.Sys.at_exit (fun () -> OpamSystem.remove_dir d);
+            OpamFilename.Dir.of_string d
           in
           { repo_root; repo_name; repo_url; repo_trust = None })
         repo_url
@@ -2939,6 +2940,13 @@ let clean =
       else
         OpamFilename.rmdir d
     in
+    let rm f =
+      if dry_run then
+        OpamConsole.msg "rm -f \"%s\"\n"
+          (OpamFilename.to_string f)
+      else
+        OpamFilename.remove f
+    in
     let switches =
       if all_switches then OpamGlobalState.switches gt
       else if switch then match OpamStateConfig.get_switch_opt () with
@@ -3005,7 +3013,8 @@ let clean =
        OpamRepositoryName.Set.iter (fun r ->
            OpamConsole.msg "Removing repository %s\n"
              (OpamRepositoryName.to_string r);
-           rmdir (OpamRepositoryPath.create root r))
+           rmdir (OpamRepositoryPath.create root r);
+           rm (OpamRepositoryPath.tar root r))
          unused_repos;
        let repos_config =
          OpamRepositoryName.Map.filter

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -310,6 +310,9 @@ let extract_in filename dirname =
 let extract_in_job filename dirname =
   OpamSystem.extract_in_job (to_string filename) ~dir:(Dir.to_string dirname)
 
+let make_tar_gz_job filename dirname =
+  OpamSystem.make_tar_gz_job (to_string filename) ~dir:(Dir.to_string dirname)
+
 type generic_file =
   | D of Dir.t
   | F of t

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -212,6 +212,8 @@ val extract_in: t -> Dir.t -> unit
 
 val extract_in_job: t -> Dir.t -> exn option OpamProcess.job
 
+val make_tar_gz_job: t -> Dir.t -> exn option OpamProcess.job
+
 (** Extract a generic file *)
 val extract_generic_file: generic_file -> Dir.t -> unit
 

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -202,6 +202,8 @@ val extract_in: dir:string -> string -> unit
 (** [extract_in_job] is similar to [extract_in], but as a job *)
 val extract_in_job: dir:string -> string -> exn option OpamProcess.job
 
+val make_tar_gz_job: dir:string -> string -> exn option OpamProcess.job
+
 (** Create a directory. Do not fail if the directory already
     exist. *)
 val mkdir: string -> unit

--- a/src/repository/opamRepositoryPath.ml
+++ b/src/repository/opamRepositoryPath.ml
@@ -13,6 +13,8 @@ open OpamFilename.Op
 
 let create root name = root / "repo" / OpamRepositoryName.to_string name
 
+let tar root name = root / "repo" // (OpamRepositoryName.to_string name ^ ".tar.gz")
+
 let download_cache root = root / "download-cache"
 
 let pin_cache_dir =

--- a/src/repository/opamRepositoryPath.mli
+++ b/src/repository/opamRepositoryPath.mli
@@ -16,6 +16,8 @@ open OpamTypes
 (** Repository local path: {i $opam/repo/<name>} *)
 val create: dirname -> repository_name -> dirname
 
+val tar: dirname -> repository_name -> filename
+
 (** Prefix where to store the downloaded files cache: {i $opam/download-cache}.
     Warning, this is relative to the opam root, not a repository root. *)
 val download_cache: dirname -> dirname

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -80,6 +80,16 @@ let repository gt repo =
         job { r with repo_url = new_url } (n-1)
   in
   job repo max_loop @@+ fun repo ->
+  OpamFilename.make_tar_gz_job
+    (OpamRepositoryPath.tar gt.root repo.repo_name)
+    repo.repo_root
+  @@+ function
+  | Some e ->
+    OpamConsole.error_and_exit `Configuration_error
+      "Failed to regenerate local repository archive: %s"
+      (Printexc.to_string e)
+  | None ->
+  OpamStd.Sys.at_exit (fun () -> OpamFilename.rmdir repo.repo_root);
   let repo_file_path = OpamRepositoryPath.repo repo.repo_root in
   if not (OpamFile.exists repo_file_path) then
     OpamConsole.warning


### PR DESCRIPTION
Makes things *much* faster on older HDDs by keeping local repositories as
.tar.gz instead of thousands of scattered files. The implementation isn't very
nice at the moment though.

This only affects cases where the marshalled cache is not present, and
when the repository files are not yet in the OS disk cache.