### PR TITLE
Set core.autocrlf and core.eol for Git remotes

### DIFF
--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -40,6 +40,16 @@ module VCS : OpamVCS.VCS = struct
       git repo_root [ "config" ; "--local" ; "fetch.prune"; "false"];
       (* We reset diff.noprefix to ensure we get a `-p1` patch and avoid <https://github.com/ocaml/opam/issues/3627>. *)
       git repo_root [ "config" ; "--local" ; "diff.noprefix"; "false"];
+      (* Disable automatic line-ending conversion and switch core.eol to Unix.
+         THIS DOES NOT MEAN ALL FILES GET LF-ONLY LINE-ENDINGS!
+         This combination of settings means that files will be checked out
+         exactly as they appear in the repository, so if files are checked in
+         with CRLF line-endings (either by not having .gitattributes with
+         core.autocrlf = false, or having an explicit eol=crlf in
+         .gitattributes), then they will still be checked out with CRLF endings.
+       *)
+      git repo_root [ "config" ; "--local" ; "core.autocrlf"; "false"];
+      git repo_root [ "config" ; "--local" ; "core.eol"; "lf"];
       (* Document the remote for user-friendliness (we don't use it) *)
       git repo_root [ "remote"; "add"; "origin"; OpamUrl.base_url repo_url ];
     ] @@+ function


### PR DESCRIPTION
This change ensures that Git always disables text file line-ending normalisation when cloning changes from a Git remote.

Separate (still to be done) work on the `OpamLocal` driver, `opam admin`, and `opam lint` code will ensure that hashes for text files are always **initially** computed using the _repository_ normalisation. This differs from the approach of previous PRs which potentially hashed two versions of the file by determining from the git if the file needs transforming prior to the single hash being computed. The only time this transformation comes into play is if a Local (i.e. rsync) remote of a Git clone is added on a platform with `core.autocrlf` set to `true` (i.e. if you are working in a Git clone of a remote with `core.autocrlf` set to `true`)