### PR TITLE
shell/install.sh: Properly update to 2.0.5, fixing "Checksum mismatch" error

### DIFF
--- a/shell/install.sh
+++ b/shell/install.sh
@@ -5,7 +5,7 @@ set -ue
 # (c) Copyright Fabrice Le Fessant INRIA/OCamlPro 2013
 # (c) Copyright Louis Gesbert OCamlPro 2014-2017
 
-VERSION='2.0.4'
+VERSION='2.0.5'
 TAG=$(echo "$VERSION" | tr '~' '-')
 DEFAULT_BINDIR=/usr/local/bin
 


### PR DESCRIPTION
The previous commit updating this to 2.0.5 updated the SHA512
hashes to that version, but forgot to update $VERSION and so was
still downloading the 2.0.4 version of $OPAM_BIN, causing a
checksum mismatch.