### PR TITLE
Avoid copying extraneous files in opam-devel example

### DIFF
--- a/opam-devel.opam
+++ b/opam-devel.opam
@@ -28,7 +28,7 @@ depends: [
 ]
 post-messages: [
 "The development version of opam has been successfully compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
-    sudo cp %{lib}%/%{name}%/* /usr/local/bin
+    sudo cp %{lib}%/%{name}%/opam /usr/local/bin
 
 If you just want to give it a try without altering your current installation, you could use instead:
     alias opam2=\"OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""


### PR DESCRIPTION
I just did `opam install opam-devel` to upgrade from 2.0.4 to 2.0.5, and in the end there was this message:
> You should not run it from there, please install the binaries to your PATH, e.g. with
>  `sudo cp <OPAMROOT>/4.05.0/lib/opam-devel/* /usr/local/bin`

I know it's just an example, but that command would actually copy the `META` and `dune-package` files as well. And since there is only a single binary there (`opam`), it seems better to just do:

       sudo cp <OPAMROOT>/4.05.0/lib/opam-devel/opam /usr/local/bin

Unless there is a use case in which `opam-devel` has more than one binary file. If so, please ignore this PR.