### PR TITLE
Fix typos

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -284,7 +284,7 @@ are not marked).
 
 1.2.1
 * Non-system compiler definitions without source are now allowed
-* Better handling of compiler "base" packages allows to move build instructions
+* Better handling of compiler "base" packages allows one to move build instructions
   from compiler definitions to packages
 * Rewritten action resolution mechanism to be based on atomic actions.
   Actions are not aborted anymore on first failure when there is no

--- a/doc/pages/External_solvers.md
+++ b/doc/pages/External_solvers.md
@@ -70,7 +70,7 @@ When you request to install a (set of) package(s), in general you do not expect 
 
 ### Specifying preferences for opam
 
-`opam` allows to specify your criteria on the command line, using the `--criteria` option, that will apply only to the current command.
+`opam` allows one to specify criteria on the command line, using the `--criteria` option, that will apply only to the current command.
 For example, if you are a very conservative user, you might try issuing the following command:
 ```
 opam install --criteria="-removed,-changed" ...

--- a/doc/pages/FAQ.md
+++ b/doc/pages/FAQ.md
@@ -107,7 +107,7 @@ enabled. Note, however, that:
 #### 🐫  Why does ``opam init`` need to add stuff to my init scripts / why is ``eval $(opam env)`` needed?
 
 This is not strictly needed, but by updating your `PATH` and a few specific
-environment variables, allows to:
+environment variables, one can:
 
 1. Automatically find executables installed in opam (current switch)
 2. Ensure the OCaml tools are going to look at the right places for installed

--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -679,7 +679,7 @@ repositories or initial distributions or packages.
 #### repo
 <a id="Repospecification"></a>
 
-The `repo` file is placed at the root of a repository, and allows to specify
+The `repo` file is placed at the root of a repository, and allows one to specify
 some specifics of the repository. It has the following optional fields:
 
 * <a id="repofield-opam-version">`opam-version: <string>`</a>:
@@ -730,7 +730,7 @@ seen with `opam init --show-default-opamrc`.
 - <a id="opamrcfield-init-scripts">`init-scripts: [ [ <string> <string> ] { <filter> } ... ]`</a>:
   These scripts will be written verbatim into the hook directory
   (`~/.opam/opam-init/hooks`) upon initialisation. The first string is the file
-  name of the script, the second its raw contents, and the filter allows to
+  name of the script, the second its raw contents, and the filter allows one to
   limit the creation of the script to specific configurations.
 - [`jobs:`](#configfield-jobs),
   [`download-command:`](#configfield-download-command),
@@ -964,7 +964,7 @@ files.
   class="opam">opam</span> ecosystem, for various systems. Each
   `[ <string> ... ] { <filter> }` element declares the strings to the left as
   identifiers to required system-managed packages, while the filter to the right
-  allows to select the systems they will be active on.
+  allows one to select the systems they will be active on.
 
     The filters typically use variables [`arch`](#opamvar-arch),
     [`os`](#opamvar-os), [`os-distribution`](#opamvar-os-distribution),
@@ -987,7 +987,7 @@ files.
 
 - <a id="opamfield-post-messages">
   `post-messages: [ <string> { <filter> } ... ]`</a>:
-  allows to print specific messages to the user after the end of installation.
+  allows one to print specific messages to the user after the end of installation.
   The special boolean variable `failure` is defined in the scope of the filter,
   and can be used to print messages in case there was an error (typically, a
   hint on how it can be resolved, or a link to an open issue). `success` is also

--- a/doc/pages/Specifying_Solver_Preferences.md
+++ b/doc/pages/Specifying_Solver_Preferences.md
@@ -34,7 +34,7 @@ When you request to install a (set of) package(s), in general you do not expect 
 
 ### Specifying preferences for opam
 
-Recent versions of `opam` allow to specify your criteria on the command line, using the `--criteria` option, that will apply only to the current command.
+Recent versions of `opam` allow one to specify criteria on the command line, using the `--criteria` option, that will apply only to the current command.
 For example, if you are a very conservative user, you might try issuing the following command:
 ```
 opam install --criteria="-removed,-changed" ...

--- a/doc/pages/Usage.md
+++ b/doc/pages/Usage.md
@@ -111,7 +111,7 @@ Creating a new switch requires re-compiling OCaml, unless you use the
 
 ### opam pin
 
-This command allows to pin a package to a specific version, but has been
+This command allows one to pin a package to a specific version, but has been
 extended to allow much more than that.
 
 The syntax is

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -178,7 +178,7 @@ let init =
         repository).";
     `P "The initial repository and defaults can be set through a \
         configuration file found at $(i,~/.opamrc) or $(i,/etc/opamrc).";
-    `P "Additionally, this command allows to customise some aspects of opam's \
+    `P "Additionally, this command allows one to customise some aspects of opam's \
         shell integration, when run initially (avoiding the interactive \
         dialog), but also at any later time.";
     `S "ARGUMENTS";
@@ -1644,7 +1644,7 @@ let repository =
         repositories, or all configured repositories with $(b,--all).";
   ] @ mk_subdoc ~defaults:["","list"] commands @ [
       `S scope_section;
-      `P "These flags allow to choose what selections are changed by $(b,add), \
+      `P "These flags allow one to choose which selections are changed by $(b,add), \
           $(b,remove), $(b,set-repos). If no flag in this section is specified \
           the updated selections default to the current switch. Multiple scopes \
           can be selected, e.g. $(b,--this-switch --set-default).";
@@ -2388,7 +2388,7 @@ let pin ?(unpin_only=false) () =
         used locally.";
     `P "If (or $(i,-)) is specified, the package is pinned without a source \
         archive. The package name can be omitted if the target is a directory \
-        containing one or more valid package definitions (this allows to do \
+        containing one or more valid package definitions (this allows one to do \
         e.g. $(i,opam pin add .) from a source directory.";
     `P "If $(i,PACKAGE) has the form $(i,name.version), the pinned package \
         will be considered as version $(i,version) by opam. Beware that this \

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -24,7 +24,7 @@ val env:
   csh:bool -> sexp:bool -> fish:bool -> inplace_path:bool ->
   unit
 
-(** Like [env] but allows to specify the precise env to print rather than
+(** Like [env] but allows one to specify the precise env to print rather than
     compute it from a switch state *)
 val print_eval_env: csh:bool -> sexp:bool -> fish:bool -> env -> unit
 

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -2262,7 +2262,7 @@ module OPAMSyntax = struct
 
   (* Post-processing functions used for some fields (optional, because we
      don't want them when linting). It's better to do them in the same pass
-     as parsing, because it allows to get file positions, which we lose
+     as parsing, because it allows one to get file positions, which we lose
      afterwards *)
 
   (* Allow 'flag:xxx' tags as flags, for compat *)

--- a/src/state/opamStateConfig.mli
+++ b/src/state/opamStateConfig.mli
@@ -50,7 +50,7 @@ include OpamStd.Config.Sig
    and type 'a options_fun := 'a options_fun
 
 (** Get the initial opam root value (from default, env or optional argument).
-    This allows to get it before doing the init, which is useful to get the
+    This allows one to get it before doing the init, which is useful to get the
     configuration file used to fill some options to init() *)
 val opamroot: ?root_dir:dirname -> unit -> dirname
 

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -51,7 +51,7 @@ add_sys_mounts() {
     done
 }
 
-# remove some unusual pathes (/nix/stored and /rw/usrlocal )
+# remove some unusual paths (/nix/stored and /rw/usrlocal )
 # use OPAM_USER_PATH_RO variable to add them
 # the OPAM_USER_PATH_RO format is the same as PATH
 # ie: export OPAM_USER_PATH_RO=/nix/store:/rw/usrlocal


### PR DESCRIPTION
Taken from https://sources.debian.org/patches/opam/2.0.3-1/0002-Fix-spelling-error-in-manpage.patch/
with some further amendments.