### PR TITLE
update: don't fail if dev source is not vcs, just set it as non dirty dev package

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -580,8 +580,12 @@ let update
              in
              match OpamSwitchState.primary_url st nv with
              | Some { OpamUrl.backend = #OpamUrl.version_control as vc; _ } ->
-               OpamProcess.Job.run @@
-               OpamRepository.is_dirty { cache_url with OpamUrl.backend = vc }
+               (try
+                  OpamProcess.Job.run @@
+                  OpamRepository.is_dirty { cache_url with OpamUrl.backend = vc }
+                with OpamSystem.Process_error _ ->
+                  log "Skipping %s, not a git repo" (OpamPackage.to_string nv);
+                  false)
              | _ -> false)
           dev_packages
     in


### PR DESCRIPTION
If from a repo, primary url backend changes from archive to vcs, on update, as the package is considered `dev`, `is dirty` check fails. 

Fixes #3991 