### PR TITLE
opam export: record vcs commit hash when a vcs url is specified

### DIFF
--- a/opam-client.opam
+++ b/opam-client.opam
@@ -24,6 +24,7 @@ depends: [
   "opam-state" {= "2.1.0~beta"}
   "opam-solver" {= "2.1.0~beta"}
   "extlib"
+  "opam-repository" {= "2.1.0~beta"}
   "re" {>= "1.9.0"}
   "cmdliner" {>= "0.9.8"}
   "dune" {build & >= "1.2.1"}

--- a/src/client/dune
+++ b/src/client/dune
@@ -3,7 +3,7 @@
   (public_name opam-client)
   (synopsis    "OCaml Package Manager client and CLI library")
   (modules     (:standard \ opamMain get_git_version))
-  (libraries   opam-state opam-solver re extlib cmdliner)
+  (libraries   opam-state opam-solver opam-repository re extlib cmdliner)
   (flags       (:standard
                (:include ../ocaml-flags-standard.sexp)
                (:include ../ocaml-flags-configure.sexp)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2084,7 +2084,8 @@ let switch =
     "remove", `remove, ["SWITCH"], "Remove the given switch from disk.";
     "export", `export, ["FILE"],
     "Save the current switch state to a file. If $(b,--full) is specified, it \
-     includes the metadata of all installed packages";
+     includes the metadata of all installed packages, and if $(b,--freeze) is \
+     specified, it freezes all vcs to their current commit.";
     "import", `import, ["FILE"],
     "Import a saved switch state. If $(b,--switch) is specified and doesn't \
      point to an existing switch, the switch will be created for the import.";
@@ -2175,6 +2176,12 @@ let switch =
        allowing to re-import even if they don't exist in the repositories (the \
        default is to include only the metadata of pinned packages)."
   in
+  let freeze =
+    mk_flag ["freeze"]
+      "When exporting, locks all VCS urls to their current commit, failing if \
+       it can not be retrieved. This ensures that an import will restore the \
+       exact state. Implies $(b,--full)."
+  in
   let no_install =
     mk_flag ["no-install"]
       "When creating a local switch, don't look for any local package \
@@ -2199,7 +2206,7 @@ let switch =
   in
   let switch
       global_options build_options command print_short
-      no_switch packages empty descr full no_install deps_only repos
+      no_switch packages empty descr full freeze no_install deps_only repos
       d_alias_of d_no_autoinstall params =
    OpamArg.deprecated_option d_alias_of None
    "alias-of" (Some "opam switch <switch-name> <compiler>");
@@ -2321,7 +2328,7 @@ let switch =
       OpamGlobalState.with_ `Lock_write @@ fun gt ->
       OpamRepositoryState.with_ `Lock_none gt @@ fun rt ->
       OpamSwitchCommand.export rt
-        ~full
+        ~full ~freeze
         (if filename = "-" then None
          else Some (OpamFile.make (OpamFilename.of_string filename)));
       `Ok ()
@@ -2461,7 +2468,7 @@ let switch =
              $global_options $build_options $command
              $print_short_flag
              $no_switch
-             $packages $empty $descr $full $no_install $deps_only
+             $packages $empty $descr $full $freeze $no_install $deps_only
              $repos $d_alias_of $d_no_autoinstall $params)),
   term_info "switch" ~doc ~man
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2328,7 +2328,7 @@ let switch =
       OpamGlobalState.with_ `Lock_write @@ fun gt ->
       OpamRepositoryState.with_ `Lock_none gt @@ fun rt ->
       OpamSwitchCommand.export rt
-        ~full ~freeze
+        ~full:(full || freeze) ~freeze
         (if filename = "-" then None
          else Some (OpamFile.make (OpamFilename.of_string filename)));
       `Ok ()

--- a/src/client/opamSwitchCommand.mli
+++ b/src/client/opamSwitchCommand.mli
@@ -42,11 +42,14 @@ val import:
 (** Export a file which contains the installed packages. If [full] is specified
     and true, export metadata of all installed packages (excluding overlay
     files) as part of the export. The export will be extended with a map of all
-    extra-files. If [None] is provided as file argument, the export is done to
-    stdout. *)
+    extra-files. If [freeze] is specified and true, VCS urls will be frozen to
+    the specific commit ID. If [None] is provided as file argument, the export
+    is done to stdout. *)
 val export:
   'a repos_state ->
+  ?freeze:bool ->
   ?full:bool ->
+  ?switch:switch ->
   OpamFile.SwitchExport.t OpamFile.t option ->
   unit
 

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -270,6 +270,7 @@ module URL: sig
   val checksum: t -> OpamHash.t list
 
   (** Constructor *)
+  val with_url: url -> t -> t
   val with_checksum: OpamHash.t list -> t -> t
 
 end


### PR DESCRIPTION
this is useful for having an export file which can be imported and will contain the exact same sources (related to #4040), part of reproducibilty efforts