### PR TITLE
show: don't require colon for fields

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -668,8 +668,9 @@ let show =
                 OpamListCommand.field_names
               ^". Multiple fields can be separated with commas, in which case \
                 field titles will be printed; the raw value of any opam-file \
-                field can be queried by suffixing a colon character (:), e.g. \
-                $(b,--field=depopts:).")
+                field can be queried by combinig with $(b,--raw). For backward \
+                compatibilty, it is possible to query field ending with a colon \
+                (:), it is the same than without.")
         ["f";"field"] in
     Arg.(value & opt (list string) [] & doc) in
   let show_empty =
@@ -738,7 +739,6 @@ let show =
       else
       let opam_content_list = OpamFile.OPAM.to_list opam in
       let get_field f =
-        let f = OpamStd.String.remove_suffix ~suffix:":" f in
         try OpamListCommand.mini_field_printer ~prettify:true ~normalise
               (List.assoc f opam_content_list)
         with Not_found -> ""
@@ -751,9 +751,7 @@ let show =
       | flds ->
         let tbl =
           List.map (fun fld ->
-              [ OpamConsole.colorise `blue
-                  (OpamStd.String.remove_suffix ~suffix:":" fld ^ ":");
-                get_field fld ])
+              [ OpamConsole.colorise `blue (fld ^ ":"); get_field fld ])
             flds
         in
         OpamStd.Format.align_table tbl |>
@@ -782,7 +780,7 @@ let show =
           atom_locs
       in
       OpamListCommand.info st
-        ~fields ~raw_opam:raw ~where ~normalise ~show_empty ~all_versions atoms;
+        ~fields ~raw ~where ~normalise ~show_empty ~all_versions atoms;
       `Ok ()
     | atom_locs, true ->
       if List.exists (function `Atom _ -> true | _ -> false) atom_locs then

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -668,9 +668,7 @@ let show =
                 OpamListCommand.field_names
               ^". Multiple fields can be separated with commas, in which case \
                 field titles will be printed; the raw value of any opam-file \
-                field can be queried by combinig with $(b,--raw). For backward \
-                compatibilty, it is possible to query field ending with a colon \
-                (:), it is the same than without.")
+                field can be queried by combinig with $(b,--raw)")
         ["f";"field"] in
     Arg.(value & opt (list string) [] & doc) in
   let show_empty =

--- a/src/client/opamListCommand.mli
+++ b/src/client/opamListCommand.mli
@@ -84,6 +84,7 @@ type output_format =
   | Synopsis_or_target (** Pinning target if pinned, synopsis otherwise *)
   | Description        (** The package description, excluding synopsis *)
   | Field of string    (** The value of the given opam-file field *)
+  | Raw_field of string   (** The raw value of the given opam-file field *)
   | Installed_version  (** Installed version or "--" if none *)
   | Pinning_target     (** Empty string if not pinned *)
   | Source_hash        (** The VC-reported ident of current version, for dev
@@ -113,9 +114,9 @@ val get_switch_state: 'a global_state -> 'a repos_state -> unlocked switch_state
 (** For documentation, includes a dummy '<field>:' for the [Field] format *)
 val field_names: (output_format * string) list
 
-val string_of_field: output_format -> string
+val string_of_field: ?raw:bool -> output_format -> string
 
-val field_of_string: string -> output_format
+val field_of_string: raw:bool -> string -> output_format
 
 type package_listing_format = {
   short: bool;
@@ -139,7 +140,7 @@ val display: 'a switch_state -> package_listing_format -> package_set -> unit
 (** Display a general summary of a collection of packages. *)
 val info:
   'a switch_state ->
-  fields:string list -> raw_opam:bool -> where:bool ->
+  fields:string list -> raw:bool -> where:bool ->
   ?normalise:bool -> ?show_empty:bool -> ?all_versions:bool ->
   atom list -> unit
 


### PR DESCRIPTION
opam show no more requires a colon for non _inferred_ fields `:`. Now, by defaults, `opam show pkg -f <field>` displays computed content if it exist, field content otherwise. If `--raw` is specified, it's the field content that is displayed (old `-f <field>:`). For backward compat, `-f <field>:` is still supported. ~it gives the same result than `-f <field>`~

Fixes #3664