### PR TITLE
doc: add distribution page

### DIFF
--- a/doc/pages/Distribution.md
+++ b/doc/pages/Distribution.md
@@ -16,7 +16,7 @@ get an up-to-date overview of official packages on most Linux distributions.
 
 | Distribution/OS               | Latest OPAM | Maintainer                                                                                                        | Notes |
 |-------------                  |-------------|-----------                                                                                                        |-------|
-| Arch Linux                    | 2.0.4       | Alexander F. Rødseth [@xyproto](https://github.com/xyproto)                                                       | [Package search](https://www.archlinux.org/packages/?sort=&q=opam)
+| Arch Linux                    | 2.0.4       | Alexander F. Rødseth [@xyproto](https://github.com/xyproto)                                                       | [Package search](https://www.archlinux.org/packages/community/x86_64/opam/)
 | Debian Linux (8,jessie)       | 1.2.0       | Mehdi Dogguy [@mehdid](https://github.com/mehdid), Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
 | Debian Linux (9,stretch)      | 1.2.2       | Mehdi Dogguy [@mehdid](https://github.com/mehdid), Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
 | Debian Linux (10,buster)      | 2.0.3       | Mehdi Dogguy [@mehdid](https://github.com/mehdid), Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)

--- a/doc/pages/Distribution.md
+++ b/doc/pages/Distribution.md
@@ -1,0 +1,52 @@
+# opam and other package managers: distributions list
+
+This page tracks the state of binary packaging of OPAM on upstream
+distributions. If you do package up OPAM for your various OS, please feel free
+to add it below, update [this file](https://github.com/ocaml/opam/tree/master/doc/pages/Distribution.md)
+and open a [pull request](https://github.com/ocaml/opam/compare).
+
+The pages/files linked are the ones that give the best overview of the available
+versions.
+
+Those [_pkgs_](http://pkgs.org/search/opam) and
+[_repology_](https://repology.org/project/opam/versions) pages may be used to
+get an up-to-date overview of official packages on most Linux distributions.
+
+### Official distribution packages
+
+| Distribution                  | Latest OPAM    | Maintainer                                                                                                                    | Notes |
+|-------------------------------|-------------   |-------------------------------------------------------------------------------------------------------------------------------|-------|
+| Debian Linux (8,jessie)       | 1.2.0          | Mehdi Dogguy, Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud)                                                  | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
+| Debian Linux (9,stretch)      | 1.2.2          | Mehdi Dogguy, Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud)                                                  | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
+| Debian Linux (10,buster)      | 1.2.2          | Mehdi Dogguy, Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud)                                                  | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
+| Debian Linux (unstable, sid)  | 2.0.0          | Mehdi Dogguy, Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud)                                                  | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
+| Ubuntu Linux (14.04,trusty)   | 1.1.1          | -                                                                                                                             | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all) - bwrap unavailable
+| Ubuntu Linux (16.04,xenial)   | 1.2.2          | -                                                                                                                             | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all) - bwrap unavailable
+| Ubuntu Linux (17.04,artful)   | 1.2.2          | -                                                                                                                             | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all)
+| Ubuntu Linux (18.04,bionic)   | 1.2.2          | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                                        | [ppa post](https://discuss.ocaml.org/t/opam-2-0-experimental-ppas/2446)
+| Homebrew (MacOS X)            | 2.0.0          | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                                        |
+| Macports (MacOS X)            | 2.0.0          | Perry E. Metzger [@pmetzger](https://www.github.com/pmetzger)                                                                 | [Package definition](https://github.com/macports/macports-ports/blob/master/sysutils/opam/Portfile)
+| Arch Linux                    | 1.1.1/2.0.0    | Vincent Bernardoff [@vbmithr](https://www.github.com/vbmithr), Pieter Goetschalckx [@314eter](https://www.github.com/314eter) | [Package search](https://aur.archlinux.org/packages/?O=0&C=0&SeB=nd&K=opam&outdated=&SB=n&SO=a&PP=50&do_Search=Go)
+| Mageia Linux (cauldron)       | 2.0.0          | David Geiger [@david_david](https://www.github.com/david_david)                                                               | [Package definition](http://svnweb.mageia.org/packages/cauldron/opam/current/SPECS/opam.spec?view=markup)
+| NixOS                         | 1.2.2/2.0.0    | Henry Till                                                                                                                    | [Package definitions](https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/tools/ocaml/opam)
+| Gnu Guix                      | 2.0.4          | -                                                                                                                             | [Package definition](https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/ocaml.scm#n42)
+| FreeBSD                       | 2.0.3          | Hannes Mehnert [@hannesm](https://www.github.com/hannesm)                                                                     | [Package search](http://www.freebsd.org/cgi/ports.cgi?query=opam&stype=all)
+| OpenBSD                       | 1.2.2          | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                                        | [Package page](http://ports.su/sysutils/opam,-main)
+| Fedora 27 +                   | 2.0.0          | Ben Rosser [@TC01](https://www.github.com/TC01)                                                                               | [Package page](https://apps.fedoraproject.org/packages/opam)
+
+### Other
+
+| Distribution                | Latest OPAM | Maintainer                                                         | Notes |
+|-----------------------------|-------------|------------------------------------                                |-------|
+| Ubuntu Linux (PPA)          | 2.0.0       | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)             | [Anil's official OPAM PPA](https://launchpad.net/~avsm) (http://anil.recoil.org/2013/09/30/travis-and-ocaml.html) and [discuss post](https://discuss.ocaml.org/t/opam-2-0-experimental-ppas/2446) 
+| Exherbo Linux               | 1.1.1       | Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) (?) | [Package page](http://git.exherbo.org/summer/packages/dev-ocaml/opam/index.html) (_ocaml-unofficial_)
+| CentOS (6,7)                | -           | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)             |
+| OpenSuse                    | -           | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)             |
+| Windows                     | -           | David Allsopp [@dra27](https://www.github.com/dra27)               | [MinGW repo](https://github.com/fdopen/opam-repository-mingw) - Andreas Hauptmann [@fdopen](https://www.github.com/fdopen)
+
+
+If you can't find latest version packages for your distribution here, see [the
+OPAM installation page](Install.html) for binaries or building from source.
+
+[Docker containers](http://hub.docker.com/r/ocaml/opam) for severals
+distributions and OCaml compiler versions are also available.

--- a/doc/pages/Distribution.md
+++ b/doc/pages/Distribution.md
@@ -12,14 +12,26 @@ Those [_pkgs_](http://pkgs.org/search/opam) and
 [_repology_](https://repology.org/project/opam/versions) pages may be used to
 get an up-to-date overview of official packages on most Linux distributions.
 
-## Official distribution packages
+## Official distribution/os packages
 
-| Distribution                  | Latest OPAM | Maintainer                                                                                                        | Notes |
+| Distribution/os               | Latest OPAM | Maintainer                                                                                                        | Notes |
 |-------------                  |-------------|-----------                                                                                                        |-------|
+| Arch Linux                    | 2.0.4       | Alexander F. Rødseth [@xyproto](https://github.com/xyproto)                                                       | [Package search](https://www.archlinux.org/packages/?sort=&q=opam)
+| CentOS (6,7)                  | -           | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                            |
 | Debian Linux (8,jessie)       | 1.2.0       | Mehdi Dogguy [@mehdid](https://github.com/mehdid), Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
 | Debian Linux (9,stretch)      | 1.2.2       | Mehdi Dogguy [@mehdid](https://github.com/mehdid), Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
 | Debian Linux (10,buster)      | 2.0.3       | Mehdi Dogguy [@mehdid](https://github.com/mehdid), Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
 | Debian Linux (unstable, sid)  | 2.0.3       | Mehdi Dogguy [@mehdid](https://github.com/mehdid), Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
+| Exherbo Linux                 | 1.1.1       | Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) (?)                                                | [Package page](http://git.exherbo.org/summer/packages/dev-ocaml/opam/index.html) (_ocaml-unofficial_)
+| Fedora 27 +                   | 2.0.0       | Ben Rosser [@TC01](https://www.github.com/TC01)                                                                   | [Package page](https://apps.fedoraproject.org/packages/opam)
+| FreeBSD                       | 2.0.4       | Hannes Mehnert [@hannesm](https://www.github.com/hannesm)                                                         | [Package search](http://www.freebsd.org/cgi/ports.cgi?query=opam&stype=all)
+| Gnu Guix                      | 2.0.4       | Julien Lepiller [@roptat](https://github.com/roptat)                                                              | [Package definition](https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/ocaml.scm#n428)
+| Homebrew (MacOS X)            | 2.0.4       |                                                                                                                   |
+| Macports (MacOS X)            | 2.0.0       | Perry E. Metzger [@pmetzger](https://www.github.com/pmetzger)                                                     | [Package definition](https://github.com/macports/macports-ports/blob/master/sysutils/opam/Portfile)
+| Mageia Linux (cauldron)       | 2.0.1       | David Geiger [@david-geiger](https://www.github.com/david-geiger)                                                 | [Package definition](http://svnweb.mageia.org/packages/cauldron/opam/current/SPECS/opam.spec?view=markup)
+| NixOS                         | 1.2.2/2.0.0 | Henry Till                                                                                                        | [Package definitions](https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/tools/ocaml/opam)
+| OpenBSD                       | 2.0.4       | Christopher Zimmerman [@madroach](https://github.com/madroach)                                                    | [Package page](http://ports.su/sysutils/opam,-main)
+| OpenSuse                      | -           | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                            |
 | Ubuntu Linux (14.04,trusty)   | 1.1.1       | -                                                                                                                 | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all) - bwrap unavailable
 | Ubuntu Linux (16.04,xenial)   | 1.2.2       | -                                                                                                                 | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all) - bwrap unavailable
 | Ubuntu Linux (17.04,artful)   | 1.2.2       | -                                                                                                                 | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all)
@@ -27,25 +39,7 @@ get an up-to-date overview of official packages on most Linux distributions.
 | Ubuntu Linux (19.04,cosmic)   | 1.2.2       | -                                                                                                                 | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all)
 | Ubuntu Linux (19.04,disco)    | 2.0.3       | -                                                                                                                 | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all)
 | Ubuntu Linux PPA              | 2.0.4       | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                            | [Anil's official OPAM PPA](https://launchpad.net/~avsm) and [ppa post](https://discuss.ocaml.org/t/opam-2-0-experimental-ppas/2446)
-| Homebrew (MacOS X)            | 2.0.0       | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                            |
-| Macports (MacOS X)            | 2.0.0       | Perry E. Metzger [@pmetzger](https://www.github.com/pmetzger)                                                     | [Package definition](https://github.com/macports/macports-ports/blob/master/sysutils/opam/Portfile)
-| Arch Linux                    | 2.0.4       | Alexander F. Rødseth [@xyproto](https://github.com/xyproto)                                                       | [Package search](https://www.archlinux.org/packages/?sort=&q=opam)
-| Mageia Linux (cauldron)       | 2.0.1       | David Geiger [@david-geiger](https://www.github.com/david-geiger)                                                 | [Package definition](http://svnweb.mageia.org/packages/cauldron/opam/current/SPECS/opam.spec?view=markup)
-| NixOS                         | 1.2.2/2.0.0 | Henry Till                                                                                                        | [Package definitions](https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/tools/ocaml/opam)
-| Gnu Guix                      | 2.0.4       | Julien Lepiller [@roptat](https://github.com/roptat)                                                              | [Package definition](https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/ocaml.scm#n428)
-| FreeBSD                       | 2.0.4       | Hannes Mehnert [@hannesm](https://www.github.com/hannesm)                                                         | [Package search](http://www.freebsd.org/cgi/ports.cgi?query=opam&stype=all)
-| OpenBSD                       | 1.2.2       | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                            | [Package page](http://ports.su/sysutils/opam,-main)
-| Fedora 27 +                   | 2.0.0       | Ben Rosser [@TC01](https://www.github.com/TC01)                                                                   | [Package page](https://apps.fedoraproject.org/packages/opam)
-
-### Other
-
-| Distribution                  | Latest OPAM | Maintainer                                                         | Notes |
-|-------------                  |-------------|-----------                                                         |-------|
-| Exherbo Linux                 | 1.1.1       | Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) (?) | [Package page](http://git.exherbo.org/summer/packages/dev-ocaml/opam/index.html) (_ocaml-unofficial_)
-| CentOS (6,7)                  | -           | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)             |
-| OpenSuse                      | -           | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)             |
-| Windows                       | -           | David Allsopp [@dra27](https://www.github.com/dra27)               | [MinGW repo](https://github.com/fdopen/opam-repository-mingw) - Andreas Hauptmann [@fdopen](https://www.github.com/fdopen)
-
+| Windows                       | -           | David Allsopp [@dra27](https://www.github.com/dra27)                                                              | [MinGW repo](https://github.com/fdopen/opam-repository-mingw) - Andreas Hauptmann [@fdopen](https://www.github.com/fdopen)
 
 If you can't find latest version packages for your distribution here, see [the
 OPAM installation page](Install.html) for binaries or building from source.

--- a/doc/pages/Distribution.md
+++ b/doc/pages/Distribution.md
@@ -12,37 +12,39 @@ Those [_pkgs_](http://pkgs.org/search/opam) and
 [_repology_](https://repology.org/project/opam/versions) pages may be used to
 get an up-to-date overview of official packages on most Linux distributions.
 
-### Official distribution packages
+## Official distribution packages
 
-| Distribution                  | Latest OPAM    | Maintainer                                                                                                                    | Notes |
-|-------------------------------|-------------   |-------------------------------------------------------------------------------------------------------------------------------|-------|
-| Debian Linux (8,jessie)       | 1.2.0          | Mehdi Dogguy, Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud)                                                  | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
-| Debian Linux (9,stretch)      | 1.2.2          | Mehdi Dogguy, Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud)                                                  | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
-| Debian Linux (10,buster)      | 1.2.2          | Mehdi Dogguy, Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud)                                                  | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
-| Debian Linux (unstable, sid)  | 2.0.0          | Mehdi Dogguy, Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud)                                                  | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
-| Ubuntu Linux (14.04,trusty)   | 1.1.1          | -                                                                                                                             | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all) - bwrap unavailable
-| Ubuntu Linux (16.04,xenial)   | 1.2.2          | -                                                                                                                             | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all) - bwrap unavailable
-| Ubuntu Linux (17.04,artful)   | 1.2.2          | -                                                                                                                             | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all)
-| Ubuntu Linux (18.04,bionic)   | 1.2.2          | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                                        | [ppa post](https://discuss.ocaml.org/t/opam-2-0-experimental-ppas/2446)
-| Homebrew (MacOS X)            | 2.0.0          | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                                        |
-| Macports (MacOS X)            | 2.0.0          | Perry E. Metzger [@pmetzger](https://www.github.com/pmetzger)                                                                 | [Package definition](https://github.com/macports/macports-ports/blob/master/sysutils/opam/Portfile)
-| Arch Linux                    | 1.1.1/2.0.0    | Vincent Bernardoff [@vbmithr](https://www.github.com/vbmithr), Pieter Goetschalckx [@314eter](https://www.github.com/314eter) | [Package search](https://aur.archlinux.org/packages/?O=0&C=0&SeB=nd&K=opam&outdated=&SB=n&SO=a&PP=50&do_Search=Go)
-| Mageia Linux (cauldron)       | 2.0.0          | David Geiger [@david_david](https://www.github.com/david_david)                                                               | [Package definition](http://svnweb.mageia.org/packages/cauldron/opam/current/SPECS/opam.spec?view=markup)
-| NixOS                         | 1.2.2/2.0.0    | Henry Till                                                                                                                    | [Package definitions](https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/tools/ocaml/opam)
-| Gnu Guix                      | 2.0.4          | -                                                                                                                             | [Package definition](https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/ocaml.scm#n42)
-| FreeBSD                       | 2.0.3          | Hannes Mehnert [@hannesm](https://www.github.com/hannesm)                                                                     | [Package search](http://www.freebsd.org/cgi/ports.cgi?query=opam&stype=all)
-| OpenBSD                       | 1.2.2          | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                                        | [Package page](http://ports.su/sysutils/opam,-main)
-| Fedora 27 +                   | 2.0.0          | Ben Rosser [@TC01](https://www.github.com/TC01)                                                                               | [Package page](https://apps.fedoraproject.org/packages/opam)
+| Distribution                  | Latest OPAM | Maintainer                                                                                                        | Notes |
+|-------------                  |-------------|-----------                                                                                                        |-------|
+| Debian Linux (8,jessie)       | 1.2.0       | Mehdi Dogguy [@mehdid](https://github.com/mehdid), Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
+| Debian Linux (9,stretch)      | 1.2.2       | Mehdi Dogguy [@mehdid](https://github.com/mehdid), Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
+| Debian Linux (10,buster)      | 2.0.3       | Mehdi Dogguy [@mehdid](https://github.com/mehdid), Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
+| Debian Linux (unstable, sid)  | 2.0.3       | Mehdi Dogguy [@mehdid](https://github.com/mehdid), Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
+| Ubuntu Linux (14.04,trusty)   | 1.1.1       | -                                                                                                                 | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all) - bwrap unavailable
+| Ubuntu Linux (16.04,xenial)   | 1.2.2       | -                                                                                                                 | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all) - bwrap unavailable
+| Ubuntu Linux (17.04,artful)   | 1.2.2       | -                                                                                                                 | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all)
+| Ubuntu Linux (18.04,bionic)   | 1.2.2       | -                                                                                                                 | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all)
+| Ubuntu Linux (19.04,cosmic)   | 1.2.2       | -                                                                                                                 | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all)
+| Ubuntu Linux (19.04,disco)    | 2.0.3       | -                                                                                                                 | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all)
+| Ubuntu Linux PPA              | 2.0.4       | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                            | [Anil's official OPAM PPA](https://launchpad.net/~avsm) and [ppa post](https://discuss.ocaml.org/t/opam-2-0-experimental-ppas/2446)
+| Homebrew (MacOS X)            | 2.0.0       | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                            |
+| Macports (MacOS X)            | 2.0.0       | Perry E. Metzger [@pmetzger](https://www.github.com/pmetzger)                                                     | [Package definition](https://github.com/macports/macports-ports/blob/master/sysutils/opam/Portfile)
+| Arch Linux                    | 2.0.4       | Alexander F. Rødseth [@xyproto](https://github.com/xyproto)                                                       | [Package search](https://www.archlinux.org/packages/?sort=&q=opam)
+| Mageia Linux (cauldron)       | 2.0.1       | David Geiger [@david-geiger](https://www.github.com/david-geiger)                                                 | [Package definition](http://svnweb.mageia.org/packages/cauldron/opam/current/SPECS/opam.spec?view=markup)
+| NixOS                         | 1.2.2/2.0.0 | Henry Till                                                                                                        | [Package definitions](https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/tools/ocaml/opam)
+| Gnu Guix                      | 2.0.4       | Julien Lepiller [@roptat](https://github.com/roptat)                                                              | [Package definition](https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/ocaml.scm#n428)
+| FreeBSD                       | 2.0.4       | Hannes Mehnert [@hannesm](https://www.github.com/hannesm)                                                         | [Package search](http://www.freebsd.org/cgi/ports.cgi?query=opam&stype=all)
+| OpenBSD                       | 1.2.2       | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                            | [Package page](http://ports.su/sysutils/opam,-main)
+| Fedora 27 +                   | 2.0.0       | Ben Rosser [@TC01](https://www.github.com/TC01)                                                                   | [Package page](https://apps.fedoraproject.org/packages/opam)
 
 ### Other
 
-| Distribution                | Latest OPAM | Maintainer                                                         | Notes |
-|-----------------------------|-------------|------------------------------------                                |-------|
-| Ubuntu Linux (PPA)          | 2.0.0       | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)             | [Anil's official OPAM PPA](https://launchpad.net/~avsm) (http://anil.recoil.org/2013/09/30/travis-and-ocaml.html) and [discuss post](https://discuss.ocaml.org/t/opam-2-0-experimental-ppas/2446) 
-| Exherbo Linux               | 1.1.1       | Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) (?) | [Package page](http://git.exherbo.org/summer/packages/dev-ocaml/opam/index.html) (_ocaml-unofficial_)
-| CentOS (6,7)                | -           | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)             |
-| OpenSuse                    | -           | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)             |
-| Windows                     | -           | David Allsopp [@dra27](https://www.github.com/dra27)               | [MinGW repo](https://github.com/fdopen/opam-repository-mingw) - Andreas Hauptmann [@fdopen](https://www.github.com/fdopen)
+| Distribution                  | Latest OPAM | Maintainer                                                         | Notes |
+|-------------                  |-------------|-----------                                                         |-------|
+| Exherbo Linux                 | 1.1.1       | Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) (?) | [Package page](http://git.exherbo.org/summer/packages/dev-ocaml/opam/index.html) (_ocaml-unofficial_)
+| CentOS (6,7)                  | -           | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)             |
+| OpenSuse                      | -           | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)             |
+| Windows                       | -           | David Allsopp [@dra27](https://www.github.com/dra27)               | [MinGW repo](https://github.com/fdopen/opam-repository-mingw) - Andreas Hauptmann [@fdopen](https://www.github.com/fdopen)
 
 
 If you can't find latest version packages for your distribution here, see [the

--- a/doc/pages/Distribution.md
+++ b/doc/pages/Distribution.md
@@ -12,17 +12,15 @@ Those [_pkgs_](http://pkgs.org/search/opam) and
 [_repology_](https://repology.org/project/opam/versions) pages may be used to
 get an up-to-date overview of official packages on most Linux distributions.
 
-## Official distribution/os packages
+## _Official_ packages
 
-| Distribution/os               | Latest OPAM | Maintainer                                                                                                        | Notes |
+| Distribution/OS               | Latest OPAM | Maintainer                                                                                                        | Notes |
 |-------------                  |-------------|-----------                                                                                                        |-------|
 | Arch Linux                    | 2.0.4       | Alexander F. Rødseth [@xyproto](https://github.com/xyproto)                                                       | [Package search](https://www.archlinux.org/packages/?sort=&q=opam)
-| CentOS (6,7)                  | -           | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                            |
 | Debian Linux (8,jessie)       | 1.2.0       | Mehdi Dogguy [@mehdid](https://github.com/mehdid), Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
 | Debian Linux (9,stretch)      | 1.2.2       | Mehdi Dogguy [@mehdid](https://github.com/mehdid), Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
 | Debian Linux (10,buster)      | 2.0.3       | Mehdi Dogguy [@mehdid](https://github.com/mehdid), Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
 | Debian Linux (unstable, sid)  | 2.0.3       | Mehdi Dogguy [@mehdid](https://github.com/mehdid), Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) | [Package search](https://packages.debian.org/search?keywords=opam&searchon=names&suite=all&section=all)
-| Exherbo Linux                 | 1.1.1       | Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) (?)                                                | [Package page](http://git.exherbo.org/summer/packages/dev-ocaml/opam/index.html) (_ocaml-unofficial_)
 | Fedora 27 +                   | 2.0.0       | Ben Rosser [@TC01](https://www.github.com/TC01)                                                                   | [Package page](https://apps.fedoraproject.org/packages/opam)
 | FreeBSD                       | 2.0.4       | Hannes Mehnert [@hannesm](https://www.github.com/hannesm)                                                         | [Package search](http://www.freebsd.org/cgi/ports.cgi?query=opam&stype=all)
 | Gnu Guix                      | 2.0.4       | Julien Lepiller [@roptat](https://github.com/roptat)                                                              | [Package definition](https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/ocaml.scm#n428)
@@ -38,6 +36,13 @@ get an up-to-date overview of official packages on most Linux distributions.
 | Ubuntu Linux (18.04,bionic)   | 1.2.2       | -                                                                                                                 | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all)
 | Ubuntu Linux (19.04,cosmic)   | 1.2.2       | -                                                                                                                 | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all)
 | Ubuntu Linux (19.04,disco)    | 2.0.3       | -                                                                                                                 | [Package search](http://packages.ubuntu.com/search?keywords=opam&searchon=names&suite=all&section=all)
+
+
+## Third party packages
+| Distribution/OS               | Latest OPAM | Maintainer                                                                                                        | Notes |
+|-------------                  |-------------|-----------                                                                                                        |-------|
+| CentOS (6,7)                  | -           | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                            |
+| Exherbo Linux                 | 1.1.1       | Nicolas Braud-Santoni [@nbraud](https://www.github.com/nbraud) (?)                                                | [Package page](http://git.exherbo.org/summer/packages/dev-ocaml/opam/index.html) (_ocaml-unofficial_)
 | Ubuntu Linux PPA              | 2.0.4       | Anil Madhavapeddy [@avsm](https://www.github.com/avsm)                                                            | [Anil's official OPAM PPA](https://launchpad.net/~avsm) and [ppa post](https://discuss.ocaml.org/t/opam-2-0-experimental-ppas/2446)
 | Windows                       | -           | David Allsopp [@dra27](https://www.github.com/dra27)                                                              | [MinGW repo](https://github.com/fdopen/opam-repository-mingw) - Andreas Hauptmann [@fdopen](https://www.github.com/fdopen)
 

--- a/doc/pages/index.menu
+++ b/doc/pages/index.menu
@@ -13,5 +13,6 @@ FAQ.md
 Tricks.md
 Packaging.md
 External_solvers.md
+Distribution.md
 
 Manual.md

--- a/doc/pages/index.menu
+++ b/doc/pages/index.menu
@@ -12,7 +12,7 @@ Usage.md
 FAQ.md
 Tricks.md
 Packaging.md
-External_solvers.md
 Distribution.md
+External_solvers.md
 
 Manual.md


### PR DESCRIPTION
As wiki is disabled, port distribution as part of opam.ocaml.org.
I updated versions information & some urls.
If maintainers (@mehdid @nbraud @avsm @pmetzger @xyproto @david-geiger @roptat @hannesm @TC01 @dra27) can take a look to check them, it'll be perfect. Like that, you'll also know about this page and be able to update it on further releases.

Thanks for all the porting work!