### PR TITLE
Correct display of dir separator on Windows

### DIFF
--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -20,7 +20,7 @@ let checked_repo_root () =
   then
     OpamConsole.error_and_exit `Bad_arguments
       "No repository found in current directory.\n\
-       Please make sure there is a \"packages/\" directory";
+       Please make sure there is a \"packages%s\" directory" Filename.dir_sep;
   repo_root
 
 
@@ -29,12 +29,14 @@ let admin_command_doc =
 
 let admin_command_man = [
   `S "DESCRIPTION";
-  `P "This command can perform various actions on repositories in the opam \
-      format. It is expected to be run from the root of a repository, i.e. a \
-      directory containing a 'repo' file and a subdirectory 'packages/' \
-      holding package definition within subdirectories. A 'compilers/' \
-      subdirectory (opam repository format version < 2) will also be used by \
-      the $(b,upgrade-format) subcommand."
+  `P (Printf.sprintf
+       "This command can perform various actions on repositories in the opam \
+        format. It is expected to be run from the root of a repository, i.e. a \
+        directory containing a 'repo' file and a subdirectory 'packages%s' \
+        holding package definition within subdirectories. A 'compilers%s' \
+        subdirectory (opam repository format version < 2) will also be used by \
+        the $(b,upgrade-format) subcommand."
+       Filename.dir_sep Filename.dir_sep)
 ]
 
 let index_command_doc =
@@ -194,8 +196,9 @@ let cache_command =
   let link_arg =
     Arg.(value & opt (some OpamArg.dirname) None &
          info ["link"] ~docv:"DIR" ~doc:
-           "Create reverse symbolic links to the archives within $(i,DIR), in \
-            the form $(b,DIR/PKG.VERSION/FILENAME).")
+           (Printf.sprintf
+             "Create reverse symbolic links to the archives within $(i,DIR), in \
+              the form $(b,DIR%sPKG.VERSION%sFILENAME)." Filename.dir_sep Filename.dir_sep))
   in
   let jobs_arg =
     Arg.(value & opt OpamArg.positive_integer 8 &
@@ -486,18 +489,20 @@ let upgrade_command =
   let doc = upgrade_command_doc in
   let man = [
     `S "DESCRIPTION";
-    `P "This command reads repositories from earlier opam versions, and \
-        converts them to repositories suitable for the current opam version. \
-        Packages might be created or renamed, and any compilers defined in the \
-        old format ('compilers/' directory) will be turned into packages, \
-        using a pre-defined hierarchy that assumes OCaml compilers."
+    `P (Printf.sprintf
+         "This command reads repositories from earlier opam versions, and \
+          converts them to repositories suitable for the current opam version. \
+          Packages might be created or renamed, and any compilers defined in the \
+          old format ('compilers%s' directory) will be turned into packages, \
+          using a pre-defined hierarchy that assumes OCaml compilers." Filename.dir_sep)
   ]
   in
   let clear_cache_arg =
     let doc =
-      "Instead of running the upgrade, clear the cache of archive hashes (held \
-       in ~/.cache), that is used to avoid re-downloading files to obtain \
-       their hashes at every run."
+      Printf.sprintf
+       "Instead of running the upgrade, clear the cache of archive hashes (held \
+        in ~%s.cache), that is used to avoid re-downloading files to obtain \
+        their hashes at every run." Filename.dir_sep
     in
     Arg.(value & flag & info ["clear-cache"] ~doc)
   in
@@ -704,15 +709,16 @@ let pattern_list_arg =
     Arg.string
 
 let env_arg =
-  Arg.(value & opt (list string) [] & info ["environment"] ~doc:
-         "Use the given opam environment, in the form of a list \
-          comma-separated 'var=value' bindings, when resolving variables. This \
-          is used e.g. when computing available packages: if undefined, \
-          availability of packages will be assumed as soon as it can not be \
-          resolved purely from globally defined variables. Note that, unless \
-          overridden, variables like 'root' or 'opam-version' may be taken \
-          from the current opam installation. What is defined in \
-          $(i,~/.opam/config) is always ignored.")
+  Arg.(value & opt (list string) [] & info ["environment"] ~doc:(
+         Printf.sprintf
+          "Use the given opam environment, in the form of a list of \
+           comma-separated 'var=value' bindings, when resolving variables. This \
+           is used e.g. when computing available packages: if undefined, \
+           availability of packages will be assumed as soon as it can not be \
+           resolved purely from globally defined variables. Note that, unless \
+           overridden, variables like 'root' or 'opam-version' may be taken \
+           from the current opam installation. What is defined in \
+           $(i,~%s.opam%sconfig) is always ignored." Filename.dir_sep Filename.dir_sep))
 
 let state_selection_arg =
   let docs = OpamArg.package_selection_section in

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -260,8 +260,8 @@ let help_sections = [
   `P "$(i,OPAMJSON) log json output to the given file (use character `%' to \
       index the files)";
   `P "$(i,OPAMLOCKED) combination of `--locked` and `--lock-suffix` options";
-  `P "$(i,OPAMLOGS logdir) sets log directory, default is a temporary directory \
-      in /tmp";
+  `P ("$(i,OPAMLOGS logdir) sets log directory, default is a temporary directory \
+       in " ^ (if Sys.win32 then "%TEMP%" else "/tmp"));
   `P "$(i,OPAMMAKECMD) set the system make command to use";
   `P "$(i,OPAMNOAUTOUPGRADE) disables automatic internal upgrade of \
       repositories in an earlier format to the current one, on 'update' or \
@@ -836,8 +836,11 @@ let shell_opt =
 
 let dot_profile_flag =
   mk_opt ["dot-profile"]
-    "FILENAME" "Name of the configuration file to update instead of \
-                $(i,~/.profile) or $(i,~/.zshrc) based on shell detection."
+    "FILENAME"
+    (Printf.sprintf
+      "Name of the configuration file to update instead of \
+       $(i,~%s.profile) or $(i,~%s.zshrc) based on shell detection."
+      Filename.dir_sep Filename.dir_sep)
     (Arg.some filename) None
 
 let repo_kind_flag =
@@ -876,16 +879,18 @@ let atom_list =
 
 let atom_or_local_list =
   arg_list "PACKAGES"
-    "List of package names, with an optional version or constraint, e.g `pkg', \
-     `pkg.1.0' or `pkg>=0.5' ; or files or directory names containing package \
-     description, with explicit directory (e.g. `./foo.opam' or `.')"
+    (Printf.sprintf
+      "List of package names, with an optional version or constraint, e.g `pkg', \
+       `pkg.1.0' or `pkg>=0.5' ; or files or directory names containing package \
+       description, with explicit directory (e.g. `.%sfoo.opam' or `.')" Filename.dir_sep)
     atom_or_local
 
 let atom_or_dir_list =
   arg_list "PACKAGES"
-    "List of package names, with an optional version or constraint, e.g `pkg', \
-     `pkg.1.0' or `pkg>=0.5' ; or directory names containing package \
-     description, with explicit directory (e.g. `./srcdir' or `.')"
+    (Printf.sprintf
+      "List of package names, with an optional version or constraint, e.g `pkg', \
+       `pkg.1.0' or `pkg>=0.5' ; or directory names containing package \
+       description, with explicit directory (e.g. `.%ssrcdir' or `.')" Filename.dir_sep)
     atom_or_dir
 
 let nonempty_atom_list =

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -75,8 +75,9 @@ let switch_to_updated_self debug opamroot =
 let global_options =
   let no_self_upgrade =
     mk_flag ~section:global_option_section ["no-self-upgrade"]
-      "Opam will replace itself with a newer binary found \
-       at $(b,OPAMROOT/opam) if present. This disables this behaviour." in
+      (Printf.sprintf
+        "Opam will replace itself with a newer binary found \
+         at $(b,OPAMROOT%sopam) if present. This disables this behaviour." Filename.dir_sep) in
   let self_upgrade no_self_upgrade options =
     let self_upgrade_status =
       if OpamStd.Config.env_string "NOSELFUPGRADE" =
@@ -169,25 +170,31 @@ let init =
   let man = [
     `S "DESCRIPTION";
     `P "Initialise the opam state, or update opam init options";
-    `P "The $(b,init) command initialises a local \"opam root\" (by default, \
-        $(i,~/.opam/)) that holds opam's data and packages. This is a \
-        necessary step for normal operation of opam. The initial software \
-        repositories are fetched, and an initial 'switch' can also be \
-        installed, according to the configuration and options. These can be \
-        afterwards configured using $(b,opam switch) and $(b,opam \
-        repository).";
-    `P "The initial repository and defaults can be set through a \
-        configuration file found at $(i,~/.opamrc) or $(i,/etc/opamrc).";
+    `P (Printf.sprintf
+         "The $(b,init) command initialises a local \"opam root\" (by default, \
+          $(i,~%s.opam%s)) that holds opam's data and packages. This is a \
+          necessary step for normal operation of opam. The initial software \
+          repositories are fetched, and an initial 'switch' can also be \
+          installed, according to the configuration and options. These can be \
+          afterwards configured using $(b,opam switch) and $(b,opam \
+          repository)."
+         Filename.dir_sep Filename.dir_sep);
+    `P (Printf.sprintf
+         "The initial repository and defaults can be set through a \
+          configuration file found at $(i,~%s.opamrc) or $(i,/etc/opamrc)."
+         Filename.dir_sep);
     `P "Additionally, this command allows one to customise some aspects of opam's \
         shell integration, when run initially (avoiding the interactive \
         dialog), but also at any later time.";
     `S "ARGUMENTS";
     `S "OPTIONS";
     `S "CONFIGURATION FILE";
-    `P "Any field from the built-in initial configuration can be overridden \
-        through $(i,~/.opamrc), $(i,/etc/opamrc), or a file supplied with \
-        $(i,--config). The default configuration for this version of opam \
-        can be obtained using $(b,--show-default-opamrc).";
+    `P (Printf.sprintf
+         "Any field from the built-in initial configuration can be overridden \
+          through $(i,~%s.opamrc), $(i,/etc/opamrc), or a file supplied with \
+          $(i,--config). The default configuration for this version of opam \
+          can be obtained using $(b,--show-default-opamrc)."
+         Filename.dir_sep);
     `S OpamArg.build_option_section;
   ] in
   let compiler =
@@ -265,8 +272,9 @@ let init =
   in
   let no_config_file =
     mk_flag ["no-opamrc"]
-      "Don't read `/etc/opamrc' or `~/.opamrc': use the default settings and \
-       the files specified through $(b,--config) only"
+      (Printf.sprintf
+      "Don't read `/etc/opamrc' or `~%s.opamrc': use the default settings and \
+       the files specified through $(b,--config) only" Filename.dir_sep)
   in
   let reinit =
     mk_flag ["reinit"]
@@ -1993,16 +2001,17 @@ let switch =
         switch set) to set the currently active switch. Without argument, \
         lists installed switches, with one switch argument, defaults to \
         $(b,set).";
-    `P ("Switch handles $(i,SWITCH) can be either a plain name, for switches \
-         that will be held inside $(i,~/.opam), or a directory name, which in \
-         that case is the directory where the switch prefix will be installed, as "
-        ^ OpamSwitch.external_dirname ^
-        ". Opam will automatically select a switch by that name found in the \
+    `P (Printf.sprintf
+         "Switch handles $(i,SWITCH) can be either a plain name, for switches \
+         that will be held inside $(i,~%s.opam), or a directory name, which in \
+         that case is the directory where the switch prefix will be installed, as \
+         %s. Opam will automatically select a switch by that name found in the \
          current directory or its parents, unless $(i,OPAMSWITCH) is set or \
          $(b,--switch) is specified. When creating a directory switch, if \
          package definitions are found locally, the user is automatically \
          prompted to install them after the switch is created unless \
-         $(b,--no-install) is specified.");
+         $(b,--no-install) is specified."
+        Filename.dir_sep OpamSwitch.external_dirname);
     `P "$(b,opam switch set) sets the default switch globally, but it is also \
         possible to select a switch in a given shell session, using the \
         environment. For that, use $(i,eval \\$(opam env \
@@ -2733,8 +2742,8 @@ let source =
           OpamConsole.error_and_exit `Sync_error "%s is not available" u
         | Result _ | Up_to_date _ ->
           OpamConsole.formatted_msg
-            "Successfully fetched %s development repo to ./%s/\n"
-            (OpamPackage.name_to_string nv) (OpamPackage.name_to_string nv)
+            "Successfully fetched %s development repo to .%s%s%s\n"
+            (OpamPackage.name_to_string nv) Filename.dir_sep (OpamPackage.name_to_string nv) Filename.dir_sep
     ) else (
       let job =
         let open OpamProcess.Job.Op in
@@ -2962,8 +2971,9 @@ let clean =
   in
   let download_cache =
     mk_flag ["c"; "download-cache"]
-      "Clear the cache of downloaded files (\\$OPAMROOT/download-cache), as \
-       well as the obsolete \\$OPAMROOT/archives, if that exists."
+      (Printf.sprintf
+        "Clear the cache of downloaded files (\\$OPAMROOT%sdownload-cache), as \
+         well as the obsolete \\$OPAMROOT%sarchives, if that exists." Filename.dir_sep Filename.dir_sep)
   in
   let repos =
     mk_flag ["unused-repositories"]

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -93,8 +93,8 @@ let copy_files st opam =
      | Some [] | None -> ()
      | Some files ->
        OpamConsole.warning
-         "Ignoring overlay files of %s (files/*) that were not found: %s"
-         (OpamPackage.Name.to_string name)
+         "Ignoring overlay files of %s (files%s*) that were not found: %s"
+         (OpamPackage.Name.to_string name) Filename.dir_sep
          (OpamStd.List.to_string (fun (b,_) -> OpamFilename.Base.to_string b)
             files));
   let destdir =

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -479,9 +479,9 @@ let read_overlays (read: package -> OpamFile.OPAM.t option) packages =
       | Some opam ->
         if OpamFile.OPAM.extra_files opam <> None then
           (OpamConsole.warning
-             "Metadata of package %s uses a files/ subdirectory, it may not be \
+             "Metadata of package %s uses a files%s subdirectory, it may not be \
               re-imported correctly (skipping definition)"
-             (OpamPackage.to_string nv);
+             (OpamPackage.to_string nv) Filename.dir_sep;
            acc)
         else OpamPackage.Name.Map.add nv.name opam acc
       | None -> acc)

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -36,7 +36,7 @@ module Dir = struct
           (OpamStd.String.remove_prefix ~prefix:("~"^Filename.dir_sep) dirname)
       else dirname
     in
-    OpamSystem.real_path dirname
+    OpamSystem.real_path (OpamSystem.forward_to_back dirname)
 
   let to_string dirname = dirname
 
@@ -142,8 +142,9 @@ type t = {
 }
 
 let create dirname basename =
-  let b1 = Filename.dirname (Base.to_string basename) in
+  let b1 = OpamSystem.forward_to_back (Filename.dirname (Base.to_string basename)) in
   let b2 = Base.of_string (Filename.basename (Base.to_string basename)) in
+  let dirname = OpamSystem.forward_to_back dirname in
   if basename = b2 then
     { dirname; basename }
   else

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -653,7 +653,7 @@ let setup
 
       OpamConsole.msg
         "\n\
-        \  In normal operation, opam only alters files within ~/.opam.\n\
+        \  In normal operation, opam only alters files within ~%s.opam.\n\
          \n\
         \  However, to best integrate with your system, some environment variables\n\
         \  should be set. If you allow it to, this initialisation step will update\n\
@@ -667,6 +667,7 @@ let setup
         \    %s\n\
          \n\
         \  You can always re-run this setup with 'opam init' later.\n\n"
+        Filename.dir_sep
         (OpamConsole.colorise `bold @@ string_of_shell shell)
         (OpamConsole.colorise `cyan @@ OpamFilename.prettify dot_profile)
         (OpamConsole.colorise `bold @@ source root shell (init_file shell))


### PR DESCRIPTION
Corrected messages which had hard-coded forward slashes in messages (e.g. `~/.opam`) either to use `Filename.dir_sep` (for simple cases like that) or `Filename.concat` to build the display properly. Messages on Windows should always use backslashes (and certainly not end up displaying a mix).

`OpamFilename.create` and `OpamFilename.Dir.of_string` (already) both normalise forward-slash to back-slash on Windows.

Note that while Windows doesn't have a concept of `~` in the normal way, it's not unreasonable to assume it (Vim-for-Windows, for example, automatically displays `~` if you set `%HOME%`, and I have another shell-related commit which sets `%HOME%` for opam users)