### PR TITLE
Forget about system wide changed packages and its depends

### DIFF
--- a/src/state/opamStateTypes.mli
+++ b/src/state/opamStateTypes.mli
@@ -141,6 +141,9 @@ type +'lock switch_state = {
   reinstall: package_set;
   (** The set of packages which needs to be reinstalled *)
 
+  remove: package_set;
+  (** The set of packages which need to be removed *)
+
   (* Missing: a cache for
      - switch-global and package variables
      - the solver universe? *)

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -278,9 +278,7 @@ let load lock_kind gt rt switch =
       conf_files
       OpamPackage.Set.empty
   in
-  let installed =
-    installed -- ext_files_changed
-  in
+  let remove = ext_files_changed in
   let reinstall =
     OpamFile.PkgList.safe_read (OpamPath.Switch.reinstall gt.root switch) ++
     changed
@@ -293,7 +291,8 @@ let load lock_kind gt rt switch =
     repos_package_index; installed_opams;
     installed; pinned; installed_roots;
     opams; conf_files;
-    packages; available_packages; reinstall;
+    packages; available_packages;
+    reinstall; remove;
   } in
   log "Switch state loaded in %.3fs" (chrono ());
   st
@@ -327,6 +326,7 @@ let load_virtual ?repos_list gt rt =
     packages;
     available_packages = lazy packages;
     reinstall = OpamPackage.Set.empty;
+    remove = OpamPackage.Set.empty;
   }
 
 let selections st =

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -259,16 +259,19 @@ let load lock_kind gt rt switch =
                 OpamConsole.error
                   "System file %s, which package %s depends upon, \
                    no longer exists.\n\
-                   The package has been marked as removed, and opam will \
-                   try to reinstall it if necessary, but you should reinstall \
+                   %s has been marked to be ignored on coming \
+                   operations (as well its reverse dependencies), unless it \
+                   is directly reinstalled. You should reinstall \
                    its system dependencies first."
                   (OpamFilename.to_string file) (OpamPackage.to_string nv)
+                  (OpamPackage.name_to_string nv)
               else if changed then
                 OpamConsole.warning
                   "File %s, which package %s depends upon, \
                    was changed on your system. \
-                   %s has been marked as removed, and will be reinstalled if \
-                   necessary."
+                   %s has been marked to be ignored on coming \
+                   operations (as well its reverse dependencies), unless it \
+                   is directly reinstalled."
                   (OpamFilename.to_string file) (OpamPackage.to_string nv)
                   (OpamPackage.name_to_string nv);
               changed)


### PR DESCRIPTION
If a package depends on a system file, its hash is stored in the config file, it permits to detect if the files changed or has been removed. In that case, it was only removed from installed packages in order to be reinstalled.
This PR propose another solution than #3814: instead of forcing re move & reinstall, it just forbid you to use these package unless system files are fixed.