### PR TITLE
Read jobs variable from OpamStateConfig

### DIFF
--- a/src/state/opamPackageVar.ml
+++ b/src/state/opamPackageVar.ml
@@ -64,7 +64,7 @@ let resolve_global gt full_var =
     | _ ->
       match V.to_string var with
       | "opam-version"  -> Some (V.string OpamVersion.(to_string current))
-      | "jobs"          -> Some (V.int (OpamFile.Config.jobs gt.config))
+      | "jobs"          -> Some (V.int (OpamStateConfig.(Lazy.force !r.jobs)))
       | "root"          -> Some (V.string (OpamFilename.Dir.to_string gt.root))
       | "make"          -> Some (V.string OpamStateConfig.(Lazy.force !r.makecmd))
       | _               -> None


### PR DESCRIPTION
The jobs variable was always read from the opam config file, so didn't
reflect the OPAMJOBS variable or --jobs parameter. Respect the
OpamStateConfig setting, as the make variable already does.

From #3881