### PR TITLE
Fix environment file handling for empty switches

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -919,9 +919,14 @@ let config =
                 ~set_opamroot ~set_opamswitch
                 ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish) ~inplace_path))
     | Some `revert_env, [] ->
-       `Ok (OpamConfigCommand.print_eval_env
-              ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
-              (OpamEnv.add [] []))
+      OpamGlobalState.with_ `Lock_none @@ fun gt ->
+      (match OpamStateConfig.get_switch_opt () with
+       | None -> `Ok ()
+       | Some sw ->
+         `Ok (OpamConfigCommand.ensure_env gt sw;
+              OpamConfigCommand.print_eval_env
+                ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
+                (OpamEnv.add [] [])))
     | Some `exec, (_::_ as c) ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
       `Ok (OpamConfigCommand.exec

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -24,6 +24,10 @@ val env:
   csh:bool -> sexp:bool -> fish:bool -> inplace_path:bool ->
   unit
 
+(** Ensures that the environment file exists in the given switch, regenerating
+    it, if necessary. *)
+val ensure_env: 'a global_state -> switch -> unit
+
 (** Like [env] but allows one to specify the precise env to print rather than
     compute it from a switch state *)
 val print_eval_env: csh:bool -> sexp:bool -> fish:bool -> env -> unit

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -189,6 +189,7 @@ let install_compiler_packages t atoms =
   (* install the compiler packages *)
   if atoms = [] then begin
     OpamFile.Environment.write (OpamPath.Switch.environment t.switch_global.root t.switch) (OpamEnv.compute_updates t);
+    OpamEnv.check_and_print_env_warning t;
     t
   end else
   let roots = OpamPackage.Name.Set.of_list (List.map fst atoms) in

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -187,7 +187,10 @@ let remove gt ?(confirm = true) switch =
 
 let install_compiler_packages t atoms =
   (* install the compiler packages *)
-  if atoms = [] then t else
+  if atoms = [] then begin
+    OpamFile.Environment.write (OpamPath.Switch.environment t.switch_global.root t.switch) (OpamEnv.compute_updates t);
+    t
+  end else
   let roots = OpamPackage.Name.Set.of_list (List.map fst atoms) in
   let not_found =
     OpamPackage.Name.Set.diff roots @@


### PR DESCRIPTION
`opam switch create foo --empty` doesn't write an `environment` file. At this point, `opam config revert-env` will not return any updates. `opam env` will regenerate file. This PR fixes both `opam switch create --empty` to write the `environment` file and also `opam config revert-env` to regenerate it if it's missing (so belt-and-braces approach). Finally, the environment is also not checked in `opam switch create --empty` because of the same branch, and this is fixed (it hurts Windows, which actually updates the environment at this point; it doesn't hurt Unix if you have the shell hook installed).