### PR TITLE
Include the version number in "compilation failed" messages

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -786,7 +786,7 @@ let build_package t ?(test=false) ?(doc=false) build_dir nv =
   | Some (cmd, result), _ | _, Some (cmd, result) ->
     OpamConsole.error
       "The compilation of %s failed at %S."
-      name (OpamProcess.string_of_command cmd);
+      (OpamPackage.to_string nv) (OpamProcess.string_of_command cmd);
     Done (Some (OpamSystem.Process_error result))
   | None, None ->
     if commands <> [] && OpamConsole.verbose () then


### PR DESCRIPTION
This is a minor improvement of the console logging when building a series of packages. If installation succeeds, the message is `* installed pkg.ver`, but if it fails, it is `the compilation of pkg failed at ...`.

This commits adds the version number to the failure message, for symmetry and to be more explicit.
(this way, one can start investigating the issue before waiting for the final message which does include the version)