### PR TITLE
Revert package definition files format to 2.0

### DIFF
--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1960,7 +1960,7 @@ end
 module OPAMSyntax = struct
 
   let internal = "opam"
-  let format_version = OpamVersion.of_string "2.1"
+  let format_version = OpamVersion.of_string "2.0"
 
   type t = {
     opam_version: opam_version;


### PR DESCRIPTION
Oops, bumping that was premature and fine handling is implemented already as part of #3499