### PR TITLE
Check package dependencies

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1128,6 +1128,57 @@ let install t ?autoupdate ?add_to_roots
   let t = update_dev_packages_t autoupdate_atoms t in
   install_t t atoms add_to_roots ~deps_only ~assume_built
 
+let check_installed t atoms =
+  let available = (Lazy.force t.available_packages) in
+  let uninstalled = OpamPackage.Set.Op.(available -- t.installed) in
+  let pkgs =
+    OpamPackage.to_map
+      (OpamFormula.packages_of_atoms available atoms)
+  in
+  let test = OpamStateConfig.(!r.build_test) in
+  let doc = OpamStateConfig.(!r.build_doc) in
+  let env p =
+    OpamFilter.deps_var_env ~build:true ~post:true ~test ~doc
+      ~dev:(OpamSwitchState.is_dev_package t p)
+  in
+  OpamPackage.Name.Map.fold (fun name versions map ->
+      let compliant, missing_opt =
+        OpamPackage.Version.Set.fold (fun version (found, missing) ->
+            if found then (found, missing)
+            else
+            let pkg = OpamPackage.create name version in
+            let cnf_formula =
+              OpamSwitchState.opam t pkg
+              |> OpamFile.OPAM.depends
+              |> OpamFilter.filter_formula (env pkg)
+              |> OpamFormula.to_cnf
+            in
+            let missing_conj =
+              List.filter
+                (List.for_all (fun ((n,_vc) as atom) ->
+                     OpamPackage.Set.for_all
+                       (fun p -> not (OpamFormula.check atom p))
+                       (OpamPackage.packages_of_name t.installed n)))
+                cnf_formula
+            in
+            if missing_conj = [] then true, None
+            else false, Some (pkg,missing_conj))
+          versions (false,None)
+      in
+      if compliant then map
+      else
+      match missing_opt with
+      | None -> assert false (* version set can't be empty *)
+      | Some (pkg, missing_conj) ->
+        OpamPackage.Map.add pkg
+          (OpamPackage.names_of_packages
+             (List.fold_left (fun names disj ->
+                  OpamPackage.Set.union names
+                    (OpamFormula.packages_of_atoms uninstalled disj))
+                 OpamPackage.Set.empty missing_conj))
+          map
+    ) pkgs OpamPackage.Map.empty
+
 let remove_t ?ask ~autoremove ~force atoms t =
   log "REMOVE autoremove:%b %a" autoremove
     (slog OpamFormula.string_of_atoms) atoms;

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -59,6 +59,11 @@ val install_t:
   atom list -> bool option -> deps_only:bool -> assume_built:bool ->
   rw switch_state
 
+(** Check that the given list of packages [atoms] have their dependencies
+    satisfied, without calling the solver. *)
+val check_installed:
+  rw switch_state -> atom list -> OpamPackage.Name.Set.t OpamPackage.Map.t
+
 (** Reinstall the given set of packages. *)
 val reinstall:
   rw switch_state -> ?assume_built:bool -> atom list -> rw switch_state

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1246,9 +1246,15 @@ let install =
        --destdir) to revert."
       Arg.(some dirname) None
   in
+  let check =
+    mk_flag ["check"]
+      "Check if dependencies are installed. If some packages are missing, \
+       it will ask if you want them installed and launch install of \
+       $(i,PACKAGES) with option $(b,deps-only) enabled."
+  in
   let install
       global_options build_options add_to_roots deps_only restore destdir
-      assume_built atoms_or_locals =
+      assume_built check atoms_or_locals =
     apply_global_options global_options;
     apply_build_options build_options;
     if atoms_or_locals = [] && not restore then
@@ -1276,11 +1282,27 @@ let install =
     in
     if atoms_or_locals = [] then `Ok () else
     let st, atoms =
-      OpamAuxCommands.autopin st ~simulate:deps_only atoms_or_locals
+      OpamAuxCommands.autopin st ~quiet:check ~simulate:(deps_only||check)
+        atoms_or_locals
     in
     if atoms = [] then
       (OpamConsole.msg "Nothing to do\n";
        OpamStd.Sys.exit_because `Success);
+    if check then
+      (let missing = OpamClient.check_installed st atoms in
+       if OpamPackage.Map.is_empty missing then
+         (OpamConsole.errmsg "All dependencies installed\n";
+          OpamStd.Sys.exit_because `Success)
+       else
+         (OpamConsole.errmsg "Missing dependencies\n";
+          OpamConsole.msg "%s\n"
+            (OpamStd.List.concat_map "\n" (fun (pkg, names) ->
+                 Printf.sprintf "%s: %s"
+                   (OpamConsole.colorise `underline (OpamPackage.to_string pkg))
+                   (OpamStd.List.concat_map ", " OpamPackage.Name.to_string
+                      (OpamPackage.Name.Set.elements names)))
+                (OpamPackage.Map.bindings missing));
+          OpamStd.Sys.exit_because `False));
     let st =
       OpamClient.install st atoms
         ~autoupdate:pure_atoms ?add_to_roots ~deps_only ~assume_built
@@ -1294,7 +1316,7 @@ let install =
   in
   Term.ret
     Term.(const install $global_options $build_options
-          $add_to_roots $deps_only $restore $destdir $assume_built
+          $add_to_roots $deps_only $restore $destdir $assume_built $check
           $atom_or_local_list),
   term_info "install" ~doc ~man
 


### PR DESCRIPTION
Add an option `--check` to install command. It checks that dependencies of given packages are satisfied in the switch. ~If not, report missing ones, and asks to install them (equivalent to install package with `--deps-only` option). Another option `--no-inst` can be used if just the check is required.
Fails with exit code `1` if dependencies are missing.~ edit: cf. further comment

Related to #3823