### PR TITLE
Sorting opam fields

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -710,6 +710,7 @@ let show =
       "Display information of all packages matching $(i,PACKAGES), not \
        restrained to a single package matching $(i,PACKAGES) constraints."
   in
+  let sort = mk_flag ["sort"] "Sort opam fields" in
   let opam_files_in_dir d =
     match OpamPinned.files_in_source d with
     | [] ->
@@ -719,13 +720,17 @@ let show =
     | l -> List.map (fun (_,f) -> Some f) l
   in
   let pkg_info global_options fields show_empty raw where
-      list_files file normalise no_lint just_file all_versions atom_locs =
+      list_files file normalise no_lint just_file all_versions sort atom_locs =
     let print_just_file f =
       let opam = match f with
         | Some f -> OpamFile.OPAM.read f
         | None -> OpamFile.OPAM.read_from_channel stdin
       in
       if not no_lint then OpamFile.OPAM.print_errors opam;
+      let opam =
+        if not sort then opam else
+          OpamFileTools.sort_opam opam
+      in
       if where then
         OpamConsole.msg "%s\n"
           (match f with
@@ -796,7 +801,7 @@ let show =
   Term.(ret
           (const pkg_info $global_options $fields $show_empty $raw $where
            $list_files $file $normalise $no_lint $just_file $all_versions
-           $atom_or_local_list)),
+           $sort $atom_or_local_list)),
   term_info "show" ~doc ~man
 
 module Common_config_flags = struct

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -2663,16 +2663,16 @@ module OPAMSyntax = struct
   (* Doesn't handle package name encoded in directory name *)
   let pp_raw_fields =
     Pp.I.check_opam_version ~format_version () -|
-    Pp.I.partition_fields is_ext_field -| Pp.map_pair
-      (Pp.I.items -|
-       OpamStd.String.Map.(Pp.pp (fun ~pos:_ -> of_list) bindings))
+    Pp.I.partition_fields ~section:true (is_ext_field @> not) -| Pp.map_pair
       (Pp.I.fields ~name:"opam-file" ~empty ~sections fields -|
        Pp.I.on_errors (fun t e -> {t with format_errors=e::t.format_errors}) -|
        handle_flags_in_tags -|
-       handle_deprecated_available) -|
+       handle_deprecated_available)
+      (Pp.I.items -|
+       OpamStd.String.Map.(Pp.pp (fun ~pos:_ -> of_list) bindings)) -|
     Pp.pp
-      (fun ~pos:_ (extensions, t) -> with_extensions extensions t)
-      (fun t -> extensions t, t)
+      (fun ~pos:_ (t, extensions) -> with_extensions extensions t)
+      (fun t -> t, extensions t)
 
   let pp_raw = Pp.I.map_file @@ pp_raw_fields
 

--- a/src/format/opamFormat.ml
+++ b/src/format/opamFormat.ml
@@ -775,10 +775,10 @@ module I = struct
       (fun ~pos:_ -> List.partition filter)
       (fun (a,b) -> a @ b)
 
-  let partition_fields filter =
+  let partition_fields ?(section=false) filter =
     partition @@ function
     | Variable (_,k,_) -> filter k
-    | _ -> false
+    | Section _ -> section
 
   let field name parse =
     pp

--- a/src/format/opamFormat.mli
+++ b/src/format/opamFormat.mli
@@ -227,9 +227,10 @@ sig
     ('a * (string * bad_format) list, 'a) t
 
   (** Partitions items in an opamfile base on a condition on the variable
-      names *)
+      names. If a section is encountered, it is kept in the second list (as
+      filter returning false), unless [section] is true. *)
   val partition_fields :
-    (string -> bool) ->
+    ?section:bool -> (string -> bool) ->
     (opamfile_item list, opamfile_item list * opamfile_item list) t
 
   (** Partitions items in an opamfile base on a generic condition on the

--- a/src/state/opamFileTools.mli
+++ b/src/state/opamFileTools.mli
@@ -104,3 +104,7 @@ val map_all_variables:
 
 val map_all_filters:
   (filter -> filter) -> OpamFile.OPAM.t -> OpamFile.OPAM.t
+
+(* Sort opam fields: author, tags, depexts, depends, depopts, conflicts,
+   pin_depends, extra_files, extra_sources *)
+val sort_opam: OpamFile.OPAM.t -> OpamFile.OPAM.t


### PR DESCRIPTION
Add sorting on opam fields, available as a function in opam-lib & as an `opam show` option.
This pr contains several things:
~- a compare function for formulas~
~- a sort function for formulas~
~- a sort function for filtered_formulas; this one calls also `OpamFilter.simplify_extended_version_formula` on filters~
→ on a seperate PR #3945 
- a sort opam file function:
  - fields are sorted given alphabetical order: author, tags, depends, depopts, depexts, conflicts, pin_depends, extra_files, extra_sources
  - `filtered_fomulas` of `depends`, `depopts`, and `conflicts` are sorted given alphabetical order and their filter : ~`build < <nothing> < test < doc < post`~ alphabetical order too

Related to ocaml/opam2web#173

~_This PR is still a __WIP__. Some discussion needed on **fields sorting**_~