### PR TITLE
Add OPAMDROPWORKINGDIR env variable

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -272,6 +272,9 @@ let help_sections = [
   `P "$(i,OPAMNO) answer no to any question asked.";
   `P "$(i,OPAMNOASPCUD) Deprecated.";
   `P "$(i,OPAMNOCHECKSUMS) enables option --no-checksums when available.";
+  `P "$(i,OPAMDROPWORKINGDIR) overrides packages previously updated with \
+      $(b,--working-dir) on update. Without this variable set, opam would keep them \
+      unchanged unless explicitely named on the command-line.";
   `P "$(i,OPAMNOSELFUPGRADE) see option `--no-self-upgrade'.";
   `P "$(i,OPAMPINKINDAUTO) sets whether version control systems should be \
       detected when pinning to a local path. Enabled by default since 1.3.0.";

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -564,7 +564,9 @@ let update
          nondev_packages)
     in
     let dirty_dev_packages, dev_packages =
-      if names <> [] then OpamPackage.Set.empty, dev_packages else
+      if names <> [] || OpamClientConfig.(!r.drop_working_dir) then
+        OpamPackage.Set.empty, dev_packages
+      else
         OpamPackage.Set.partition
           (fun nv ->
              let src_cache = OpamSwitchState.source_dir st nv in

--- a/src/client/opamClientConfig.ml
+++ b/src/client/opamClientConfig.ml
@@ -17,6 +17,7 @@ type t = {
   reuse_build_dir: bool;
   inplace_build: bool;
   working_dir: bool;
+  drop_working_dir: bool;
   ignore_pin_depends: bool;
   show: bool;
   fake: bool;
@@ -35,6 +36,7 @@ let default = {
   reuse_build_dir = false;
   inplace_build = false;
   working_dir = false;
+  drop_working_dir = false;
   ignore_pin_depends = false;
   show = false;
   fake = false;
@@ -53,6 +55,7 @@ type 'a options_fun =
   ?reuse_build_dir:bool ->
   ?inplace_build:bool ->
   ?working_dir:bool ->
+  ?drop_working_dir:bool ->
   ?ignore_pin_depends:bool ->
   ?show:bool ->
   ?fake:bool ->
@@ -71,6 +74,7 @@ let setk k t
     ?reuse_build_dir
     ?inplace_build
     ?working_dir
+    ?drop_working_dir
     ?ignore_pin_depends
     ?show
     ?fake
@@ -96,6 +100,7 @@ let setk k t
     json_out = t.json_out + json_out;
     root_is_ok = t.root_is_ok + root_is_ok;
     no_auto_upgrade = t.no_auto_upgrade + no_auto_upgrade;
+    drop_working_dir = t.drop_working_dir + drop_working_dir;
   }
 
 let set t = setk (fun x () -> x) t
@@ -119,6 +124,7 @@ let initk k =
     ?reuse_build_dir:(env_bool "REUSEBUILDDIR")
     ?inplace_build:(env_bool "INPLACEBUILD")
     ?working_dir:(env_bool "WORKINGDIR")
+    ?drop_working_dir:(env_bool "DROPWORKINGDIR")
     ?ignore_pin_depends:(env_bool "IGNOREPINDEPENDS")
     ?show:(env_bool "SHOW")
     ?fake:(env_bool "FAKE")

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -20,6 +20,7 @@ type t = private {
   reuse_build_dir: bool;
   inplace_build: bool;
   working_dir: bool;
+  drop_working_dir: bool;
   ignore_pin_depends: bool;
   show: bool;
   fake: bool;
@@ -39,6 +40,7 @@ type 'a options_fun =
   ?reuse_build_dir:bool ->
   ?inplace_build:bool ->
   ?working_dir:bool ->
+  ?drop_working_dir:bool ->
   ?ignore_pin_depends:bool ->
   ?show:bool ->
   ?fake:bool ->
@@ -72,6 +74,7 @@ val opam_init:
   ?reuse_build_dir:bool ->
   ?inplace_build:bool ->
   ?working_dir:bool ->
+  ?drop_working_dir:bool ->
   ?ignore_pin_depends:bool ->
   ?show:bool ->
   ?fake:bool ->


### PR DESCRIPTION
Mainly for CI.
It permit to not block update of packages previously installed with `--working-dir` (or that happen to have a dirty source tree).

Related to #3727 and more especially https://github.com/ocaml/opam/issues/3727#issuecomment-459016232.

/cc @RalfJung