### PR TITLE
Re-enable (opam) developper mode repository cache check

### DIFF
--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -32,7 +32,8 @@ module Cache = struct
       let b = Bytes.create magic_len in
       really_input ic b 0 magic_len;
       Bytes.to_string b in
-    if file_magic <> this_magic then (
+    if not OpamCoreConfig.developer &&
+      file_magic <> this_magic then (
       log "Bad cache: incompatible magic string %S (expected %S)."
         file_magic this_magic;
       None


### PR DESCRIPTION
Revert "repo state cache: disable developer mode check"
This reverts #3795