### PR TITLE
Makefile: add --profile=$(DUNE_PROFILE) to remaning invocations of dune

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,11 @@ ifneq ($(LIBINSTALL_DIR),)
 endif
 
 opam-devel.install: $(DUNE_DEP)
-	$(DUNE) build $(DUNE_ARGS) -p opam opam.install
+	$(DUNE) build --profile=$(DUNE_PROFILE) $(DUNE_ARGS) -p opam opam.install
 	sed -e "s/bin:/libexec:/" opam.install > $@
 
 opam-%.install: $(DUNE_DEP)
-	$(DUNE) build $(DUNE_ARGS) -p opam-$* $@
+	$(DUNE) build --profile=$(DUNE_PROFILE) $(DUNE_ARGS) -p opam-$* $@
 
 .PHONY: build-opam-installer
 build-opam-installer: $(DUNE_DEP) 
@@ -169,7 +169,7 @@ crowbar: $(DUNE_DEP)
 .PHONY: crowbar-afl
 # runs the real AFL deal, but needs to be done in a +afl switch
 crowbar-afl: $(DUNE_DEP)
-	dune build src/crowbar/test.exe
+	$(DUNE) build --profile=$(DUNE_PROFILE) $(DUNE_ARGS) src/crowbar/test.exe
 	mkdir -p /tmp/opam-crowbar-input -p /tmp/opam-crowbar-output
 	echo foo > /tmp/opam-crowbar-input/foo
 	afl-fuzz -i /tmp/opam-crowbar-input -o /tmp/opam-crowbar-output dune exec src/crowbar/test.exe @@


### PR DESCRIPTION
observed in https://github.com/ocaml/ocaml-ci-scripts/pull/258 that opam-format on 4.10 fails to install since warnings are treat as errors (see CI log at https://travis-ci.org/github/ocaml/ocaml-ci-scripts/jobs/666251349?utm_medium=notification&utm_source=github_status).

maybe this should be backported to the 2.0 branch and a 2.0.7 being released?