### PR TITLE
Support Dune 1.7.0 and later

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -43,7 +43,8 @@ man:
 	done
 	$(OPAM_INSTALLER) $(HELPFMT) > man/opam-installer.1 2>> man/err
 # Dune doesn't (yet) support --no-print-directory
-	@if grep -v "^Entering directory '" man/err > man/err2 ; then cat man/err2 ; false ; fi
+	@sed -f man.sed man/err > man/err2
+	@if test -s man/err2 ; then cat man/err2 ; false ; fi
 
 man-html: man
 	rm -rf man-html

--- a/doc/man.sed
+++ b/doc/man.sed
@@ -1,0 +1,7 @@
+/^Entering directory '/d
+/^File .*jbuild", line 1, characters 0-0:/{
+  :a
+  N
+  /Note: You can use.*to dune/!ba
+}
+/Warning: jbuild files are deprecated/d


### PR DESCRIPTION
Dune 1.7.0 displays a deprecation warning for jbuild files which needs to be suppressed when generating the man pages.

Fixes #3870.