### PR TITLE
Fix hg / darcs opam1.2 url parsing

### DIFF
--- a/src/core/opamUrl.ml
+++ b/src/core/opamUrl.ml
@@ -36,7 +36,7 @@ let split_url =
         opt @@ seq [
           (* Backend *)
           opt @@ seq [ group @@ rep @@ diff any (set "+:");
-                       char '+' ];
+                       alt [ char '+'; str "://"] ];
           (* Protocol *)
           group @@ rep @@ diff any (char ':');
           (* Separator *)


### PR DESCRIPTION
`hg://https://...` is wrongly translated to `hg+ssh://https//...` instead of `hg+https://...`