### PR TITLE
make cold: fail if patch or bunzip2 missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ compiler:
 	env MAKE=$(MAKE) ./shell/bootstrap-ocaml.sh $(OCAML_PORT)
 
 cold: compiler
-	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" ./configure $(CONFIGURE_ARGS)
+	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" ./configure --enable-cold-check $(CONFIGURE_ARGS)
 	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" $(MAKE) lib-ext
 	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" $(MAKE)
 

--- a/configure
+++ b/configure
@@ -699,6 +699,7 @@ enable_checks
 enable_developer_mode
 with_mccs
 with_private_runtime
+enable_cold_check
 enable_certificate_check
 '
       ac_precious_vars='build_alias
@@ -1338,6 +1339,7 @@ Optional Features:
 
   --enable-developer-mode Enable developer features
 
+  --enable-cold-check     Fail on some check necessary for make cold
   --disable-certificate-check
                           Do not check the certificate of opam's dependency
                           archives
@@ -3167,6 +3169,12 @@ else
 fi
 
 
+# Check whether --enable-cold_check was given.
+if test "${enable_cold_check+set}" = set; then :
+  enableval=$enable_cold_check; COLD_CHECK=yes
+fi
+
+
 if test "x" != "x$LIB_PREFIX"; then :
 
   CPATH=$CPATH:$LIB_PREFIX/include
@@ -4816,6 +4824,15 @@ else
   BUNZIP2="$ac_cv_prog_BUNZIP2"
 fi
 
+
+if test "x${COLD_CHECK}" = "xyes" ; then
+  if test "x$PATCH"  = "x" ; then
+    as_fn_error $? "You must have patch installed." "$LINENO" 5
+  fi
+  if test "x$BUNZIP2"  = "x" ; then
+    as_fn_error $? "You must have bunzip2 installed." "$LINENO" 5
+  fi
+fi
 
 if test "${OCAML_OS_TYPE}" = "Win32"; then :
 

--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,11 @@ AC_ARG_WITH([private_runtime],
                  [For a mingw-w64 build, manifest the runtime DLLs locally in Opam.Runtime.arch]),,[with_private_runtime=no]
 )
 
+AC_ARG_ENABLE([cold_check],
+  AC_HELP_STRING([--enable-cold-check],
+                 [Fail on some check necessary for make cold]),[COLD_CHECK=yes],[]
+)
+
 AS_IF([test "x" != "x$LIB_PREFIX"], [
   CPATH=$CPATH:$LIB_PREFIX/include
   LIBRARY_PATH=$LIBRARY_PATH:$LIB_PREFIX/lib
@@ -224,6 +229,15 @@ AC_CHECK_TOOL(DUNE,dune)
 AC_CHECK_TOOL(CPPO,cppo)
 AC_CHECK_TOOL(PATCH,patch)
 AC_CHECK_TOOL(BUNZIP2,bunzip2)
+
+if test "x${COLD_CHECK}" = "xyes" ; then
+  if test "x$PATCH"  = "x" ; then
+    AC_MSG_ERROR([You must have patch installed.])
+  fi
+  if test "x$BUNZIP2"  = "x" ; then
+    AC_MSG_ERROR([You must have bunzip2 installed.])
+  fi
+fi
 
 AS_IF([test "${OCAML_OS_TYPE}" = "Win32"],[
   AC_MSG_CHECKING([for a workable solution for ln -s])


### PR DESCRIPTION
Add `--enable-cold-check` to configure in order to fail if some checks are strongly required (ftm only patch & bunzip2).

Fixes #3842