### PR TITLE
Update guix install instructions

### DIFF
--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -173,13 +173,13 @@ apt install opam
 ##### Versions older than 18.04
 Use the binary distribution. Instructions provided at https://opam.ocaml.org/doc/Install.html#Binary-distribution
 
-#### Guix & GuixSD
+#### Guix & Guix System
 
 The opam package for [guix](https://www.gnu.org/software/guix/) can be installed with the command:
 
 ```
 # Guix
-guix package -i opam
+guix install opam
 ```
 
 ## From Sources


### PR DESCRIPTION
Guix has changed its terminology, so the full system is now called Guix System instead of GuixSD (see [this note](https://www.gnu.org/software/guix/manual/en/html_node/Introduction.html#DOCF2) in the manual).

Guix also added a simpler alias to `guix package -i` called `guix install` and we try to encourage users to use it most of the time.

Thanks :)