### PR TITLE
Use proper module names

### DIFF
--- a/src/client/dune
+++ b/src/client/dune
@@ -2,7 +2,7 @@
   (name        opam_client)
   (public_name opam-client)
   (synopsis    "OCaml Package Manager client and CLI library")
-  (modules     (:standard \ opamMain get-git-version))
+  (modules     (:standard \ opamMain get_git_version))
   (libraries   opam-state opam-solver re cmdliner)
   (flags       (:standard
                (:include ../ocaml-flags-standard.sexp)
@@ -41,10 +41,10 @@
   (action  (ignore-stderr (with-stdout-to %{targets} (system "git rev-parse --quiet --verify HEAD || echo .")))))
 
 (rule
-  (with-stdout-to get-git-version.ml (echo "print_string @@ let v = \"%{read-lines:git-sha}\" in if v = \".\" then \"let version = None\" else \"let version = Some \\\"\" ^ v ^ \"\\\"\"")))
+  (with-stdout-to get_git_version.ml (echo "print_string @@ let v = \"%{read-lines:git-sha}\" in if v = \".\" then \"let version = None\" else \"let version = Some \\\"\" ^ v ^ \"\\\"\"")))
 
 (rule
-  (with-stdout-to opamGitVersion.ml (run ocaml %{dep:get-git-version.ml})))
+  (with-stdout-to opamGitVersion.ml (run ocaml %{dep:get_git_version.ml})))
 
 (rule
   (targets linking.sexp)


### PR DESCRIPTION
get-git-version isn't a proper module name. This commit switches it into
a valid module name.

In 2.3.0, dune main validation more strict. So we ended up accidentally
breaking this. Opam should not rely on this.