### PR TITLE
Make reinstall handling stricter

### DIFF
--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -23,6 +23,7 @@ module type SET = sig
   val find: (elt -> bool) -> t -> elt
   val find_opt: (elt -> bool) -> t -> elt option
   val safe_add: elt -> t -> t
+  val fixpoint: (elt -> t) -> t -> t
 
   module Op : sig
     val (++): t -> t -> t
@@ -238,6 +239,16 @@ module Set = struct
       if mem elt t
       then failwith (Printf.sprintf "duplicate entry %s" (O.to_string elt))
       else add elt t
+
+    let fixpoint f =
+      let open Op in
+      let rec aux fullset curset =
+        if is_empty curset then fullset else
+        let newset = fold (fun nv set -> set ++ f nv) curset empty in
+        aux (fullset ++ curset) (newset -- fullset)
+      in
+      aux empty
+
   end
 
 end

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -36,6 +36,10 @@ module type SET = sig
   (** Raises Failure in case the element is already present *)
   val safe_add: elt -> t -> t
 
+  (** Accumulates the resulting sets of a function of elements until a fixpoint
+      is reached *)
+  val fixpoint: (elt -> t) -> t -> t
+
   module Op : sig
     val (++): t -> t -> t (** Infix set union *)
 

--- a/src/solver/opamSolver.mli
+++ b/src/solver/opamSolver.mli
@@ -105,6 +105,14 @@ val reverse_dependencies :
   package_set ->
   package list
 
+module PkgGraph: Graph.Sig.I
+  with type V.t = OpamPackage.t
+val dependency_graph :
+  depopts:bool -> build:bool -> post:bool ->
+  installed:bool ->
+  ?unavailable:bool ->
+  universe -> PkgGraph.t
+
 (** Check the current set of installed packages in a universe for
     inconsistencies *)
 val check_for_conflicts : universe -> OpamCudf.conflict option


### PR DESCRIPTION
i.e. don't allow to change packages transitively depending on
something marked for reinstall without doing the reinstall.

The first two patches just add helpers to the library:

- a function to compute a dependency graph directly on the opam
  packages (going through Dose and using back-and-forward conversion
  though). Unused at the moment but may come in handy for some uses
  (e.g. opam2web)

- a Set.fixpoint function, used e.g. to directly compute transitive
  dependency cones directly on opam packages (without going through
  Dose this time)