### PR TITLE
Include extra-files in switch export if `full` is provided, on import create an overlay directory with the file contents

### DIFF
--- a/opam-client.opam
+++ b/opam-client.opam
@@ -23,6 +23,7 @@ build: [
 depends: [
   "opam-state" {= "2.1.0~beta"}
   "opam-solver" {= "2.1.0~beta"}
+  "extlib"
   "re" {>= "1.9.0"}
   "cmdliner" {>= "0.9.8"}
   "dune" {build & >= "1.2.1"}

--- a/src/client/dune
+++ b/src/client/dune
@@ -3,7 +3,7 @@
   (public_name opam-client)
   (synopsis    "OCaml Package Manager client and CLI library")
   (modules     (:standard \ opamMain get_git_version))
-  (libraries   opam-state opam-solver re cmdliner)
+  (libraries   opam-state opam-solver re extlib cmdliner)
   (flags       (:standard
                (:include ../ocaml-flags-standard.sexp)
                (:include ../ocaml-flags-configure.sexp)

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -373,7 +373,7 @@ let prepare_package_source st nv dir =
           | Some (_, String (_, value)) ->
             let value' = Base64.decode_string value in
             let my = OpamHash.compute_from_string ~kind:(OpamHash.kind hash) value' in
-            if String.equal (OpamHash.contents my) (OpamHash.contents hash) then
+            if OpamHash.contents my = OpamHash.contents hash then
               OpamFilename.write dst value'
             else
               failwith "Bad hash for inline extra-files"

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2251,8 +2251,6 @@ let switch =
         ~full
         (if filename = "-" then None
          else Some (OpamFile.make (OpamFilename.of_string filename)));
-      OpamRepositoryState.drop rt;
-      OpamGlobalState.drop gt;
       `Ok ()
     | Some `import, [filename] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3101,6 +3101,7 @@ let clean =
            cleandir (OpamPath.Switch.backup_dir root sw);
            cleandir (OpamPath.Switch.build_dir root sw);
            cleandir (OpamPath.Switch.remove_dir root sw);
+           cleandir (OpamPath.Switch.extra_files_dir root sw);
            let pinning_overlay_dirs =
              List.map
                (fun nv -> OpamPath.Switch.Overlay.package root sw nv.name)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2245,10 +2245,14 @@ let switch =
       OpamSwitchState.drop st;
       `Ok ()
     | Some `export, [filename] ->
-      OpamSwitchCommand.export
+      OpamGlobalState.with_ `Lock_write @@ fun gt ->
+      OpamRepositoryState.with_ `Lock_none gt @@ fun rt ->
+      OpamSwitchCommand.export rt
         ~full
         (if filename = "-" then None
          else Some (OpamFile.make (OpamFilename.of_string filename)));
+      OpamRepositoryState.drop rt;
+      OpamGlobalState.drop gt;
       `Ok ()
     | Some `import, [filename] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -477,30 +477,44 @@ let import_t ?ask importfile t =
   end;
   t
 
-let read_overlays (read: package -> OpamFile.OPAM.t option) packages =
+let read_overlays ~repos_roots (read: package -> OpamFile.OPAM.t option) packages =
   OpamPackage.Set.fold (fun nv acc ->
       match read nv with
       | Some opam ->
-        if OpamFile.OPAM.extra_files opam <> None then
-          (OpamConsole.warning
-             "Metadata of package %s uses a files%s subdirectory, it may not be \
-              re-imported correctly (skipping definition)"
-             (OpamPackage.to_string nv) Filename.dir_sep;
-           acc)
-        else OpamPackage.Name.Map.add nv.name opam acc
+        let opam' = match OpamFile.OPAM.get_extra_files ~repos_roots opam with
+          | [] -> opam
+          | files ->
+            (* read file and embed them into opam *)
+            List.fold_left (fun opam (file, _rel_file, hash) ->
+                if OpamFilename.exists file &&
+                   OpamHash.check_file (OpamFilename.to_string file) hash then
+                  let value = OpamFilename.read file in
+                  let value' = Base64.encode_string value in
+                  let name = "x-extra-file-" ^ OpamHash.contents hash in
+                  OpamFile.OPAM.add_extension opam name
+                    (OpamParserTypes.String (OpamTypesBase.pos_null, value'))
+                else begin
+                  OpamConsole.warning "Ignoring file %s with invalid hash"
+                    (OpamFilename.to_string file);
+                  opam
+                end)
+              opam files
+        in
+        OpamPackage.Name.Map.add nv.name opam' acc
       | None -> acc)
     packages
     OpamPackage.Name.Map.empty
 
-let export ?(full=false) filename =
+let export rt ?(full=false) filename =
   let switch = OpamStateConfig.get_switch () in
   let root = OpamStateConfig.(!r.root_dir) in
   let export =
     OpamFilename.with_flock `Lock_none (OpamPath.Switch.lock root switch)
     @@ fun _ ->
     let selections = S.safe_read (OpamPath.Switch.selections root switch) in
+    let repos_roots = OpamRepositoryState.get_root rt in
     let overlays =
-      read_overlays (fun nv ->
+      read_overlays ~repos_roots (fun nv ->
           OpamFileTools.read_opam
             (OpamPath.Switch.Overlay.package root switch nv.name))
         selections.sel_pinned
@@ -508,7 +522,7 @@ let export ?(full=false) filename =
     let overlays =
       if full then
         OpamPackage.Name.Map.union (fun a _ -> a) overlays @@
-        read_overlays (fun nv ->
+        read_overlays ~repos_roots (fun nv ->
             OpamFile.OPAM.read_opt
               (OpamPath.Switch.installed_opam root switch nv))
           (selections.sel_installed -- selections.sel_pinned)

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -528,7 +528,10 @@ let export rt ?(full=false) filename =
           (selections.sel_installed -- selections.sel_pinned)
       else overlays
     in
-    { OpamFile.SwitchExport.selections; overlays }
+    let extra_files =
+      OpamHash.Map.empty
+    in
+    { OpamFile.SwitchExport.selections; extra_files; overlays }
   in
   match filename with
   | None   -> OpamFile.SwitchExport.write_to_channel stdout export
@@ -560,6 +563,7 @@ let reinstall init_st =
   in
   import_t { OpamFile.SwitchExport.
              selections = OpamSwitchState.selections init_st;
+             extra_files = OpamHash.Map.empty;
              overlays = OpamPackage.Name.Map.empty; }
     st
 
@@ -575,6 +579,7 @@ let import st filename =
       try
         let selections = OpamFile.LegacyState.read_from_string import_str in
         { OpamFile.SwitchExport.selections;
+          extra_files = OpamHash.Map.empty;
           overlays = OpamPackage.Name.Map.empty }
       with e1 -> OpamStd.Exn.fatal e1; raise e
   in

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -519,13 +519,7 @@ let export rt ?(full=false) filename =
     in
     let overlays =
       OpamPackage.Map.fold (fun nv opam nmap ->
-          if (not full) && OpamFile.OPAM.extra_files opam <> None then
-            (OpamConsole.warning
-               "Metadata of package %s uses a files%s subdirectory, it may not be \
-                re-imported correctly (skipping definition)"
-               (OpamPackage.to_string nv) Filename.dir_sep;
-             nmap)
-          else OpamPackage.Name.Map.add nv.name opam nmap)
+          OpamPackage.Name.Map.add nv.name opam nmap)
         opams OpamPackage.Name.Map.empty
     in
     let extra_files =

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -372,6 +372,19 @@ let switch lock gt switch =
 let import_t ?ask importfile t =
   log "import switch";
 
+  let extra_files = importfile.OpamFile.SwitchExport.extra_files in
+  let dir = OpamPath.Switch.extra_files_dir t.switch_global.root t.switch in
+  OpamHash.Map.iter (fun hash content ->
+      let value = Base64.decode_string content in
+      let my = OpamHash.compute_from_string ~kind:(OpamHash.kind hash) value in
+      if OpamHash.contents my = OpamHash.contents hash then
+        let dst =
+          let base = OpamFilename.Base.of_string (OpamHash.contents hash) in
+          OpamFilename.create dir base in
+          OpamFilename.write dst value
+      else
+        failwith "Bad hash for inline extra-files") extra_files;
+
   let import_sel = importfile.OpamFile.SwitchExport.selections in
   let import_opams = importfile.OpamFile.SwitchExport.overlays in
 

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -529,7 +529,7 @@ let read_extra_files ~repos_roots (read: package -> OpamFile.OPAM.t option) data
             acc files)
     packages data
 
-let export rt ?(full=false) ?(freeze = false) filename =
+let export rt ?(full=false) filename =
   let switch = OpamStateConfig.get_switch () in
   let root = OpamStateConfig.(!r.root_dir) in
   let export =
@@ -537,15 +537,15 @@ let export rt ?(full=false) ?(freeze = false) filename =
     @@ fun _ ->
     let selections = S.safe_read (OpamPath.Switch.selections root switch) in
     let overlays =
-        read_overlays (not freeze) (fun nv ->
+        read_overlays (not full) (fun nv ->
             OpamFileTools.read_opam
               (OpamPath.Switch.Overlay.package root switch nv.name))
           selections.sel_pinned
     in
     let overlays =
-      if full || freeze then
+      if full then
         OpamPackage.Name.Map.union (fun a _ -> a) overlays @@
-        read_overlays (not freeze) (fun nv ->
+        read_overlays (not full) (fun nv ->
             OpamFile.OPAM.read_opt
               (OpamPath.Switch.installed_opam root switch nv))
           (selections.sel_installed -- selections.sel_pinned)
@@ -553,7 +553,7 @@ let export rt ?(full=false) ?(freeze = false) filename =
         overlays
     in
     let extra_files =
-      if freeze then
+      if full then
         let repos_roots = OpamRepositoryState.get_root rt in
         let data =
           read_extra_files ~repos_roots (fun nv ->

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -380,7 +380,8 @@ let import_t ?ask importfile t =
       if OpamHash.contents my = OpamHash.contents hash then
         let dst =
           let base = OpamFilename.Base.of_string (OpamHash.contents hash) in
-          OpamFilename.create dir base in
+          OpamFilename.create dir base
+        in
           OpamFilename.write dst value
       else
         failwith "Bad hash for inline extra-files") extra_files;

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -373,14 +373,16 @@ let import_t ?ask importfile t =
   log "import switch";
 
   let extra_files = importfile.OpamFile.SwitchExport.extra_files in
-  let dir = OpamPath.Switch.extra_files_dir t.switch_global.root t.switch in
+  let xfiles_dir =
+    OpamPath.Switch.extra_files_dir t.switch_global.root t.switch
+  in
   OpamHash.Map.iter (fun hash content ->
       let value = Base64.decode_string content in
       let my = OpamHash.compute_from_string ~kind:(OpamHash.kind hash) value in
       if OpamHash.contents my = OpamHash.contents hash then
         let dst =
           let base = OpamFilename.Base.of_string (OpamHash.contents hash) in
-          OpamFilename.create dir base
+          OpamFilename.create xfiles_dir base
         in
           OpamFilename.write dst value
       else
@@ -468,6 +470,7 @@ let import_t ?ask importfile t =
         extra_attributes = []; }
   in
   OpamSolution.check_solution t solution;
+  OpamFilename.rmdir xfiles_dir;
   if not (OpamStateConfig.(!r.dryrun) || OpamClientConfig.(!r.show))
   then begin
     (* Put imported overlays in place *)

--- a/src/client/opamSwitchCommand.mli
+++ b/src/client/opamSwitchCommand.mli
@@ -42,7 +42,7 @@ val import:
 (** Export a file which contains the installed packages. If full is specified
     and true, export metadata of all installed packages (excluding overlay
     files) as part of the export. [None] means export to stdout. *)
-val export: ?full:bool -> OpamFile.SwitchExport.t OpamFile.t option -> unit
+val export: 'a repos_state -> ?full:bool -> OpamFile.SwitchExport.t OpamFile.t option -> unit
 
 (** Remove the given compiler switch, and returns the updated state (unchanged
     in case [confirm] is [true] and the user didn't confirm) *)

--- a/src/client/opamSwitchCommand.mli
+++ b/src/client/opamSwitchCommand.mli
@@ -41,14 +41,12 @@ val import:
 
 (** Export a file which contains the installed packages. If [full] is specified
     and true, export metadata of all installed packages (excluding overlay
-    files) as part of the export. If [freeze] is specified and true, the export
-    will be extended with a map of all extra-files. The option [freeze] implies
-    [full]. If [None] is provided as file argument, the export is done to
+    files) as part of the export. The export will be extended with a map of all
+    extra-files. If [None] is provided as file argument, the export is done to
     stdout. *)
 val export:
   'a repos_state ->
   ?full:bool ->
-  ?freeze:bool ->
   OpamFile.SwitchExport.t OpamFile.t option ->
   unit
 

--- a/src/client/opamSwitchCommand.mli
+++ b/src/client/opamSwitchCommand.mli
@@ -39,10 +39,18 @@ val import:
   OpamFile.SwitchExport.t OpamFile.t option ->
   rw switch_state
 
-(** Export a file which contains the installed packages. If full is specified
+(** Export a file which contains the installed packages. If [full] is specified
     and true, export metadata of all installed packages (excluding overlay
-    files) as part of the export. [None] means export to stdout. *)
-val export: 'a repos_state -> ?full:bool -> OpamFile.SwitchExport.t OpamFile.t option -> unit
+    files) as part of the export. If [freeze] is specified and true, the export
+    will be extended with a map of all extra-files. The option [freeze] implies
+    [full]. If [None] is provided as file argument, the export is done to
+    stdout. *)
+val export:
+  'a repos_state ->
+  ?full:bool ->
+  ?freeze:bool ->
+  OpamFile.SwitchExport.t OpamFile.t option ->
+  unit
 
 (** Remove the given compiler switch, and returns the updated state (unchanged
     in case [confirm] is [true] and the user didn't confirm) *)

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -683,6 +683,7 @@ end
 module SwitchExport: sig
   type t = {
     selections: switch_selections;
+    extra_files: string OpamHash.Map.t;
     overlays: OPAM.t OpamPackage.Name.Map.t;
   }
   include IO_FILE with type t := t

--- a/src/format/opamPath.ml
+++ b/src/format/opamPath.ml
@@ -117,6 +117,10 @@ module Switch = struct
 
   let sources_dir t a = meta t a / "sources"
 
+  let extra_files_dir t a = sources_dir t a / "extra-files"
+
+  let extra_file t a h = extra_files_dir t a / OpamHash.contents h
+
   let sources t a nv = sources_dir t a / OpamPackage.to_string nv
 
   let pinned_package t a name = sources_dir t a / OpamPackage.Name.to_string name

--- a/src/format/opamPath.ml
+++ b/src/format/opamPath.ml
@@ -117,9 +117,9 @@ module Switch = struct
 
   let sources_dir t a = meta t a / "sources"
 
-  let extra_files_dir t a = sources_dir t a / "extra-files"
+  let extra_files_dir t a = meta t a / "extra-files-cache"
 
-  let extra_file t a h = extra_files_dir t a / OpamHash.contents h
+  let extra_file t a h = extra_files_dir t a // OpamHash.contents h
 
   let sources t a nv = sources_dir t a / OpamPackage.to_string nv
 

--- a/src/format/opamPath.mli
+++ b/src/format/opamPath.mli
@@ -153,6 +153,10 @@ module Switch: sig
       $meta/sources/$name.$version/} *)
   val sources: t -> switch -> package -> dirname
 
+  val extra_files_dir: t -> switch -> dirname
+
+  val extra_file: t -> switch -> OpamHash.t -> dirname
+
   (** Mirror of the sources for a given pinned package: {i
       $meta/sources/$name/} (without version) *)
   val pinned_package: t -> switch -> name -> dirname

--- a/src/format/opamPath.mli
+++ b/src/format/opamPath.mli
@@ -153,9 +153,13 @@ module Switch: sig
       $meta/sources/$name.$version/} *)
   val sources: t -> switch -> package -> dirname
 
+  (** Temporary switch-local directory where a by-hash map of extra files may be stored.
+      This is used for switch-imports: {i $meta/extra-files-cache} *)
   val extra_files_dir: t -> switch -> dirname
 
-  val extra_file: t -> switch -> OpamHash.t -> dirname
+  (** Extra file with the given hash from the temporary switch-import cache:
+      {i $meta/extra-files-cache/HASH} *)
+  val extra_file: t -> switch -> OpamHash.t -> filename
 
   (** Mirror of the sources for a given pinned package: {i
       $meta/sources/$name/} (without version) *)


### PR DESCRIPTION
Why I'm doing this? I worked on reproducible builds and tooling thereof, where it is very convenient to use opam export and import for rebuilding the same artifact. The current situation that an export contains only a subset of packages (and thus an import may be incomplete or using package metadata from elsewhere) does not fit well into the reproducible builds concept.

~~This PR embeds https://github.com/mirage/ocaml-base64 into opam, I'm happy to remove this and use a dependency for that (but I didn't know how to add depedencies for opam) -- or use a hex encoding if prefered.~~

//cc @rjbou 