### PR TITLE
Working-dir fixes

### DIFF
--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -315,7 +315,9 @@ let parallel_apply t ~requested ?add_roots ~assume_built action_graph =
   in
 
   let inplace =
-    if OpamClientConfig.(!r.inplace_build) || assume_built then
+    if OpamClientConfig.(!r.inplace_build)
+    || assume_built
+    || OpamClientConfig.(!r.working_dir) then
       OpamPackage.Set.fold (fun nv acc ->
           match
             OpamStd.Option.Op.(OpamSwitchState.url t nv >>| OpamFile.URL.url >>=

--- a/src/repository/opamDarcs.ml
+++ b/src/repository/opamDarcs.ml
@@ -161,6 +161,18 @@ module VCS = struct
     darcs dir [ "whatsnew"; "--quiet"; "--summary" ]
     @@> fun r -> Done (OpamProcess.check_success_and_cleanup r)
 
+  let modified_files repo_root =
+    darcs repo_root [ "whatsnew"; "--summary" ] @@> fun r ->
+    OpamSystem.raise_on_process_error r;
+    let files =
+      OpamStd.List.filter_map (fun line ->
+          match OpamStd.String.split line ' ' with
+          | ("A" | "M")::file::[]
+          | _::"->"::file::[] -> Some file
+          | _ -> None) r.OpamProcess.r_stdout
+    in
+    Done (List.sort_uniq compare files)
+
   let get_remote_url ?hash:_ repo_root =
     darcs repo_root [ "show"; "repo" ]
     @@> function

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -231,6 +231,18 @@ module VCS : OpamVCS.VCS = struct
       OpamProcess.cleanup ~force:true r; Done true
     | r -> OpamSystem.process_error r
 
+  let modified_files repo_root =
+    git repo_root ~verbose:false [ "status" ; "--short" ] @@> fun r ->
+    OpamSystem.raise_on_process_error r;
+    let files =
+      OpamStd.List.filter_map (fun line ->
+          match OpamStd.String.split line ' ' with
+          | ("A" | "M" | "AM")::file::[]
+          | ("R"|"RM"|"C"|"CM")::_::"->"::file::[] -> Some file
+          | _ -> None) r.OpamProcess.r_stdout
+    in
+    Done files
+
   let origin = "origin"
 
   (** check if a hash or branch is present in remote origin and returns  *)

--- a/src/repository/opamHg.ml
+++ b/src/repository/opamHg.ml
@@ -116,6 +116,17 @@ module VCS = struct
     OpamSystem.raise_on_process_error r;
     Done (r.OpamProcess.r_stdout = [])
 
+  let modified_files repo_root =
+    hg repo_root [ "status"; "--subrepos" ] @@> fun r ->
+    OpamSystem.raise_on_process_error r;
+    let files =
+      OpamStd.List.filter_map (fun line ->
+          match OpamStd.String.split line ' ' with
+          | ("A" | "M")::file::[] -> Some file
+          | _ -> None) r.OpamProcess.r_stdout
+    in
+    Done files
+
   let get_remote_url ?hash repo_root =
     hg repo_root [ "paths"; "default" ]
     @@> function

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -69,7 +69,9 @@ module type S = sig
   val revision: dirname -> version option OpamProcess.job
 
   (** Like [pull_url], except for locally-bound version control backends, where
-      it should get the latest, uncommitted source. *)
+      it should get the latest, uncommitted source. First, it performs a
+      [pull_url], then remove deleted files, and finally copy via rsync
+      unversioned & modified-uncommitted files. *)
   val sync_dirty:
     dirname -> url -> filename option download OpamProcess.job
 

--- a/src/repository/opamVCS.mli
+++ b/src/repository/opamVCS.mli
@@ -67,6 +67,10 @@ module type VCS = sig
       [false] after [reset] has been called. *)
   val is_dirty: dirname -> bool OpamProcess.job
 
+  (** Returns the list of files under version control, modified in the working
+      tree but not comitted *)
+  val modified_files: dirname -> string list OpamProcess.job
+
   val get_remote_url: ?hash:string -> dirname -> url option OpamProcess.job
 end
 


### PR DESCRIPTION
* Don't fetch dev packages when `working-dir` is set
* Copy uncommited modified versioned file
