### PR TITLE
Opam{Git,Hg}: Fix diffs in presence of binary files

### DIFF
--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -165,7 +165,7 @@ module VCS : OpamVCS.VCS = struct
        unregistered directories. *)
     OpamSystem.raise_on_process_error r;
     (* We also reset diff.noprefix here to handle already existing repo. *)
-    git repo_root ~stdout:patch_file [ "-c" ; "diff.noprefix=false" ; "diff" ; "--no-ext-diff" ; "-R" ; "-p" ; rref; "--" ]
+    git repo_root ~stdout:patch_file [ "-c" ; "diff.noprefix=false" ; "diff" ; "--text" ; "--no-ext-diff" ; "-R" ; "-p" ; rref; "--" ]
     @@> fun r ->
     if not (OpamProcess.check_success_and_cleanup r) then
       (finalise ();

--- a/src/repository/opamHg.ml
+++ b/src/repository/opamHg.ml
@@ -69,7 +69,7 @@ module VCS = struct
     let finalise () = OpamSystem.remove_file patch_file in
     OpamProcess.Job.catch (fun e -> finalise (); raise e) @@ fun () ->
     let mark = mark_from_url repo_url in
-    hg repo_root ~stdout:patch_file [ "diff"; "--subrepos"; "--reverse";
+    hg repo_root ~stdout:patch_file [ "diff"; "--text"; "--subrepos"; "--reverse";
         "--rev"; mark ] @@> fun r ->
     if OpamProcess.is_failure r then
       (finalise ();


### PR DESCRIPTION
Since https://github.com/ocaml/opam-repository/pull/14287, opam-repository marks patch files as binaries.

However, in https://github.com/ocaml/opam-repository/pull/14331, a problem occurs: upon `opam update`, opam doesn't transfer binary files from the source repository to the local repository.

This PR should fix the problem. However I'm not too sure why opam uses diff in the first place. Moreover, it seems that `opam update` with a git repository as source will let the local repository in a state with non-committed changes and with no new git commits at all. I'm wondering if a better fix would be to simply remove this diff function which doesn't seem to be used anywhere but in `OpamVCS.fetch_repo_update`. I'll be happy to provide a patch if so.

In the meantime I think this patch is simple enough to be accepted.
Note: `OpamDarcs.diff` already takes into account binary files.

cc @dra27 