### PR TITLE
Add missing Cmdliner.Manpage.escape calls

### DIFF
--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -36,7 +36,7 @@ let admin_command_man = [
         holding package definition within subdirectories. A 'compilers%s' \
         subdirectory (opam repository format version < 2) will also be used by \
         the $(b,upgrade-format) subcommand."
-       Filename.dir_sep Filename.dir_sep)
+       Filename.dir_sep Filename.dir_sep |> Cmdliner.Manpage.escape)
 ]
 
 let index_command_doc =
@@ -198,7 +198,7 @@ let cache_command =
          info ["link"] ~docv:"DIR" ~doc:
            (Printf.sprintf
              "Create reverse symbolic links to the archives within $(i,DIR), in \
-              the form $(b,DIR%sPKG.VERSION%sFILENAME)." Filename.dir_sep Filename.dir_sep))
+              the form $(b,DIR%sPKG.VERSION%sFILENAME)." Filename.dir_sep Filename.dir_sep |> Cmdliner.Manpage.escape))
   in
   let jobs_arg =
     Arg.(value & opt OpamArg.positive_integer 8 &
@@ -266,7 +266,7 @@ let add_hashes_command =
           "This command scans through package definitions, and add hashes as \
            requested (fetching the archives if required). A cache is generated \
            in %s for subsequent runs."
-          (OpamFilename.Dir.to_string cache_dir));
+          (OpamFilename.Dir.to_string cache_dir |> Cmdliner.Manpage.escape));
   ]
   in
   let hash_kinds = [`MD5; `SHA256; `SHA512] in
@@ -494,7 +494,7 @@ let upgrade_command =
           converts them to repositories suitable for the current opam version. \
           Packages might be created or renamed, and any compilers defined in the \
           old format ('compilers%s' directory) will be turned into packages, \
-          using a pre-defined hierarchy that assumes OCaml compilers." Filename.dir_sep)
+          using a pre-defined hierarchy that assumes OCaml compilers." Filename.dir_sep |> Cmdliner.Manpage.escape)
   ]
   in
   let clear_cache_arg =
@@ -502,7 +502,7 @@ let upgrade_command =
       Printf.sprintf
        "Instead of running the upgrade, clear the cache of archive hashes (held \
         in ~%s.cache), that is used to avoid re-downloading files to obtain \
-        their hashes at every run." Filename.dir_sep
+        their hashes at every run." Filename.dir_sep |> Cmdliner.Manpage.escape
     in
     Arg.(value & flag & info ["clear-cache"] ~doc)
   in
@@ -718,7 +718,7 @@ let env_arg =
            resolved purely from globally defined variables. Note that, unless \
            overridden, variables like 'root' or 'opam-version' may be taken \
            from the current opam installation. What is defined in \
-           $(i,~%s.opam%sconfig) is always ignored." Filename.dir_sep Filename.dir_sep))
+           $(i,~%s.opam%sconfig) is always ignored." Filename.dir_sep Filename.dir_sep |> Cmdliner.Manpage.escape))
 
 let state_selection_arg =
   let docs = OpamArg.package_selection_section in

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -840,7 +840,7 @@ let dot_profile_flag =
     (Printf.sprintf
       "Name of the configuration file to update instead of \
        $(i,~%s.profile) or $(i,~%s.zshrc) based on shell detection."
-      Filename.dir_sep Filename.dir_sep)
+      Filename.dir_sep Filename.dir_sep |> Cmdliner.Manpage.escape)
     (Arg.some filename) None
 
 let repo_kind_flag =
@@ -882,7 +882,7 @@ let atom_or_local_list =
     (Printf.sprintf
       "List of package names, with an optional version or constraint, e.g `pkg', \
        `pkg.1.0' or `pkg>=0.5' ; or files or directory names containing package \
-       description, with explicit directory (e.g. `.%sfoo.opam' or `.')" Filename.dir_sep)
+       description, with explicit directory (e.g. `.%sfoo.opam' or `.')" Filename.dir_sep |> Cmdliner.Manpage.escape)
     atom_or_local
 
 let atom_or_dir_list =
@@ -890,7 +890,7 @@ let atom_or_dir_list =
     (Printf.sprintf
       "List of package names, with an optional version or constraint, e.g `pkg', \
        `pkg.1.0' or `pkg>=0.5' ; or directory names containing package \
-       description, with explicit directory (e.g. `.%ssrcdir' or `.')" Filename.dir_sep)
+       description, with explicit directory (e.g. `.%ssrcdir' or `.')" Filename.dir_sep |> Cmdliner.Manpage.escape)
     atom_or_dir
 
 let nonempty_atom_list =

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -77,7 +77,7 @@ let global_options =
     mk_flag ~section:global_option_section ["no-self-upgrade"]
       (Printf.sprintf
         "Opam will replace itself with a newer binary found \
-         at $(b,OPAMROOT%sopam) if present. This disables this behaviour." Filename.dir_sep) in
+         at $(b,OPAMROOT%sopam) if present. This disables this behaviour." Filename.dir_sep |> Cmdliner.Manpage.escape) in
   let self_upgrade no_self_upgrade options =
     let self_upgrade_status =
       if OpamStd.Config.env_string "NOSELFUPGRADE" =
@@ -178,11 +178,11 @@ let init =
           installed, according to the configuration and options. These can be \
           afterwards configured using $(b,opam switch) and $(b,opam \
           repository)."
-         Filename.dir_sep Filename.dir_sep);
+         Filename.dir_sep Filename.dir_sep |> Cmdliner.Manpage.escape);
     `P (Printf.sprintf
          "The initial repository and defaults can be set through a \
           configuration file found at $(i,~%s.opamrc) or $(i,/etc/opamrc)."
-         Filename.dir_sep);
+         Filename.dir_sep |> Cmdliner.Manpage.escape);
     `P "Additionally, this command allows one to customise some aspects of opam's \
         shell integration, when run initially (avoiding the interactive \
         dialog), but also at any later time.";
@@ -194,7 +194,7 @@ let init =
           through $(i,~%s.opamrc), $(i,/etc/opamrc), or a file supplied with \
           $(i,--config). The default configuration for this version of opam \
           can be obtained using $(b,--show-default-opamrc)."
-         Filename.dir_sep);
+         Filename.dir_sep |> Cmdliner.Manpage.escape);
     `S OpamArg.build_option_section;
   ] in
   let compiler =
@@ -274,7 +274,7 @@ let init =
     mk_flag ["no-opamrc"]
       (Printf.sprintf
       "Don't read `/etc/opamrc' or `~%s.opamrc': use the default settings and \
-       the files specified through $(b,--config) only" Filename.dir_sep)
+       the files specified through $(b,--config) only" Filename.dir_sep |> Cmdliner.Manpage.escape)
   in
   let reinit =
     mk_flag ["reinit"]
@@ -2033,7 +2033,7 @@ let switch =
          package definitions are found locally, the user is automatically \
          prompted to install them after the switch is created unless \
          $(b,--no-install) is specified."
-        Filename.dir_sep OpamSwitch.external_dirname);
+        Filename.dir_sep OpamSwitch.external_dirname |> Cmdliner.Manpage.escape);
     `P "$(b,opam switch set) sets the default switch globally, but it is also \
         possible to select a switch in a given shell session, using the \
         environment. For that, use $(i,eval \\$(opam env \
@@ -3004,7 +3004,7 @@ let clean =
     mk_flag ["c"; "download-cache"]
       (Printf.sprintf
         "Clear the cache of downloaded files (\\$OPAMROOT%sdownload-cache), as \
-         well as the obsolete \\$OPAMROOT%sarchives, if that exists." Filename.dir_sep Filename.dir_sep)
+         well as the obsolete \\$OPAMROOT%sarchives, if that exists." Filename.dir_sep Filename.dir_sep |> Cmdliner.Manpage.escape)
   in
   let repos =
     mk_flag ["unused-repositories"]


### PR DESCRIPTION
#3893 uses Windows separators in various opam messages - the ones which are cmdliner terms need to be escaped, which this PR addresses. This PR is also a prerequisite of #3902.