### PR TITLE
lint: add result in json output

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2859,8 +2859,13 @@ let lint =
           "--package and a file argument are incompatible"
     in
     let msg = if normalise then OpamConsole.errmsg else OpamConsole.msg in
-    let err =
-      List.fold_left (fun err opam_f ->
+    let json =
+      match OpamClientConfig.(!r.json_out) with
+      | None -> None
+      | Some _ -> Some []
+    in
+    let err,json =
+      List.fold_left (fun (err,json) opam_f ->
           try
             let warnings,opam =
               match opam_f with
@@ -2906,15 +2911,24 @@ let lint =
                 (OpamFileTools.warns_to_string warnings);
             if normalise then
               OpamStd.Option.iter (OpamFile.OPAM.write_to_channel stdout) opam;
-            err || failed
+            let json =
+              OpamStd.Option.map
+                (List.cons
+                   (OpamFileTools.warns_to_json
+                      ?filename:(OpamStd.Option.map OpamFile.to_string opam_f)
+                      warnings))
+                json
+            in
+            (err || failed), json
           with
           | Parsing.Parse_error
           | OpamLexer.Error _
           | OpamPp.Bad_format _ ->
             msg "File format error\n";
-            true)
-        false files
+            (true, json))
+        (false, json) files
     in
+    OpamStd.Option.iter (fun json -> OpamJson.append "lint" (`A json)) json;
     if err then OpamStd.Sys.exit_because `False
   in
   Term.(const lint $global_options $files $package $normalise $short $warnings

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2913,7 +2913,7 @@ let lint =
               OpamStd.Option.iter (OpamFile.OPAM.write_to_channel stdout) opam;
             let json =
               OpamStd.Option.map
-                (List.cons
+                (OpamStd.List.cons
                    (OpamFileTools.warns_to_json
                       ?filename:(OpamStd.Option.map OpamFile.to_string opam_f)
                       warnings))

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -808,6 +808,35 @@ let warns_to_string ws =
          (Printf.sprintf "  %16s %2d: %s" ws n s))
     ws
 
+let warns_to_json ?filename ws =
+  let filename =
+  match filename with
+  | Some f -> f
+  | None -> "stdout"
+  in
+  let warn, err =
+    List.fold_left (fun (w,e) (n,we,s) ->
+        let arr =
+          `O [ "id", `Float (float_of_int n);
+               "message", `String s]
+        in
+        match we with
+        | `Warning -> arr::w, e
+        | `Error -> w, arr::e) ([],[]) ws
+  in
+  let result =
+  match warn,err with
+  | [],[] -> "passed"
+  | _, _::_ -> "error"
+  | _::_, [] -> "warning"
+  in
+  `O [
+    "file", `String filename;
+    "result", `String result;
+     "warnings", `A warn;
+     "errors", `A err
+  ]
+
 (* Package definition loading *)
 
 open OpamFilename.Op

--- a/src/state/opamFileTools.mli
+++ b/src/state/opamFileTools.mli
@@ -57,6 +57,25 @@ val lint_string:
 (** Utility function to print validation results *)
 val warns_to_string: (int * [`Warning|`Error] * string) list -> string
 
+(** Utility function to construct a json of validation results.
+    The format is as follow:
+    { "file"     : string <filename>,
+      "result"   : string (passed | error | warning),
+      "warnings" :
+        [ { "id"      : int,
+            "message" : string <warning message> },
+          ...
+        ],
+      "errors"   :
+        [ { "id"      : int,
+            "message" : string <error message> },
+          ...
+        ]
+    }
+*)
+val warns_to_json:
+  ?filename:string -> (int * [`Warning|`Error] * string) list -> OpamJson.t
+
 (** Read the opam metadata from a given directory (opam file, with possible
     overrides from url and descr files). Also includes the names and hashes
     of files below files/


### PR DESCRIPTION
fixes #3046.
As described in https://github.com/ocaml/opam/issues/3046#issuecomment-495246961, format is:
```
"lint": 
    [
      { "file"     : string <filename>,
        "result"   : string (passed | error | warning),
        "warnings" :
          [ { "id"      : int,
              "message" : string <warning message> },
            ...
          ],
        "errors"   :
          [ { "id"      : int,
              "message" : string <error message> },
            ...
          ]
      },
      ...
    ]
```