### PR TITLE
opamFile extensions (x- fields) enhancements

### DIFF
--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -2252,6 +2252,9 @@ module OPAMSyntax = struct
     if not (is_ext_field fld) then invalid_arg "OpamFile.OPAM.add_extension";
     {t with
      extensions = OpamStd.String.Map.add fld (pos_null,syn) t.extensions }
+  let remove_extension t fld =
+    if not (is_ext_field fld) then invalid_arg "OpamFile.OPAM.remove_extension";
+    {t with extensions = OpamStd.String.Map.remove fld t.extensions }
 
   let with_url url t =
     let format_errors =

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -824,7 +824,9 @@ module Syntax = struct
                    OpamPrinter.items [f] :: strs
                  with Not_found -> strs
              with Not_found | OpamPp.Bad_format _ ->
-               if OpamStd.String.starts_with ~prefix:"x-" name then
+               if OpamStd.String.starts_with ~prefix:"x-" name &&
+                  OpamStd.List.find_opt (fun i -> it_ident i = `Var name)
+                    syn_t.file_contents <> None then
                  field_str (`Var name) :: strs
                else strs)
           | Section (pos, {section_kind; section_name; section_items}) ->

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -594,6 +594,8 @@ module OPAM: sig
 
   val add_extension: t -> string -> value -> t
 
+  val remove_extension: t -> string -> t
+
   val with_deprecated_build_doc: command list -> t -> t
 
   val with_deprecated_build_test: command list -> t -> t


### PR DESCRIPTION
this PR consists of two commits:
- add `remove_extension : t -> string -> t`
- change behaviour of `to_string_with_preserved_format` to not treat `x-` specially. I'm not sure why the code was around, is there a test / example for the previous behaviour @AltGr?