### PR TITLE
Interleave download actions with build/install actions

### DIFF
--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -381,7 +381,7 @@ let parallel_apply t _action ~requested ?add_roots ~assume_built action_graph =
       (* Print a warning, but still do the remove *)
       OpamConsole.warning
         "The sources of the following couldn't be obtained, they may be \
-         uncleanly installed:\n%s"
+         uncleanly removed:\n%s"
         (OpamStd.Format.itemize OpamPackage.to_string
            (OpamPackage.Set.elements failed_fetch));
     let store_time =

--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -97,6 +97,8 @@ module Symbols = struct
   let upwards_arrow = Uchar.of_int 0x2191
   let downwards_arrow = Uchar.of_int 0x2193
   let up_down_arrow = Uchar.of_int 0x2195
+  let downwards_double_arrow = Uchar.of_int 0x21d3
+  let downwards_black_arrow = Uchar.of_int 0x2b07
 end
 
 type win32_glyph_checker = {

--- a/src/core/opamConsole.mli
+++ b/src/core/opamConsole.mli
@@ -63,6 +63,8 @@ module Symbols : sig
   val upwards_arrow : OpamCompat.Uchar.t
   val downwards_arrow : OpamCompat.Uchar.t
   val up_down_arrow : OpamCompat.Uchar.t
+  val downwards_double_arrow : OpamCompat.Uchar.t
+  val downwards_black_arrow : OpamCompat.Uchar.t
 end
 
 val utf8_symbol:

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -234,6 +234,7 @@ type 'a inst_action = [
 type 'a concrete_action = [
   | 'a atomic_action
   | `Build of 'a
+  | `Fetch of 'a
 ]
 
 type 'a action = [

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -147,11 +147,11 @@ let pkg_flag_of_string = function
   | s -> Pkgflag_Unknown s
 
 let action_contents = function
-  | `Remove p | `Install p | `Reinstall p | `Build p -> p
+  | `Remove p | `Install p | `Reinstall p | `Build p | `Fetch p -> p
   | `Change (_,_,p) -> p
 
 let full_action_contents = function
-  | `Remove p | `Install p | `Reinstall p | `Build p -> [p]
+  | `Remove p | `Install p | `Reinstall p | `Build p | `Fetch p -> [p]
   | `Change (_,p1,p2) -> [p1; p2]
 
 let map_atomic_action f = function
@@ -166,6 +166,7 @@ let map_highlevel_action f = function
 let map_concrete_action f = function
   | #atomic_action as a -> map_atomic_action f a
   | `Build p -> `Build (f p)
+  | `Fetch p -> `Fetch (f p)
 
 let map_action f = function
   | #highlevel_action as a -> map_highlevel_action f a

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -267,20 +267,22 @@ let pull_tree
   | Not_available _ ->
     if checksums = [] && OpamRepositoryConfig.(!r.force_checksums = Some true)
     then
-      OpamConsole.error_and_exit `File_error
-        "%s: Missing checksum, and `--require-checksums` was set."
-        label;
-    pull_from_mirrors label ?working_dir cache_dir local_dirname checksums
-      remote_urls
-    @@+ function
-    | Up_to_date None -> Done (Up_to_date ())
-    | Up_to_date (Some archive) | Result (Some archive) ->
-      OpamFilename.with_tmp_dir_job @@ fun tmpdir ->
-      let tmp_archive = OpamFilename.(create tmpdir (basename archive)) in
-      OpamFilename.move ~src:archive ~dst:tmp_archive;
-      extract_archive tmp_archive
-    | Result None -> Done (Result ())
-    | Not_available _ as na -> Done na
+      Done (
+        Not_available (
+          Some ("missing checksum"),
+          label ^ ": Missing checksum, and `--require-checksums` was set."))
+    else
+      pull_from_mirrors label ?working_dir cache_dir local_dirname checksums
+        remote_urls
+      @@+ function
+      | Up_to_date None -> Done (Up_to_date ())
+      | Up_to_date (Some archive) | Result (Some archive) ->
+        OpamFilename.with_tmp_dir_job @@ fun tmpdir ->
+        let tmp_archive = OpamFilename.(create tmpdir (basename archive)) in
+        OpamFilename.move ~src:archive ~dst:tmp_archive;
+        extract_archive tmp_archive
+      | Result None -> Done (Result ())
+      | Not_available _ as na -> Done na
 
 let revision dirname url =
   let kind = url.OpamUrl.backend in
@@ -314,16 +316,18 @@ let pull_file label ?cache_dir ?(cache_urls=[])  ?(silent_hits=false)
   | Not_available _ ->
     if checksums = [] && OpamRepositoryConfig.(!r.force_checksums = Some true)
     then
-      OpamConsole.error_and_exit `File_error
-        "%s: Missing checksum, and `--require-checksums` was set."
-        label;
-    OpamFilename.with_tmp_dir_job (fun tmpdir ->
-        pull_from_mirrors label cache_dir tmpdir checksums remote_urls
-        @@| function
-        | Up_to_date _ -> assert false
-        | Result (Some f) -> OpamFilename.move ~src:f ~dst:file; Result ()
-        | Result None -> let m = "is a directory" in Not_available (Some m, m)
-        | Not_available _ as na -> na)
+      Done (
+        Not_available
+          (Some "missing checksum",
+           label ^ ": Missing checksum, and `--require-checksums` was set."))
+    else
+      OpamFilename.with_tmp_dir_job (fun tmpdir ->
+          pull_from_mirrors label cache_dir tmpdir checksums remote_urls
+          @@| function
+          | Up_to_date _ -> assert false
+          | Result (Some f) -> OpamFilename.move ~src:f ~dst:file; Result ()
+          | Result None -> let m = "is a directory" in Not_available (Some m, m)
+          | Not_available _ as na -> na)
 
 let pull_file_to_cache label ~cache_dir ?(cache_urls=[]) checksums remote_urls =
   let text = OpamProcess.make_command_text label "dl" in

--- a/src/solver/opamActionGraph.mli
+++ b/src/solver/opamActionGraph.mli
@@ -42,8 +42,14 @@ module type SIG = sig
   (** Expand install actions, adding a build action preceding them.
       The argument [noop_remove] is a function that should return `true`
       for package where the `remove` action is known not to modify the
-      filesystem (such as `conf-*` package). *)
-  val explicit: ?noop_remove:(package -> bool) -> t -> t
+      filesystem (such as `conf-*` package).
+      The argument [sources_needed] is a function that should return `true`
+      for packages that require fetching sources (packages that do not
+      require it are typically up-to-date pins or "in-place" builds). *)
+  val explicit:
+    ?noop_remove:(package -> bool) ->
+    sources_needed:(package -> bool) ->
+    t -> t
 
   (** Folds on all recursive successors of the given action, including itself,
       depth-first. *)

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -847,10 +847,11 @@ let compute_root_causes g requested reinstall =
       (* Nothing can cause these actions after itself *)
       Unknown
     | (`Install _ | `Reinstall _), `Before, _ ->
-      (* An install or reinstall doesn't cause any oter actions on its
+      (* An install or reinstall doesn't cause any other actions on its
          dependendants *)
       Unknown
     | `Build _, _, _ | _, _, `Build _ -> assert false
+    | `Fetch _, _, _ | _, _, `Fetch _ -> assert false (* XXX CHECK *)
   in
   let get_causes acc roots =
     let rec aux seen depth pkgname causes =

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -576,7 +576,7 @@ let new_packages sol =
       match action with
       | `Install p | `Change (_,_,p) ->
         OpamPackage.Set.add (OpamCudf.cudf2opam p) packages
-      | `Reinstall _ | `Remove _ | `Build _ -> packages
+      | `Reinstall _ | `Remove _ | `Build _ | `Fetch _ -> packages
   ) sol OpamPackage.Set.empty
 
 let all_packages sol =
@@ -594,7 +594,7 @@ let stats sol =
       | `Change (`Down,_,_) -> {stats with s_downgrade = stats.s_downgrade+1}
       | `Reinstall _ -> {stats with s_reinstall = stats.s_reinstall+1}
       | `Remove _ -> {stats with s_remove = stats.s_remove+1}
-      | `Build _ -> stats)
+      | `Build _ | `Fetch _ -> stats)
     (OpamCudf.ActionGraph.reduce sol)
     { s_install=0; s_reinstall=0; s_upgrade=0; s_downgrade=0; s_remove=0 }
 
@@ -660,7 +660,7 @@ let print_solution ~messages ~append ~requested ~reinstall t =
           match a with
           | `Install p | `Change (_,_,p) | `Reinstall p ->
             messages (OpamCudf.cudf2opam p)
-          | `Remove _ | `Build _ -> []
+          | `Remove _ | `Build _ | `Fetch _ -> []
         in
         action :: actions, (cause, messages) :: details
       ) t ([],[])

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -148,6 +148,14 @@ let repositories rt repos =
   OpamRepositoryState.Cache.save rt;
   failed, rt
 
+let report_fetch_failure pkg = function
+  | Not_available (s, l) ->
+    let msg = match s with None -> l | Some s -> s in
+    OpamConsole.msg "[%s] fetching sources failed: %s\n"
+      (OpamConsole.colorise `red (OpamPackage.to_string pkg)) msg;
+    Not_available (s, l)
+  | res -> res
+
 let fetch_dev_package url srcdir ?(working_dir=false) nv =
   let remote_url = OpamFile.URL.url url in
   let mirrors = remote_url :: OpamFile.URL.mirrors url in
@@ -156,6 +164,8 @@ let fetch_dev_package url srcdir ?(working_dir=false) nv =
   OpamRepository.pull_tree
     ~cache_dir:(OpamRepositoryPath.download_cache OpamStateConfig.(!r.root_dir))
     (OpamPackage.to_string nv) srcdir checksum ~working_dir mirrors
+  @@| report_fetch_failure nv
+
 
 let pinned_package st ?version ?(working_dir=false) name =
   log "update-pinned-package %s%a" (OpamPackage.Name.to_string name)
@@ -480,22 +490,23 @@ let download_package_source st nv dirname =
     match OpamFile.OPAM.url opam with
     | None   -> Done None
     | Some u ->
-      OpamRepository.pull_tree (OpamPackage.to_string nv)
+      (OpamRepository.pull_tree (OpamPackage.to_string nv)
         ~cache_dir ~cache_urls
         dirname
         (OpamFile.URL.checksum u)
         (OpamFile.URL.url u :: OpamFile.URL.mirrors u)
+       @@| report_fetch_failure nv)
       @@| OpamStd.Option.some
   in
   let fetch_extra_source_job (name, u) = function
     | Some (Not_available _) as err -> Done err
     | ret ->
-      OpamRepository.pull_file_to_cache
-        (OpamPackage.to_string nv ^"/"^ OpamFilename.Base.to_string name)
-        ~cache_dir ~cache_urls
-        (OpamFile.URL.checksum u)
-        (OpamFile.URL.url u :: OpamFile.URL.mirrors u)
-      @@| function
+      (OpamRepository.pull_file_to_cache
+         (OpamPackage.to_string nv ^"/"^ OpamFilename.Base.to_string name)
+         ~cache_dir ~cache_urls
+         (OpamFile.URL.checksum u)
+         (OpamFile.URL.url u :: OpamFile.URL.mirrors u)
+       @@| report_fetch_failure nv) @@| function
       | Not_available _ as na -> Some na
       | _ -> ret
   in


### PR DESCRIPTION
Caveats:
 - ~~Change of behavior: in the current implementation, if a "remove" needs a "fetch" and the fetch fails, opam will print a warning but do the remove nonetheless (by just removing the files). In this PR, if the fetch fails, the remove will automatically get cancelled. In practice, this can happen only for a few packages that do not use light-uninstall, but it would be annoying nonetheless. It would probably be nice to give the user a way around this, using --force or something.~~
- Currently, the jobs pool is shared between build and fetch actions. This can be improved, by implementing two separate pools in the scheduler, which should improve parallelism further.
This can be done in a separate PR.