### PR TITLE
Refactor the return types of OpamSolution.{apply,resolve_and_apply}

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -292,7 +292,7 @@ let upgrade_t ?strict_upgrade ?auto_install ?ask ?(check=false) ~all atoms t =
          then `False
          else `Success)
     else
-    let t, result = OpamSolution.apply ?ask t Upgrade ~requested solution in
+    let t, result = OpamSolution.apply ?ask t ~requested solution in
     if result = Nothing_to_do then (
       let to_check =
         if OpamPackage.Name.Set.is_empty requested then t.installed
@@ -500,7 +500,7 @@ let fixup t =
     | Success solution ->
       let _, req_rm, _ = orphans ~transitive:false t in
       let t, res =
-        OpamSolution.apply ~ask:true t Upgrade
+        OpamSolution.apply ~ask:true t
           ~requested:(OpamPackage.names_of_packages (requested ++ req_rm))
           solution in
       t, Success res
@@ -1098,7 +1098,7 @@ let install_t t ?ask atoms add_to_roots ~deps_only ~assume_built =
           add_to_roots
       in
       let t, res =
-        OpamSolution.apply ?ask t Install ~requested:names ?add_roots
+        OpamSolution.apply ?ask t ~requested:names ?add_roots
           ~assume_built solution in
       t, Success res
   in

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -260,7 +260,7 @@ end
 
 (* Process the atomic actions in a graph in parallel, respecting graph order,
    and report to user. Takes a graph of atomic actions *)
-let parallel_apply t _action ~requested ?add_roots ~assume_built action_graph =
+let parallel_apply t ~requested ?add_roots ~assume_built action_graph =
   log "parallel_apply";
 
   let remove_action_packages =
@@ -797,7 +797,7 @@ let run_hook_job t name ?(local=[]) w =
     Done true
 
 (* Apply a solution *)
-let apply ?ask t action ~requested ?add_roots ?(assume_built=false) solution =
+let apply ?ask t ~requested ?add_roots ?(assume_built=false) solution =
   log "apply";
   if OpamSolver.solution_is_empty solution then
     (* The current state satisfies the request contraints *)
@@ -885,7 +885,7 @@ let apply ?ask t action ~requested ?add_roots ?(assume_built=false) solution =
         OpamStd.Sys.exit_because `Configuration_error;
       let t0 = t in
       let t, r =
-        parallel_apply t action ~requested ?add_roots ~assume_built action_graph
+        parallel_apply t ~requested ?add_roots ~assume_built action_graph
       in
       let success = match r with | OK _ -> true | _ -> false in
       let post_session =
@@ -935,5 +935,5 @@ let resolve_and_apply ?ask t action ~orphans ?reinstall ~requested ?add_roots
          (OpamSwitchState.unavailable_reason t) cs);
     t, Conflicts cs
   | Success solution ->
-    let t, res = apply ?ask t action ~requested ?add_roots ~assume_built solution in
+    let t, res = apply ?ask t ~requested ?add_roots ~assume_built solution in
     t, Success res

--- a/src/client/opamSolution.mli
+++ b/src/client/opamSolution.mli
@@ -36,7 +36,7 @@ val apply:
   ?add_roots:OpamPackage.Name.Set.t ->
   ?assume_built:bool ->
   OpamSolver.solution ->
-  rw switch_state * solver_result
+  rw switch_state * solution_result
 
 (** Call the solver to get a solution and then call [apply]. If [ask] is not
     specified, prompts the user whenever the solution isn't obvious from the
@@ -52,12 +52,15 @@ val resolve_and_apply:
   ?add_roots:OpamPackage.Name.Set.t ->
   ?assume_built:bool ->
   atom request ->
-  rw switch_state * solver_result
+  rw switch_state * (solution_result, OpamCudf.conflict) result
 
 (** Raise an error if no solution is found or in case of error. Unless [quiet]
     is set, print a message indicating that nothing was done on an empty
     solution. *)
-val check_solution: ?quiet:bool -> 'a switch_state -> solver_result -> unit
+val check_solution:
+  ?quiet:bool -> 'a switch_state ->
+  (solution_result, 'conflict) result ->
+  unit
 
 (** {2 Atoms} *)
 

--- a/src/client/opamSolution.mli
+++ b/src/client/opamSolution.mli
@@ -31,7 +31,6 @@ val resolve:
 val apply:
   ?ask:bool ->
   rw switch_state ->
-  user_action ->
   requested:OpamPackage.Name.Set.t ->
   ?add_roots:OpamPackage.Name.Set.t ->
   ?assume_built:bool ->

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -266,7 +266,8 @@ let install_compiler_packages t atoms =
     OpamSolution.apply ~ask:OpamClientConfig.(!r.show) t Switch
       ~requested:roots
       solution in
-  OpamSolution.check_solution ~quiet:OpamClientConfig.(not !r.show) t result;
+  OpamSolution.check_solution ~quiet:OpamClientConfig.(not !r.show) t
+    (Success result);
   t
 
 let install gt ~rt ?synopsis ?repos ~update_config ~packages ?(local_compiler=false) switch =

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -263,7 +263,7 @@ let install_compiler_packages t atoms =
   in
   let t = { t with compiler_packages = to_install_pkgs } in
   let t, result =
-    OpamSolution.apply ~ask:OpamClientConfig.(!r.show) t Switch
+    OpamSolution.apply ~ask:OpamClientConfig.(!r.show) t
       ~requested:roots
       solution in
   OpamSolution.check_solution ~quiet:OpamClientConfig.(not !r.show) t

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -251,14 +251,17 @@ type 'a cause =
   | Unknown
 
 (** Solver result *)
-type solver_result =
+type actions_result = {
+  actions_successes : package action list;
+  actions_errors : (package action * exn) list;
+  actions_aborted : package action list;
+}
+
+type solution_result =
   | Nothing_to_do
   | OK of package action list (** List of successful actions *)
   | Aborted
-  | No_solution
-  | Partial_error of package action list * package action list * package action list
-  (** List of successful actions, list of actions with errors,
-      list of remaining undone actions *)
+  | Partial_error of actions_result
 
 (** Solver result *)
 type ('a, 'b) result =


### PR DESCRIPTION
The goal of this PR is to make `OpamSolution.apply` return a bit more information about what happened, in particular for the jobs that failed.

This is joint work with @gasche .