### PR TITLE
Proposal: refresh the Unicode symbols we use for actions

### DIFF
--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -98,6 +98,11 @@ module Symbols = struct
   let downwards_arrow = Uchar.of_int 0x2193
   let up_down_arrow = Uchar.of_int 0x2195
   let downwards_double_arrow = Uchar.of_int 0x21d3
+  let black_down_pointing_triangle = Uchar.of_int 0x25bc
+  let black_up_pointing_triangle = Uchar.of_int 0x25b2
+  let white_diamond = Uchar.of_int 0x25c7
+  let black_diamond = Uchar.of_int 0x25c6
+  let white_diamond_containing_black_small_diamond = Uchar.of_int 0x25c8
   let downwards_black_arrow = Uchar.of_int 0x2b07
 end
 

--- a/src/core/opamConsole.mli
+++ b/src/core/opamConsole.mli
@@ -65,6 +65,11 @@ module Symbols : sig
   val up_down_arrow : OpamCompat.Uchar.t
   val downwards_double_arrow : OpamCompat.Uchar.t
   val downwards_black_arrow : OpamCompat.Uchar.t
+  val black_down_pointing_triangle : OpamCompat.Uchar.t
+  val black_up_pointing_triangle : OpamCompat.Uchar.t
+  val white_diamond : OpamCompat.Uchar.t
+  val black_diamond : OpamCompat.Uchar.t
+  val white_diamond_containing_black_small_diamond : OpamCompat.Uchar.t
 end
 
 val utf8_symbol:

--- a/src/solver/opamActionGraph.ml
+++ b/src/solver/opamActionGraph.ml
@@ -35,26 +35,31 @@ let symbol_of_action =
   let open OpamConsole in
   function
   | `Remove _ ->
-      utf8_symbol Symbols.circled_division_slash
-                  ~alternates:[Symbols.greek_small_letter_lambda] "X"
+      utf8_symbol Symbols.white_diamond
+                  ~alternates:[Symbols.circled_division_slash] "X"
   | `Install _ ->
-      utf8_symbol Symbols.asterisk_operator
-                  ~alternates:[Symbols.six_pointed_black_star] "*"
+      utf8_symbol Symbols.black_diamond
+                  ~alternates:[Symbols.asterisk_operator;
+                               Symbols.six_pointed_black_star] "*"
   | `Change (`Up,_,_) ->
-      utf8_symbol Symbols.north_east_arrow
-                  ~alternates:[Symbols.upwards_arrow] "U"
+      utf8_symbol Symbols.black_up_pointing_triangle
+                  ~alternates:[Symbols.north_east_arrow;
+                               Symbols.upwards_arrow] "U"
   | `Change (`Down,_,_) ->
-      utf8_symbol Symbols.south_east_arrow
-                  ~alternates:[Symbols.downwards_arrow] "D"
+      utf8_symbol Symbols.black_down_pointing_triangle
+                  ~alternates:[Symbols.south_east_arrow;
+                               Symbols.downwards_arrow] "D"
   | `Reinstall _ ->
-      utf8_symbol Symbols.clockwise_open_circle_arrow
-                  ~alternates:[Symbols.up_down_arrow] "R"
+      utf8_symbol Symbols.white_diamond_containing_black_small_diamond
+                  ~alternates:[Symbols.clockwise_open_circle_arrow;
+                               Symbols.up_down_arrow] "R"
   | `Build _ ->
       utf8_symbol Symbols.greek_small_letter_lambda
                   ~alternates:[Symbols.six_pointed_black_star] "B"
   | `Fetch _ ->
-    utf8_symbol Symbols.downwards_double_arrow
-      ~alternates:[Symbols.downwards_black_arrow] "F"
+    utf8_symbol Symbols.downwards_black_arrow
+      ~alternates:[Symbols.downwards_double_arrow;
+                   Symbols.black_down_pointing_triangle] "F"
 
 let action_strings ?utf8 a =
   if utf8 = None && (OpamConsole.utf8 ()) || utf8 = Some true


### PR DESCRIPTION
the new ones should display better on standard terminals

Not sure it looks better though:

▲ upgrade
▼ downgrade
◆ install
◇ remove
◈ reinstall
⬇ download
λ build

(current set:
↗ upgrade
↘ downgrade
∗ install
⊘ remove
↻ reinstall
▼ download
λ build
)