### PR TITLE
Patch cmdliner

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,8 +13,8 @@ check_linker text eol=lf
 # For diffing simplicity, the patch re-write test uses LF endings on Windows
 tests/patcher-test.reference text eol=lf
 
-# Treat patches as binary for safety
-*.patch binary
+# Don't normalise patch files
+*.patch -text
 
 # Actual binary files
 *.pdf binary

--- a/src_ext/patches/cmdliner.common/0001-Escape-default-values.patch
+++ b/src_ext/patches/cmdliner.common/0001-Escape-default-values.patch
@@ -1,0 +1,26 @@
+From 5a16084c90548aa4ce8da2415685594215d5bfd0 Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Wed, 26 Jun 2019 18:05:28 +0100
+Subject: [PATCH] Escape default values
+
+Signed-off-by: David Allsopp <david.allsopp@metastack.com>
+---
+ src/cmdliner_docgen.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/cmdliner_docgen.ml b/src/cmdliner_docgen.ml
+index 054164f..e41aa60 100644
+--- a/src/cmdliner_docgen.ml
++++ b/src/cmdliner_docgen.ml
+@@ -146,7 +146,7 @@ let arg_to_man_item ~errs ~subst ~buf a =
+   | Cmdliner_info.Val v ->
+       match Lazy.force v with
+       | "" -> strf "%s" (or_env ~value:false a)
+-      | v -> strf "absent=%s%s" v (or_env ~value:true a)
++      | v -> strf "absent=%s%s" (esc v) (or_env ~value:true a)
+   in
+   let optvopt = match Cmdliner_info.arg_opt_kind a with
+   | Cmdliner_info.Opt_vopt v -> strf "default=%s" v
+-- 
+2.20.1.windows.1
+


### PR DESCRIPTION
This PR serves two purposes:

- It updates the `.gitattributes` handling of patch files in the same way as https://github.com/ocaml/opam-repository/pull/14348 which means that Git will not mess around line endings, but otherwise treats them as text files (which can be diff'd, etc.)
- It moves the patch for https://github.com/dbuenzli/cmdliner/pull/111 into `src_ext` since this is a blocker for #3902 on Windows