### PR TITLE
Tested wrong variable in OPAMW_HasGlyph

### DIFF
--- a/src/stubs/opamWindows.c
+++ b/src/stubs/opamWindows.c
@@ -548,7 +548,7 @@ CAMLprim value OPAMW_HasGlyph(value checker, value scalar)
   }
 #endif
 
-  OPAMreturn(Val_bool(test != 0xffff));
+  OPAMreturn(Val_bool(index != 0xffff));
 }
 
 CAMLprim value OPAMW_process_putenv(value pid, value key, value val)


### PR DESCRIPTION
Stub was checking the *input* character rather than the *output* character and thus assumed all glyphs were available...