### PR TITLE
Fix auto upgrade of `ocaml-system`

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -447,7 +447,7 @@ let upgrade t ?check ~all names =
     if OpamPackage.Set.is_empty base_to_update then
       None, t
     else
-      (log "unlocking base packages to fix  %s"
+      (log "unlocking base packages to fix %s"
          (OpamPackage.Set.to_string base_to_update);
        Some t.compiler_packages,
        { t with compiler_packages = OpamPackage.Set.empty })

--- a/src/state/opamStateTypes.mli
+++ b/src/state/opamStateTypes.mli
@@ -142,7 +142,7 @@ type +'lock switch_state = {
   (** The set of packages which needs to be reinstalled *)
 
   remove: package_set;
-  (** The set of packages which need to be removed *)
+  (** The set of packages which needs to be removed *)
 
   (* Missing: a cache for
      - switch-global and package variables

--- a/src/state/opamStateTypes.mli
+++ b/src/state/opamStateTypes.mli
@@ -141,6 +141,9 @@ type +'lock switch_state = {
   reinstall: package_set;
   (** The set of packages which needs to be reinstalled *)
 
+  remove: package_set;
+  (** The set of packages which need to be removed *)
+
   (* Missing: a cache for
      - switch-global and package variables
      - the solver universe? *)

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -278,9 +278,7 @@ let load lock_kind gt rt switch =
       conf_files
       OpamPackage.Set.empty
   in
-  let installed =
-    installed -- ext_files_changed
-  in
+  let remove = ext_files_changed in
   let reinstall =
     OpamFile.PkgList.safe_read (OpamPath.Switch.reinstall gt.root switch) ++
     changed
@@ -293,7 +291,8 @@ let load lock_kind gt rt switch =
     repos_package_index; installed_opams;
     installed; pinned; installed_roots;
     opams; conf_files;
-    packages; available_packages; reinstall;
+    packages; available_packages;
+    reinstall; remove;
   } in
   log "Switch state loaded in %.3fs" (chrono ());
   st
@@ -327,6 +326,7 @@ let load_virtual ?repos_list gt rt =
     packages;
     available_packages = lazy packages;
     reinstall = OpamPackage.Set.empty;
+    remove = OpamPackage.Set.empty;
   }
 
 let selections st =


### PR DESCRIPTION
System compiler upgrade (closes #3708) using `opam upgrade --fixup`: base packages are unlocked automatically in order to update compiler packages to current system installed, or an `ocaml-variant` if no `ocaml-system` is found.