### PR TITLE
Bits 'n bobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ opam-installer: $(DUNE_DEP)
 	$(LN_S) -f _build/default/src/tools/opam_installer.exe $@$(EXE)
 
 opam-admin.top: $(DUNE_DEP)
-	$(DUNE) build --profile=$(DUNE_PROFILE) $(DUNE_ARGS) src/tools/opam_admin_top.bc
-	$(LN_S) -f _build/default/src/tools/opam_admin_top.bc $@$(EXE)
+	$(DUNE) build --profile=$(DUNE_PROFILE) $(DUNE_ARGS) src/tools/opam_admin_topstart.bc
+	$(LN_S) -f _build/default/src/tools/opam_admin_topstart.bc $@$(EXE)
 
 lib-ext:
 	$(MAKE) -j -C src_ext lib-ext

--- a/admin-scripts/compilers-to-packages.ml
+++ b/admin-scripts/compilers-to-packages.ml
@@ -94,8 +94,15 @@ OpamStd.String.Map.iter (fun c comp_file ->
             in
             OpamFilename.with_tmp_dir_job @@ fun dir ->
             try
+              (* Download to package.patch, rather than allowing the name to be
+                 guessed since, on Windows, some of the characters which are
+                 valid in URLs are not valid in filenames *)
+              let f =
+                let base = OpamFilename.Base.of_string "package.patch" in
+                OpamFilename.create dir base
+              in
               OpamProcess.Job.catch err
-                (OpamDownload.download ~overwrite:false url dir @@| fun f ->
+                (OpamDownload.download_as ~overwrite:false url f @@| fun () ->
                  Some (url, OpamFilename.digest f, None))
             with e -> err e)
         (OpamFile.Comp.patches comp)

--- a/src/client/opamAdminRepoUpgrade.ml
+++ b/src/client/opamAdminRepoUpgrade.ml
@@ -186,7 +186,14 @@ let do_upgrade repo_root =
          OpamFilename.with_tmp_dir_job @@ fun dir ->
          OpamProcess.Job.ignore_errors ~default:None
            (fun () ->
-              OpamDownload.download ~overwrite:false url dir @@| fun f ->
+                (* Download to package.patch, rather than allowing the name to be
+                   guessed since, on Windows, some of the characters which are
+                   valid in URLs are not valid in filenames *)
+              let f =
+                let base = OpamFilename.Base.of_string "package.patch" in
+                OpamFilename.create dir base
+              in
+              OpamDownload.download_as ~overwrite:false url f @@| fun () ->
               let hash = OpamHash.compute (OpamFilename.to_string f) in
               Hashtbl.add url_md5 url hash;
               Some hash)),

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -30,6 +30,12 @@ let default_compiler =
 let eval_variables = [
   OpamVariable.of_string "sys-ocaml-version", ["ocamlc"; "-vnum"],
   "OCaml version present on your system independently of opam, if any";
+  OpamVariable.of_string "sys-ocaml-arch", ["sh"; "-c"; "ocamlc -config | tr -d '\\r' | grep '^architecture: ' | sed -e 's/.*: //' -e 's/i386/i686/' -e 's/amd64/x86_64/'"],
+  "Target architecture of the OCaml compiler present on your system";
+  OpamVariable.of_string "sys-ocaml-cc", ["sh"; "-c"; "ocamlc -config | tr -d '\\r' | grep '^ccomp_type: ' | sed -e 's/.*: //'"],
+  "Host C Compiler type of the OCaml compiler present on your system";
+  OpamVariable.of_string "sys-ocaml-libc", ["sh"; "-c"; "ocamlc -config | tr -d '\\r' | grep '^os_type: ' | sed -e 's/.*: //' -e 's/Win32/msvc/' -e '/^msvc$/!s/.*/libc/'"],
+  "Host C Runtime Library type of the OCaml compiler present on your system";
 ]
 
 let os_filter os =

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -162,7 +162,8 @@ let opam_file_from_1_2_to_2_0 ?filename opam =
     aux available
   in
   let pkg_deps =
-    if NMap.mem ocaml_wrapper_pkgname pkg_deps ||
+    if OpamVersion.compare (OpamFile.OPAM.opam_version opam) v2_0 >= 0 ||
+       NMap.mem ocaml_wrapper_pkgname pkg_deps ||
        OpamFile.OPAM.has_flag Pkgflag_Conf opam
     then pkg_deps
     else NMap.add ocaml_wrapper_pkgname Empty pkg_deps

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -65,6 +65,8 @@ let upgrade_depexts_to_2_0_beta5 filename depexts =
          None)
     depexts
 
+let v2_0 = OpamVersion.of_string "2.0"
+
 let opam_file_from_1_2_to_2_0 ?filename opam =
   let ocaml_pkgname = OpamPackage.Name.of_string "ocaml" in
 
@@ -329,7 +331,7 @@ let opam_file_from_1_2_to_2_0 ?filename opam =
         | ft -> ft)
   in
   opam |>
-  OpamFile.OPAM.with_opam_version (OpamVersion.of_string "2.0") |>
+  OpamFile.OPAM.with_opam_version v2_0 |>
   OpamFile.OPAM.with_depends depends |>
   OpamFile.OPAM.with_depopts depopts |>
   OpamFile.OPAM.with_conflicts conflicts |>
@@ -1038,8 +1040,6 @@ let from_2_0_beta_to_2_0_beta5 root conf =
     (List.filter (fun (v,_,_) -> not (List.mem v rem_eval_variables))
        (OpamFile.Config.eval_variables conf))
     conf
-
-let v2_0 = OpamVersion.of_string "2.0"
 
 let from_2_0_beta5_to_2_0 _ conf = conf
 

--- a/src/state/opamPackageVar.ml
+++ b/src/state/opamPackageVar.ml
@@ -23,6 +23,7 @@ let global_variable_names = [
                            configuration";
   "root",                 "The current opam root directory";
   "make",                 "The 'make' command to use";
+  "exe",                  "Suffix needed for executable filenames (Windows)";
 ]
 
 let package_variable_names = [
@@ -67,6 +68,7 @@ let resolve_global gt full_var =
       | "jobs"          -> Some (V.int (OpamStateConfig.(Lazy.force !r.jobs)))
       | "root"          -> Some (V.string (OpamFilename.Dir.to_string gt.root))
       | "make"          -> Some (V.string OpamStateConfig.(Lazy.force !r.makecmd))
+      | "exe"           -> Some (V.string (OpamStd.Sys.executable_name ""))
       | _               -> None
 
 (** Resolve switch-global variables only, as allowed by the 'available:'

--- a/src/tools/dune
+++ b/src/tools/dune
@@ -1,17 +1,25 @@
-(executable
+(library
   (name         opam_admin_top)
+  (public_name  opam-admin.top)
+  (synopsis     "OCaml Package Manager admin toplevel")
   (modules      opam_admin_top)
+  (libraries    opam-client opam-file-format compiler-libs.toplevel re)
+  (wrapped      false))
+
+(executable
+  (name         opam_admin_topstart)
+  (public_name  opam-admin.top)
+  (package      opam-admin)
+  (modes        byte)
+  (modules      opam_admin_topstart)
+  (libraries    opam-admin.top)
   (ocamlc_flags (:standard
                 (:include ../ocaml-flags-standard.sexp)
                 (:include ../ocaml-flags-configure.sexp)
                 (:include ../ocaml-context-flags.sexp)
-                -linkall))
-  (libraries    opam-client opam-file-format compiler-libs.toplevel re))
+                -linkall)))
 
-(install
-  (section bin)
-  (package opam-admin)
-  (files   (opam_admin_top.bc as opam-admin.top)))
+(rule (with-stdout-to opam_admin_topstart.ml (echo "include Opam_admin_top\n\nlet _ = Topmain.main ()")))
 
 (executable
   (name    opam_check)

--- a/src/tools/opam_admin_top.ml
+++ b/src/tools/opam_admin_top.ml
@@ -128,5 +128,3 @@ let filter fn patterns =
       List.exists (fun re -> OpamStd.String.exact_match re str) regexps
 
 let filter_packages = filter OpamPackage.to_string
-
-let _ = Topmain.main ()


### PR DESCRIPTION
Shedding the weight of some simpler commits:

- `opam-admin.top` - prior to Jbuilder, this was built using `ocamlmktop`. I converted this badly, because the existing code now works as a toplevel, but you can't run a script by having `#!opam-admin.top` or `opam-admin.top foo.ml`. The commit generates the `let _ = Topmain.main ()` in a second file which is used to create `opam-admin.top` and the actual `opam_admin_top.ml` is now used to generate a library. This means that scripts have two choices - you can either `#require "opam-admin.top"` in your script, or you can run an `.ml` file with `opam_admin_top` (although you need `opam_admin_top.cmi` in the same directory as your script).
- `%{exe}%` does exactly what it says on the tin. The main reason for making it a global is to standardise the name used (so there's no temptation for `%{ext_exe}%`, etc. This extension is intentionally blank on Cygwin because Cygwin has its own official handling for automatically adding `.exe`.
- Back when originally working on this, I was converting 1.2 repos to 2.0 regularly - it was a nuisance for flexdll that the `ocaml` dependency kept getting re-added after I'd manually removed it... this legacy commit doesn't do that if the `opam-version` of the file is already `2.0`. The principle may be useful in the future...
- Also in `opam admin upgrade` was an attempt to download URLs using their filename. Fine for a lot of things, but troublesome on Windows when you start having `?` characters, etc., so this patch downloads patches and other referenced files using a safe filename (it's only to compute their checksums).
- I'd like, prior to any kind of global depext variable support, to introduce `sys-ocaml-arch`, `sys-ocaml-libc` and `sys-ocaml-cc` to allow accurate selection of the system compiler on Windows (this may prove unnecessary with the other work we've been looking into on switch parameters, but I don't think these variables would ever do any harm in future).