### PR TITLE
repo: fall back in case archive doesn't exist

### DIFF
--- a/src/client/opamRepositoryCommand.ml
+++ b/src/client/opamRepositoryCommand.ml
@@ -119,6 +119,7 @@ let set_url rt name url trust_anchors =
   OpamFilename.cleandir (OpamRepositoryPath.root rt.repos_global.root name);
   OpamFilename.remove (OpamRepositoryPath.tar rt.repos_global.root name);
   let repo = { repo with repo_url = url; repo_trust = trust_anchors; } in
+  OpamRepositoryState.remove_from_repos_tmp  rt name;
   update_repos_config rt (OpamRepositoryName.Map.add name repo rt.repositories)
 
 let print_selection rt ~short repos_list =

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -167,13 +167,20 @@ let load_repo repo repo_root =
     (t ());
   repo_def, opams
 
+let clean_repo_tmp tmp_dir =
+  if Lazy.is_val tmp_dir then
+    let d = Lazy.force tmp_dir in
+    OpamFilename.cleandir d;
+    OpamFilename.rmdir_cleanup d
+
+let remove_from_repos_tmp rt name =
+  OpamStd.Option.iter (fun tmp_dir ->
+      clean_repo_tmp tmp_dir;
+      Hashtbl.remove rt.repos_tmp name)
+    (Hashtbl.find_opt rt.repos_tmp name)
+
 let cleanup rt =
-  Hashtbl.iter (fun _ tmp_dir ->
-      if Lazy.is_val tmp_dir then
-        let d = Lazy.force tmp_dir in
-        OpamFilename.cleandir d;
-        OpamFilename.rmdir_cleanup d
-    ) rt.repos_tmp;
+  Hashtbl.iter (fun _ tmp_dir -> clean_repo_tmp tmp_dir) rt.repos_tmp;
   Hashtbl.clear rt.repos_tmp
 
 let get_root_raw root repos_tmp name =

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -174,10 +174,10 @@ let clean_repo_tmp tmp_dir =
     OpamFilename.rmdir_cleanup d
 
 let remove_from_repos_tmp rt name =
-  OpamStd.Option.iter (fun tmp_dir ->
-      clean_repo_tmp tmp_dir;
-      Hashtbl.remove rt.repos_tmp name)
-    (Hashtbl.find_opt rt.repos_tmp name)
+  try
+    clean_repo_tmp (Hashtbl.find rt.repos_tmp name);
+    Hashtbl.remove rt.repos_tmp name
+  with Not_found -> ()
 
 let cleanup rt =
   Hashtbl.iter (fun _ tmp_dir -> clean_repo_tmp tmp_dir) rt.repos_tmp;

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -177,9 +177,9 @@ let cleanup rt =
   Hashtbl.clear rt.repos_tmp
 
 let get_root_raw root repos_tmp name =
-  match Hashtbl.find repos_tmp name with
-  | lazy repo_root -> repo_root
-  | exception Not_found -> OpamRepositoryPath.root root name
+  try
+    Lazy.force (Hashtbl.find repos_tmp name)
+  with Not_found -> OpamRepositoryPath.root root name
 
 let get_root rt name =
   get_root_raw rt.repos_global.root rt.repos_tmp name
@@ -214,8 +214,12 @@ let load lock_kind gt =
       then
         let tmp = lazy (
           let tmp_root = Lazy.force repos_tmp_root in
-          OpamFilename.extract_in tar tmp_root;
-          OpamFilename.Op.(tmp_root / OpamRepositoryName.to_string name)
+          if OpamFilename.exists tar then
+            (OpamFilename.extract_in tar tmp_root;
+             OpamFilename.Op.(tmp_root / OpamRepositoryName.to_string name))
+          else
+            (log "Missing repository archive %s" (OpamFilename.to_string tar);
+             raise Not_found)
         ) in
         Hashtbl.add repos_tmp name tmp
     ) repositories;

--- a/src/state/opamRepositoryState.mli
+++ b/src/state/opamRepositoryState.mli
@@ -88,6 +88,9 @@ val unlock: ?cleanup:bool -> 'a repos_state -> unlocked repos_state
 *)
 val drop: ?cleanup:bool -> 'a repos_state -> unit
 
+(** Cleanup before removing the repository from temporary table *)
+val remove_from_repos_tmp: 'a repos_state -> repository_name -> unit
+
 (** Clears tmp files corresponding to a repo state (uncompressed repository
     contents) *)
 val cleanup: 'a repos_state -> unit


### PR DESCRIPTION
When changing a repo url, the previous archive is discarded, but later opam tries extracted it (caching in `repo.repos_tmp`). Adds a fall back for that case. 