### PR TITLE
Remove & reinstall of system wide changed packages

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1070,7 +1070,8 @@ let install_t t ?ask atoms add_to_roots ~deps_only ~assume_built =
        available_packages) in
   let t = {t with available_packages = lazy available_packages} in
 
-  if pkg_new = [] && OpamPackage.Set.is_empty pkg_reinstall then t else
+  if pkg_new = [] && OpamPackage.Set.is_empty pkg_reinstall
+     && OpamPackage.Set.is_empty t.remove then t else
   let t, atoms =
     if assume_built then
       assume_built_restrictions t atoms

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -338,8 +338,14 @@ let parallel_apply t ~requested ?add_roots ~assume_built action_graph =
   let action_graph = (* Add build actions *)
     let noop_remove nv =
       OpamAction.noop_remove_package t nv in
+    let need_remove =
+      if OpamPackage.Set.is_empty t.remove then None
+      else
+      let n_remove = OpamPackage.names_of_packages t.remove in
+      Some (fun p -> OpamPackage.(Name.Set.mem (name p) n_remove))
+    in
     PackageActionGraph.explicit
-      ~noop_remove
+      ?need_remove ~noop_remove
       ~sources_needed:(fun p -> OpamPackage.Set.mem p sources_needed)
       action_graph
   in

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -943,6 +943,15 @@ let resolve t action ~orphans ?reinstall ~requested request =
       (`A (List.map (fun s -> `String s) (Array.to_list Sys.argv)));
     OpamJson.append "switch" (OpamSwitch.to_json t.switch)
   );
+  let reinstall =
+    match reinstall with
+    | Some set -> Some (OpamPackage.Set.union set t.remove)
+    | None ->
+      if OpamPackage.Set.is_empty t.remove then
+        None
+      else
+        Some t.remove
+  in
   Json.output_request request action;
   let r =
     OpamSolver.resolve

--- a/src/solver/opamActionGraph.mli
+++ b/src/solver/opamActionGraph.mli
@@ -45,8 +45,13 @@ module type SIG = sig
       filesystem (such as `conf-*` package).
       The argument [sources_needed] is a function that should return `true`
       for packages that require fetching sources (packages that do not
-      require it are typically up-to-date pins or "in-place" builds). *)
+      require it are typically up-to-date pins or "in-place" builds).
+      The argument [need_remove] is a function that should return `true` for
+      the package that need to be mandatory removed. It is used to add the
+      remove action as a predecessor of the build action, in order to prevent
+      non removal because of build fail.*)
   val explicit:
+    ?need_remove:(package -> bool) ->
     ?noop_remove:(package -> bool) ->
     sources_needed:(package -> bool) ->
     t -> t

--- a/src/state/opamStateTypes.mli
+++ b/src/state/opamStateTypes.mli
@@ -141,6 +141,9 @@ type +'lock switch_state = {
   reinstall: package_set;
   (** The set of packages which needs to be reinstalled *)
 
+  remove: package_set;
+  (** The set of packages which need to be removed *)
+
   (* Missing: a cache for
      - switch-global and package variables
      - the solver universe? *)

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -278,9 +278,7 @@ let load lock_kind gt rt switch =
       conf_files
       OpamPackage.Set.empty
   in
-  let installed =
-    installed -- ext_files_changed
-  in
+  let remove = ext_files_changed in
   let reinstall =
     OpamFile.PkgList.safe_read (OpamPath.Switch.reinstall gt.root switch) ++
     changed
@@ -293,7 +291,8 @@ let load lock_kind gt rt switch =
     repos_package_index; installed_opams;
     installed; pinned; installed_roots;
     opams; conf_files;
-    packages; available_packages; reinstall;
+    packages; available_packages;
+    reinstall; remove;
   } in
   log "Switch state loaded in %.3fs" (chrono ());
   st
@@ -327,6 +326,7 @@ let load_virtual ?repos_list gt rt =
     packages;
     available_packages = lazy packages;
     reinstall = OpamPackage.Set.empty;
+    remove = OpamPackage.Set.empty;
   }
 
 let selections st =


### PR DESCRIPTION
If a package depends on a system file, its hash is stored in the config file, it permits to detect if the files changed or has been removed. In that case, it was only removed from installed packages in order to be reinstalled.
This PR propose a deeper management of these packages modfication, by 
- adding them automatically to the reinstall packages list (even if nothing is needed to be installed)
- changing their action graph: we need the package to be removed in any case, even if the build fails.
Current action graph precedence adds remove action after the build, it is changed for these packages and their dependences

possible side effect: new `ocaml-system` is not installable, opam deleted all your packages in the current switch.