### PR TITLE
Update working dir

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1012,7 +1012,8 @@ let global_options =
       "Whenever updating packages that are bound to a local, \
        version-controlled directory, update to the current working state of \
        their source instead of the last committed state, or the ref they are \
-       pointing to. \
+       pointing to. As source directory is copied as it is, it it isn't clean \
+       it may result on a opam build failure.\
        This only affects packages explicitly listed on the command-line.\
        It can also be set with $(b,\\$OPAMWORKINGDIR). "
   in


### PR DESCRIPTION
`working-dir` option didn't copy all local files, just uncomiited changes of version controlled ones, which leads to some rsync errors (if a file is deleted), and not handling new ones.
This PR changes this behavior by copying all current source directory (except `_build` directory). It may result to some build failure is current source directory is not clean.