### PR TITLE
Experimental generalisation of the job scheduler

### DIFF
--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -536,8 +536,8 @@ let parallel_apply t _action ~requested ?add_roots ~assume_built action_graph =
           inplace OpamFilename.Dir.Map.empty |>
         OpamFilename.Dir.Map.values
       in
-      let mutually_exclusive =
-        installs_removes ::
+      let pools =
+        (installs_removes, 1) ::
         OpamStd.List.filter_map
           (fun excl ->
              match
@@ -547,7 +547,7 @@ let parallel_apply t _action ~requested ?add_roots ~assume_built action_graph =
                     if PackageActionGraph.mem_vertex action_graph act
                     then Some act else None)
                  excl
-             with [] | [_] -> None | l -> Some l)
+             with [] | [_] -> None | l -> Some (l,1))
           same_inplace_source
       in
       let results =
@@ -555,7 +555,7 @@ let parallel_apply t _action ~requested ?add_roots ~assume_built action_graph =
           ~jobs:(Lazy.force OpamStateConfig.(!r.jobs))
           ~command:job
           ~dry_run:OpamStateConfig.(!r.dryrun)
-          ~mutually_exclusive
+          ~pools
           action_graph
       in
       if OpamClientConfig.(!r.json_out <> None) then

--- a/src/core/opamParallel.mli
+++ b/src/core/opamParallel.mli
@@ -53,13 +53,17 @@ module type SIG = sig
   module G : G
 
   (** Runs the job [command ~pred v] for every node [v] in a graph, in
-      topological order, using [jobs] concurrent processes. [pred] is the
-      associative list of job results on direct predecessors of [v]. *)
+      topological order using [jobs] concurrent processes. Separate (possibly
+      intersecting) node pools can be specified, with a separate number of
+      allowed processes. The [jobs] maximum applies to the remaining nodes.
+
+      The [pred] argument provided to the [command] function is the associative
+      list of job results on direct predecessors of [v]. *)
   val iter:
     jobs:int ->
     command:(pred:(G.V.t * 'a) list -> G.V.t -> 'a OpamProcess.job) ->
     ?dry_run:bool ->
-    ?mutually_exclusive:(G.V.t list list) ->
+    ?pools:((G.V.t list * int) list) ->
     G.t ->
     unit
 
@@ -69,7 +73,7 @@ module type SIG = sig
     jobs:int ->
     command:(pred:(G.V.t * 'a) list -> G.V.t -> 'a OpamProcess.job) ->
     ?dry_run:bool ->
-    ?mutually_exclusive:(G.V.t list list) ->
+    ?pools:((G.V.t list * int) list) ->
     G.t ->
     (G.V.t * 'a) list
 


### PR DESCRIPTION
This generalises the "mutually excusive sets", by providing separate job
pools for different subsets of the tasks. This will be useful to
parallelise downloads and builds efficiently.