### PR TITLE
install: remove conflicting packages if deps-only

### DIFF
--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -50,13 +50,15 @@ val reinit:
 val install:
   rw switch_state ->
   ?autoupdate:atom list -> ?add_to_roots:bool -> ?deps_only:bool ->
-  ?assume_built:bool -> atom list -> rw switch_state
+  ?ignore_conflicts:bool -> ?assume_built:bool -> atom list ->
+  rw switch_state
 
 (** Low-level version of [reinstall], bypassing the package name sanitization
     and dev package update, and offering more control *)
 val install_t:
   rw switch_state -> ?ask:bool ->
-  atom list -> bool option -> deps_only:bool -> assume_built:bool ->
+  atom list -> bool option -> deps_only:bool ->
+  ?ignore_conflicts:bool -> assume_built:bool ->
   rw switch_state
 
 (** Check that the given list of packages [atoms] have their dependencies

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1250,6 +1250,10 @@ let install =
     mk_flag  ["deps-only"]
       "Install all its dependencies, but don't actually install the package."
   in
+  let ignore_conflicts =
+    mk_flag ["ignore-conflicts"]
+      "Used with $(b,--deps-only), ignores conflicts of given package"
+  in
   let restore =
     mk_flag ["restore"]
       "Attempt to restore packages that were marked for installation but have \
@@ -1272,8 +1276,8 @@ let install =
        $(i,PACKAGES) with option $(b,deps-only) enabled."
   in
   let install
-      global_options build_options add_to_roots deps_only restore destdir
-      assume_built check atoms_or_locals =
+      global_options build_options add_to_roots deps_only ignore_conflicts
+      restore destdir assume_built check atoms_or_locals =
     apply_global_options global_options;
     apply_build_options build_options;
     if atoms_or_locals = [] && not restore then
@@ -1324,7 +1328,8 @@ let install =
           OpamStd.Sys.exit_because `False));
     let st =
       OpamClient.install st atoms
-        ~autoupdate:pure_atoms ?add_to_roots ~deps_only ~assume_built
+        ~autoupdate:pure_atoms ?add_to_roots ~deps_only ~ignore_conflicts
+        ~assume_built
     in
     match destdir with
     | None -> `Ok ()
@@ -1335,8 +1340,8 @@ let install =
   in
   Term.ret
     Term.(const install $global_options $build_options
-          $add_to_roots $deps_only $restore $destdir $assume_built $check
-          $atom_or_local_list),
+          $add_to_roots $deps_only $ignore_conflicts $restore $destdir
+          $assume_built $check $atom_or_local_list),
   term_info "install" ~doc ~man
 
 (* REMOVE *)


### PR DESCRIPTION
In case of dependencies only install, there is no need to keep restriction of conflicting package.
Related to #3846