### PR TITLE
ensure that Env.get is initialized lazily, not before .init functions are called

### DIFF
--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -572,9 +572,9 @@ let verbose_print_cmd p =
      else Printf.sprintf " (CWD=%s)" p.p_cwd)
 
 let verbose_print_out =
-  let pfx = OpamConsole.colorise `yellow "- " in
+  let pfx = lazy (OpamConsole.colorise `yellow "- ") in
   fun s ->
-    OpamConsole.msg "%s%s\n" pfx s
+    OpamConsole.msg "%s%s\n" (Lazy.force pfx) s
 
 (** Semi-synchronous printing of the output of a command *)
 let set_verbose_f, print_verbose_f, isset_verbose_f, stop_verbose_f =

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -132,10 +132,10 @@ let atom2cudf _universe (version_map : int OpamPackage.Map.t) (name,cstr) =
 
 let lag_function =
   let exp =
-    OpamStd.Option.default 1 (OpamStd.Config.env_int "VERSIONLAGPOWER")
+    lazy (OpamStd.Option.default 1 (OpamStd.Config.env_int "VERSIONLAGPOWER"))
   in
   let rec power n x = if n <= 0 then 1 else x * power (n-1) x in
-  power exp
+  fun x -> power (Lazy.force exp) x
 
 let opam2cudf universe version_map packages =
   let set_to_bool_map set =


### PR DESCRIPTION
(joint work with Armaël Guéneau)

OpamStd.Env.get is opam's entry point to access the process
environment. It caches the whole environment lazily, on the first
environment access. Most environment-accessing parts of the code are
written with carefully placed lazy thunks, to ensure that they are
computed on first need (when the .init functions are called) rather
than at module initialization. This PR fixes a few places that would
still force the environment at module-initialization time.

This is important for programs that would like to modify the
environment (using Unix.putenv) before calling opam-lib functions, and
ensure that opam functions do see the modified environment. Before
this commit, the environment was cached at module-loading time and
could never be modified by user code.

We had to change the definition of `OpamSys.home ()` slightly: this
function is forced at module-initialization time
(in OpamStateConfig.default) in a way that seems hard to remove, so
this function now makes a direct call to `Unix.getenv` instead of
going through the `Env` cache.

(This changes slightly its semantics as previously, on Windows,
environment lookup would happen modulo-case, so the user would be able
to put "Home" or "home" in their environment. We believe that this is
acceptable -- most Windows user do not have a HOME environment
variable at all anyway.)

We think it would be nice to have a testsuite item to ensure that the
environment remains loaded lazily (not before .init() functions
are called), but we are not completely sure where/how to write this
testcase, so would rather leave this part to someone else.