### PR TITLE
Optimise repository loading

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -307,7 +307,9 @@ let prepare_package_source st nv dir =
               (Printf.sprintf "Bad hash for %s" (OpamFilename.to_string src))
           else
             OpamFilename.copy ~src ~dst:(OpamFilename.create dir base))
-        (OpamFile.OPAM.get_extra_files opam);
+        (OpamFile.OPAM.get_extra_files
+           ~repos_roots:(OpamRepositoryState.get_root st.switch_repos)
+           opam);
       None
     with e -> Some e
   in

--- a/src/client/opamAdminCheck.ml
+++ b/src/client/opamAdminCheck.ml
@@ -402,8 +402,7 @@ let get_obsolete univ opams =
     aggregates PkgSet.empty
 
 let check ~quiet ~installability ~cycles ~obsolete ~ignore_test repo_root =
-  let repo = OpamRepositoryBackend.local repo_root in
-  let pkg_prefixes = OpamRepository.packages_with_prefixes repo in
+  let pkg_prefixes = OpamRepository.packages_with_prefixes repo_root in
   let opams =
     OpamPackage.Map.fold (fun nv prefix acc ->
         let opam_file = OpamRepositoryPath.opam repo_root prefix nv in

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -707,7 +707,9 @@ let get_virtual_switch_state repo_root env =
   } in
   let repo_file = OpamRepositoryPath.repo repo_root in
   let repo_def = OpamFile.Repo.safe_read repo_file in
-  let opams = OpamRepositoryState.load_opams_from_dir repo_root in
+  let opams =
+    OpamRepositoryState.load_opams_from_dir repo.repo_name repo_root
+  in
   let gt = {
     global_lock = OpamSystem.lock_none;
     root = OpamStateConfig.(!r.root_dir);

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -716,12 +716,17 @@ let get_virtual_switch_state repo_root env =
     global_variables = OpamVariable.Map.empty;
   } in
   let singl x = OpamRepositoryName.Map.singleton repo.repo_name x in
+  let repos_tmp =
+    let t = Hashtbl.create 1 in
+    Hashtbl.add t repo.repo_name (lazy repo_root); t
+  in
   let rt = {
     repos_global = gt;
     repos_lock = OpamSystem.lock_none;
     repositories = singl repo;
     repos_definitions = singl repo_def;
     repo_opams = singl opams;
+    repos_tmp;
   } in
   let st = OpamSwitchState.load_virtual ~repos_list:[repo.repo_name] gt rt in
   if env = [] then st else

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -849,7 +849,7 @@ let init
         if failed <> [] then
           OpamConsole.error_and_exit `Sync_error
             "Initial download of repository failed";
-        gt, OpamRepositoryState.unlock rt,
+        gt, OpamRepositoryState.unlock ~cleanup:false rt,
         (if dontswitch then OpamFormula.Empty
          else OpamFile.InitConfig.default_compiler init_config)
       with e ->

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2829,7 +2829,7 @@ let lint =
              | name, None -> OpamSwitchState.get_package st name
            in
            let opam = OpamSwitchState.opam st nv in
-           match OpamPinned.orig_opam_file (OpamPackage.name nv) opam with
+           match OpamPinned.orig_opam_file st (OpamPackage.name nv) opam with
            | None -> raise Not_found
            | some -> [some]
          with Not_found ->

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -364,12 +364,7 @@ let init =
     let repo =
       OpamStd.Option.map (fun url ->
           let repo_url = OpamUrl.parse ?backend:repo_kind url in
-          let repo_root =
-            let d = OpamSystem.mk_temp_dir () in
-            OpamStd.Sys.at_exit (fun () -> OpamSystem.remove_dir d);
-            OpamFilename.Dir.of_string d
-          in
-          { repo_root; repo_name; repo_url; repo_trust = None })
+          { repo_name; repo_url; repo_trust = None })
         repo_url
     in
     let gt, rt, default_compiler =
@@ -1000,8 +995,9 @@ let config =
                       if OpamUrl.root repo.repo_url =
                          OpamUrl.root OpamInitDefaults.repository_url
                       then
-                        OpamFile.Repo.safe_read
-                          (OpamRepositoryPath.repo repo.repo_root) |>
+                        OpamRepositoryName.Map.find
+                          repo.repo_name
+                          state.switch_repos.repos_definitions |>
                         OpamFile.Repo.stamp
                       else dft
                     in
@@ -3049,7 +3045,7 @@ let clean =
        OpamRepositoryName.Set.iter (fun r ->
            OpamConsole.msg "Removing repository %s\n"
              (OpamRepositoryName.to_string r);
-           rmdir (OpamRepositoryPath.create root r);
+           rmdir (OpamRepositoryPath.root root r);
            rm (OpamRepositoryPath.tar root r))
          unused_repos;
        let repos_config =

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -763,8 +763,18 @@ let info st ~fields ~raw_opam ~where ?normalise ?(show_empty=false) atoms =
       if where then
         OpamConsole.msg "%s\n"
           (match OpamFile.OPAM.metadata_dir opam with
-           | Some dir ->
-             OpamFilename.Dir.to_string OpamFilename.Op.(dir / "opam")
+           | Some (None, dir) -> Filename.concat dir "opam"
+           | Some (Some repo, rdir) ->
+             let repo_dir = OpamRepositoryPath.root st.switch_global.root repo in
+             let tar = OpamRepositoryPath.tar st.switch_global.root repo in
+             if OpamFilename.exists tar &&
+                not (OpamFilename.exists_dir repo_dir) then
+               Printf.sprintf "<%s>%s%s"
+                 (OpamFilename.to_string tar)
+                 Filename.dir_sep
+                 rdir
+             else
+               OpamFilename.Dir.to_string OpamFilename.Op.(repo_dir / rdir)
            | None -> "<nowhere>")
       else if raw_opam then
         OpamFile.OPAM.write_to_channel stdout opam

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -676,8 +676,7 @@ let display st format packages =
     OpamStd.Format.align_table |>
     OpamConsole.print_table ?cut:format.wrap stdout ~sep:format.separator
 
-let get_switch_state gt =
-  let rt = OpamRepositoryState.load `Lock_none gt in
+let get_switch_state gt rt =
   match OpamStateConfig.get_switch_opt () with
   | None -> OpamSwitchState.load_virtual gt rt
   | Some sw -> OpamSwitchState.load `Lock_none gt rt sw

--- a/src/client/opamListCommand.mli
+++ b/src/client/opamListCommand.mli
@@ -108,7 +108,7 @@ val default_list_format: output_format list
 
 (** Gets either the current switch state, if a switch is selected, or a virtual
     state corresponding to the configured repos *)
-val get_switch_state: 'a global_state -> unlocked switch_state
+val get_switch_state: 'a global_state -> 'a repos_state -> unlocked switch_state
 
 (** For documentation, includes a dummy '<field>:' for the [Field] format *)
 val field_names: (output_format * string) list

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -83,7 +83,11 @@ let get_source_definition ?version st nv url =
 
 let copy_files st opam =
   let name = OpamFile.OPAM.name opam in
-  let files = OpamFile.OPAM.get_extra_files opam in
+  let files =
+    OpamFile.OPAM.get_extra_files
+      ~repos_roots:(OpamRepositoryState.get_root st.switch_repos)
+      opam
+  in
   if files = [] then
     (match OpamFile.OPAM.extra_files opam with
      | Some [] | None -> ()

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -225,7 +225,7 @@ let edit st ?version name =
         | Some o -> OpamFile.OPAM.with_version new_nv.version o
      in
      OpamFile.OPAM.write_with_preserved_format
-       ?format_from:(OpamPinned.orig_opam_file name base_opam)
+       ?format_from:(OpamPinned.orig_opam_file st name base_opam)
        temp_file base_opam);
   match edit_raw name temp_file with
   | None -> st
@@ -516,7 +516,7 @@ and source_pin
     if need_edit then
       (if not (OpamFile.exists temp_file) then
          OpamFile.OPAM.write_with_preserved_format
-           ?format_from:(OpamPinned.orig_opam_file name opam_base)
+           ?format_from:(OpamPinned.orig_opam_file st name opam_base)
            temp_file opam_base;
        OpamStd.Option.Op.(
          edit_raw name temp_file >>|
@@ -555,7 +555,7 @@ and source_pin
     let opam = copy_files st opam in
 
     OpamFile.OPAM.write_with_preserved_format
-      ?format_from:(OpamPinned.orig_opam_file name opam)
+      ?format_from:(OpamPinned.orig_opam_file st name opam)
       (OpamPath.Switch.Overlay.opam st.switch_global.root st.switch nv.name)
       opam;
 

--- a/src/client/opamRepositoryCommand.ml
+++ b/src/client/opamRepositoryCommand.ml
@@ -246,7 +246,7 @@ let update_with_auto_upgrade rt repo_names =
            OpamConsole.msg "Upgrading repository \"%s\"...\n"
              (OpamRepositoryName.to_string r.repo_name);
            let open OpamProcess.Job.Op in
-           let repo_root = OpamRepositoryState.get_root rt r in
+           let repo_root = OpamRepositoryState.get_repo_root rt r in
            OpamAdminRepoUpgrade.do_upgrade repo_root;
            OpamProcess.Job.run
              (OpamFilename.make_tar_gz_job
@@ -262,7 +262,9 @@ let update_with_auto_upgrade rt repo_names =
              OpamFile.Repo.safe_read (OpamRepositoryPath.repo repo_root) |>
              OpamFile.Repo.with_root_url r.repo_url
            in
-           let opams = OpamRepositoryState.load_opams_from_dir repo_root in
+           let opams =
+             OpamRepositoryState.load_opams_from_dir r.repo_name repo_root
+           in
            let rt = {
              rt with
              repos_definitions =

--- a/src/client/opamRepositoryCommand.ml
+++ b/src/client/opamRepositoryCommand.ml
@@ -246,8 +246,7 @@ let update_with_auto_upgrade rt repo_names =
            OpamConsole.msg "Upgrading repository \"%s\"...\n"
              (OpamRepositoryName.to_string r.repo_name);
            let open OpamProcess.Job.Op in
-           OpamRepositoryState.with_repo_root rt.repos_global r @@
-           fun repo_root ->
+           let repo_root = OpamRepositoryState.get_root rt r in
            OpamAdminRepoUpgrade.do_upgrade repo_root;
            OpamProcess.Job.run
              (OpamFilename.make_tar_gz_job

--- a/src/client/opamSwitchCommand.mli
+++ b/src/client/opamSwitchCommand.mli
@@ -20,7 +20,7 @@ open OpamStateTypes
     globally, unless it is external *)
 val install:
   rw global_state ->
-  ?rt:'a repos_state ->
+  rt:'a repos_state ->
   ?synopsis:string ->
   ?repos:repository_name list ->
   update_config:bool ->
@@ -49,7 +49,7 @@ val export: ?full:bool -> OpamFile.SwitchExport.t OpamFile.t option -> unit
 val remove: rw global_state -> ?confirm:bool -> switch -> rw global_state
 
 (** Changes the currently active switch *)
-val switch: 'a lock -> rw global_state -> switch -> 'a switch_state
+val switch: 'a lock -> rw global_state -> switch -> unit
 
 (** Reinstall the given compiler switch. *)
 val reinstall: rw switch_state -> rw switch_state

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -310,6 +310,9 @@ let extract_in filename dirname =
 let extract_in_job filename dirname =
   OpamSystem.extract_in_job (to_string filename) ~dir:(Dir.to_string dirname)
 
+let make_tar_gz_job filename dirname =
+  OpamSystem.make_tar_gz_job (to_string filename) ~dir:(Dir.to_string dirname)
+
 type generic_file =
   | D of Dir.t
   | F of t

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -44,6 +44,9 @@ end
 
 let raw_dir s = s
 
+let mk_tmp_dir () =
+  Dir.of_string @@ OpamSystem.mk_temp_dir ()
+
 let with_tmp_dir fn =
   OpamSystem.with_tmp_dir (fun dir -> fn (Dir.of_string dir))
 

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -93,6 +93,9 @@ val with_tmp_dir: (Dir.t -> 'a) -> 'a
 (** Provide an automatically cleaned up temp directory to a job *)
 val with_tmp_dir_job: (Dir.t -> 'a OpamProcess.job) -> 'a OpamProcess.job
 
+(** Raw function to create a temporary directory. No automatic cleanup *)
+val mk_tmp_dir: unit -> Dir.t
+
 (** Create a new Dir.t and resolve symlinks *)
 val concat_and_resolve: Dir.t -> string -> Dir.t
 

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -212,6 +212,8 @@ val extract_in: t -> Dir.t -> unit
 
 val extract_in_job: t -> Dir.t -> exn option OpamProcess.job
 
+val make_tar_gz_job: t -> Dir.t -> exn option OpamProcess.job
+
 (** Extract a generic file *)
 val extract_generic_file: generic_file -> Dir.t -> unit
 

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -202,6 +202,8 @@ val extract_in: dir:string -> string -> unit
 (** [extract_in_job] is similar to [extract_in], but as a job *)
 val extract_in_job: dir:string -> string -> exn option OpamProcess.job
 
+val make_tar_gz_job: dir:string -> string -> exn option OpamProcess.job
+
 (** Create a directory. Do not fail if the directory already
     exist. *)
 val mkdir: string -> unit

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -314,8 +314,10 @@ module OPAM: sig
     descr      : Descr.t option;
 
     (* Related metadata directory (not an actual field of the file)
-       This can be used to locate e.g. the files/ overlays *)
-    metadata_dir: dirname option;
+       This can be used to locate e.g. the files/ overlays.
+       If the repository is specified, the string is a relative path from its
+       root. It should otherwise be an absolute path. *)
+    metadata_dir: (repository_name option * string) option;
 
     (* Names and hashes of the files below files/ *)
     extra_files: (OpamFilename.Base.t * OpamHash.t) list option;
@@ -477,17 +479,25 @@ module OPAM: sig
 
   val get_url: t -> url option
 
-  (** Related metadata directory (not an actual field of the file, linked to the
-      file location).
+  (** Related metadata directory (either repository name + relative path, or
+      absolute path; not an actual field of the file, linked to the file
+      location).
       This can be used to locate e.g. the files/ overlays *)
-  val metadata_dir: t -> dirname option
+  val metadata_dir: t -> (repository_name option * string) option
+
+  (** Gets the resolved metadata dir, given a mapping of repository names to
+      their roots *)
+  val get_metadata_dir:
+    repos_roots:(repository_name -> dirname) -> t -> dirname option
 
   (** Names and hashes of the files below files/ *)
   val extra_files: t -> (OpamFilename.Base.t * OpamHash.t) list option
 
   (** Looks up the extra files, and returns their full paths, relative path to
       the package source, and hash. Doesn't check the hashes. *)
-  val get_extra_files: t -> (filename * basename * OpamHash.t) list
+  val get_extra_files:
+    repos_roots:(repository_name -> dirname) ->
+    t -> (filename * basename * OpamHash.t) list
 
   (** Returns the errors that were found when parsing the file, associated to
       their fields (that were consequently ignored) *)
@@ -597,7 +607,7 @@ module OPAM: sig
   val with_url: URL.t -> t -> t
   val with_url_opt: URL.t option -> t -> t
 
-  val with_metadata_dir: dirname option -> t -> t
+  val with_metadata_dir: (repository_name option * string) option -> t -> t
 
   val with_extra_files: (OpamFilename.Base.t * OpamHash.t) list -> t -> t
   val with_extra_files_opt: (OpamFilename.Base.t * OpamHash.t) list option -> t -> t

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -170,7 +170,6 @@ type trust_anchors = {
 (** Repositories *)
 type repository = {
   repo_name    : repository_name;
-  repo_root    : dirname; (** The root of opam's local mirror for this repo *)
   repo_url     : url;
   repo_trust   : trust_anchors option;
 }

--- a/src/repository/opamRepository.mli
+++ b/src/repository/opamRepository.mli
@@ -15,19 +15,16 @@
 open OpamTypes
 
 (** Get the list of packages *)
-val packages: repository -> package_set
+val packages: dirname -> package_set
 
 (** Get the list of packages (and their possible prefix) *)
-val packages_with_prefixes: repository -> string option package_map
+val packages_with_prefixes: dirname -> string option package_map
 
 (** {2 Repository backends} *)
 
-(** Initialize {i $opam/repo/$repo} *)
-val init: dirname -> repository_name -> unit OpamProcess.job
-
 (** Update {i $opam/repo/$repo}. Raises [Failure] in case the update couldn't be
     achieved. *)
-val update: repository -> unit OpamProcess.job
+val update: repository -> dirname -> unit OpamProcess.job
 
 (** Fetch an URL and put the resulting tree into the supplied directory. The URL
     must either point to a tree (VCS, rsync) or to a known archive type. In case

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -35,17 +35,9 @@ end
 let compare r1 r2 = compare r1.repo_name r2.repo_name
 
 let to_string r =
-  Printf.sprintf "%s at %s from %s"
+  Printf.sprintf "%s from %s"
     (OpamRepositoryName.to_string r.repo_name)
-    (OpamFilename.Dir.to_string r.repo_root)
     (OpamUrl.to_string r.repo_url)
-
-let local dirname = {
-  repo_name     = OpamRepositoryName.of_string "local";
-  repo_root     = dirname;
-  repo_url      = OpamUrl.empty;
-  repo_trust    = None;
-}
 
 let to_json r =
   `O  [ ("name", OpamRepositoryName.to_json r.repo_name);

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -82,10 +82,6 @@ val to_json: repository -> json
 (** Compare repositories *)
 val compare: repository -> repository -> int
 
-(** Create a local repository on a given path, without remote (only for external
-    tools, not to be mistaken for an opam repo with a local url) *)
-val local: dirname -> repository
-
 (** [check_digest file expected] check that the [file] digest is the
     one [expected]. *)
 val check_digest: filename -> OpamHash.t option -> bool

--- a/src/repository/opamRepositoryPath.ml
+++ b/src/repository/opamRepositoryPath.ml
@@ -11,7 +11,7 @@
 
 open OpamFilename.Op
 
-let create root name = root / "repo" / OpamRepositoryName.to_string name
+let root root name = root / "repo" / OpamRepositoryName.to_string name
 
 let tar root name = root / "repo" // (OpamRepositoryName.to_string name ^ ".tar.gz")
 

--- a/src/repository/opamRepositoryPath.ml
+++ b/src/repository/opamRepositoryPath.ml
@@ -13,6 +13,8 @@ open OpamFilename.Op
 
 let create root name = root / "repo" / OpamRepositoryName.to_string name
 
+let tar root name = root / "repo" // (OpamRepositoryName.to_string name ^ ".tar.gz")
+
 let download_cache root = root / "download-cache"
 
 let pin_cache_dir =

--- a/src/repository/opamRepositoryPath.mli
+++ b/src/repository/opamRepositoryPath.mli
@@ -16,6 +16,8 @@ open OpamTypes
 (** Repository local path: {i $opam/repo/<name>} *)
 val create: dirname -> repository_name -> dirname
 
+val tar: dirname -> repository_name -> filename
+
 (** Prefix where to store the downloaded files cache: {i $opam/download-cache}.
     Warning, this is relative to the opam root, not a repository root. *)
 val download_cache: dirname -> dirname

--- a/src/repository/opamRepositoryPath.mli
+++ b/src/repository/opamRepositoryPath.mli
@@ -14,7 +14,7 @@
 open OpamTypes
 
 (** Repository local path: {i $opam/repo/<name>} *)
-val create: dirname -> repository_name -> dirname
+val root: dirname -> repository_name -> dirname
 
 val tar: dirname -> repository_name -> filename
 

--- a/src/state/opamFileTools.mli
+++ b/src/state/opamFileTools.mli
@@ -59,8 +59,16 @@ val warns_to_string: (int * [`Warning|`Error] * string) list -> string
 
 (** Read the opam metadata from a given directory (opam file, with possible
     overrides from url and descr files). Also includes the names and hashes
-    of files below files/ *)
+    of files below files/
+    Warning: use [read_repo_opam] instead for correctly reading files from
+    repositories!*)
 val read_opam: dirname -> OpamFile.OPAM.t option
+
+(** Like [read_opam], but additionally fills in the [metadata_dir] info
+    correctly for the given repository. *)
+val read_repo_opam:
+  repo_name:repository_name -> repo_root:dirname ->
+  dirname -> OpamFile.OPAM.t option
 
 (** Adds data from 'url' and 'descr' files found in the specified dir or the
     opam file's metadata dir, if not already present in the opam file. if

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -78,7 +78,11 @@ let opam_file_from_1_2_to_2_0 ?filename opam =
   let filename = match filename with
     | Some f -> OpamFile.to_string f
     | None -> match OpamFile.OPAM.metadata_dir opam with
-      | Some d -> OpamFilename.to_string (d // "opam")
+      | Some (Some r, rel_d) ->
+        Printf.sprintf "<%s>/%s/opam" (OpamRepositoryName.to_string r) rel_d
+      | Some (None, abs_d) ->
+        let d = OpamFilename.Dir.of_string abs_d in
+        OpamFilename.to_string (d // "opam")
       | None -> "opam file"
   in
   let available =

--- a/src/state/opamPinned.ml
+++ b/src/state/opamPinned.ml
@@ -191,9 +191,11 @@ let files_in_source d =
            (OpamFilename.to_string f);
          None)
 
-let orig_opam_file name opam =
+let orig_opam_file st name opam =
   let open OpamStd.Option.Op in
-  OpamFile.OPAM.metadata_dir opam >>= fun dir ->
+  OpamFile.OPAM.get_metadata_dir
+    ~repos_roots:(OpamRepositoryState.get_root st.switch_repos)
+    opam >>= fun dir ->
   OpamStd.List.find_opt OpamFilename.exists [
     dir // (OpamPackage.Name.to_string name ^ ".opam");
     dir // "opam"

--- a/src/state/opamPinned.mli
+++ b/src/state/opamPinned.mli
@@ -48,4 +48,5 @@ val name_of_opam_filename: dirname -> filename -> name option
 (** Finds back the location of the opam file this package definition was loaded
     from *)
 val orig_opam_file:
-  OpamPackage.Name.t -> OpamFile.OPAM.t -> OpamFile.OPAM.t OpamFile.t option
+  'a switch_state -> OpamPackage.Name.t -> OpamFile.OPAM.t ->
+  OpamFile.OPAM.t OpamFile.t option

--- a/src/state/opamRepositoryState.mli
+++ b/src/state/opamRepositoryState.mli
@@ -54,23 +54,31 @@ val load_opams_from_dir: OpamFilename.Dir.t -> OpamFile.OPAM.t OpamPackage.Map.t
 (** Load all the metadata within the local mirror of the given repository,
     without cache *)
 val load_repo:
-  'a global_state -> repository ->
+  repository -> OpamFilename.Dir.t ->
   OpamFile.Repo.t * OpamFile.OPAM.t OpamPackage.Map.t
 
-(** Runs the given function with access to a (possibly temporary) directory
-    containing the extracted structure of the given repository, and cleans it up
-    afterwards if temporary. The basename of the directory is guaranteed to
-    match the repository name (this is important for e.g. [tar]) *)
-val with_repo_root:
-  'a global_state -> repository -> (OpamFilename.Dir.t -> 'b) -> 'b
+(** Get the (lazily extracted) repository root for the given repository *)
+val get_root: 'a repos_state -> repository -> OpamFilename.Dir.t
 
-(** As [with_repo_root], but on jobs *)
-val with_repo_root_job:
-  'a global_state -> repository ->
-  (OpamFilename.Dir.t -> 'b OpamProcess.job) -> 'b OpamProcess.job
+(* (\** Runs the given function with access to a (possibly temporary) directory
+ *     containing the extracted structure of the given repository, and cleans it up
+ *     afterwards if temporary. The basename of the directory is guaranteed to
+ *     match the repository name (this is important for e.g. [tar]) *\)
+ * val with_repo_root:
+ *   'a global_state -> repository -> (OpamFilename.Dir.t -> 'b) -> 'b
+ * 
+ * (\** As [with_repo_root], but on jobs *\)
+ * val with_repo_root_job:
+ *   'a global_state -> repository ->
+ *   (OpamFilename.Dir.t -> 'b OpamProcess.job) -> 'b OpamProcess.job *)
 
-(** Releases any locks on the given repos_state *)
-val unlock: 'a repos_state -> unlocked repos_state
+(** Releases any locks on the given repos_state, and cleans the tmp extracted
+    tree if any unless [cleanup=false] *)
+val unlock: ?cleanup:bool -> 'a repos_state -> unlocked repos_state
+
+(** Clears tmp files corresponding to a repo state (uncompressed repository
+    contents) *)
+val cleanup: 'a repos_state -> unit
 
 (** Calls the provided function, ensuring a temporary write lock on the given
     repository state*)

--- a/src/state/opamRepositoryState.mli
+++ b/src/state/opamRepositoryState.mli
@@ -49,9 +49,25 @@ val build_index:
     ROOT/repos/) *)
 val get_repo: 'a repos_state -> repository_name -> repository
 
+val load_opams_from_dir: OpamFilename.Dir.t -> OpamFile.OPAM.t OpamPackage.Map.t
+
 (** Load all the metadata within the local mirror of the given repository,
     without cache *)
-val load_repo_opams: repository -> OpamFile.OPAM.t OpamPackage.Map.t
+val load_repo:
+  'a global_state -> repository ->
+  OpamFile.Repo.t * OpamFile.OPAM.t OpamPackage.Map.t
+
+(** Runs the given function with access to a (possibly temporary) directory
+    containing the extracted structure of the given repository, and cleans it up
+    afterwards if temporary. The basename of the directory is guaranteed to
+    match the repository name (this is important for e.g. [tar]) *)
+val with_repo_root:
+  'a global_state -> repository -> (OpamFilename.Dir.t -> 'b) -> 'b
+
+(** As [with_repo_root], but on jobs *)
+val with_repo_root_job:
+  'a global_state -> repository ->
+  (OpamFilename.Dir.t -> 'b OpamProcess.job) -> 'b OpamProcess.job
 
 (** Releases any locks on the given repos_state *)
 val unlock: 'a repos_state -> unlocked repos_state
@@ -59,8 +75,8 @@ val unlock: 'a repos_state -> unlocked repos_state
 (** Calls the provided function, ensuring a temporary write lock on the given
     repository state*)
 val with_write_lock:
-  ?dontblock:bool -> 'a repos_state -> (rw repos_state -> 'b * rw repos_state) ->
-  'b * 'a repos_state
+  ?dontblock:bool -> 'a repos_state -> (rw repos_state -> 'b * rw repos_state)
+  -> 'b * 'a repos_state
 
 (** Writes the repositories config file back to disk *)
 val write_config: rw repos_state -> unit

--- a/src/state/opamRepositoryState.mli
+++ b/src/state/opamRepositoryState.mli
@@ -49,7 +49,7 @@ val build_index:
     ROOT/repos/) *)
 val get_repo: 'a repos_state -> repository_name -> repository
 
-val load_opams_from_dir: OpamFilename.Dir.t -> OpamFile.OPAM.t OpamPackage.Map.t
+val load_opams_from_dir: repository_name -> dirname -> OpamFile.OPAM.t OpamPackage.Map.t
 
 (** Load all the metadata within the local mirror of the given repository,
     without cache *)
@@ -58,7 +58,10 @@ val load_repo:
   OpamFile.Repo.t * OpamFile.OPAM.t OpamPackage.Map.t
 
 (** Get the (lazily extracted) repository root for the given repository *)
-val get_root: 'a repos_state -> repository -> OpamFilename.Dir.t
+val get_root: 'a repos_state -> repository_name -> OpamFilename.Dir.t
+
+(** Same as [get_root], but with a repository rather than just a name as argument *)
+val get_repo_root: 'a repos_state -> repository -> OpamFilename.Dir.t
 
 (* (\** Runs the given function with access to a (possibly temporary) directory
  *     containing the extracted structure of the given repository, and cleans it up

--- a/src/state/opamStateTypes.mli
+++ b/src/state/opamStateTypes.mli
@@ -79,6 +79,10 @@ type +'lock repos_state = {
 
   repo_opams: OpamFile.OPAM.t package_map repository_name_map;
   (** All opam files that can be found in the configured repositories *)
+
+  repos_tmp: (OpamRepositoryName.t, OpamFilename.Dir.t Lazy.t) Hashtbl.t;
+  (** Temporary directories containing the uncompressed contents of the
+      repositories *)
 } constraint 'lock = 'lock lock
 
 (** State of a given switch: options, available and installed packages, etc.*)

--- a/src/state/opamSwitchAction.ml
+++ b/src/state/opamSwitchAction.ml
@@ -154,7 +154,9 @@ let install_metadata st nv =
       in
       OpamFilename.mkdir (OpamFilename.dirname dst);
       OpamFilename.copy ~src:f ~dst)
-    (OpamFile.OPAM.get_extra_files opam)
+    (OpamFile.OPAM.get_extra_files
+       ~repos_roots:(OpamRepositoryState.get_root st.switch_repos)
+       opam)
 
 let remove_metadata st packages =
   OpamPackage.Set.iter (fun nv ->

--- a/src/state/opamSwitchAction.ml
+++ b/src/state/opamSwitchAction.ml
@@ -122,7 +122,7 @@ let add_to_reinstall st ~unpinned_only packages =
     OpamFile.PkgList.write reinstall_file reinstall;
   { st with reinstall = st.reinstall ++ add_reinst_packages }
 
-let set_current_switch lock gt ?rt switch =
+let set_current_switch lock gt ~rt switch =
   if OpamSwitch.is_external switch then
     OpamConsole.error_and_exit `Bad_arguments
       "Can not set external switch '%s' globally. To set it in the current \
@@ -132,10 +132,7 @@ let set_current_switch lock gt ?rt switch =
   let config = OpamFile.Config.with_switch switch gt.config in
   let gt = { gt with config } in
   OpamGlobalState.write gt;
-  let rt = match rt with
-    | Some rt -> { rt with repos_global = gt }
-    | None -> OpamRepositoryState.load `Lock_none gt
-  in
+  let rt = { rt with repos_global = gt } in
   let st = OpamSwitchState.load lock gt rt switch in
   OpamEnv.write_dynamic_init_scripts st;
   st

--- a/src/state/opamSwitchAction.mli
+++ b/src/state/opamSwitchAction.mli
@@ -27,7 +27,7 @@ val write_selections: rw switch_state -> unit
 (** Updates the defined default switch and loads its state; fails and exits with
     a message if the switch is external *)
 val set_current_switch:
-  'a lock -> rw global_state -> ?rt:'b repos_state -> switch -> 'a switch_state
+  'a lock -> rw global_state -> rt:'b repos_state -> switch -> 'a switch_state
 
 (** Create the default global_config structure for a switch, including default
     prefix *)

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -368,7 +368,9 @@ let files st nv =
   | None -> []
   | Some opam ->
     List.map (fun (file,_base,_hash) -> file)
-      (OpamFile.OPAM.get_extra_files opam)
+      (OpamFile.OPAM.get_extra_files
+         ~repos_roots:(OpamRepositoryState.get_root st.switch_repos)
+         opam)
 
 let package_config st name =
   OpamPackage.Map.find

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -80,6 +80,16 @@ let repository gt repo =
         job { r with repo_url = new_url } (n-1)
   in
   job repo max_loop @@+ fun repo ->
+  OpamFilename.make_tar_gz_job
+    (OpamRepositoryPath.tar gt.root repo.repo_name)
+    repo.repo_root
+  @@+ function
+  | Some e ->
+    OpamConsole.error_and_exit `Configuration_error
+      "Failed to regenerate local repository archive: %s"
+      (Printexc.to_string e)
+  | None ->
+  OpamStd.Sys.at_exit (fun () -> OpamFilename.rmdir repo.repo_root);
   let repo_file_path = OpamRepositoryPath.repo repo.repo_root in
   if not (OpamFile.exists repo_file_path) then
     OpamConsole.warning

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -41,10 +41,11 @@ let eval_redirect gt repo repo_root =
     if redirect_url = repo.repo_url then None
     else Some (redirect_url, f)
 
-let repository gt repo =
+let repository rt repo =
   let max_loop = 10 in
+  let gt = rt.repos_global in
   if repo.repo_url = OpamUrl.empty then Done (fun rt -> rt) else
-  OpamRepositoryState.with_repo_root_job gt repo @@ fun repo_root ->
+  let repo_root = OpamRepositoryState.get_root rt repo in
   (* Recursively traverse redirection links, but stop after 10 steps or if
      we cycle back to the initial repo. *)
   let rec job r n =
@@ -144,7 +145,7 @@ let repositories rt repos =
            (OpamRepositoryName.to_string repo.repo_name)
            (match ex with Failure s -> s | ex -> Printexc.to_string ex);
          Done ([repo], fun t -> t)) @@
-    fun () -> repository rt.repos_global repo @@|
+    fun () -> repository rt repo @@|
     fun f -> [], f
   in
   let failed, rt_update =


### PR DESCRIPTION
Repositories stored in `~/.opam/repo` contain thousand of tiny files
and directories, and can take a huge amount of time to load on HDDs,
networked or old filesystems. This is not visible in normal use
because there is a marshalled cache, but can cause `opam update` to be
extremely slow (it now needs to compute a diff on the files, which
requires re-loading the repository drom disk), or big lags when
changing your opam version (and the full file tree is not yet in the
OS memory cache).

The solution proposed here is extremely pragmatic, yet quite
efficient: we store the repository contents as `.tar.gz` files in
`~/.opam/repo` instead. Rather than resorting to a complex in-memory
structure, we just untar them to `/tmp` when they need to be read, and
re-tar them after modification (`opam update`, or format upgrade
only). Then we let the OS disk cache do the job: in normal operation,
the tree never needs to be flushed to disk, and loading the `.tar.gz`
is orders of magnitude faster than loading the individual files.

Note that this is done even for `rsync` or `git` repositories, which
is not particularly clean, but works. In the case of `git`, it would
be possible to just store a bare repository, and use `git` to extract
the individual files (this could even be done explicitely, directly to
memory, see how `Camelus` performs). But it does not seem worth the
additional implementation cost at the moment.