### PR TITLE
Support etc_root and etcexec_root in opam-installer

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -1227,6 +1227,10 @@ allowed.
   installs relative to `<prefix>/share/` (since opam 1.2.0)
 - <a id="installfield-etc">`etc:`</a>
   installs to `<prefix>/etc/<pkgname>/`
+- <a id="installfield-etc_root">`etc_root:`</a>
+  installs to `<prefix>/etc/` (since <span class="opam">opam</span> 2.0.6)
+- <a id="installfield-etcexec_root">`etc_root:`</a>
+  installs to `<prefix>/etc/`, with the `exec` bit set (since <span class="opam">opam</span> 2.0.6)
 - <a id="installfield-doc">`doc:`</a>
   installs to `<prefix>/doc/<pkgname>/`
 - <a id="installfield-stublibs">`stublibs:`</a>

--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -1228,9 +1228,9 @@ allowed.
 - <a id="installfield-etc">`etc:`</a>
   installs to `<prefix>/etc/<pkgname>/`
 - <a id="installfield-etc_root">`etc_root:`</a>
-  installs to `<prefix>/etc/` (since <span class="opam">opam</span> 2.0.6)
+  installs to `<prefix>/etc/` (since <span class="opam">opam</span> 2.1.0~beta4)
 - <a id="installfield-etcexec_root">`etc_root:`</a>
-  installs to `<prefix>/etc/`, with the `exec` bit set (since <span class="opam">opam</span> 2.0.6)
+  installs to `<prefix>/etc/`, with the `exec` bit set (since <span class="opam">opam</span> 2.1.0~beta4)
 - <a id="installfield-doc">`doc:`</a>
   installs to `<prefix>/doc/<pkgname>/`
 - <a id="installfield-stublibs">`stublibs:`</a>

--- a/master_changes.md
+++ b/master_changes.md
@@ -114,6 +114,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Opam installer
   *
+  * Support `etc_root` and `etcexec_root` in `opam-installer` [#3958 @hongchangwu]
 
 ## State
   *

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -154,6 +154,8 @@ let preprocess_dot_install_t st nv build_dir =
 
     (* Etc files *)
     false, (instdir_pkg P.etc), I.etc;
+    false, (instdir_gen P.etc_dir), I.etc_root;
+    true, (instdir_gen P.etc_dir), I.etcexec_root;
 
     (* Documentation files *)
     false, (instdir_pkg P.doc), I.doc;
@@ -709,6 +711,8 @@ let remove_package_aux
     remove_files_and_dir OpamPath.Switch.share OpamFile.Dot_install.share;
     remove_files OpamPath.Switch.share_dir OpamFile.Dot_install.share_root;
     remove_files_and_dir OpamPath.Switch.etc OpamFile.Dot_install.etc;
+    remove_files OpamPath.Switch.etc_dir OpamFile.Dot_install.etc_root;
+    remove_files OpamPath.Switch.etc_dir OpamFile.Dot_install.etcexec_root;
     remove_files (OpamPath.Switch.man_dir ?num:None) OpamFile.Dot_install.man;
     remove_files_and_dir OpamPath.Switch.doc OpamFile.Dot_install.doc;
 

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3211,7 +3211,7 @@ end
 module Dot_installSyntax = struct
 
   let internal = ".install"
-  let format_version = OpamVersion.of_string "2.0"
+  let format_version = OpamVersion.of_string "2.1"
 
   type t =  {
     bin     : (basename optional * basename option) list;

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3222,6 +3222,8 @@ module Dot_installSyntax = struct
     share   : (basename optional * basename option) list;
     share_root: (basename optional * basename option) list;
     etc     : (basename optional * basename option) list;
+    etc_root: (basename optional * basename option) list;
+    etcexec_root: (basename optional * basename option) list;
     doc     : (basename optional * basename option) list;
     man     : (basename optional * basename option) list;
     libexec : (basename optional * basename option) list;
@@ -3240,6 +3242,8 @@ module Dot_installSyntax = struct
     share    = [];
     share_root = [];
     etc      = [];
+    etc_root = [];
+    etcexec_root = [];
     man      = [];
     libexec  = [];
     lib_root = [];
@@ -3256,6 +3260,8 @@ module Dot_installSyntax = struct
   let share t = t.share
   let share_root t = t.share_root
   let etc t = t.etc
+  let etc_root t = t.etc_root
+  let etcexec_root t = t.etcexec_root
   let raw_man t = t.man
   let doc t = t.doc
   let libexec t = t.libexec
@@ -3271,6 +3277,8 @@ module Dot_installSyntax = struct
   let with_share share t = { t with share }
   let with_share_root share_root t = { t with share_root }
   let with_etc etc t = { t with etc }
+  let with_etc_root etc_root t = { t with etc_root }
+  let with_etcexec_root etcexec_root t = { t with etcexec_root }
   let with_man man t = { t with man }
   let with_doc doc t = { t with doc }
   let with_libexec libexec t = { t with libexec }
@@ -3348,6 +3356,8 @@ module Dot_installSyntax = struct
       "share", Pp.ppacc with_share share pp_field;
       "share_root", Pp.ppacc with_share_root share_root pp_field;
       "etc", Pp.ppacc with_etc etc pp_field;
+      "etc_root", Pp.ppacc with_etc_root etc_root pp_field;
+      "etcexec_root", Pp.ppacc with_etcexec_root etcexec_root pp_field;
       "doc", Pp.ppacc with_doc doc pp_field;
       "man", Pp.ppacc with_man raw_man pp_field;
       "libexec", Pp.ppacc with_libexec libexec pp_field;

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -838,6 +838,12 @@ module Dot_install: sig
   (** List of etc files *)
   val etc: t -> (basename optional * basename option) list
 
+  (** List of etc files not relative to the package's dir *)
+  val etc_root: t -> (basename optional * basename option) list
+
+  (** List of etc files not relative to the package's dir and with +x set *)
+  val etcexec_root: t -> (basename optional * basename option) list
+
   (** List of doc files *)
   val doc: t -> (basename optional * basename option) list
 

--- a/src/tools/opam_installer.ml
+++ b/src/tools/opam_installer.ml
@@ -195,6 +195,8 @@ let iter_install f instfile o =
       dest_pkg                    D.share,    S.share instfile,      false;
       dest_global                 D.share_dir,S.share_root instfile, false;
       dest_pkg                    D.etc,      S.etc instfile,        false;
+      dest_global                 D.etc_dir,  S.etc_root instfile,   false;
+      dest_global                 D.etc_dir,  S.etcexec_root instfile, true;
       dest_pkg    ?fix:o.docdir   D.doc,      S.doc instfile,        false; ]
 
 let install options =


### PR DESCRIPTION
### Use case

Startup scripts for Linux system daemons are traditionally installed under `/etc/init.d`.