### PR TITLE
[docs] Fixed git command in packaging docs

### DIFF
--- a/doc/pages/Packaging.md
+++ b/doc/pages/Packaging.md
@@ -77,7 +77,7 @@ publish --help` for more options.
 First tag the project. Assuming this is version 0.1:
 ```
 git tag -a 0.1
-git push 0.1
+git push origin 0.1
 ```
 Alternatively, you can create a release using the web UI
 (https://github.com/USER/REPO/releases/new).


### PR DESCRIPTION
Currently [the docs](https://opam.ocaml.org/doc/Packaging.html) suggest to do
```
git tag -a 0.1
git push 0.1
```
I think the second command should be `git push origin 0.1` (`git push 0.1` tries to push to repository called 0.1).
