### PR TITLE
opamCudf: provide machine-readable information on conflicts caused by cycles

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -173,6 +173,7 @@ users)
   * Process control: close stdin by default for Windows subprocesses and on all platforms for the download command [#4615 @dra27]
   * [BUG] handle converted variables correctly when no_undef_expand is true [#4811 @timbertson]
   * [BUG] check Unix.has_symlink before using Unix.symlink [#4962 @jonahbeckford]
+  * OpamCudf: provide machine-readable information on conflicts caused by cycles [#4039 @gasche]
 
 ## Test
   * Update crowbar with compare functions [#4918 @rjbou]
@@ -237,6 +238,8 @@ users)
 ## opam-repository
 ## opam-state
 ## opam-solver
+  * `OpamCudf`: Change type of `conflict_case.Conflict_cycle` (`string list list` to `Cudf.package action list list`) and `cycle_conflict`, `string_of_explanations`, `conflict_explanations_raw` types accordingly [#4039 @gasche]
+  * `OpamCudf`: add `conflict_cycles` [#4039 @gasche]
 ## opam-format
   * `OpamStd.ABSTRACT`: add `compare` and `equal`, that added those functions to `OpamSysPkg` and `OpamVariable` [#4918 @rjbou]
   * Add OpamPackage.Version.default returning the version number used when no version is given for a package [#4949 @kit-ty-kate]
@@ -244,5 +247,4 @@ users)
   * OpamSystem: avoid calling Unix.environment at top level [#4789 @hannesm]
   * `OpamStd.ABSTRACT`: add `compare` and `equal`, that added those functions to `OpamFilename`, `OpamHash`, `OpamStd`, `OpamStd`, `OpamUrl`, and `OpamVersion` [#4918 @rjbou]
   * `OpamHash`: add `sort` from strongest to weakest kind
-
-  * OpamSystem.real_path: Remove the double chdir trick on OCaml >= 4.13.0 [#4961 @kit-ty-kate]
+  * `OpamSystem.real_path`: Remove the double chdir trick on OCaml >= 4.13.0 [#4961 @kit-ty-kate]

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -421,7 +421,7 @@ exception Cyclic_actions of Action.t list list
 
 type conflict_case =
   | Conflict_dep of (unit -> Dose_algo.Diagnostic.reason list)
-  | Conflict_cycle of string list list
+  | Conflict_cycle of Cudf.package action list list
 type conflict =
   Cudf.universe * int package_map * conflict_case
 
@@ -974,7 +974,10 @@ let extract_explanations packages cudfnv2opam reasons : explanation list =
   | _ -> explanations
 
 let strings_of_cycles cycles =
-  List.map arrow_concat cycles
+  let string_of_cycle cycle =
+    List.map string_of_action cycle
+    |> arrow_concat in
+  List.map string_of_cycle cycles
 
 let string_of_conflict ?(start_column=0) (msg1, msg2, msg3) =
   let width = OpamStd.Sys.terminal_columns () - start_column - 2 in
@@ -1027,6 +1030,11 @@ let conflict_explanations packages unav_reasons = function
     List.rev_map (string_of_explanation unav_reasons) explanations, []
   | _univ, _version_map, Conflict_cycle cycles ->
     [], strings_of_cycles cycles
+
+let conflict_cycles = function
+  | _cudf_universe, _version_map, Conflict_cycle cycles ->
+     Some (List.map (List.map (map_action cudf2opam)) cycles)
+  | _ -> None
 
 let string_of_explanations unav_reasons (cflts, cycles) =
   let cflts = List.map (string_of_explanation unav_reasons) cflts in

--- a/src/solver/opamCudf.mli
+++ b/src/solver/opamCudf.mli
@@ -213,7 +213,7 @@ val make_conflicts:
   Dose_algo.Diagnostic.diagnosis -> ('a, conflict) result
 val cycle_conflict:
   version_map:int package_map -> Cudf.universe ->
-  string list list -> ('a, conflict) result
+  Cudf.package action list list -> ('a, conflict) result
 
 type explanation =
   [ `Conflict of string option * string list * bool
@@ -232,7 +232,7 @@ val string_of_conflicts:
 
 val string_of_explanations:
   (name * OpamFormula.version_formula -> string) ->
-  explanation list * string list list ->
+  explanation list * Action.t list list ->
   string
 
 (** Returns two lists:
@@ -247,12 +247,14 @@ val string_of_explanation:
   string * string list * string list
 
 val conflict_explanations_raw:
-  package_set -> conflict -> explanation list * string list list
+  package_set -> conflict -> explanation list * Action.t list list
 
 (** Properly concat a single conflict as returned by [conflict_explanations] for
    display *)
 val string_of_conflict:
   ?start_column:int -> string * string list * string list -> string
+
+val conflict_cycles : conflict -> package action list list option
 
 (** Dumps the given cudf universe to the given channel *)
 val dump_universe: out_channel -> Cudf.universe -> unit

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -418,12 +418,7 @@ let cleanup_request universe (req:atom request) =
   { req with wish_install; wish_upgrade }
 
 let cycle_conflict ~version_map univ cycles =
-  OpamCudf.cycle_conflict ~version_map univ
-    (List.map
-       (List.map
-          (fun a ->
-             Action.to_string (map_action OpamCudf.cudf2opam a)))
-       cycles)
+  OpamCudf.cycle_conflict ~version_map univ cycles
 
 let resolve universe request =
   log "resolve request=%a" (slog string_of_request) request;

--- a/tests/reftests/opamrt-big-upgrade.test
+++ b/tests/reftests/opamrt-big-upgrade.test
@@ -88,7 +88,7 @@ installed: [
   "yojson.1.1.6"
   "zed.1.2"
 ]
-### opam switch import init.export --switch test-import --fake
+### opam switch import init.export --switch test-import --fake | unordered
 The following actions will be faked:
   - install base-unix           base
   - install ocaml-base-compiler 4.01.0beta1 [required by ocaml]


### PR DESCRIPTION
For conflicts caused by cyclic actions, the opamCudf API would
previously only allow to observe the cycle with actions described as
strings for human pretty-printing.

We would like to write a script, using the opam API, that can react to
solution errors caused by cycles by patching the query and calling the
solver again. For this we need a machine-readable representation of
conflict cycles. ("We" here is myself and @Armael.)

The present commit makes the minimal change to the opamCudf API to
make this possible:

- The internal representation of cycles is changed to take CUDF
  packages (the most general information) instead of strings.
- The `OpamCudf.cycle_conflicts` function has its type changed accordingly
  (this changes the module interface and may break library consumers).
- A new function `OpamCudf.conflict_cycles` is exposed to recover
  a cycle representation carrying "opam package" actions.

Remark: `conflict_cycles` is in the style of the current API on the
abstract `conflict` type, which is not very good: a conflict is
a variant/sum type in hiding (either an incompatibility in the query
or a cycle in the solution), and functions do something in one case
and silently return nothing in the other.

It would be nicer to expose a variant-sum type view of the conflict
type to users, but this should be discussed with OPAM maintainers, and
is not a requirement for our work.