### PR TITLE
default to use "fetch" on FreeBSD / "ftp" on OpenBSD

### DIFF
--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -41,19 +41,29 @@ let wget_args = [
   CString "-U", None; user_agent, None;
 ]
 
+let fetch_args = [
+  CIdent "url", None;
+  CString "-o", None; CIdent "out", None;
+]
+
+let ftp_args = [
+  CIdent "url", None;
+]
+
 let download_args ~url ~out ~retry ?checksum ~compress =
   let cmd, _ = Lazy.force OpamRepositoryConfig.(!r.download_tool) in
   let cmd =
     match cmd with
     | [(CIdent "wget"), _] -> cmd @ wget_args
+    | [(CIdent "fetch"), _] -> cmd @ fetch_args
+    | [(CIdent "ftp"), _] -> cmd @ ftp_args
     | [_] -> cmd @ curl_args (* Assume curl if the command is a single arg *)
     | _ -> cmd
   in
   OpamFilter.single_command (fun v ->
       if not (OpamVariable.Full.is_global v) then None else
       match OpamVariable.to_string (OpamVariable.Full.variable v) with
-      | "curl" -> Some (S "curl")
-      | "wget" -> Some (S "wget")
+      | ("curl" | "wget" | "fetch" | "ftp") as dl_tool-> Some (S dl_tool)
       | "url" -> Some (S (OpamUrl.to_string url))
       | "out" -> Some (S out)
       | "retry" -> Some (S (string_of_int retry))

--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -44,10 +44,13 @@ let wget_args = [
 let fetch_args = [
   CIdent "url", None;
   CString "-o", None; CIdent "out", None;
+  CString "--user-agent", None; user_agent, None;
 ]
 
 let ftp_args = [
   CIdent "url", None;
+  CString "-o", None; CIdent "out", None;
+  CString "-U", None; user_agent, None;
 ]
 
 let download_args ~url ~out ~retry ?checksum ~compress =


### PR DESCRIPTION
thanks a lot to @rjbou for the commit, I adjusted (as requested in #3735 the command line arguments of `fetch`/`ftp` in the last commit (and rebased the others to master), namely:
- pass user-agent
- pass output filename
- pass URL

I read through the command-line arguments passed to curl, and that looks pretty similar (e.g. fetch follows redirects automatically). I also tested this on FreeBSD, working nicely (don't have a OpenBSD to really test it, maybe someone else (/cc @avsm @adamsteen) would like to do this?

> @rjbou On default init config, I've only put `fetch`/`ftp` as required tools, and in OpamDownload, I've set `fetch`/`ftp` as default command, curl as fallback. In that case, should we add `curl` in recommended_tools:?

in contrast to Linux, both BSDs ship their distribution as kernel plus userland / world -- and the latter not only contains basic utilities (such as a C compiler etc.), but also fetch/ftp - of course you can compile your custom *BSD system which does not include any such tools (and then opam should need curl/a C compiler/make/...) - but that's not anything I recommend to support via opam (plus the download command can already be overridden via OPAMFETCH). So IMHO this is good as is, we don't really need to suggest people to install curl.

Some output from opam:
```
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+ /usr/bin/fetch "https://opam.ocaml.org/cache/sha256/e2/e294aa1f920205da2c9f0ab909e2755b070702cb4fdb47a94b9c18e55cdf774d" "-o" "/usr/home/hannes/.opam/download-cache/sha256/e2/e294aa1f920205da2c9f0ab909e2755b070702cb4fdb47a94b9c18e55cdf774d.tmp.part" "--user-agent" "opam/2.1.0~beta"
- /usr/home/hannes/.opam/download-cache/sha256/e2/e294aa1f920205d          47 kB  308 kBps    00s
```