### PR TITLE
Add `lock` option

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -159,21 +159,22 @@ type build_options = {
   jobs          : int option;
   ignore_constraints_on: name list option;
   unlock_base   : bool;
-  locked: string option;
+  locked        : bool;
+  lock_suffix   : string;
 }
 
 let create_build_options
     keep_build_dir reuse_build_dir inplace_build make no_checksums
     req_checksums build_test build_doc show dryrun skip_update
-    fake jobs ignore_constraints_on unlock_base locked = {
+    fake jobs ignore_constraints_on unlock_base locked lock_suffix = {
   keep_build_dir; reuse_build_dir; inplace_build; make;
   no_checksums; req_checksums; build_test; build_doc; show; dryrun;
-  skip_update; fake; jobs; ignore_constraints_on; unlock_base; locked;
+  skip_update; fake; jobs; ignore_constraints_on; unlock_base;
+  locked; lock_suffix
 }
 
 let apply_build_options b =
   let flag f = if f then Some true else None in
-  let some x = match x with None -> None | some -> Some some in
   OpamRepositoryConfig.update
     (* ?download_tool:(OpamTypes.arg list * dl_tool_kind) Lazy.t *)
     (* ?retries:int *)
@@ -194,7 +195,7 @@ let apply_build_options b =
       OpamStd.Option.Op.(b.ignore_constraints_on >>|
                          OpamPackage.Name.Set.of_list)
     ?unlock_base:(flag b.unlock_base)
-    ?locked:(some b.locked)
+    ?locked:(if b.locked then Some (Some b.lock_suffix) else None)
     ();
   OpamClientConfig.update
     ?keep_build_dir:(flag b.keep_build_dir)
@@ -255,7 +256,7 @@ let help_sections = [
   `P "$(i,OPAMJOBS) sets the maximum number of parallel workers to run.";
   `P "$(i,OPAMJSON) log json output to the given file (use character `%' to \
       index the files)";
-  `P "$(i,OPAMLOCKED) see install option `--locked`";
+  `P "$(i,OPAMLOCKED) combination of `--locked` and `--lock-suffix` options";
   `P "$(i,OPAMLOGS logdir) sets log directory, default is a temporary directory \
       in /tmp";
   `P "$(i,OPAMMAKECMD) set the system make command to use";
@@ -1031,6 +1032,23 @@ let global_options =
         $ignore_pin_depends
         $d_no_aspcud)
 
+(* lock options *)
+let locked section =
+  mk_flag ~section ["locked"]
+    "In commands that use opam files found from pinned sources, if a variant \
+     of the file with an added .$(i,locked) extension is found (e.g. \
+     $(b,foo.opam.locked) besides $(b,foo.opam)), that will be used instead. \
+     This is typically useful to offer a more specific set of dependencies \
+     and reproduce similar build contexts, hence the name. The $(i, lock)\
+     option can be used to generate such files, based on the versions \
+     of the dependencies currently installed on the host. This is equivalent \
+     to setting the $(b,\\$OPAMLOCKED) environment variable. Note that this \
+     option doesn't generally affect already pinned packages."
+let lock_suffix section =
+  mk_opt ~section ["lock-suffix"] "SUFFIX"
+    "Set locked files suffix to $(i,SUFFIX)."
+    Arg.(string) ("locked")
+
 (* Options common to all build commands *)
 let build_option_section = "PACKAGE BUILD OPTIONS"
 let build_options =
@@ -1116,25 +1134,13 @@ let build_options =
       "Allow changes to the packages set as switch base (typically, the main \
        compiler). Use with caution. This is equivalent to setting the \
        $(b,\\$OPAMUNLOCKBASE) environment variable" in
-  let locked =
-    let open Arg in
-    value & opt ~vopt:(Some "locked") (some string) None &
-    info ~docs:section ~docv:"SUFFIX" ["locked"] ~doc:
-      "In commands that use opam files found from pinned sources, if a variant \
-       of the file with an added .$(i,SUFFIX) extension is found (e.g. \
-       $(b,foo.opam.locked) besides $(b,foo.opam)), that will be used instead. \
-       This is typically useful to offer a more specific set of dependencies \
-       and reproduce similar build contexts, hence the name. The $(i, lock)\
-       option can be used to generate such files, based on the versions \
-       of the dependencies currently installed on the host. This is equivalent \
-       to setting the $(b,\\$OPAMLOCKED) environment variable. Note that this \
-       option doesn't generally affect already pinned packages."
-  in
+  let locked = locked section in
+  let lock_suffix = lock_suffix section in
   Term.(const create_build_options
     $keep_build_dir $reuse_build_dir $inplace_build $make
     $no_checksums $req_checksums $build_test $build_doc $show $dryrun
     $skip_update $fake $jobs_flag $ignore_constraints_on
-    $unlock_base $locked)
+    $unlock_base $locked $lock_suffix)
 
 (* Option common to install commands *)
 let assume_built =

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1124,8 +1124,8 @@ let build_options =
        of the file with an added .$(i,SUFFIX) extension is found (e.g. \
        $(b,foo.opam.locked) besides $(b,foo.opam)), that will be used instead. \
        This is typically useful to offer a more specific set of dependencies \
-       and reproduce similar build contexts, hence the name. The $(i,opam \
-       lock) plugin can be used to generate such files, based on the versions \
+       and reproduce similar build contexts, hence the name. The $(i, lock)\
+       option can be used to generate such files, based on the versions \
        of the dependencies currently installed on the host. This is equivalent \
        to setting the $(b,\\$OPAMLOCKED) environment variable. Note that this \
        option doesn't generally affect already pinned packages."

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -120,6 +120,9 @@ val assume_built: bool Term.t
 (** Applly build options *)
 val apply_build_options: build_options -> unit
 
+(** Lock options *)
+val locked: string -> bool Term.t
+val lock_suffix: string -> string Term.t
 
 (** {3 Package listing and filtering options} *)
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3099,6 +3099,19 @@ let lock =
     `P "If paths (filename or directory) are given, those opam files are locked. \
         If package is given, installed one is locked, otherwise its latest version.";
     `P "Fails if all mandatory dependencies are not installed in the switch.";
+    `S "What is changed in the locked file?";
+    `P "- $(i,depends) are fixed to their specific versions, with all filters \
+        removed (except for the exceptions below";
+    `P "- $(i,depopts) that are installed in the current switch are turned into \
+        depends, with their version set. Others are set in the $(i,conflict) field";
+    `P "- `{dev}`, `{with-test}, and `{with-doc}` filters are kept if all \
+        packages of a specific filters are installed in the switch. Versions are \
+        fixed and the same filter is on all dependencies that are added from \
+        them";
+    `P "- $(i,pin-depends) are kept and new ones are added if in the \
+        dependencies some packages are pinned ";
+    `P "- pins are resolved: if a package is locally pinned, opam tries to get \
+        its remote url and branch, and sets this as the target URL";
     `S "ARGUMENTS";
     `S "OPTIONS";
   ]

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3123,7 +3123,7 @@ let lock =
           let locked_fname =
             OpamFilename.add_extension
               (OpamFilename.of_string (OpamPackage.name_to_string nv))
-              lock_suffix
+              ("opam." ^ lock_suffix)
           in
           OpamFile.OPAM.write_with_preserved_format
             (OpamFile.make locked_fname) locked;

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3113,6 +3113,9 @@ let lock =
     OpamGlobalState.with_ `Lock_none @@ fun gt ->
     OpamSwitchState.with_ `Lock_none gt @@ fun st ->
     let st, packages = OpamLockCommand.select_packages atom_locs st in
+    if OpamPackage.Set.is_empty packages then
+      OpamConsole.msg "No lock file generated\n"
+    else
     let pkg_done =
       OpamPackage.Set.fold (fun nv msgs ->
           let opam = OpamSwitchState.opam st nv in

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3084,23 +3084,29 @@ let clean =
   term_info "clean" ~doc ~man
 
 (* LOCK *)
+let lock_doc = "Create locked opam files to share build environments across hosts."
 let lock =
-  let doc = "Create locked opam files to share build environments across hosts." in
+  let doc = lock_doc in
   let man = [
     `S "DESCRIPTION";
-    `P "This utility reads opam package definitions files, checks the current \
+    `P "Generates a lock file of a package: checks the current \
         state of their installed dependencies, and outputs modified versions of \
-        the files with a $(i,.locked) suffix, where all the (transitive) \
+        the opam file with a $(i,.locked) suffix, where all the (transitive) \
         dependencies and pinnings have been bound strictly to the currently \
         installed version.";
     `P "By using these locked opam files, it is then possible to recover the \
         precise build environment that was setup when they were generated.";
+    `P "If paths (filename or directory) are given, those opam files are locked. \
+        If package is given, installed one is locked, otherwise its latest version.";
+    `P "Fails if all mandatory dependencies are not installed in the switch.";
+    `S "ARGUMENTS";
+    `S "OPTIONS";
     `S OpamArg.build_option_section;
   ]
   in
   let only_direct_flag =
     Arg.(value & flag & info ["direct-only"] ~doc:
-           "Only lock direct dependencies, rather than the whole dependency tree")
+           "Only lock direct dependencies, rather than the whole dependency tree.")
   in
   let get_git_url url nv dir =
     let module VCS =

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3083,6 +3083,194 @@ let clean =
         $logs $switch $all_switches),
   term_info "clean" ~doc ~man
 
+(* LOCK *)
+let lock =
+  let doc = "Create locked opam files to share build environments across hosts." in
+  let man = [
+    `S "DESCRIPTION";
+    `P "This utility reads opam package definitions files, checks the current \
+        state of their installed dependencies, and outputs modified versions of \
+        the files with a $(i,.locked) suffix, where all the (transitive) \
+        dependencies and pinnings have been bound strictly to the currently \
+        installed version.";
+    `P "By using these locked opam files, it is then possible to recover the \
+        precise build environment that was setup when they were generated."
+  ]
+  in
+  let file =
+    Arg.(value & pos_all file ["."] & info [] ~docv:"FILE" ~doc:
+           "Select opam files to rewrite. the output will be put in \
+            $(i,FILE).locked. If a directory is specified, all package \
+            definitions in this directory will be processed.")
+  in
+  let only_direct_flag =
+    Arg.(value & flag & info ["direct-only"; "d"] ~doc:
+           "Only lock direct dependencies, rather than the whole dependency tree")
+  in
+  let get_git_url url nv dir =
+    OpamFilename.in_dir dir @@ fun () ->
+    try
+      match OpamSystem.read_command_output ["git";"remote";"get-url";"origin"] with
+      | [url0] ->
+        let u = OpamUrl.parse ~backend:`git url0 in
+        if OpamUrl.local_dir u <> None then None else
+        let hash =
+          match url.OpamUrl.hash with
+          | None ->
+            OpamProcess.Job.run (OpamGit.VCS.current_branch dir)
+          | Some hash ->
+            match OpamSystem.read_command_output
+                    ["git"; "branch"; "-r"; "--contains"; hash] with
+            | _::_ -> Some hash
+            | [] ->
+              (let b_default =
+                 match List.map (fun x -> OpamStd.String.split x '/')
+                         (OpamSystem.read_command_output
+                            ["git"; "symbolic-re"; "refs/remotes/origin/HEAD"]) with
+                 | [_::_::_::b::[]] -> Some b
+                 | _ -> None
+               in
+               OpamConsole.warning
+                 "Referenced git branch for %s is not available in remote: %s.%s"
+                 (OpamConsole.colorise `underline (OpamPackage.to_string nv))
+                 (OpamUrl.to_string u)
+                 (OpamStd.Option.to_string
+                    (fun b ->
+                       Printf.sprintf "\nReplace it by default remote branch %s."
+                         (OpamConsole.colorise `underline b))
+                    b_default);
+               b_default)
+        in
+        Some { u with OpamUrl.hash = hash }
+      | _ -> None
+    with OpamSystem.Command_not_found _ | OpamSystem.Process_error _ ->
+      (OpamConsole.error "Can't retrieve remote informations for %s"
+         (OpamPackage.to_string nv);
+       None)
+  in
+  let lock_opam ?(only_direct=false) st opam =
+    let opam = OpamFormatUpgrade.opam_file opam in
+    let nv = OpamFile.OPAM.package opam in
+    let st =
+      { st with opams = OpamPackage.Map.add nv opam st.opams }
+    in
+    let univ =
+      OpamSwitchState.universe st
+        ~requested:(OpamPackage.Name.Set.singleton nv.name)
+        Query
+    in
+    let all_depends =
+      OpamSolver.dependencies
+        ~depopts:true ~build:true ~post:true ~installed:true
+        univ (OpamPackage.Set.singleton nv) |>
+      List.filter (fun nv1 -> nv1 <> nv)
+    in
+    let depends =
+      if only_direct then
+        let names =
+          OpamFilter.filter_formula ~default:true (fun _ -> None)
+            (OpamFile.OPAM.depends opam) |>
+          OpamFormula.fold_left (fun acc (n,_) -> OpamPackage.Name.Set.add n acc)
+            OpamPackage.Name.Set.empty
+        in
+        List.filter (fun nv -> OpamPackage.Name.Set.mem nv.name names) all_depends
+      else all_depends
+    in
+    let depends_formula =
+      OpamFormula.ands
+        (List.rev_map (fun nv ->
+             Atom (nv.name, Atom
+                     (Constraint
+                        (`Eq, FString (OpamPackage.version_to_string nv)))))
+            depends)
+    in
+    let all_depopts =
+      OpamFormula.packages st.packages
+        (OpamFilter.filter_deps
+           ~build:true ~test:true ~doc:true ~dev:true ~default:true ~post:false
+           (OpamFile.OPAM.depopts opam))
+    in
+    let installed_depopts = OpamPackage.Set.inter all_depopts st.installed in
+    let uninstalled_depopts =
+      OpamPackage.(Name.Set.diff
+                     (names_of_packages all_depopts)
+                     (names_of_packages installed_depopts))
+    in
+    let conflicts =
+      OpamFormula.ors
+        (OpamFile.OPAM.conflicts opam ::
+         List.map (fun _ -> Atom (nv.name, Empty))
+           (OpamPackage.Name.Set.elements uninstalled_depopts))
+    in
+    let pin_depends =
+      OpamStd.List.filter_map (fun nv ->
+          if not (OpamSwitchState.is_pinned st nv.name) then None else
+          match OpamSwitchState.primary_url st nv with
+          | None -> None
+          | Some u ->
+            match OpamUrl.local_dir u with
+            | Some d ->
+              let err () =
+                OpamConsole.warning "Dependency %s is pinned to local target %s"
+                  (OpamPackage.to_string nv) (OpamUrl.to_string u);
+                None
+              in
+              if u.OpamUrl.backend = `git then
+                match get_git_url u nv d with
+                | Some resolved_u ->
+                  OpamConsole.note "Local pin %s resolved to %s"
+                    (OpamUrl.to_string u) (OpamUrl.to_string resolved_u);
+                  Some (nv, resolved_u)
+                | None -> err ()
+              else err ()
+            | None -> Some (nv, u))
+        all_depends
+    in
+    opam |>
+    OpamFile.OPAM.with_depopts OpamFormula.Empty |>
+    OpamFile.OPAM.with_depends depends_formula |>
+    OpamFile.OPAM.with_conflicts conflicts |>
+    OpamFile.OPAM.with_pin_depends pin_depends
+  in
+  let lock global_options only_direct files =
+    apply_global_options global_options;
+    let files =
+      List.fold_left (fun acc f ->
+          if Sys.is_directory f then
+            let d = OpamFilename.Dir.of_string f in
+            let fs = OpamPinned.files_in_source d in
+            if fs = [] then
+              OpamConsole.error_and_exit `Bad_arguments
+                "No package definition files found at %s"
+                OpamFilename.Dir.(to_string d);
+            List.rev_append fs acc
+          else (None, OpamFile.make (OpamFilename.of_string f)) :: acc)
+        [] files
+      |> List.rev
+    in
+    let opams =
+      List.map (fun (nameopt, f) ->
+          let opam = OpamFile.OPAM.read f in
+          f, match nameopt with
+          | None -> opam
+          | Some n -> OpamFile.OPAM.with_name n opam)
+        files
+    in
+    OpamGlobalState.with_ `Lock_none @@ fun gt ->
+    OpamSwitchState.with_ `Lock_none gt @@ fun st ->
+    List.iter (fun (f, opam) ->
+        let locked = lock_opam ~only_direct st opam in
+        let ext = OpamStd.Option.default "lock" OpamStateConfig.(!r.locked) in
+        let locked_file =
+          OpamFile.(make (OpamFilename.add_extension (filename f) ext))
+        in
+        OpamFile.OPAM.write_with_preserved_format ~format_from:f locked_file locked;
+        OpamConsole.msg "Wrote %s\n" (OpamFile.to_string locked_file))
+      opams
+  in
+  Term.(pure lock $global_options $only_direct_flag $file),
+  Term.info "opam-lock" ~doc ~man
+
 (* HELP *)
 let help =
   let doc = "Display help about opam and opam commands." in
@@ -3183,6 +3371,7 @@ let commands = [
   source;
   lint;
   clean;
+  lock;
   admin;
   help;
 ]

--- a/src/client/opamLockCommand.ml
+++ b/src/client/opamLockCommand.ml
@@ -1,4 +1,15 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2019 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
 open OpamTypes
+
 
 let select_packages atom_locs st =
   let st, atoms =

--- a/src/client/opamLockCommand.ml
+++ b/src/client/opamLockCommand.ml
@@ -1,0 +1,172 @@
+open OpamTypes
+
+let select_packages atom_locs st =
+  let st, atoms =
+    OpamAuxCommands.simulate_autopin ~quiet:true ~for_view:true st atom_locs
+  in
+  let packages =
+    OpamFormula.packages_of_atoms OpamPackage.Set.Op.(st.packages ++ st.installed) atoms
+  in
+  if OpamPackage.Set.is_empty packages then
+    OpamConsole.error_and_exit `Not_found "No package matching %s"
+      (OpamFormula.string_of_atoms atoms)
+  else
+    (let names = OpamPackage.names_of_packages packages in
+     let missing =
+       OpamStd.List.filter_map (fun (n,vc) ->
+           if OpamPackage.Name.Set.mem n names then None
+           else Some (n,vc)) atoms
+     in
+     if missing <> [] then
+       OpamConsole.error "No package matching %s"
+         (OpamFormula.string_of_atoms missing);
+     (* we keep only one version of each package, the pinned or installed one,
+        the latest version otherwise ; and the one that have their dependencies \
+        installed *)
+     let packages =
+       OpamPackage.Name.Set.fold (fun name acc ->
+           let pkgs = OpamPackage.packages_of_name packages name in
+           let pkg =
+             let open OpamPackage.Set.Op in
+             let pinned = pkgs %% st.pinned in
+             if OpamPackage.Set.is_empty pinned then
+               pkgs %% st.installed
+             else pinned
+           in
+           let nv =
+             match OpamPackage.Set.elements pkg with
+             | [nv] -> nv
+             | _ ->
+               (let nv = OpamPackage.Set.max_elt pkgs in
+                OpamConsole.note "Package %s is not installed nor pinned, generating lock \
+                                  file for its latest version %s"
+                  (OpamConsole.colorise `underline (OpamPackage.Name.to_string name))
+                  (OpamConsole.colorise `underline (OpamPackage.version_to_string nv));
+                nv)
+           in
+           let atoms =
+             OpamFormula.atoms (OpamPackageVar.all_depends st (OpamSwitchState.opam st nv))
+           in
+           let missing =
+             List.filter (fun (n,vc) ->
+                 OpamPackage.Set.fold (fun nv satisf ->
+                     satisf || not (OpamFormula.check (n,vc) nv))
+                   (OpamPackage.packages_of_name st.installed n) false)
+               atoms
+           in
+           if missing <> [] then
+             (OpamConsole.error
+                "Skipping %s, dependencies are not satisfied in this switch, \
+                 not installed packages are:\n%s"
+                (OpamPackage.to_string nv)
+                (OpamStd.Format.itemize OpamFormula.string_of_atom missing);
+              acc)
+           else
+             OpamPackage.Set.add nv acc)
+         names OpamPackage.Set.empty
+     in
+     st, packages)
+
+let get_git_url url nv dir =
+  let module VCS =
+    (val OpamRepository.find_backend_by_kind url.OpamUrl.backend)
+  in
+  let open OpamProcess.Job.Op in
+  OpamProcess.Job.run @@
+  VCS.get_remote_url ?hash:url.OpamUrl.hash dir @@| function
+  | Some u ->
+    (if u.OpamUrl.hash = None then
+       OpamConsole.warning
+         "Referenced git branch for %s is not available in remote: %s, \
+          use default branch instead."
+         (OpamConsole.colorise `underline (OpamPackage.to_string nv))
+         (OpamUrl.to_string u);
+     Some u)
+  | _ ->
+    (OpamConsole.error "Can't retrieve remote informations for %s"
+       (OpamPackage.to_string nv);
+     None)
+
+let lock_opam ?(only_direct=false) st opam =
+  let nv = OpamFile.OPAM.package opam in
+  let univ =
+    OpamSwitchState.universe st
+      ~requested:(OpamPackage.Name.Set.singleton nv.name)
+      Query
+  in
+  let all_depends =
+    OpamSolver.dependencies
+      ~depopts:true ~build:true ~post:true ~installed:true
+      univ (OpamPackage.Set.singleton nv) |>
+    List.filter (fun nv1 -> nv1 <> nv)
+  in
+  let depends =
+    if only_direct then
+      let names =
+        OpamFilter.filter_formula ~default:true (fun _ -> None)
+          (OpamFile.OPAM.depends opam) |>
+        OpamFormula.fold_left (fun acc (n,_) -> OpamPackage.Name.Set.add n acc)
+          OpamPackage.Name.Set.empty
+      in
+      List.filter (fun nv -> OpamPackage.Name.Set.mem nv.name names) all_depends
+    else all_depends
+  in
+  let depends =
+    List.sort (fun nv nv' -> OpamPackage.Name.compare nv'.name nv.name) depends
+  in
+  let depends_formula =
+    OpamFormula.ands
+      (List.rev_map (fun nv ->
+           Atom (nv.name, Atom
+                   (Constraint
+                      (`Eq, FString (OpamPackage.version_to_string nv)))))
+          depends)
+  in
+  let all_depopts =
+    OpamFormula.packages st.packages
+      (OpamFilter.filter_deps
+         ~build:true ~test:true ~doc:true ~dev:true ~default:true ~post:false
+         (OpamFile.OPAM.depopts opam))
+  in
+  let installed_depopts = OpamPackage.Set.inter all_depopts st.installed in
+  let uninstalled_depopts =
+    OpamPackage.(Name.Set.diff
+                   (names_of_packages all_depopts)
+                   (names_of_packages installed_depopts))
+  in
+  let conflicts =
+    OpamFormula.ors
+      (OpamFile.OPAM.conflicts opam ::
+       List.map (fun _-> Atom (nv.name, Empty))
+         (OpamPackage.Name.Set.elements uninstalled_depopts))
+  in
+  let pin_depends =
+    OpamStd.List.filter_map (fun nv ->
+        if not (OpamSwitchState.is_pinned st nv.name) then None else
+        match OpamSwitchState.primary_url st nv with
+        | None -> None
+        | Some u ->
+          match OpamUrl.local_dir u with
+          | Some d ->
+            let local_warn () =
+              OpamConsole.warning "Dependency %s is pinned to local target %s"
+                (OpamPackage.to_string nv) (OpamUrl.to_string u);
+              None
+            in
+            (match u.OpamUrl.backend with
+             | #OpamUrl.version_control ->
+               (match get_git_url u nv d with
+                | Some resolved_u ->
+                  OpamConsole.note "Local pin %s resolved to %s"
+                    (OpamUrl.to_string u) (OpamUrl.to_string resolved_u);
+                  Some (nv, resolved_u)
+                | None -> local_warn ())
+             | _ -> local_warn ())
+          | None -> Some (nv, u))
+      all_depends
+  in
+  opam |>
+  OpamFile.OPAM.with_depopts OpamFormula.Empty |>
+  OpamFile.OPAM.with_depends depends_formula |>
+  OpamFile.OPAM.with_conflicts conflicts |>
+  OpamFile.OPAM.with_pin_depends pin_depends

--- a/src/client/opamLockCommand.ml
+++ b/src/client/opamLockCommand.ml
@@ -125,6 +125,7 @@ let lock_opam ?(only_direct=false) st opam =
                       (`Eq, FString (OpamPackage.version_to_string nv)))))
           depends)
   in
+  (* keep installed depopts in depends and set as conflicting uninstalled ones *)
   let all_depopts =
     OpamFormula.packages st.packages
       (OpamFilter.filter_deps
@@ -140,7 +141,7 @@ let lock_opam ?(only_direct=false) st opam =
   let conflicts =
     OpamFormula.ors
       (OpamFile.OPAM.conflicts opam ::
-       List.map (fun _-> Atom (nv.name, Empty))
+       List.map (fun n -> Atom (n, Empty))
          (OpamPackage.Name.Set.elements uninstalled_depopts))
   in
   let pin_depends =

--- a/src/client/opamLockCommand.ml
+++ b/src/client/opamLockCommand.ml
@@ -45,13 +45,16 @@ let select_packages atom_locs st =
                 nv)
            in
            let atoms =
-             OpamFormula.atoms (OpamPackageVar.all_depends st (OpamSwitchState.opam st nv))
+             OpamFormula.atoms (OpamPackageVar.all_depends ~depopts:false st
+                                  (OpamSwitchState.opam st nv))
            in
            let missing =
              List.filter (fun (n,vc) ->
+                 let pkgs = (OpamPackage.packages_of_name st.installed n) in
+                 OpamPackage.Set.is_empty pkgs ||
                  OpamPackage.Set.fold (fun nv satisf ->
                      satisf || not (OpamFormula.check (n,vc) nv))
-                   (OpamPackage.packages_of_name st.installed n) false)
+                   pkgs false)
                atoms
            in
            if missing <> [] then

--- a/src/client/opamLockCommand.mli
+++ b/src/client/opamLockCommand.mli
@@ -1,0 +1,7 @@
+open OpamTypes
+open OpamStateTypes
+
+val select_packages:
+  [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
+  'a switch_state -> 'a switch_state * package_set
+val lock_opam: ?only_direct:bool -> 'a switch_state -> OpamFile.OPAM.t -> OpamFile.OPAM.t

--- a/src/client/opamLockCommand.mli
+++ b/src/client/opamLockCommand.mli
@@ -1,7 +1,25 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2019 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+
+(** Functions handling the "opam lock" command *)
+
 open OpamTypes
 open OpamStateTypes
 
+(** Select packages to lock. If a package have at least one of its direct
+    dependencies not installed in the switch, it is dropped. Returns the state
+    with non present packages pinned, and kept packages. *)
 val select_packages:
   [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
   'a switch_state -> 'a switch_state * package_set
+
+(** Returns the locked opam file, according its depends, depopts, and pins. *)
 val lock_opam: ?only_direct:bool -> 'a switch_state -> OpamFile.OPAM.t -> OpamFile.OPAM.t

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -91,6 +91,9 @@ module B = struct
 
   let sync_dirty dir url = pull_url dir None url
 
+  let get_remote_url ?hash:_ _ =
+    Done None
+
 end
 
 (* Helper functions used by opam-admin *)

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -226,4 +226,7 @@ module B = struct
 
   let sync_dirty dir url = pull_url dir None url
 
+  let get_remote_url ?hash:_ _ =
+    Done None
+
 end

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -30,6 +30,9 @@ module type S = sig
   val repo_update_complete: dirname -> url -> unit OpamProcess.job
   val revision: dirname -> version option OpamProcess.job
   val sync_dirty: dirname -> url -> filename option download OpamProcess.job
+  val get_remote_url:
+    ?hash:string -> dirname ->
+    url option OpamProcess.job
 end
 
 let compare r1 r2 = compare r1.repo_name r2.repo_name

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -73,6 +73,12 @@ module type S = sig
   val sync_dirty:
     dirname -> url -> filename option download OpamProcess.job
 
+  (** [get_remote_url ?hash dirname] return the distant url of repo [dirname], \
+      if found. When [hash] is specified, it checks that this hash (branch or \
+      commit) is present in the distant repository and returns the url with \
+      this hash. If the hash is absent it returns the remote url with no hash. *)
+  val get_remote_url:
+    ?hash:string -> dirname -> url option OpamProcess.job
 end
 
 (** Pretty-print *)

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -27,6 +27,7 @@ module type VCS = sig
   val vc_dir: dirname -> dirname
   val current_branch: dirname -> string option OpamProcess.job
   val is_dirty: dirname -> bool OpamProcess.job
+  val get_remote_url: ?hash:string -> dirname -> url option OpamProcess.job
 end
 
 let convert_path =
@@ -133,5 +134,7 @@ module Make (VCS: VCS) = struct
           | Up_to_date _ -> Up_to_date None
           | Result _ -> Result None
           | Not_available _ as na -> na)
+
+  let get_remote_url = VCS.get_remote_url
 
 end

--- a/src/repository/opamVCS.mli
+++ b/src/repository/opamVCS.mli
@@ -66,6 +66,8 @@ module type VCS = sig
       compares specifically to the last fetched state. This should always be
       [false] after [reset] has been called. *)
   val is_dirty: dirname -> bool OpamProcess.job
+
+  val get_remote_url: ?hash:string -> dirname -> url option OpamProcess.job
 end
 
 (** Create a backend from a [VCS] implementation. *)

--- a/src/state/opamPinned.ml
+++ b/src/state/opamPinned.ml
@@ -52,12 +52,12 @@ let check_locked default =
            OpamPackage.Name.Set.empty lock_depends
        in
        let base_formula =
-         OpamFilter.filter_deps ~build:true ~post:true ~test:true ~doc:true
-           ~dev:true base_depends
+         OpamFilter.filter_deps ~build:true ~post:true ~test:false ~doc:false
+           ~dev:false base_depends
        in
        let lock_formula =
-         OpamFilter.filter_deps ~build:true ~post:true ~test:true ~doc:true
-           ~dev:true lock_depends
+         OpamFilter.filter_deps ~build:true ~post:true ~test:false ~doc:false
+           ~dev:false lock_depends
        in
        let lpkg_f =
          lock_formula


### PR DESCRIPTION
Integrates lock option in opam. In order to do that, I've made also some needed changes:
- split `--locked` into `--locked` && `--lock-suffix`, no change on `OPAMLOCKED`
- add new `get_remote_url` on `OpamVCS`that retrieve repo remote url , and in case of hash (branch or commit) check that they are present in distant repo (used for `pin-depends`).

`lock` option is mainly the same than `opam-lock` plugin, except it is more integrated in opam uses: not only take files, but paths and packages, check for uninstalled dependencies, nonexistent packages.

Closes #3734, closes #3769 and related to #3694
