### PR TITLE
Don't include .gitattributes in index.tar.gz

### DIFF
--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -103,5 +103,5 @@ let make_index_tar_gz repo_root =
     let to_include = [ "version"; "packages"; "repo" ] in
     match List.filter Sys.file_exists to_include with
     | [] -> ()
-    | d  -> OpamSystem.command ("tar" :: "czhf" :: "index.tar.gz" :: d)
+    | d  -> OpamSystem.command ("tar" :: "czhf" :: "index.tar.gz" :: "--exclude=.git*" :: d)
   )


### PR DESCRIPTION
https://github.com/ocaml/opam-repository/pull/14287 introduced `.gitattributes` files to opam-repository. There's no need for the project-specific ones to be included in `index.tar.gz` so this PR updates `OpamHTTP.make_index_tar_gz` to exclude them.

At the moment, the files have been removed (https://github.com/ocaml/opam-repository/pull/14294), but I've tested this locally.

Posix has very little to say about `tar`, so it's possible that the `--exclude` option locks to this GNU tar. Not sure if that particularly matters for `opam admin`. It'd be handy if this patch were applied to the `opam` which regenerates `https://opam.ocaml.org/index.tar.gz`, though.