### PR TITLE
Update Packaging.md: ocaml-native changed to ocaml:native

### DIFF
--- a/doc/pages/Packaging.md
+++ b/doc/pages/Packaging.md
@@ -218,6 +218,6 @@ This is just a very short introduction, don't be afraid to consult
 
     ```
     ["./configure" "--with-foo" {ocaml-version > "3.12"} "--prefix=%{prefix}%"]
-    [make "byte"] { !ocaml-native }
-    [make "native"] { ocaml-native }
+    [make "byte"] { !ocaml:native }
+    [make "native"] { ocaml:native }
     ```


### PR DESCRIPTION
It seems that the variable ocaml-native has been renamed to ocaml:native. This pull request updates the documentation accordingly.