### PR TITLE
2.0.5 lint backported commits

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2759,7 +2759,12 @@ let lint =
        an opam file directly."
       Arg.(some package) None
   in
-  let lint global_options files package normalise short warnings_sel =
+  let check_upstream =
+    mk_flag ["check-upstream"]
+      "Check upstream, archive availability and checksum(s)"
+  in
+  let lint global_options files package normalise short warnings_sel
+      check_upstream =
     apply_global_options global_options;
     let opam_files_in_dir d =
       match OpamPinned.files_in_source d with
@@ -2809,9 +2814,9 @@ let lint =
           try
             let warnings,opam =
               match opam_f with
-              | Some f -> OpamFileTools.lint_file f
+              | Some f -> OpamFileTools.lint_file ~check_upstream f
               | None ->
-                OpamFileTools.lint_channel
+                OpamFileTools.lint_channel ~check_upstream
                   (OpamFile.make (OpamFilename.of_string "-")) stdin
             in
             let enabled =
@@ -2862,7 +2867,8 @@ let lint =
     in
     if err then OpamStd.Sys.exit_because `False
   in
-  Term.(const lint $global_options $files $package $normalise $short $warnings),
+  Term.(const lint $global_options $files $package $normalise $short $warnings
+        $check_upstream),
   term_info "lint" ~doc ~man
 
 (* CLEAN *)

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -111,6 +111,7 @@ let map_all_filters f t =
   with_deprecated_build_test (map_commands t.deprecated_build_test) |>
   with_deprecated_build_doc (map_commands t.deprecated_build_doc)
 
+(* Returns all variables from all commands (or on given [command]) and all filters *)
 let all_variables ?exclude_post ?command t =
   let commands =
     match command with
@@ -680,7 +681,7 @@ let lint ?check_extra_files ?(check_upstream=false) t =
        (upstream_error <> None));
     (let with_test =
        List.exists ((=) (OpamVariable.Full.of_string "with-test"))
-         (all_variables ~exclude_post:true ~command:(t.run_test) t)
+         (OpamFilter.commands_variables t.run_test)
      in
      cond 61 `Warning
        "`with-test` variable in `run-test` is out of scope, it will be ignored"

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -623,7 +623,7 @@ let lint ?check_extra_files ?(check_upstream=false) t =
     cond 57 `Error
       "Synopsis and description must not be both empty"
       (t.descr = None || t.descr = Some OpamFile.Descr.empty);
-    (let vars = all_variables ~exclude_post:false t in
+    (let vars = all_variables ~exclude_post:false ~command:[] t in
      let exists svar =
        List.exists (fun v -> v = OpamVariable.Full.of_string svar) vars
      in

--- a/src/state/opamFileTools.mli
+++ b/src/state/opamFileTools.mli
@@ -23,6 +23,7 @@ val template: package -> OpamFile.OPAM.t
    checked. *)
 val lint:
   ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
+  ?check_upstream: bool ->
   OpamFile.OPAM.t -> (int * [`Warning|`Error] * string) list
 
 (** Same as [lint], but operates on a file, which allows catching parse errors
@@ -31,6 +32,7 @@ val lint:
    [filename] *)
 val lint_file:
   ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
+  ?check_upstream: bool ->
   OpamFile.OPAM.t OpamFile.typed_file ->
   (int * [`Warning|`Error] * string) list * OpamFile.OPAM.t option
 
@@ -39,6 +41,7 @@ val lint_file:
    [filename] *)
 val lint_channel:
   ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
+  ?check_upstream: bool ->
   OpamFile.OPAM.t OpamFile.typed_file -> in_channel ->
   (int * [`Warning|`Error] * string) list * OpamFile.OPAM.t option
 
@@ -47,6 +50,7 @@ val lint_channel:
    directory besides [filename] *)
 val lint_string:
   ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
+  ?check_upstream: bool ->
   OpamFile.OPAM.t OpamFile.typed_file -> string ->
   (int * [`Warning|`Error] * string) list * OpamFile.OPAM.t option
 


### PR DESCRIPTION
Some linting related backported commits : 
- be8621b (#3758)  add check-upstream option
- a5895c0 (#3763) & 0f19e1c (#3860) add warning for with-test in run-test field 
- 518e500 (#3871) restrain doc warning to filters
