### PR TITLE
Sorting formulas functions

### DIFF
--- a/src/format/opamFilter.ml
+++ b/src/format/opamFilter.ml
@@ -659,3 +659,16 @@ let atomise_extended =
           | Or (a, b) -> Or (aux filters a, aux filters b)
         in
         aux (FBool true) cs)
+
+let sort_filtered_formula compare ff =
+  let f = OpamFormula.sort compare ff in
+  let rec vc_sort = function
+    | Empty -> Empty
+    | Atom (n,vf) ->
+      Atom (n, (OpamStd.Option.default vf
+                  (simplify_extended_version_formula vf)))
+    | Block f -> Block (vc_sort f)
+    | And (f,f') -> And (vc_sort f, vc_sort f')
+    | Or (f,f') -> Or (vc_sort f, vc_sort f')
+  in
+  vc_sort f

--- a/src/format/opamFilter.mli
+++ b/src/format/opamFilter.mli
@@ -199,3 +199,10 @@ val atomise_extended:
   filtered_formula ->
   (OpamPackage.Name.t * (filter * (relop * filter) option))
     OpamFormula.formula
+
+(* Uses [OpamFormula.sort] to sort on names, and sort version formulas with
+   [simplify_extended_version_formula]. *)
+val sort_filtered_formula:
+  ((name * filter filter_or_constraint OpamFormula.formula)
+  -> (name * filter filter_or_constraint OpamFormula.formula) -> int)
+  -> filtered_formula -> filtered_formula

--- a/src/format/opamFormula.ml
+++ b/src/format/opamFormula.ml
@@ -403,6 +403,21 @@ let is_disjunction t =
   in
   aux t
 
+let rec sort comp f=
+  match f with
+  | (Empty | Atom _) as f -> f
+  | Block f -> Block (sort comp f)
+  | And _ as f ->
+    ands_to_list f
+    |> List.rev_map (sort comp)
+    |> List.sort (compare_formula comp)
+    |> ands
+  | Or _ as f ->
+    ors_to_list f
+    |> List.rev_map (sort comp)
+    |> List.sort (compare_formula comp)
+    |> ors
+
 let atoms t =
   fold_right (fun accu x -> x::accu) [] (to_atom_formula t)
 

--- a/src/format/opamFormula.mli
+++ b/src/format/opamFormula.mli
@@ -74,6 +74,8 @@ type 'a formula =
   | And of 'a formula * 'a formula
   | Or of 'a formula * 'a formula
 
+val compare_formula: ('a -> 'a -> int) -> 'a formula -> 'a formula -> int
+
 (** Eval a formula *)
 val eval: ('a -> bool) -> 'a formula -> bool
 

--- a/src/format/opamFormula.mli
+++ b/src/format/opamFormula.mli
@@ -131,6 +131,10 @@ val fold_left: ('a -> 'b -> 'a) -> 'a -> 'b formula -> 'a
 (** Fold function (bottom-up, right-to-left) *)
 val fold_right: ('a -> 'b -> 'a) -> 'a -> 'b formula -> 'a
 
+(** Sort formula, using [compare] function. `Block` around `Or` and `And` \
+    are removed. *)
+val sort: ('a -> 'a -> int) -> 'a formula -> 'a formula
+
 (** Expressions composed entirely of version constraints *)
 type version_formula = version_constraint formula
 


### PR DESCRIPTION
Intially, this is part of #3866 

from https://github.com/ocaml/opam/pull/3866#issue-287591110 : 
- a compare function for formulas
- a sort function for formulas
- a sort function for filtered_formulas; this one calls also `OpamFilter.simplify_extended_version_formula` on filters