### PR TITLE
lint: add check_upstream option

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2795,7 +2795,12 @@ let lint =
        an opam file directly."
       Arg.(some package) None
   in
-  let lint global_options files package normalise short warnings_sel =
+  let check_upstream =
+    mk_flag ["check-upstream"]
+      "Check upstream, archive availability and checksum(s)"
+  in
+  let lint global_options files package normalise short warnings_sel
+      check_upstream =
     apply_global_options global_options;
     let opam_files_in_dir d =
       match OpamPinned.files_in_source d with
@@ -2845,9 +2850,9 @@ let lint =
           try
             let warnings,opam =
               match opam_f with
-              | Some f -> OpamFileTools.lint_file f
+              | Some f -> OpamFileTools.lint_file ~check_upstream f
               | None ->
-                OpamFileTools.lint_channel
+                OpamFileTools.lint_channel ~check_upstream
                   (OpamFile.make (OpamFilename.of_string "-")) stdin
             in
             let enabled =
@@ -2898,7 +2903,8 @@ let lint =
     in
     if err then OpamStd.Sys.exit_because `False
   in
-  Term.(const lint $global_options $files $package $normalise $short $warnings),
+  Term.(const lint $global_options $files $package $normalise $short $warnings
+        $check_upstream),
   term_info "lint" ~doc ~man
 
 (* CLEAN *)

--- a/src/state/opamFileTools.mli
+++ b/src/state/opamFileTools.mli
@@ -23,6 +23,7 @@ val template: package -> OpamFile.OPAM.t
    checked. *)
 val lint:
   ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
+  ?check_upstream: bool ->
   OpamFile.OPAM.t -> (int * [`Warning|`Error] * string) list
 
 (** Same as [lint], but operates on a file, which allows catching parse errors
@@ -31,6 +32,7 @@ val lint:
    [filename] *)
 val lint_file:
   ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
+  ?check_upstream: bool ->
   OpamFile.OPAM.t OpamFile.typed_file ->
   (int * [`Warning|`Error] * string) list * OpamFile.OPAM.t option
 
@@ -39,6 +41,7 @@ val lint_file:
    [filename] *)
 val lint_channel:
   ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
+  ?check_upstream: bool ->
   OpamFile.OPAM.t OpamFile.typed_file -> in_channel ->
   (int * [`Warning|`Error] * string) list * OpamFile.OPAM.t option
 
@@ -47,6 +50,7 @@ val lint_channel:
    directory besides [filename] *)
 val lint_string:
   ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
+  ?check_upstream: bool ->
   OpamFile.OPAM.t OpamFile.typed_file -> string ->
   (int * [`Warning|`Error] * string) list * OpamFile.OPAM.t option
 


### PR DESCRIPTION
To check reachability & availability of archive, and verify checksums.
Adds:
- warning 59: check_upstram && no checksum given
- error 60: check_upstream && (unavailable archive or don't verify at least one checksum)