### PR TITLE
Add a --download-only flag to "opam install"

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -21,6 +21,7 @@ New option/command/subcommand are prefixed with ◈.
 ## Install
   * The stdout of `pre-` and `post-session` hooks is now propagated to the user [#4382 @AltGr - fix #4359]
   * `post-install` hooks are allowed to modify or remove installed files, the but not add new ones. Those changes are integrated in changes file [#4388 @lefessan]
+  * ◈ Add `--download-only` flag [#4071 @Armael @rjbou - fix #4036]
 
 ## Remove
   * Fix `opam remove --autoremove <PKG>` to not autoremove unrelated packages [#4369 @AltGr - fix #4250 #4332]

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1076,7 +1076,7 @@ let filter_unpinned_locally t atoms f =
     atoms
 
 let install_t t ?ask ?(ignore_conflicts=false) ?(depext_only=false)
-    atoms add_to_roots ~deps_only ~assume_built =
+    ?(download_only=false) atoms add_to_roots ~deps_only ~assume_built =
   log "INSTALL %a" (slog OpamFormula.string_of_atoms) atoms;
   let names = OpamPackage.Name.Set.of_list (List.rev_map fst atoms) in
 
@@ -1229,7 +1229,7 @@ let install_t t ?ask ?(ignore_conflicts=false) ?(depext_only=false)
       in
       let t, res =
         OpamSolution.apply ?ask t ~requested:names ?add_roots
-          ~assume_built solution in
+          ~download_only ~assume_built solution in
       t, Some (Success res)
   in
   OpamStd.Option.iter (OpamSolution.check_solution t) solution;
@@ -1237,14 +1237,15 @@ let install_t t ?ask ?(ignore_conflicts=false) ?(depext_only=false)
 
 let install t ?autoupdate ?add_to_roots
     ?(deps_only=false) ?(ignore_conflicts=false) ?(assume_built=false)
-    ?(depext_only=false) names =
+    ?(download_only=false) ?(depext_only=false) names =
   let atoms = OpamSolution.sanitize_atom_list ~permissive:true t names in
   let autoupdate_atoms = match autoupdate with
     | None -> atoms
     | Some a -> OpamSolution.sanitize_atom_list ~permissive:true t a
   in
   let t = update_dev_packages_t autoupdate_atoms t in
-  install_t t ~ignore_conflicts ~depext_only atoms add_to_roots ~deps_only ~assume_built
+  install_t t atoms add_to_roots
+    ~ignore_conflicts ~depext_only ~deps_only ~download_only ~assume_built
 
 let remove_t ?ask ~autoremove ~force atoms t =
   log "REMOVE autoremove:%b %a" autoremove

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -51,14 +51,15 @@ val reinit:
 val install:
   rw switch_state ->
   ?autoupdate:atom list -> ?add_to_roots:bool -> ?deps_only:bool ->
-  ?ignore_conflicts:bool -> ?assume_built:bool -> ?depext_only:bool ->
-  atom list ->
+  ?ignore_conflicts:bool -> ?assume_built:bool -> ?download_only:bool ->
+  ?depext_only:bool -> atom list ->
   rw switch_state
 
 (** Low-level version of [reinstall], bypassing the package name sanitization
     and dev package update, and offering more control *)
 val install_t:
-  rw switch_state -> ?ask:bool -> ?ignore_conflicts:bool -> ?depext_only:bool ->
+  rw switch_state ->
+  ?ask:bool -> ?ignore_conflicts:bool -> ?depext_only:bool -> ?download_only:bool ->
   atom list -> bool option -> deps_only:bool -> assume_built:bool ->
   rw switch_state
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1515,6 +1515,10 @@ let install cli =
     mk_flag ~cli (cli_from cli2_1) ["ignore-conflicts"]
       "Used with $(b,--deps-only), ignores conflicts of given package"
   in
+  let download_only =
+    mk_flag ~cli (cli_from cli2_1) ["download-only"]
+      "Fetch the sources of the packages, but don't build or install anything."
+  in
   let restore =
     mk_flag ~cli cli_original ["restore"]
       "Attempt to restore packages that were marked for installation but have \
@@ -1545,7 +1549,7 @@ let install cli =
   let install
       global_options build_options add_to_roots deps_only ignore_conflicts
       restore destdir assume_built check recurse subpath depext_only
-      atoms_or_locals () =
+      download_only atoms_or_locals () =
     apply_global_options global_options;
     apply_build_options build_options;
     if atoms_or_locals = [] && not restore then
@@ -1606,7 +1610,7 @@ let install cli =
     let st =
       OpamClient.install st atoms
         ~autoupdate:pure_atoms ?add_to_roots ~deps_only ~ignore_conflicts
-        ~assume_built ~depext_only
+        ~assume_built ~depext_only ~download_only
     in
     match destdir with
     | None -> `Ok ()
@@ -1619,7 +1623,7 @@ let install cli =
     Term.(const install $global_options cli $build_options cli
           $add_to_roots $deps_only $ignore_conflicts $restore $destdir
           $assume_built cli $check $recurse cli $subpath cli $depext_only
-          $atom_or_local_list)
+          $download_only $atom_or_local_list)
 
 (* REMOVE *)
 let remove_doc = "Remove a list of packages."
@@ -2701,7 +2705,8 @@ let switch cli =
            if no_action || OpamFormula.satisfies_depends st.installed invariant
            then st
            else OpamClient.install_t
-               st ~ask:true [] None ~deps_only:false ~assume_built:false
+               st ~ask:true [] None
+               ~deps_only:false ~assume_built:false
          in
          OpamSwitchState.drop st;
          `Ok ())

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1163,7 +1163,7 @@ let apply ?ask t ~requested ?add_roots ?(assume_built=false)
         OpamConsole.msg "===== %s =====\n" (OpamSolver.string_of_stats stats);
     );
     if not OpamClientConfig.(!r.show) &&
-       confirmation ?ask requested action_graph
+       (download_only || confirmation ?ask requested action_graph)
     then (
       let t =
         install_depexts t @@ OpamPackage.Set.inter

--- a/src/client/opamSolution.mli
+++ b/src/client/opamSolution.mli
@@ -34,6 +34,7 @@ val apply:
   requested:OpamPackage.Name.Set.t ->
   ?add_roots:OpamPackage.Name.Set.t ->
   ?assume_built:bool ->
+  ?download_only:bool ->
   ?force_remove:bool ->
   OpamSolver.solution ->
   rw switch_state * solution_result
@@ -52,6 +53,7 @@ val resolve_and_apply:
   requested:OpamPackage.Name.Set.t ->
   ?add_roots:OpamPackage.Name.Set.t ->
   ?assume_built:bool ->
+  ?download_only:bool ->
   ?force_remove:bool ->
   atom request ->
   rw switch_state * (solution_result, OpamCudf.conflict) result


### PR DESCRIPTION
This implements #4036  (cc @kit-ty-kate ).

This is still WIP because even when using the option, we get the usual message:
```
The following actions will be performed:
  ∗ install dune            2.1.3
  ∗ install conf-gmp        1      [required by z3]
...
===== ∗ 9 =====
Do you want to continue? [Y/n]
```

It would be better to recall explicitly at this point that in fact, this will only fetch the sources of the packages. I'm not sure how to do it though, in part because this message is currently printed using the graph before the build and fetch actions are made explicit, so we only have install/remove/reinstall/(change?) actions.