### PR TITLE
Update mccs

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -281,7 +281,7 @@ if [ "$TRAVIS_BUILD_STAGE_NAME" = "Hygiene" ] ; then
   cd src_ext
   ../shell/re-patch.sh
   if [[ $(find patches -name \*.old | wc -l) -ne 0 ]] ; then
-    echo -e "[\e[31mERROR\e[0m] ../shell/re-patch.sh should be run from src_ext"
+    echo -e "[\e[31mERROR\e[0m] ../shell/re-patch.sh should be run from src_ext before CI check"
     git diff
     ERROR=1
   fi

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -33,8 +33,8 @@ MD5_dose3 = e7d4b1840383c6732f29a47c08ba5650
 
 $(call PKG_SAME,dose3)
 
-URL_mccs = https://github.com/AltGr/ocaml-mccs/archive/1.1+10.tar.gz
-MD5_mccs = 21fa1652179d47baebd2e3f3cfdbf1d7
+URL_mccs = https://github.com/AltGr/ocaml-mccs/archive/1.1+11.tar.gz
+MD5_mccs = 9c0038d0e945f742b9320a662566288b
 
 $(call PKG_SAME,mccs)
 

--- a/src_ext/patches/mccs/0001-Fix-operator-requiring-const-specifier-in-C-17.patch
+++ b/src_ext/patches/mccs/0001-Fix-operator-requiring-const-specifier-in-C-17.patch
@@ -1,0 +1,23 @@
+From 8b037cbf9f1bd93543573a2420bb6a804d3a8d86 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Antonin=20D=C3=A9cimo?= <antonin.decimo@gmail.com>
+Date: Sat, 14 Mar 2020 17:27:25 +0100
+Subject: [PATCH] Fix operator requiring const specifier in C++17
+
+Close #27
+---
+ src/cudf.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/cudf.h b/src/cudf.h
+index c68753c..23d4ae8 100644
+--- a/src/cudf.h
++++ b/src/cudf.h
+@@ -118,7 +118,7 @@ class CUDFVersionedPackage: public CUDFPackage {
+ // Compares two versioned package (used by ordered set packages likes CUDFVersionedPackageSet)
+ class CUDFPackage_comparator {
+ public:
+-  bool operator()(CUDFVersionedPackage *p1, CUDFVersionedPackage *p2) {
++  bool operator()(CUDFVersionedPackage *p1, CUDFVersionedPackage *p2) const {
+     if (p1->version < p2->version)
+       return true;
+     else

--- a/src_ext/patches/mccs/0001-Fix-operator-requiring-const-specifier-in-C-17.patch
+++ b/src_ext/patches/mccs/0001-Fix-operator-requiring-const-specifier-in-C-17.patch
@@ -1,18 +1,7 @@
-From 8b037cbf9f1bd93543573a2420bb6a804d3a8d86 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Antonin=20D=C3=A9cimo?= <antonin.decimo@gmail.com>
-Date: Sat, 14 Mar 2020 17:27:25 +0100
-Subject: [PATCH] Fix operator requiring const specifier in C++17
-
-Close #27
----
- src/cudf.h | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/src/cudf.h b/src/cudf.h
-index c68753c..23d4ae8 100644
---- a/src/cudf.h
-+++ b/src/cudf.h
-@@ -118,7 +118,7 @@ class CUDFVersionedPackage: public CUDFPackage {
+diff -Naur a/src/cudf.h b/src/cudf.h
+--- a/src/cudf.h	2019-12-11 16:55:17.000000000 +0000
++++ b/src/cudf.h	2020-03-27 13:29:20.497173037 +0000
+@@ -118,7 +118,7 @@
  // Compares two versioned package (used by ordered set packages likes CUDFVersionedPackageSet)
  class CUDFPackage_comparator {
  public:


### PR DESCRIPTION
Turns out mcss was updated for 2.0.6, but not on the master branch. Also, MSVC and G++ in C++17 mode won’t compile mccs without the second patch. I have opened a PR: https://github.com/AltGr/ocaml-mccs/pull/29.