### PR TITLE
Handle failure or interruption of tar during 'opam update'

### DIFF
--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -114,6 +114,7 @@ let repository rt repo =
     repo_root
   @@+ function
   | Some e ->
+    OpamStd.Exn.fatal e;
     Printf.ksprintf failwith
       "Failed to regenerate local repository archive: %s"
       (Printexc.to_string e)


### PR DESCRIPTION
The partial tar file wasn't removed in case of failure, which broke coming
runs. This writes to a temp file to be even safer.