### PR TITLE
Introduce `drop` to replace `ignore (unlock ..)` for more lock-type-safety

### DIFF
--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -115,7 +115,7 @@ let check_and_run_external_commands () =
             OpamSolverConfig.init ();
             OpamClientConfig.init ();
             OpamSwitchState.with_ `Lock_write gt (fun st ->
-                ignore @@
+                OpamSwitchState.drop @@
                 OpamClient.install st [OpamSolution.eq_atom_of_package nv]
               );
             match OpamSystem.resolve_command ~env command with

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -162,8 +162,8 @@ let with_write_lock ?dontblock gt f =
 
 let with_ lock f =
   let gt = load lock in
-  try let r = f gt in ignore (unlock gt); r
-  with e -> OpamStd.Exn.finalise e (fun () -> ignore (unlock gt))
+  try let r = f gt in drop gt; r
+  with e -> OpamStd.Exn.finalise e (fun () -> drop gt)
 
 let write gt =
   OpamFile.Config.write (OpamPath.config gt.root) gt.config

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -148,6 +148,9 @@ let unlock gt =
   OpamSystem.funlock gt.global_lock;
   (gt :> unlocked global_state)
 
+let drop gt =
+  let _ = unlock gt in ()
+
 let with_write_lock ?dontblock gt f =
   let ret, gt =
     OpamFilename.with_flock_upgrade `Lock_write ?dontblock gt.global_lock

--- a/src/state/opamGlobalState.mli
+++ b/src/state/opamGlobalState.mli
@@ -46,6 +46,15 @@ val repos_list: 'a global_state -> repository_name list
 (** Releases any locks on the given global_state *)
 val unlock: 'a global_state -> unlocked global_state
 
+(** Releases any locks on the given global state and then ignores it.
+
+    Using [drop gt] is equivalent to [ignore (unlock gt)],
+    and safer than other uses of [ignore]
+    where it is not enforced by the type-system
+    that the value is unlocked before it is lost.
+*)
+val drop: 'a global_state -> unit
+
 (** Calls the provided function, ensuring a temporary write lock on the given
     global state *)
 val with_write_lock:

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -297,6 +297,9 @@ let unlock ?cleanup:(cln=true) rt =
   OpamSystem.funlock rt.repos_lock;
   (rt :> unlocked repos_state)
 
+let drop ?cleanup rt =
+  let _ = unlock ?cleanup rt in ()
+
 let with_write_lock ?dontblock rt f =
   let ret, rt =
     OpamFilename.with_flock_upgrade `Lock_write ?dontblock rt.repos_lock

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -311,7 +311,7 @@ let with_write_lock ?dontblock rt f =
 
 let with_ lock gt f =
   let rt = load lock gt in
-  OpamStd.Exn.finally (fun () -> ignore (unlock rt)) (fun () -> f rt)
+  OpamStd.Exn.finally (fun () -> drop rt) (fun () -> f rt)
 
 let write_config rt =
   OpamFile.Repos_config.write (OpamPath.repos_config rt.repos_global.root)

--- a/src/state/opamRepositoryState.mli
+++ b/src/state/opamRepositoryState.mli
@@ -79,6 +79,15 @@ val get_repo_root: 'a repos_state -> repository -> OpamFilename.Dir.t
     tree if any unless [cleanup=false] *)
 val unlock: ?cleanup:bool -> 'a repos_state -> unlocked repos_state
 
+(** Releases any locks on the given repos_state and then ignores it.
+
+    Using [drop ?cleanup rt] is equivalent to [ignore (unlock ?cleanup rt)],
+    and safer than other uses of [ignore]
+    where it is not enforced by the type-system
+    that the value is unlocked before it is lost.
+*)
+val drop: ?cleanup:bool -> 'a repos_state -> unit
+
 (** Clears tmp files corresponding to a repo state (uncompressed repository
     contents) *)
 val cleanup: 'a repos_state -> unit

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -801,10 +801,10 @@ let with_ lock ?rt ?(switch=OpamStateConfig.get_switch ()) gt f =
   @@ fun rt ->
   let st = load lock gt rt switch in
   let cleanup_backup = do_backup lock st in
-  try let r = f st in ignore (unlock st); cleanup_backup true; r
+  try let r = f st in drop st; cleanup_backup true; r
   with e ->
     OpamStd.Exn.finalise e @@ fun () ->
-    ignore (unlock st);
+    drop st;
     if not OpamCoreConfig.(!r.keep_log_dir) then cleanup_backup false
 
 let update_repositories gt update_fun switch =

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -338,6 +338,9 @@ let unlock st =
   OpamSystem.funlock st.switch_lock;
   (st :> unlocked switch_state)
 
+let drop st =
+  let _ = unlock st in ()
+
 let with_write_lock ?dontblock st f =
   let ret, st =
     OpamFilename.with_flock_upgrade `Lock_write ?dontblock st.switch_lock

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -54,6 +54,15 @@ val compute_available_packages:
 (** Releases any locks on the given switch_state *)
 val unlock: 'a switch_state -> unlocked switch_state
 
+(** Releases any locks on the given switch state and then ignores it.
+
+    Using [drop st] is equivalent to [ignore (unlock st)],
+    and safer than other uses of [ignore]
+    where it is not enforced by the type-system
+    that the value is unlocked before it is lost.
+*)
+val drop: 'a switch_state -> unit
+
 (** Calls the provided function, ensuring a temporary write lock on the given
     switch state *)
 val with_write_lock:


### PR DESCRIPTION
This PR, coming out of joint work with @Armael, can be summarized by the corresponding mli documentation:

```ocaml
(** Releases any locks on the given global state and then ignores it.
    Using [drop gt] is equivalent to [ignore (unlock gt)],
    and safer than other uses of [ignore]
    where it is not enforced by the type-system
    that the value is unlocked before it is lost.
*)
val drop: 'a global_state -> unit
```

The idea is applied to all three kinds of states-with-locks (global, switch, repos), and then `drop` is consistently used within the whole opam codebase, to remove `ignore` on possibly-still-locked locks as a code smell. See the commit message of the first commit for more design details.

Example from the patch:

```diff
- ignore (OpamSwitchState.unlock st);
- ignore (clear_switch gt switch)
+ OpamSwitchState.drop st;
+ OpamGlobalState.drop (clear_switch gt switch)
```

I didn't find any instance where locks were silently ignored incorrectly. Besides the fact that the resulting code is generally nicer, the point of porting the whole opam codebase is to encourage clueless users of opam-lib (us, for example) to follow the same style and avoid mistakes there.