### PR TITLE
pass url last in download commands, this is necessary for ftp at least

### DIFF
--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -37,20 +37,20 @@ let wget_args = [
   CString "--content-disposition", None;
   CString "-t", None; CIdent "retry", None;
   CString "-O", None; CIdent "out", None;
-  CIdent "url", None;
   CString "-U", None; user_agent, None;
+  CIdent "url", None;
 ]
 
 let fetch_args = [
-  CIdent "url", None;
   CString "-o", None; CIdent "out", None;
   CString "--user-agent", None; user_agent, None;
+  CIdent "url", None;
 ]
 
 let ftp_args = [
-  CIdent "url", None;
   CString "-o", None; CIdent "out", None;
   CString "-U", None; user_agent, None;
+  CIdent "url", None;
 ]
 
 let download_args ~url ~out ~retry ?checksum ~compress =


### PR DESCRIPTION
I could reproduce the issue seen by @adamsteen while testing `ftp` on OpenBSD -- once the URL is parsed, all other arguments are ignored. This lead to `ftp` downloading the archive, but instead of saving at the location opam intended, it was saved as `filename`, which opam did not expect.