### PR TITLE
repo: on add error, display also the parsed url

### DIFF
--- a/src/client/opamRepositoryCommand.ml
+++ b/src/client/opamRepositoryCommand.ml
@@ -64,18 +64,20 @@ let add rt name url trust_anchors =
     -> rt
   | Some r ->
     OpamConsole.error_and_exit `Bad_arguments
-      "Repository %s is already set up %s. To change that, use 'opam \
-       repository set-url'."
+      "Repository %s is already set up%s. To change that, use 'opam \
+       repository set-url %s %s'."
       (OpamRepositoryName.to_string name)
       (if r.repo_url <> url then
-         "and points to "^OpamUrl.to_string r.repo_url
+         " and points to "^OpamUrl.to_string r.repo_url
        else match r.repo_trust with
-         | None -> "without trust anchors"
+         | None -> " without trust anchors"
          | Some ta ->
-           Printf.sprintf "with trust anchors %s and quorum %d"
+           Printf.sprintf " with trust anchors %s and quorum %d"
              (OpamStd.List.concat_map ~nil:"()" "," String.escaped
                 ta.fingerprints)
              ta.quorum)
+      (OpamRepositoryName.to_string name)
+      (OpamUrl.to_string url)
   | None ->
     let repo = { repo_name = name; repo_url = url;
                  repo_trust = trust_anchors; }


### PR DESCRIPTION
When `repo add name url` fails because of an already registered repo mismatching url, printing also the opam parsed resulting url helps to understand the error origin (missing `//`, etc.)
Fixes #4085 