### PR TITLE
Init: fix sandboxing update & `ni` option

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -765,7 +765,7 @@ let update_with_init_config ?(overwrite=false) config init_config =
     (I.default_compiler init_config)
 
 let reinit ?(init_config=OpamInitDefaults.init_config()) ~interactive
-    ?dot_profile ?update_config ?env_hook ?completion config shell =
+    ?dot_profile ?update_config ?env_hook ?completion ?inplace config shell =
   let root = OpamStateConfig.(!r.root_dir) in
   let config = update_with_init_config config init_config in
   let _all_ok = init_checks ~hard_fail_exn:false init_config in
@@ -784,7 +784,7 @@ let reinit ?(init_config=OpamInitDefaults.init_config()) ~interactive
   in
   OpamEnv.write_custom_init_scripts root custom_init_scripts;
   OpamEnv.setup root ~interactive
-    ?dot_profile ?update_config ?env_hook ?completion shell;
+    ?dot_profile ?update_config ?env_hook ?completion ?inplace shell;
   let gt = OpamGlobalState.load `Lock_write in
   let rt = OpamRepositoryState.load `Lock_write gt in
   OpamConsole.header_msg "Updating repositories";

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -38,9 +38,8 @@ val init:
    (defaults to [OpamInitDefaults.init_config]) for the settings that are unset,
    and updates all repositories *)
 val reinit:
-  ?init_config:OpamFile.InitConfig.t ->
-  interactive:bool ->
-  ?dot_profile:filename -> ?update_config:bool -> ?env_hook:bool -> ?completion:bool ->
+  ?init_config:OpamFile.InitConfig.t -> interactive:bool -> ?dot_profile:filename ->
+  ?update_config:bool -> ?env_hook:bool -> ?completion:bool -> ?inplace:bool ->
   OpamFile.Config.t -> shell -> unit
 
 (** Install the given list of packages. [add_to_roots], if given, specifies that

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -522,7 +522,7 @@ let write_init_shell_scripts root =
   in
   List.iter (write_script (OpamPath.init root)) scripts
 
-let write_static_init_scripts root ?completion ?env_hook () =
+let write_static_init_scripts root ?completion ?env_hook ?(inplace=false) () =
   write_init_shell_scripts root;
   let update_scripts filef scriptf enable =
     let scripts =
@@ -532,13 +532,18 @@ let write_static_init_scripts root ?completion ?env_hook () =
           | _ -> None)
         shells_list
     in
-    match enable with
-    | Some true ->
+    match enable, inplace with
+    | Some true, _ ->
       List.iter (write_script (OpamPath.init root)) scripts
-    | Some false ->
-      List.iter (fun (f,_) -> OpamFilename.remove (OpamPath.init root // f))
+    | _, true ->
+      List.iter (fun ((f,_) as fs) ->
+          if OpamFilename.exists (OpamPath.init root // f) then
+            write_script (OpamPath.init root) fs)
         scripts
-    | None -> ()
+    | Some false, _ ->
+      List.iter (fun (f,_) ->
+          OpamFilename.remove (OpamPath.init root // f)) scripts
+    | None, _ -> ()
   in
   update_scripts complete_file complete_script completion;
   update_scripts env_hook_file env_hook_script env_hook
@@ -658,7 +663,7 @@ let check_and_print_env_warning st =
 
 let setup
     root ~interactive ?dot_profile ?update_config ?env_hook ?completion
-    shell =
+    ?inplace shell =
   let update_dot_profile =
     match update_config, dot_profile, interactive with
     | Some false, _, _ -> None
@@ -716,11 +721,13 @@ let setup
     | Some b, _ -> Some b
     | None, false -> None
     | None, true ->
-      Some
-        (OpamConsole.confirm ~default:false
-           "A hook can be added to opam's init scripts to ensure that the \
-            shell remains in sync with the opam environment when they are \
-            loaded. Set that up?")
+      (* not just interactive mode *)
+      if update_config <> None || completion <> None then None else
+          Some
+          (OpamConsole.confirm ~default:false
+             "A hook can be added to opam's init scripts to ensure that the \
+              shell remains in sync with the opam environment when they are \
+              loaded. Set that up?")
   in
   update_user_setup root ?dot_profile:update_dot_profile shell;
-  write_static_init_scripts root ?completion ?env_hook ()
+  write_static_init_scripts root ?completion ?env_hook ?inplace ()

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -86,7 +86,7 @@ val full_with_path:
     and asking the user if either [update_config] or [shell_hook] are unset *)
 val setup:
   dirname -> interactive:bool -> ?dot_profile:filename ->
-  ?update_config:bool -> ?env_hook:bool -> ?completion:bool ->
+  ?update_config:bool -> ?env_hook:bool -> ?completion:bool -> ?inplace:bool ->
   shell -> unit
 
 (* (\** Display the global and user configuration for OPAM. *\)
@@ -98,9 +98,10 @@ val update_user_setup:
 
 (** Write the generic scripts in ~/.opam/opam-init needed to import state for
     various shells. If specified, completion and env_hook files can also be
-    written or removed (the default is to keep them as they are) *)
+    written or removed (the default is to keep them as they are). If [inplace]
+    is true, they are updated if they exist. *)
 val write_static_init_scripts:
-  dirname -> ?completion:bool -> ?env_hook:bool -> unit -> unit
+  dirname -> ?completion:bool -> ?env_hook:bool -> ?inplace:bool -> unit -> unit
 
 (** Write into [OpamPath.hooks_dir] the given custom scripts (listed as
     (filename, content)), normally provided by opamrc ([OpamFile.InitConfig]) *)


### PR DESCRIPTION
* Sandboxing update broken in case an matching hash file is present
* When using `-ni` , completion & env hook files were removed