### PR TITLE
Change OpamStateTypes.switch_state.conf_files from package_map to name_map

### DIFF
--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -403,8 +403,8 @@ let parallel_apply t ~requested ?add_roots ~assume_built action_graph =
     let t =
       { !t_ref with
         installed = visible_installed;
-        conf_files = OpamPackage.Map.filter
-            (fun nv _ -> OpamPackage.Set.mem nv visible_installed)
+        conf_files = OpamPackage.Name.Map.filter
+            (fun name _ -> OpamPackage.Set.exists (fun pkg -> OpamPackage.Name.equal name pkg.name) visible_installed)
             !t_ref.conf_files; }
     in
     let nv = action_contents action in

--- a/src/format/opamPackage.ml
+++ b/src/format/opamPackage.ml
@@ -36,6 +36,9 @@ module Version = struct
 
   let compare = OpamVersionCompare.compare
 
+  let equal v1 v2 =
+    compare v1 v2 = 0
+
   let to_json x =
     `String (to_string x)
   let of_json = function
@@ -84,6 +87,9 @@ module Name = struct
     match compare (String.lowercase_ascii n1) (String.lowercase_ascii n2) with
     | 0 -> compare n1 n2
     | i -> i
+
+  let equal n1 n2 =
+    compare n1 n2 = 0
 
   let to_json x = `String x
   let of_json = function

--- a/src/format/opamPackage.mli
+++ b/src/format/opamPackage.mli
@@ -21,6 +21,9 @@ module Version: sig
 
   (** Compare two versions using the Debian version scheme *)
   val compare: t -> t -> int
+
+  (** Are two package versions equal? *)
+  val equal: t -> t -> bool
 end
 
 (** Names *)
@@ -30,6 +33,8 @@ module Name: sig
   (** Compare two package names *)
   val compare: t -> t -> int
 
+  (** Are two package names equal? *)
+  val equal: t -> t -> bool
 end
 
 type t = private {

--- a/src/state/opamPackageVar.ml
+++ b/src/state/opamPackageVar.ml
@@ -212,11 +212,7 @@ let resolve st ?opam:opam_arg ?(local=OpamVariable.Map.empty) v =
   let read_package_var v =
     let get name =
       try
-        let cfg =
-          OpamPackage.Map.find
-            (OpamPackage.package_of_name st.installed name)
-            st.conf_files
-        in
+        let cfg = OpamPackage.Name.Map.find name st.conf_files in
         OpamFile.Dot_config.variable cfg (OpamVariable.Full.variable v)
       with Not_found -> None
     in

--- a/src/state/opamStateTypes.mli
+++ b/src/state/opamStateTypes.mli
@@ -112,7 +112,7 @@ type +'lock switch_state = {
       in separate files), as well as the original metadata directory (that can
       be used to retrieve the files/ subdir) *)
 
-  conf_files: OpamFile.Dot_config.t package_map;
+  conf_files: OpamFile.Dot_config.t name_map;
   (** The opam-config of installed packages (from
       ".opam-switch/config/pkgname.config") *)
 

--- a/src/state/opamSwitchAction.ml
+++ b/src/state/opamSwitchAction.ml
@@ -215,7 +215,7 @@ let add_to_installed st ?(root=false) nv =
     OpamFile.Dot_config.safe_read
       (OpamPath.Switch.config st.switch_global.root st.switch nv.name)
   in
-  let st = { st with conf_files = OpamPackage.Map.add nv conf st.conf_files } in
+  let st = { st with conf_files = OpamPackage.Name.Map.add nv.name conf st.conf_files } in
   if not OpamStateConfig.(!r.dryrun) then (
     install_metadata st nv;
     if OpamFile.OPAM.env opam <> [] &&
@@ -243,4 +243,4 @@ let remove_from_installed ?(keep_as_root=false) st nv =
   then
     (* note: don't remove_metadata just yet *)
     OpamEnv.write_dynamic_init_scripts st;
-  { st with conf_files = OpamPackage.Map.remove nv st.conf_files }
+  { st with conf_files = OpamPackage.Name.Map.remove nv.name st.conf_files }

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -231,14 +231,15 @@ let load lock_kind gt rt switch =
   in
   let conf_files =
     OpamPackage.Set.fold (fun nv acc ->
-        OpamPackage.Map.add nv
+        OpamPackage.Name.Map.add nv.name
           (OpamFile.Dot_config.safe_read
              (OpamPath.Switch.config gt.root switch nv.name))
           acc)
-      installed OpamPackage.Map.empty
+      installed OpamPackage.Name.Map.empty
   in
   let ext_files_changed =
-    OpamPackage.Map.fold (fun nv conf acc ->
+    OpamPackage.Name.Map.fold (fun name conf acc ->
+        let nv = OpamPackage.package_of_name installed name in
         if
           List.exists (fun (file, hash) ->
               let exists = OpamFilename.exists file in
@@ -322,7 +323,7 @@ let load_virtual ?repos_list gt rt =
     installed_roots = OpamPackage.Set.empty;
     repos_package_index = opams;
     opams;
-    conf_files = OpamPackage.Map.empty;
+    conf_files = OpamPackage.Name.Map.empty;
     packages;
     available_packages = lazy packages;
     reinstall = OpamPackage.Set.empty;
@@ -376,9 +377,7 @@ let files st nv =
          opam)
 
 let package_config st name =
-  OpamPackage.Map.find
-    (OpamPackage.package_of_name st.installed name)
-    st.conf_files
+  OpamPackage.Name.Map.find name st.conf_files
 
 let is_name_installed st name =
   OpamPackage.has_name st.installed name


### PR DESCRIPTION
Currently, the API for accessing `.config` files is a little awkward - only one `.config` file may be installed, and they physically never refer to version numbers, yet the API uses `OpamPackage.t` with slightly awkward calls to `OpamPackage.package_of_name` (awkward because it forces you to query the set of installed packages in order to get a fake version of the package to look up a file from a map which was keyed on name only, not name+version!).

This PR changes the type of `conf_files` to be a `name_map`. The semantics of `OpamSwitchState.package_config` are subtly different in that a `.config` file can be loaded for a package which is not installed - that at present would indicate a "corrupt" OPAMROOT but happens to be rather useful for something I'm working on...