### PR TITLE
config: add 'config setopt' and 'setopt' (sub)commands to modify global config fields

### DIFF
--- a/doc/man/opam-topics.inc
+++ b/doc/man/opam-topics.inc
@@ -113,6 +113,14 @@
                  (diff opam-var.err %{dep:opam-var.0}))))
 
 (rule
+  (with-stdout-to opam-set-opt.0 (echo "")))
+(rule
+  (targets opam-set-opt.1 opam-set-opt.err)
+  (action (progn (with-stderr-to opam-set-opt.err
+                   (with-stdout-to opam-set-opt.1 (run %{bin:opam} set-opt --help=groff)))
+                 (diff opam-set-opt.err %{dep:opam-set-opt.0}))))
+
+(rule
   (with-stdout-to opam-config.0 (echo "")))
 (rule
   (targets opam-config.1 opam-config.err)
@@ -226,6 +234,7 @@
     opam-env.1 
     opam-exec.1 
     opam-var.1 
+    opam-set-opt.1 
     opam-config.1 
     opam-upgrade.1 
     opam-update.1 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -915,16 +915,6 @@ let config ?(setopt=false) () =
       mk_subcommands commands
   in
   let open Common_config_flags in
-  let wrap_gt set =
-    OpamGlobalState.with_ `Lock_write @@ fun gt ->
-    OpamGlobalState.drop @@ set gt
-  in
-  let wrap_st set =
-    OpamGlobalState.with_ `Lock_none @@ fun gt ->
-    OpamSwitchState.with_ `Lock_write gt @@ fun st ->
-    OpamSwitchState.drop @@ set st;
-    OpamGlobalState.drop @@ gt
-  in
 
   let config global_options
       command shell sexp inplace_path
@@ -962,28 +952,31 @@ let config ?(setopt=false) () =
                   (List.map OpamPackage.Name.of_string params))
        with Failure msg -> `Error (false, msg))
     | Some `set_var, ["sw"|"switch"; var; value] ->
-      (wrap_st @@ fun st ->
-      OpamConfigCommand.set_var_switch st var (Some value));
+      OpamGlobalState.with_ `Lock_none @@ fun gt ->
+      OpamSwitchState.with_ `Lock_write gt @@ fun st ->
+      let _st = OpamConfigCommand.set_var_switch st var (Some value) in
       `Ok ()
     | Some `set_var, ["sw"|"switch"; var] ->
-      (wrap_st @@ fun st ->
-      OpamConfigCommand.set_var_switch st var None);
+      OpamGlobalState.with_ `Lock_none @@ fun gt ->
+      OpamSwitchState.with_ `Lock_write gt @@ fun st ->
+      let _st = OpamConfigCommand.set_var_switch st var None in
       `Ok ()
     | Some `set_var, ["gl"|"global"; var; value] ->
-      (wrap_gt @@ fun gt ->
-      OpamConfigCommand.set_var_global gt var (Some value));
+      OpamGlobalState.with_ `Lock_write @@ fun gt ->
+      let _gt = OpamConfigCommand.set_var_global gt var (Some value) in
       `Ok ()
     | Some `set_var, ["gl"|"global"; var] ->
-      (wrap_gt @@ fun gt ->
-      OpamConfigCommand.set_var_global gt var None);
+      OpamGlobalState.with_ `Lock_write @@ fun gt ->
+      let _gt = OpamConfigCommand.set_var_global gt var None in
       `Ok ()
     | Some `set_opt, ("sw"|"switch")::fvs ->
-      (wrap_st @@ fun st ->
-       List.fold_left OpamConfigCommand.set_opt_switch st fvs);
+      OpamGlobalState.with_ `Lock_none @@ fun gt ->
+      OpamSwitchState.with_ `Lock_write gt @@ fun st ->
+      let _st = List.fold_left OpamConfigCommand.set_opt_switch st fvs in
       `Ok ()
     | Some `set_opt, ("gl"|"global")::fvs ->
-      (wrap_gt @@ fun gt ->
-       List.fold_left OpamConfigCommand.set_opt_global gt fvs);
+      OpamGlobalState.with_ `Lock_write @@ fun gt ->
+      let _gt = List.fold_left OpamConfigCommand.set_opt_global gt fvs in
       `Ok ()
     | Some `expand, [str] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -1128,27 +1121,30 @@ let config ?(setopt=false) () =
       OpamConsole.warning
         "Subcommand set is deprecated. Use set-var switch %s %s instead."
         var value;
-      (wrap_st @@ fun st ->
-      OpamConfigCommand.set_var_switch st var (Some value));
+      OpamGlobalState.with_ `Lock_none @@ fun gt ->
+      OpamSwitchState.with_ `Lock_write gt @@ fun st ->
+      let _st = OpamConfigCommand.set_var_switch st var (Some value) in
       `Ok ()
     | Some `unset, [var] ->
       OpamConsole.warning
         "Subcommand set is deprecated. Use set-var switch %s instead." var;
-      (wrap_st @@ fun st ->
-      OpamConfigCommand.set_var_switch st var None);
+      OpamGlobalState.with_ `Lock_none @@ fun gt ->
+      OpamSwitchState.with_ `Lock_write gt @@ fun st ->
+      let _st = OpamConfigCommand.set_var_switch st var None in
       `Ok ()
     | Some `set_global, [var; value] ->
       OpamConsole.warning
         "Subcommand set-global is deprecated. Use set-var global %s %s instead."
         var value;
-      (wrap_gt @@ fun gt ->
-       OpamConfigCommand.set_var_global gt var (Some value));
+      OpamGlobalState.with_ `Lock_write @@ fun gt ->
+      let _gt = OpamConfigCommand.set_var_global gt var (Some value) in
       `Ok ()
     | Some `unset_global, [var] ->
       OpamConsole.warning
         "Subcommand set-global is deprecated. Use set-var global %s instead."
         var;
-      (wrap_gt @@ fun gt -> OpamConfigCommand.set_var_global gt var None);
+      OpamGlobalState.with_ `Lock_write @@ fun gt ->
+      let _gt = OpamConfigCommand.set_var_global gt var None in
       `Ok ()
     | command, params -> bad_subcommand commands ("config", command, params)
   in

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -837,7 +837,7 @@ end
 
 (* CONFIG *)
 let config_doc = "Display configuration options for packages."
-let config =
+let config ?(setopt=false) () =
   let doc = config_doc in
   let commands = [
     "env", `env, [],
@@ -907,7 +907,13 @@ let config =
     @ [`S "OPTIONS"]
   in
 
-  let command, params = mk_subcommands commands in
+  let command, params =
+    if setopt then
+      Term.const (Some `set_opt),
+      Arg.(value & pos_all string [] & Arg.info [])
+    else
+      mk_subcommands commands
+  in
   let open Common_config_flags in
   let wrap_gt set =
     OpamGlobalState.with_ `Lock_write @@ fun gt ->
@@ -3426,7 +3432,8 @@ let commands = [
   remove; make_command_alias remove "uninstall";
   reinstall;
   update; upgrade;
-  config; var; exec; env;
+  config (); make_command_alias (config ~setopt:true ()) ~options:" set-opt" "set-opt";
+  var; exec; env;
   repository; make_command_alias repository "remote";
   switch;
   pin (); make_command_alias (pin ~unpin_only:true ()) ~options:" remove" "unpin";

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -871,9 +871,9 @@ let config ?(setopt=false) () =
      changing a configured path will not move any files! This command does not \
      perform any variable expansion.";
     "set-opt", `set_opt, ["[switch|global]"; "FIELD[(+=|-=|=)VALUE]"],
-    "Set the given opam configuration field in the global configuration file.\
-     If $(b,op VALUE) is omitted, $(b,FIELD) is set to its default initial \
-     configuration, as after a fresh init (use `opam init \
+    "Set the given opam configuration field in the global/switch configuration \
+     file.  If $(b,op VALUE) is omitted, $(b,FIELD) is reset to its default \
+     initial configuration, as after a fresh init (use `opam init \
      show-default-opamrc` to display it)";
     "expand", `expand, ["STRING"],
     "Expand variable interpolations in the given string";

--- a/src/client/opamCommands.mli
+++ b/src/client/opamCommands.mli
@@ -49,7 +49,7 @@ val update: command
 val upgrade: command
 
 (** opam config *)
-val config: command
+val config: ?setopt:bool -> unit -> command
 
 (** opam repository *)
 val repository: command

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -13,6 +13,7 @@ let log fmt = OpamConsole.log "CONFIG" fmt
 let slog = OpamConsole.slog
 
 open OpamTypes
+open OpamTypesBase
 open OpamStateTypes
 
 let help t =
@@ -699,9 +700,11 @@ let set_var_global gt var value =
     stv_find = (fun (k,_,_) -> k = var);
     stv_state = gt;
     stv_varstr = (fun v ->
-        Printf.sprintf
-          "[%s \"%s\" \"Set through 'opam config set-var global'\"]"
-          (OpamVariable.to_string var) v);
+        OpamPrinter.value (List (pos_null, [
+            Ident (pos_null, OpamVariable.to_string var);
+            String (pos_null, v);
+            String (pos_null, "Set through 'opam config set-var global'")
+          ])));
     stv_set_opt = (fun gt s ->
         set_opt_global_t ~inner:true gt ("global-variables"^s));
     stv_remove_elem = (fun rest gt ->
@@ -723,7 +726,9 @@ let set_var_switch st var value =
     stv_find = (fun (k,_) -> k = var);
     stv_state = st;
     stv_varstr = (fun v ->
-        Printf.sprintf "%s: \"%s\"" (OpamVariable.to_string var) v);
+        OpamPrinter.items
+          [Variable
+             (pos_null, OpamVariable.to_string var, String (pos_null, v))]);
     stv_set_opt = (fun st s ->
         set_opt_switch_t ~inner:true st ("variables"^s));
     stv_remove_elem = (fun rest st ->

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -377,12 +377,22 @@ let variable gt v =
       "Variable %s not found"
       (OpamVariable.Full.to_string v)
 
+(* For function that takes two config and update (add or remove) elements in a
+   field. Used for appending or deleting element in config file fields *)
 type 'config fld_updater =  ('config -> 'config -> 'config)
+(* Only some field can be modifiable. [Modifiable] is for user modifiable
+   field,  [InModifiable] for fields that can only be modified from inner opam
+   code (see [set_var_global]).
+   First argument is the addition function, the second the remove one. *)
 type 'config fld_policy =
   | Fixed
   | Modifiable of 'config fld_updater * 'config fld_updater
   | InModifiable of 'config fld_updater * 'config fld_updater
 
+(* "Configuration" of the [set_opt] function. As modification can be on global
+   or config switch, on normal fields and sections, adding, removing, or
+   overwritng values, this record type permits to aggregate all needed inputs.
+   See [set_opt_global] and [set_opt_switch]. *)
 type 'config confset =
   {
     stg_fields: (string * ('config, value) OpamPp.field_parser) list;

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -46,11 +46,23 @@ val subst: 'a global_state -> basename list -> unit
 (** Prints expansion of variables in string *)
 val expand: 'a global_state -> string -> unit
 
+(*
 (** Sets or unsets switch config variables *)
 val set: full_variable -> string option -> unit
 
 (** Sets or unsets global config variables *)
 val set_global: full_variable -> string option -> unit
+*)
+
+(** [set_opt_global gt field value] sets global config [field] to [value] in
+    <opamroot>/config file. Modifiable fields are a subset of all defined file
+    in [OpamFile.Config.t]. If the given [value] is [None], [field] is reverted
+    to its initial value as defined in [OpamInitDefaults.init_config], to
+    default value otherwise ([OpamFile.Config.empty]).*)
+val set_opt_global: rw global_state -> string -> string option -> rw global_state
+val set_opt_switch: rw switch_state -> string -> string option -> rw switch_state
+val set_var_global: rw global_state -> OpamVariable.Full.t -> string option -> rw global_state
+val set_var_switch: rw switch_state -> OpamVariable.Full.t -> string option -> rw switch_state
 
 (** Execute a command in a subshell, after variable expansion *)
 val exec:

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -46,14 +46,6 @@ val subst: 'a global_state -> basename list -> unit
 (** Prints expansion of variables in string *)
 val expand: 'a global_state -> string -> unit
 
-(*
-(** Sets or unsets switch config variables *)
-val set: full_variable -> string option -> unit
-
-(** Sets or unsets global config variables *)
-val set_global: full_variable -> string option -> unit
-*)
-
 (** [set_opt_global gt field_value] updates global config field with value
     (using prefix '+=', '-=', '=') in <opamroot>/config file.
     Modifiable fields are a subset of all defined fields in [OpamFile.Config.t].

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -14,10 +14,10 @@
 open OpamTypes
 open OpamStateTypes
 
-(** Display the current environment. Booleans csh, sexp and fish set an alternative
-    output (unspecified if more than one is true, sh-style by default).
-    [inplace_path] changes how the PATH variable is updated when there is already
-    an opam entry: either at the same rank, or pushed in front. *)
+(** Display the current environment. Booleans csh, sexp and fish set an
+    alternative output (unspecified if more than one is true, sh-style by
+    default). [inplace_path] changes how the PATH variable is updated when there
+    is already an opam entry: either at the same rank, or pushed in front. *)
 val env:
   'a global_state -> switch ->
   ?set_opamroot:bool -> ?set_opamswitch:bool ->
@@ -47,23 +47,25 @@ val subst: 'a global_state -> basename list -> unit
 val expand: 'a global_state -> string -> unit
 
 (** [set_opt_global gt field_value] updates global config field with value
-    (using prefix '+=', '-=', '=') in <opamroot>/config file.
-    Modifiable fields are a subset of all defined fields in [OpamFile.Config.t].
-    [field_value] is a string of the form "field[(+=|-=|=)value]". In the case
-    where it contains only the field name, field is reverted to its initial
-    value as defined in [OpamInitDefaults.init_config], to default value
-    otherwise ([OpamFile.Config.empty]).*)
+    (using prefix '+=', '-=', '=') in <opamroot>/config file. Modifiable fields
+    are a subset of all defined fields in [OpamFile.Config.t]. [field_value] is
+    a string of the form "field[(+=|-=|=)value]". In the case where it contains
+    only the field name, field is reverted to its initial value as defined in
+    [OpamInitDefaults.init_config], to default value otherwise
+    ([OpamFile.Config.empty]).*)
 val set_opt_global: rw global_state -> string -> rw global_state
 
 (** As [set_opt_global], [set_opt_switch] updates switch config file in
     <opamroot>/<switch>/.opam-switch/switch-config. *)
 val set_opt_switch: rw switch_state -> string -> rw switch_state
 
-(** [set_var_global] and [set_var_switch] update respectively
-    `global-variables` field in global config and `variables` field in switch
-    config, by appending the new variables to current set *)
-val set_var_global: rw global_state -> string -> string option -> rw global_state
-val set_var_switch: rw switch_state -> string -> string option -> rw switch_state
+(** [set_var_global] and [set_var_switch] update respectively `global-variables`
+    field in global config and `variables` field in switch config, by appending
+    the new variables to current set *)
+val set_var_global:
+  rw global_state -> string -> string option -> rw global_state
+val set_var_switch:
+  rw switch_state -> string -> string option -> rw switch_state
 
 (** Execute a command in a subshell, after variable expansion *)
 val exec:

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -54,13 +54,21 @@ val set: full_variable -> string option -> unit
 val set_global: full_variable -> string option -> unit
 *)
 
-(** [set_opt_global gt field value] sets global config [field] to [value] in
-    <opamroot>/config file. Modifiable fields are a subset of all defined file
-    in [OpamFile.Config.t]. If the given [value] is [None], [field] is reverted
-    to its initial value as defined in [OpamInitDefaults.init_config], to
-    default value otherwise ([OpamFile.Config.empty]).*)
+(** [set_opt_global gt field value] updates global config [field] with [value]
+    (using prefix '+=', '_=', '=', or nothing) in <opamroot>/config file.
+    Modifiable fields are a subset of all defined file in [OpamFile.Config.t].
+    If the given [value] is [None], [field] is reverted to its initial value as
+    defined in [OpamInitDefaults.init_config], to default value otherwise
+    ([OpamFile.Config.empty]).*)
 val set_opt_global: rw global_state -> string -> string option -> rw global_state
+
+(** As [set_opt_global], [set_opt_switch] updates switch config file in
+    <opamroot>/<switch>/.opam-switch/switch-config. *)
 val set_opt_switch: rw switch_state -> string -> string option -> rw switch_state
+
+(** [set_var_global] and [set_var_switch] update respectively
+    `global-variables` field in global config and `variables` field in switch
+    config, by appending the new variables to current set *)
 val set_var_global: rw global_state -> OpamVariable.Full.t -> string option -> rw global_state
 val set_var_switch: rw switch_state -> OpamVariable.Full.t -> string option -> rw switch_state
 

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -54,23 +54,24 @@ val set: full_variable -> string option -> unit
 val set_global: full_variable -> string option -> unit
 *)
 
-(** [set_opt_global gt field value] updates global config [field] with [value]
-    (using prefix '+=', '_=', '=', or nothing) in <opamroot>/config file.
-    Modifiable fields are a subset of all defined file in [OpamFile.Config.t].
-    If the given [value] is [None], [field] is reverted to its initial value as
-    defined in [OpamInitDefaults.init_config], to default value otherwise
-    ([OpamFile.Config.empty]).*)
-val set_opt_global: rw global_state -> string -> string option -> rw global_state
+(** [set_opt_global gt field_value] updates global config field with value
+    (using prefix '+=', '-=', '=') in <opamroot>/config file.
+    Modifiable fields are a subset of all defined fields in [OpamFile.Config.t].
+    [field_value] is a string of the form "field[(+=|-=|=)value]". In the case
+    where it contains only the field name, field is reverted to its initial
+    value as defined in [OpamInitDefaults.init_config], to default value
+    otherwise ([OpamFile.Config.empty]).*)
+val set_opt_global: rw global_state -> string -> rw global_state
 
 (** As [set_opt_global], [set_opt_switch] updates switch config file in
     <opamroot>/<switch>/.opam-switch/switch-config. *)
-val set_opt_switch: rw switch_state -> string -> string option -> rw switch_state
+val set_opt_switch: rw switch_state -> string -> rw switch_state
 
 (** [set_var_global] and [set_var_switch] update respectively
     `global-variables` field in global config and `variables` field in switch
     config, by appending the new variables to current set *)
-val set_var_global: rw global_state -> OpamVariable.Full.t -> string option -> rw global_state
-val set_var_switch: rw switch_state -> OpamVariable.Full.t -> string option -> rw switch_state
+val set_var_global: rw global_state -> string -> string option -> rw global_state
+val set_var_switch: rw switch_state -> string -> string option -> rw switch_state
 
 (** Execute a command in a subshell, after variable expansion *)
 val exec:

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1084,6 +1084,7 @@ module ConfigSyntax = struct
   let with_switch_opt switch t = { t with switch }
   let with_switch switch t = { t with switch = Some switch }
   let with_jobs jobs t = { t with jobs = Some jobs}
+  let with_jobs_opt jobs t = { t with jobs }
   let with_dl_tool dl_tool t = { t with dl_tool = Some dl_tool }
   let with_dl_tool_opt dl_tool t = { t with dl_tool }
   let with_dl_jobs dl_jobs t = { t with dl_jobs }
@@ -1093,8 +1094,9 @@ module ConfigSyntax = struct
     { t with solver_criteria =
                (kind,criterion)::List.remove_assoc kind t.solver_criteria }
   let with_best_effort_prefix s t = { t with best_effort_prefix = Some s }
+  let with_best_effort_prefix_opt s t = { t with best_effort_prefix = s }
   let with_solver solver t = { t with solver = Some solver }
-  let with_solver_opt solver t = { t with solver = solver }
+  let with_solver_opt solver t = { t with solver }
   let with_wrappers wrappers t = { t with wrappers }
   let with_global_variables global_variables t = { t with global_variables }
   let with_eval_variables eval_variables t = { t with eval_variables }
@@ -1122,6 +1124,8 @@ module ConfigSyntax = struct
     default_compiler = OpamFormula.Empty;
   }
 
+  (* When adding a field, make sure to add it in
+     [OpamConfigCommand.set_config_field] if it is a user modifiable field *)
   let fields =
     let with_switch sw t =
       if t.switch = None then with_switch sw t
@@ -1202,7 +1206,6 @@ module ConfigSyntax = struct
       "cores", Pp.ppacc_opt
         with_jobs OpamStd.Option.none
         Pp.V.pos_int;
-      "system_ocaml-version", Pp.ppacc_ignore;
       "system-ocaml-version", Pp.ppacc_ignore;
     ] @
     List.map

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1124,8 +1124,8 @@ module ConfigSyntax = struct
     default_compiler = OpamFormula.Empty;
   }
 
-  (* When adding a field, make sure to add it in
-     [OpamConfigCommand.set_config_field] if it is a user modifiable field *)
+  (* When adding a field or section, make sure to add it in
+     [OpamConfigCommand.set_opt_global_t] if it is a user modifiable field *)
   let fields =
     let with_switch sw t =
       if t.switch = None then with_switch sw t
@@ -1511,6 +1511,8 @@ module Switch_configSyntax = struct
     env = [];
   }
 
+  (* When adding a field or section, make sure to add it in
+     [OpamConfigCommand.set_opt_switch] if it is a user modifiable field *)
   let sections = [
     "paths", Pp.ppacc
       (fun paths t -> {t with paths}) (fun t -> t.paths)

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -90,6 +90,18 @@ module Wrappers: sig
   val pre_session: t -> command list
   val post_session: t -> command list
 
+  val with_pre_build: command list -> t -> t
+  val with_wrap_build: command list -> t -> t
+  val with_post_build: command list -> t -> t
+  val with_pre_install: command list -> t -> t
+  val with_wrap_install: command list -> t -> t
+  val with_post_install: command list -> t -> t
+  val with_pre_remove: command list -> t -> t
+  val with_wrap_remove: command list -> t -> t
+  val with_post_remove: command list -> t -> t
+  val with_pre_session: command list -> t -> t
+  val with_post_session: command list -> t -> t
+
   val empty : t
 
   val add: outer:t -> inner:t -> t
@@ -114,11 +126,13 @@ module Config: sig
 
   val with_criteria: (solver_criteria * string) list -> t -> t
   val with_best_effort_prefix: string -> t -> t
+  val with_best_effort_prefix_opt: string option-> t -> t
 
   val with_solver: arg list -> t -> t
   val with_solver_opt: arg list option -> t -> t
 
   val with_jobs: int -> t -> t
+  val with_jobs_opt: int option -> t -> t
   val with_dl_tool: arg list -> t -> t
   val with_dl_tool_opt: arg list option -> t -> t
   val with_dl_jobs: int -> t -> t
@@ -172,6 +186,8 @@ module Config: sig
   val validation_hook: t -> arg list option
 
   val default_compiler: t -> formula
+
+  val fields: (string * (t, value) OpamPp.field_parser) list
 
 end
 
@@ -889,6 +905,8 @@ module Switch_config: sig
   val variable: t -> variable -> variable_contents option
   val path: t -> std_path -> string option
   val wrappers: t -> Wrappers.t
+  val sections: (string * (t, (string option * opamfile_item list) list) OpamPp.field_parser) list
+  val fields: (string * (t, value) OpamPp.field_parser) list
   include IO_FILE with type t := t
 end
 


### PR DESCRIPTION
Modifiable fields are `download-command`, `download-jobs`, `jobs`, `best-effort-prefix-criteria`, `solver`, `global-variables`, `eval-variables`, `repository-validation-command`, `solver-criteria`, `solver-upgrade-criteria`, `solver-fixup-criteria`.
On revert mode, value is reverted to its init config value if available, deleted otherwise.

ecit: cf https://github.com/ocaml/opam/pull/3992#issuecomment-557638448