### PR TITLE
Show multiple versions of a package

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -700,6 +700,10 @@ let show =
        $(b,--fields) is used. Only raw opam-file fields can be queried. If no \
        PACKAGES argument is given, read opam file from stdin."
   in
+  let all_versions = mk_flag ["all-versions"]
+      "Display information of all packages matching $(i,PACKAGES), not \
+       restrained to a single package matching $(i,PACKAGES) constraints."
+  in
   let opam_files_in_dir d =
     match OpamPinned.files_in_source d with
     | [] ->
@@ -709,7 +713,7 @@ let show =
     | l -> List.map (fun (_,f) -> Some f) l
   in
   let pkg_info global_options fields show_empty raw where
-      list_files file normalise no_lint just_file atom_locs =
+      list_files file normalise no_lint just_file all_versions atom_locs =
     let print_just_file f =
       let opam = match f with
         | Some f -> OpamFile.OPAM.read f
@@ -769,7 +773,7 @@ let show =
           atom_locs
       in
       OpamListCommand.info st
-        ~fields ~raw_opam:raw ~where ~normalise ~show_empty atoms;
+        ~fields ~raw_opam:raw ~where ~normalise ~show_empty ~all_versions atoms;
       `Ok ()
     | atom_locs, true ->
       if List.exists (function `Atom _ -> true | _ -> false) atom_locs then
@@ -787,8 +791,9 @@ let show =
       `Ok ()
   in
   Term.(ret
-          (const pkg_info $global_options $fields $show_empty $raw $where $list_files
-           $file $normalise $no_lint $just_file $atom_or_local_list)),
+          (const pkg_info $global_options $fields $show_empty $raw $where
+           $list_files $file $normalise $no_lint $just_file $all_versions
+           $atom_or_local_list)),
   term_info "show" ~doc ~man
 
 module Common_config_flags = struct

--- a/src/client/opamListCommand.mli
+++ b/src/client/opamListCommand.mli
@@ -140,7 +140,7 @@ val display: 'a switch_state -> package_listing_format -> package_set -> unit
 val info:
   'a switch_state ->
   fields:string list -> raw_opam:bool -> where:bool ->
-  ?normalise:bool -> ?show_empty:bool ->
+  ?normalise:bool -> ?show_empty:bool -> ?all_versions:bool ->
   atom list -> unit
 
 (** Prints the value of an opam field in a shortened way (with [prettify] -- the

--- a/src/format/opamFormula.ml
+++ b/src/format/opamFormula.ml
@@ -214,9 +214,10 @@ let check (name,cstr) package =
   | None -> true
   | Some (relop, v) -> eval_relop relop (OpamPackage.version package) v
 
-let packages_of_atoms pkgset atoms =
-  (* Conjunction for constraints over the same name, but disjunction on the
-     package names *)
+let packages_of_atoms ?(disj=false) pkgset atoms =
+  (* Conjunction for constraints over the same name (unless [disj@ is
+     specified), but disjunction on the package names *)
+  let ffilter = if disj then List.exists else List.for_all in
   let by_name =
     List.fold_left (fun acc (n,_ as atom) ->
         OpamPackage.Name.Map.update n (fun a -> atom::a) [] acc)
@@ -225,7 +226,7 @@ let packages_of_atoms pkgset atoms =
   OpamPackage.Name.Map.fold (fun name atoms acc ->
       OpamPackage.Set.union acc @@
       OpamPackage.Set.filter
-        (fun nv -> List.for_all (fun a -> check a nv) atoms)
+        (fun nv -> ffilter (fun a -> check a nv) atoms)
         (OpamPackage.packages_of_name pkgset name))
     by_name OpamPackage.Set.empty
 

--- a/src/format/opamFormula.mli
+++ b/src/format/opamFormula.mli
@@ -36,8 +36,11 @@ val check: atom -> OpamPackage.t -> bool
 
 (** Return all packages satisfying the given atoms from a set (i.e. name
     matching at least one of the atoms, version matching all atoms with the
-    appropriate name) *)
-val packages_of_atoms: OpamPackage.Set.t -> atom list -> OpamPackage.Set.t
+    appropriate name). If [disj] is true, returns packages that satisfy at
+    least one of the constraint of a given name, otherwise that satisfy all
+    constraints. *)
+val packages_of_atoms:
+  ?disj:bool -> OpamPackage.Set.t -> atom list -> OpamPackage.Set.t
 
 (** AND formulas *)
 type 'a conjunction = 'a list


### PR DESCRIPTION
Show by default don't admit as argument several versions of a given package name. This pr adds an option `--all-versions` to display information of __all__ packages that satisfy `PACKAGES` constraints.

Closes #2980