### PR TITLE
Set opam env variables once

### DIFF
--- a/src/state/shellscripts/env_hook.csh
+++ b/src/state/shellscripts/env_hook.csh
@@ -1,1 +1,1 @@
-alias precmd 'eval `opam env --shell=csh --readonly`'
+eval `opam env --shell=csh --readonly`


### PR DESCRIPTION
env_hook.csh uses precmd to set its environment variables, meaning they will be set every time the prompt is about to be displayed. I don't see anything in the variables that require them to be kept in sync with the shell state (e.g., cwd), so I think precmd is overkill. Isn't it enough to just set them at startup?