### PR TITLE
Read jobs variable from OpamStateConfig

### DIFF
--- a/src/state/opamPackageVar.ml
+++ b/src/state/opamPackageVar.ml
@@ -64,7 +64,7 @@ let resolve_global gt full_var =
     | _ ->
       match V.to_string var with
       | "opam-version"  -> Some (V.string OpamVersion.(to_string current))
-      | "jobs"          -> Some (V.int (OpamFile.Config.jobs gt.config))
+      | "jobs"          -> Some (V.int (OpamStateConfig.(Lazy.force !r.jobs)))
       | "root"          -> Some (V.string (OpamFilename.Dir.to_string gt.root))
       | "make"          -> Some (V.string OpamStateConfig.(Lazy.force !r.makecmd))
       | _               -> None


### PR DESCRIPTION
The jobs variable was always read from the opam config file, so didn't reflect the `OPAMJOBS` variable or `--jobs parameter`. This hurts https://github.com/ocaml/opam-repository/pull/14257, as it means there's no way to prevent parallelism.

In general, using `jobs` to control build system parallelism is of course imperfect, although for OCaml itself this is more likely to be sound, since the compiler is usually a bottleneck during package installation.

This PR makes `jobs` behave in the same way as `make`, reading the `OpamStateConfig` value, which is influenced by `OPAMJOBS` and also `--jobs`. With this change, `OPAMJOBS=1000 opam config var jobs` displays 1000 instead of the value of `jobs` recorded at `opam init` time.