### PR TITLE
DirTrack: check both size and mtime for cached entries

### DIFF
--- a/src/core/opamDirTrack.ml
+++ b/src/core/opamDirTrack.ml
@@ -60,7 +60,7 @@ let cached_digest =
   fun f size mtime ->
     try
       let csize, cmtime, digest = Hashtbl.find item_cache f in
-      if csize = size || mtime = cmtime then Digest.to_hex digest
+      if csize = size && mtime = cmtime then Digest.to_hex digest
       else raise Not_found
     with Not_found ->
       let digest = Digest.file f in


### PR DESCRIPTION
the earlier code checked size OR mtime for equality, whereas it should be size AND mtime to avoid bad cache lookups