### PR TITLE
JSON (de)serialization for OpamParallel graphs

### DIFF
--- a/src/core/opamParallel.ml
+++ b/src/core/opamParallel.ml
@@ -272,6 +272,7 @@ module type GRAPH = sig
   module Dot : sig val output_graph : out_channel -> t -> unit end
   val transitive_closure:  ?reflexive:bool -> t -> unit
   val build: V.t list -> E.t list -> t
+  val compare : t -> t -> int
   val to_json : t OpamJson.encoder
   val of_json : t OpamJson.decoder
 end
@@ -310,6 +311,15 @@ module MakeGraph (X: VERTEX) = struct
     List.iter (add_vertex graph) vertices;
     List.iter (add_edge_e graph) edges;
     graph
+
+  let compare g1 g2 =
+    let module Vertices = Set.Make(Vertex) in
+    let module Edges = Set.Make(E) in
+    let vertices g = fold_vertex Vertices.add g Vertices.empty in
+    let edges g = fold_edges_e Edges.add g Edges.empty in
+    match Vertices.compare (vertices g1) (vertices g2) with
+    | 0 -> Edges.compare (edges g1) (edges g2)
+    | n -> n
 
   let to_json (graph : t) : OpamJson.t =
     let vertex_map =

--- a/src/core/opamParallel.ml
+++ b/src/core/opamParallel.ml
@@ -22,8 +22,10 @@ module type VERTEX = sig
   include Graph.Sig.COMPARABLE with type t := t
 end
 
+type dependency_label = unit
+
 module type G = sig
-  include Graph.Sig.I
+  include Graph.Sig.I with type E.label = dependency_label
   module Vertex: VERTEX with type t = V.t
   module Topological: sig
     val fold: (V.t -> 'a -> 'a) -> t -> 'a -> 'a
@@ -259,7 +261,7 @@ module Make (G : G) = struct
 end
 
 module type GRAPH = sig
-  include Graph.Sig.I
+  include Graph.Sig.I with type E.label = dependency_label
   include Graph.Oper.S with type g = t
   module Topological : sig
     val fold : (V.t -> 'a -> 'a) -> t -> 'a -> 'a

--- a/src/core/opamParallel.mli
+++ b/src/core/opamParallel.mli
@@ -98,6 +98,7 @@ module type GRAPH = sig
                          and type G.V.t = vertex
   module Dot : sig val output_graph : out_channel -> t -> unit end
   val transitive_closure:  ?reflexive:bool -> t -> unit
+  val build: V.t list -> E.t list -> t
   val to_json : t OpamJson.encoder
   val of_json : t OpamJson.decoder
 end

--- a/src/core/opamParallel.mli
+++ b/src/core/opamParallel.mli
@@ -98,6 +98,8 @@ module type GRAPH = sig
                          and type G.V.t = vertex
   module Dot : sig val output_graph : out_channel -> t -> unit end
   val transitive_closure:  ?reflexive:bool -> t -> unit
+  val to_json : t OpamJson.encoder
+  val of_json : t OpamJson.decoder
 end
 
 module MakeGraph (V: VERTEX) : GRAPH with type V.t = V.t

--- a/src/core/opamParallel.mli
+++ b/src/core/opamParallel.mli
@@ -99,6 +99,7 @@ module type GRAPH = sig
   module Dot : sig val output_graph : out_channel -> t -> unit end
   val transitive_closure:  ?reflexive:bool -> t -> unit
   val build: V.t list -> E.t list -> t
+  val compare : t -> t -> int
   val to_json : t OpamJson.encoder
   val of_json : t OpamJson.decoder
 end

--- a/src/core/opamParallel.mli
+++ b/src/core/opamParallel.mli
@@ -16,8 +16,10 @@ module type VERTEX = sig
   include Graph.Sig.COMPARABLE with type t := t
 end
 
+type dependency_label = unit
+
 module type G = sig
-  include Graph.Sig.I
+  include Graph.Sig.I with type E.label = dependency_label
   module Vertex: VERTEX with type t = V.t
   module Topological: sig
     val fold: (V.t -> 'a -> 'a) -> t -> 'a -> 'a
@@ -86,7 +88,7 @@ module Make (G : G) : SIG with module G = G
                            and type G.V.t = G.V.t
 
 module type GRAPH = sig
-  include Graph.Sig.I
+  include Graph.Sig.I with type E.label = dependency_label
   include Graph.Oper.S with type g = t
   module Topological : sig
     val fold : (V.t -> 'a -> 'a) -> t -> 'a -> 'a

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -55,6 +55,11 @@ let is_available universe wish_remove (name, _ as c) =
   &&
   List.for_all (fun (n, _) -> n <> name) wish_remove
 
+let solution_to_json solution =
+  OpamCudf.ActionGraph.to_json solution
+let solution_of_json json =
+  OpamCudf.ActionGraph.of_json json
+
 let cudf_versions_map universe packages =
   log ~level:3 "cudf_versions_map";
   let add_referred_to_packages filt acc refmap =

--- a/src/solver/opamSolver.mli
+++ b/src/solver/opamSolver.mli
@@ -48,6 +48,10 @@ val print_solution:
   requested:name_set -> reinstall:package_set ->
   solution -> unit
 
+(** Serialize a solution *)
+val solution_to_json : solution OpamJson.encoder
+val solution_of_json : solution OpamJson.decoder
+
 (** Computes an opam->cudf version map from a set of package *)
 val cudf_versions_map: universe -> package_set -> int OpamPackage.Map.t
 


### PR DESCRIPTION
This PR provides JSON in/out functions for OpamParallel graphs, and in particular for the `OpamSolver.solution` type.

I needed to introduce new functions to the OpamParallel API, and to make the signatures less abstract (to reveal that the graph is unlabelled). See the commit messages for explanations.

(feature request from @Armael in the context of our marracheck work)