### PR TITLE
opamDownload: terminate (with double dashes) list of command-line opts

### DIFF
--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -30,6 +30,7 @@ let curl_args = [
   CString "--user-agent", None; user_agent, None;
   CString "-L", None;
   CString "-o", None; CIdent "out", None;
+  CString "--", None; (* End list of options *)
   CIdent "url", None;
 ]
 
@@ -38,18 +39,21 @@ let wget_args = [
   CString "-t", None; CIdent "retry", None;
   CString "-O", None; CIdent "out", None;
   CString "-U", None; user_agent, None;
+  CString "--", None; (* End list of options *)
   CIdent "url", None;
 ]
 
 let fetch_args = [
   CString "-o", None; CIdent "out", None;
   CString "--user-agent", None; user_agent, None;
+  CString "--", None; (* End list of options *)
   CIdent "url", None;
 ]
 
 let ftp_args = [
   CString "-o", None; CIdent "out", None;
   CString "-U", None; user_agent, None;
+  CString "--", None; (* End list of options *)
   CIdent "url", None;
 ]
 


### PR DESCRIPTION
opamDownload: terminate (with double dashes) list of command-line options preceding unnamed positional arguments to bolster opam against problems with dashes in weird places.

Failure to do this is a pretty common source of security issues, see for instance [CVE-2018-1000006](https://web.archive.org/web/20190702112128/https://medium.com/0xcc/electrons-bug-shellexecute-to-blame-cacb433d0d62).

Note that this is different from e.g. [CVE-2017-17519](https://security-tracker.debian.org/tracker/CVE-2017-17519) ([code](https://github.com/ocaml-batteries-team/batteries-included/blob/master/src/batteriesConfig.mlp#L28)); passing each argument as an array element to execve does not preclude argument parsing, it merely prevents whitespace issues from breaking up the arguments differently than intended.

As originally suggested in https://github.com/ocaml/opam/pull/3904#issuecomment-507488474