### PR TITLE
Fix misspelled environment variable in man page

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -284,7 +284,7 @@ let help_sections = [
   `P "$(i,OPAMPRECISETRACKING) fine grain tracking of directories";
   `P "$(i,OPAMREQUIRECHECKSUMS) Enables option `--require-checksums' when \
       available (e.g. for `opam install`).";
-  `P "$(i,OPAMRETRES) sets the number of tries before failing downloads.";
+  `P "$(i,OPAMRETRIES) sets the number of tries before failing downloads.";
   `P "$(i,OPAMROOT) see option `--root'. This is automatically set by \
       `opam env --root=DIR --set-root'.";
   `P "$(i,OPAMROOTISOK) don't complain when running as root.";


### PR DESCRIPTION
The usage of this variable is correctly spelled: https://github.com/ocaml/opam/blob/abf8fd8d9e2e0cd743e88d61a3dc82661b733e22/src/repository/opamRepositoryConfig.ml#L121

only the man page is wrong.