### PR TITLE
Git internal & inplace source copy

### DIFF
--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -373,7 +373,7 @@ let autopin st ?(simulate=false) ?quiet atom_or_local_list =
   in
   let st =
     let working_dir =
-      if OpamClientConfig.(!r.working_dir) then already_pinned_set
+      if OpamClientConfig.(!r.working_dir || !r.inplace_build) then already_pinned_set
       else OpamPackage.Set.empty
     in
     let _result, st, _updated =

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -138,7 +138,7 @@ let update_dev_packages_t atoms t =
       (OpamConsole.colorise `bold "opam update");
 
   if OpamClientConfig.(!r.skip_dev_update) then t else
-  let working_dir = OpamClientConfig.(!r.working_dir) in
+  let working_dir = OpamClientConfig.(!r.working_dir || !r.inplace_build) in
   let to_update =
     List.fold_left (fun to_update (name,_) ->
         try

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -151,6 +151,11 @@ module VCS : OpamVCS.VCS = struct
     if OpamProcess.is_failure r then
       OpamSystem.internal_error "Git error: %s not found." rref
     else
+      git repo_root [ "clean"; "-fdx" ]
+      @@> fun r ->
+      if OpamProcess.is_failure r then
+        OpamSystem.internal_error "Git error: %s not found." rref
+      else
       if OpamFilename.exists (repo_root // ".gitmodules") then
         git repo_root [ "submodule"; "update"; "--init"; "--recursive" ]
         @@> fun r ->


### PR DESCRIPTION
This PR contains several things:
- add a `git clean` on `reset_tree` to keep source dir clean
- review `sync_dirty` on git:
  * use git to synchronize, then rsync & remove others files
  * exclude `_build`, `_opam` & vcs directories
- When `--inplace-build` is given, it does a dirty synchronisation of the sources, in order to keep tracking package stats (clean, local or dirty)