### PR TITLE
Option configuration, v2

### DIFF
--- a/doc/man/opam-topics.inc
+++ b/doc/man/opam-topics.inc
@@ -113,12 +113,12 @@
                  (diff opam-var.err %{dep:opam-var.0}))))
 
 (rule
-  (with-stdout-to opam-set-opt.0 (echo "")))
+  (with-stdout-to opam-option.0 (echo "")))
 (rule
-  (targets opam-set-opt.1 opam-set-opt.err)
-  (action (progn (with-stderr-to opam-set-opt.err
-                   (with-stdout-to opam-set-opt.1 (run %{bin:opam} set-opt --help=groff)))
-                 (diff opam-set-opt.err %{dep:opam-set-opt.0}))))
+  (targets opam-option.1 opam-option.err)
+  (action (progn (with-stderr-to opam-option.err
+                   (with-stdout-to opam-option.1 (run %{bin:opam} option --help=groff)))
+                 (diff opam-option.err %{dep:opam-option.0}))))
 
 (rule
   (with-stdout-to opam-config.0 (echo "")))
@@ -234,7 +234,7 @@
     opam-env.1 
     opam-exec.1 
     opam-var.1 
-    opam-set-opt.1 
+    opam-option.1 
     opam-config.1 
     opam-upgrade.1 
     opam-update.1 

--- a/doc/man/opam-topics.inc
+++ b/doc/man/opam-topics.inc
@@ -105,12 +105,12 @@
                  (diff opam-exec.err %{dep:opam-exec.0}))))
 
 (rule
-  (with-stdout-to opam-var.0 (echo "")))
+  (with-stdout-to opam-config.0 (echo "")))
 (rule
-  (targets opam-var.1 opam-var.err)
-  (action (progn (with-stderr-to opam-var.err
-                   (with-stdout-to opam-var.1 (run %{bin:opam} var --help=groff)))
-                 (diff opam-var.err %{dep:opam-var.0}))))
+  (targets opam-config.1 opam-config.err)
+  (action (progn (with-stderr-to opam-config.err
+                   (with-stdout-to opam-config.1 (run %{bin:opam} config --help=groff)))
+                 (diff opam-config.err %{dep:opam-config.0}))))
 
 (rule
   (with-stdout-to opam-option.0 (echo "")))
@@ -121,12 +121,12 @@
                  (diff opam-option.err %{dep:opam-option.0}))))
 
 (rule
-  (with-stdout-to opam-config.0 (echo "")))
+  (with-stdout-to opam-var.0 (echo "")))
 (rule
-  (targets opam-config.1 opam-config.err)
-  (action (progn (with-stderr-to opam-config.err
-                   (with-stdout-to opam-config.1 (run %{bin:opam} config --help=groff)))
-                 (diff opam-config.err %{dep:opam-config.0}))))
+  (targets opam-var.1 opam-var.err)
+  (action (progn (with-stderr-to opam-var.err
+                   (with-stdout-to opam-var.1 (run %{bin:opam} var --help=groff)))
+                 (diff opam-var.err %{dep:opam-var.0}))))
 
 (rule
   (with-stdout-to opam-upgrade.0 (echo "")))
@@ -233,9 +233,9 @@
     opam-repository.1 
     opam-env.1 
     opam-exec.1 
-    opam-var.1 
-    opam-option.1 
     opam-config.1 
+    opam-option.1 
+    opam-var.1 
     opam-upgrade.1 
     opam-update.1 
     opam-reinstall.1 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -914,9 +914,9 @@ let config ?(option=false) () =
     "unset", `unset, ["VAR"],
     "Deprecated, see $(b,set-var).";
     "set-global", `set_global, ["VAR";"VALUE"],
-    "Deprecated, see $(b,set-opt).";
+    "Deprecated, see $(b,set-var).";
     "unset-global", `unset_global, ["VAR"],
-    "Deprecated, see $(b,set-opt).";
+    "Deprecated, see $(b,set-var).";
    ] in
   let man = [
     `S "DESCRIPTION";

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -986,7 +986,7 @@ let config ?(option=false) () =
         else match cmd with
           | `set_var -> `None_set_var
           | `option -> match args with
-            | [] -> `Switch
+            | [] -> `All
             | f::_ -> OpamConfigCommand.get_scope f
       in
       let apply =
@@ -1007,6 +1007,11 @@ let config ?(option=false) () =
        | `None_set_var ->
          `Error (true, "set-var: no scope defined, \
                         use '--global' or '--switch sw'")
+       | `All ->
+         OpamGlobalState.with_ `Lock_read @@ fun gt ->
+         OpamSwitchState.with_ `Lock_read gt @@ fun st ->
+         OpamConfigCommand.options_list gt st;
+         `Ok ()
        | (`Global | `Switch) as scope ->
          (match cmd, apply with
           | `option, (`empty | `value_wt_eq _ as apply) ->

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -859,8 +859,8 @@ module Var_Option_Common = struct
         "No option named '%s' found. Use 'opam option [--global]' to list them"
         field
     | `All ->
-      OpamGlobalState.with_ `Lock_read @@ fun gt ->
-      OpamSwitchState.with_ `Lock_read gt @@ fun st ->
+      OpamGlobalState.with_ `Lock_none @@ fun gt ->
+      OpamSwitchState.with_ `Lock_none gt @@ fun st ->
       (match cmd with
        | `var -> OpamConfigCommand.vars_list gt st
        | `option -> OpamConfigCommand.options_list gt st);
@@ -871,13 +871,13 @@ module Var_Option_Common = struct
         (match scope with
          | `Switch ->
            OpamGlobalState.with_ `Lock_none @@ fun gt ->
-           OpamSwitchState.with_ `Lock_read gt @@ fun st ->
+           OpamSwitchState.with_ `Lock_none gt @@ fun st ->
            (match cmd with
             | `var -> OpamConfigCommand.vars_list_switch st
             | `option -> OpamConfigCommand.options_list_switch st);
            `Ok ()
          | `Global ->
-           OpamGlobalState.with_ `Lock_read @@ fun gt ->
+           OpamGlobalState.with_ `Lock_none @@ fun gt ->
            (match cmd with
             | `var -> OpamConfigCommand.vars_list_global gt
             | `option -> OpamConfigCommand.options_list_global gt);
@@ -886,13 +886,13 @@ module Var_Option_Common = struct
         (match scope with
          | `Switch ->
            OpamGlobalState.with_ `Lock_none @@ fun gt ->
-           OpamSwitchState.with_ `Lock_read gt @@ fun st ->
+           OpamSwitchState.with_ `Lock_none gt @@ fun st ->
            (match cmd with
             | `var -> OpamConfigCommand.var_show_switch st v
             | `option -> OpamConfigCommand.option_show_switch st v);
            `Ok ()
          | `Global ->
-           OpamGlobalState.with_ `Lock_read @@ fun gt ->
+           OpamGlobalState.with_ `Lock_none @@ fun gt ->
            (match cmd with
             | `var -> OpamConfigCommand.var_show_global gt v
             | `option -> OpamConfigCommand.option_show_global gt v);
@@ -957,8 +957,8 @@ let var =
     | _, None ->
       var_option global global_options `var varvalue
     | None, Some pkg ->
-      OpamGlobalState.with_ `Lock_read @@ fun gt ->
-      OpamSwitchState.with_ `Lock_read gt @@ fun st ->
+      OpamGlobalState.with_ `Lock_none @@ fun gt ->
+      OpamSwitchState.with_ `Lock_none gt @@ fun st ->
       (try `Ok (OpamConfigCommand.list st [pkg])
        with Failure msg -> `Error (false, msg))
     | _, _ ->
@@ -1126,12 +1126,12 @@ let config =
       `Ok (OpamConfigCommand.exec
              gt ~set_opamroot ~set_opamswitch ~inplace_path c)
     | Some `list, [] ->
-      OpamGlobalState.with_ `Lock_read @@ fun gt ->
-      OpamSwitchState.with_ `Lock_read gt @@ fun st ->
+      OpamGlobalState.with_ `Lock_none @@ fun gt ->
+      OpamSwitchState.with_ `Lock_none gt @@ fun st ->
       `Ok (OpamConfigCommand.vars_list gt st)
     | Some `list, params ->
-      OpamGlobalState.with_ `Lock_read @@ fun gt ->
-      OpamSwitchState.with_ `Lock_read gt @@ fun st ->
+      OpamGlobalState.with_ `Lock_none @@ fun gt ->
+      OpamSwitchState.with_ `Lock_none gt @@ fun st ->
       (try `Ok (OpamConfigCommand.list st
                   (List.map OpamPackage.Name.of_string params))
        with Failure msg -> `Error (false, msg))
@@ -1139,8 +1139,8 @@ let config =
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
       `Ok (OpamConfigCommand.expand gt str)
     | Some `var, [var] ->
-      OpamGlobalState.with_ `Lock_read @@ fun gt ->
-      OpamSwitchState.with_ `Lock_read gt @@ fun st ->
+      OpamGlobalState.with_ `Lock_none @@ fun gt ->
+      OpamSwitchState.with_ `Lock_none gt @@ fun st ->
       (try `Ok (OpamConfigCommand.variable st var)
        with Failure msg -> `Error (false, msg))
     | Some `subst, (_::_ as files) ->

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -835,21 +835,7 @@ module Var_Option_Common = struct
 
   let global = mk_flag ["global"] "Act on global configuration"
 
-  let var_value var =
-    let svar = match var with `var -> "VAR" | `field -> "FIELD" in
-    let docv = svar ^ "[(=|+=|-=)[VALUE]]" in
-    let doc =
-      Printf.sprintf
-        "If only $(i,%s) is given, displays its associated value. \
-         If $(i,VALUE) is absent, $(i,%s)'s value is %s. Otherwise, its value \
-         is updated: overwrite (=), append (+=), or remove of an element (-=)."
-        svar svar
-        (match var with `var -> "removed" | `field -> "reverted")
-    in
-    Arg.(value & pos 0 (some string) None & info ~docv ~doc [])
-
   let is_set var = OpamStd.String.contains_char var '='
-
   let var_option global global_options cmd var =
     let scope =
       if global then `Global
@@ -942,7 +928,15 @@ let var =
         This command does not perform any variable expansion.";
   ] in
   let open Var_Option_Common in
-  let varvalue = var_value `var in
+  let varvalue =
+    let docv = "VAR[=[VALUE]]" in
+    let doc =
+      "If only $(i,VAR) is given, displays its associated value. \
+       If $(i,VALUE) is absent, $(i,VAR)'s value is removed. Otherwise, its \
+       value is overwritten."
+    in
+    Arg.(value & pos 0 (some string) None & info ~docv ~doc [])
+  in
   let package =
     mk_opt ["package"] "PACKAGE"
       "List all variables defined for the given package"
@@ -980,7 +974,16 @@ let option =
         display it)."
   ] in
   let open Var_Option_Common in
-  let fieldvalue = var_value `field in
+  let fieldvalue =
+    let docv = "FIELD[(=|+=|-=)[VALUE]]" in
+    let doc =
+      "If only $(i,FIELD) is given, displays its associated value. If \
+       $(i,VALUE) is absent, $(i,FIELD)'s value is reverted. Otherwise, its \
+       value is updated: overwrite (=), append (+=), or remove of an element \
+       (-=)."
+    in
+    Arg.(value & pos 0 (some string) None & info ~docv ~doc [])
+  in
   let option global_options fieldvalue global =
     apply_global_options global_options;
     var_option global global_options `option fieldvalue

--- a/src/client/opamCommands.mli
+++ b/src/client/opamCommands.mli
@@ -49,7 +49,7 @@ val update: command
 val upgrade: command
 
 (** opam config *)
-val config: ?setopt:bool -> unit -> command
+val config: ?option:bool -> unit -> command
 
 (** opam repository *)
 val repository: command

--- a/src/client/opamCommands.mli
+++ b/src/client/opamCommands.mli
@@ -49,7 +49,7 @@ val update: command
 val upgrade: command
 
 (** opam config *)
-val config: ?option:bool -> unit -> command
+val config: command
 
 (** opam repository *)
 val repository: command

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -803,7 +803,7 @@ let print_fields fields =
     |> List.map (fun (name, value) ->
         let value = match value with
           | None -> "{}"
-          | Some value -> (OpamPrinter.value value)
+          | Some value -> (OpamPrinter.Normalise.value value)
         in
         [
           OpamConsole.colorise `bold name ;

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -51,7 +51,8 @@ let help t =
         content % `blue;
         "#"; doc
       ])
-    (OpamVariable.Map.bindings all_global_vars) |>
+    (List.sort (fun (x,_) (x',_) -> compare x x')
+       (OpamVariable.Map.bindings all_global_vars)) |>
   OpamStd.Format.align_table |>
   OpamConsole.print_table stdout ~sep:" ";
 
@@ -69,7 +70,8 @@ let help t =
         OpamVariable.to_string var % `bold;
         OpamVariable.string_of_variable_contents value % `blue;
       ])
-    (global.OpamFile.Switch_config.variables) |>
+    (List.sort (fun (x,_) (x',_) -> compare x' x)
+       global.OpamFile.Switch_config.variables) |>
   OpamStd.Format.align_table |>
   OpamConsole.print_table stdout ~sep:" ";
 

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -568,6 +568,16 @@ let switch_allowed_fields, switch_allowed_sections  =
       [
         ("synopsis", Atomic,
          fun t -> { t with synopsis = empty.synopsis });
+        ("setenv", Modifiable (
+            (fun nc c -> { c with env = nc.env @ c.env }),
+            (fun nc c ->
+               let env =
+                 List.filter (fun (vr,op,vl,_) ->
+                     None = OpamStd.List.find_opt (fun (vr',op',vl',_) ->
+                         vr = vr' && op = op' && vl = vl') nc.env) c.env
+               in
+               { c with env })),
+         fun t -> { t with env = empty.env });
       ] @ allwd_wrappers empty.wrappers wrappers
         (fun wrappers t -> { t with wrappers }))
   in

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -896,9 +896,9 @@ let get_scope field =
     with Invalid_argument _ -> field
   in
   let find l = OpamStd.List.find_opt (fun (f,_) -> f = field) l in
-  if find OpamFile.Config.fields <> None then
-    `Global
-  else if find OpamFile.Switch_config.fields <> None
-       || find OpamFile.Switch_config.sections <> None then
+  if find OpamFile.Switch_config.fields <> None
+  || find OpamFile.Switch_config.sections <> None then
     `Switch
+  else if find OpamFile.Config.fields <> None then
+    `Global
   else `None field

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -588,10 +588,6 @@ let switch_allowed_fields, switch_allowed_sections =
     in
     lazy (
       OpamFile.Switch_config.([
-          ("paths", Modifiable (
-              (fun nc c -> { c with paths = nc.paths @ c.paths }),
-              (fun nc c -> { c with paths = rem_elem nc.paths c.paths })),
-           (fun c -> { c with paths = empty.paths }));
           ("variables", InModifiable (
               (fun nc c -> { c with variables = nc.variables @ c.variables }),
               (fun nc c ->

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -842,3 +842,16 @@ let option_show conf field =
 
 let option_show_switch st field = option_show (confset_switch st) field
 let option_show_global gt field = option_show (confset_global gt) field
+
+let get_scope field =
+  let field =
+    try fst (parse_upd field)
+    with Invalid_argument _ -> field
+  in
+  let find l = OpamStd.List.find_opt (fun (f,_) -> f = field) l in
+  if find OpamFile.Config.fields <> None then
+    `Global
+  else if find OpamFile.Switch_config.fields <> None
+       || find OpamFile.Switch_config.sections <> None then
+    `Switch
+  else `None field

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -830,7 +830,7 @@ let find_section section name_value =
   | [] -> [section, None]
   | section -> List.map (fun (n,v) -> n, Some v) section
 
-let options_list to_list conf =
+let options_list_t to_list conf =
   let name_value = to_list conf.stg_config in
   let fields =
     OpamStd.List.filter_map (fun (field, policy, _) ->
@@ -850,9 +850,16 @@ let options_list to_list conf =
   print_fields (fields @ sections)
 
 let options_list_switch st =
-  options_list OpamFile.Switch_config.to_list (confset_switch st)
+  options_list_t OpamFile.Switch_config.to_list (confset_switch st)
 let options_list_global gt =
-  options_list OpamFile.Config.to_list (confset_global gt)
+  options_list_t OpamFile.Config.to_list (confset_global gt)
+
+let options_list gt st =
+  OpamConsole.header_msg "Global configuration";
+  options_list_global gt;
+  OpamConsole.header_msg "Switch configuration (%s)"
+    (OpamSwitch.to_string st.switch);
+  options_list_switch st
 
 let option_show to_list conf field =
   match OpamStd.List.assoc_opt field conf.stg_fields with

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -76,6 +76,7 @@ val set_var_switch:
 (** List switch or global fields/sections and their value *)
 val options_list_switch: ro switch_state -> unit
 val options_list_global: ro global_state -> unit
+val options_list       : ro global_state -> ro switch_state -> unit
 
 (** Display [field] name and content in the global or switch configuration *)
 val option_show_switch: ro switch_state -> string -> unit

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -35,10 +35,10 @@ val print_eval_env: csh:bool -> sexp:bool -> fish:bool -> env -> unit
 (** Display the content of all available variables; global summary if the list
     is empty, package name "-" is understood as global configuration *)
 val list:
-  'a global_state -> name list -> unit
+  ro global_state -> name list -> unit
 
 (** Display the content of a given variable *)
-val variable: 'a global_state -> full_variable -> unit
+val variable: ro global_state -> full_variable -> unit
 
 (** Substitute files *)
 val subst: 'a global_state -> basename list -> unit
@@ -70,9 +70,9 @@ val set_opt_switch: rw switch_state -> string -> rw switch_state
     field in global config and `variables` field in switch config, by appending
     the new variables to current set *)
 val set_var_global:
-  rw global_state -> string -> string option -> rw global_state
+  rw global_state -> string -> rw global_state
 val set_var_switch:
-  rw switch_state -> string -> string option -> rw switch_state
+  rw switch_state -> string -> rw switch_state
 
 (** List switch and/or global fields/sections and their value *)
 val options_list       : ro global_state -> ro switch_state -> unit
@@ -83,6 +83,7 @@ val options_list_global: ro global_state -> unit
 val option_show_switch: ro switch_state -> string -> unit
 val option_show_global: ro global_state -> string -> unit
 
-(** Given an `opam config option` field or field-value argument, detect the
-    scope, switch, global or inexistent field *)
+(** Given an `opam option` field or field-value argument, detect the scope,
+    switch, global or inexistent field
+    (cf. [OpamCommands.Var_Option_Common.var_option]) *)
 val get_scope: string -> [> `Switch | `Global | `None of string ]

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -46,6 +46,12 @@ val subst: 'a global_state -> basename list -> unit
 (** Prints expansion of variables in string *)
 val expand: 'a global_state -> string -> unit
 
+(** Execute a command in a subshell, after variable expansion *)
+val exec:
+  [< unlocked ] global_state ->
+  ?set_opamroot:bool -> ?set_opamswitch:bool -> inplace_path:bool ->
+  string list -> unit
+
 (** [set_opt_global gt field_value] updates global config field with value
     (using prefix '+=', '-=', '=') in <opamroot>/config file. Modifiable fields
     are a subset of all defined fields in [OpamFile.Config.t]. [field_value] is
@@ -66,9 +72,3 @@ val set_var_global:
   rw global_state -> string -> string option -> rw global_state
 val set_var_switch:
   rw switch_state -> string -> string option -> rw switch_state
-
-(** Execute a command in a subshell, after variable expansion *)
-val exec:
-  [< unlocked ] global_state ->
-  ?set_opamroot:bool -> ?set_opamswitch:bool -> inplace_path:bool ->
-  string list -> unit

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -58,7 +58,8 @@ val exec:
     a string of the form "field[(+=|-=|=)value]". In the case where it contains
     only the field name, field is reverted to its initial value as defined in
     [OpamInitDefaults.init_config], to default value otherwise
-    ([OpamFile.Config.empty]).*)
+    ([OpamFile.Config.empty]).
+    May raise [Invalid_argument] or [OpamStd.Sys.Exit 2]. *)
 val set_opt_global: rw global_state -> string -> rw global_state
 
 (** As [set_opt_global], [set_opt_switch] updates switch config file in

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -72,3 +72,11 @@ val set_var_global:
   rw global_state -> string -> string option -> rw global_state
 val set_var_switch:
   rw switch_state -> string -> string option -> rw switch_state
+
+(** List switch or global fields/sections and their value *)
+val options_list_switch: ro switch_state -> unit
+val options_list_global: ro global_state -> unit
+
+(** Display [field] name and content in the global or switch configuration *)
+val option_show_switch: ro switch_state -> string -> unit
+val option_show_global: ro global_state -> string -> unit

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -33,10 +33,10 @@ val ensure_env: 'a global_state -> switch -> unit
 val print_eval_env: csh:bool -> sexp:bool -> fish:bool -> env -> unit
 
 (** Display the content of all available packages variables *)
-val list: ro switch_state -> name list -> unit
+val list: unlocked switch_state -> name list -> unit
 
 (** Display the content of a given variable, deprecated *)
-val variable: ro switch_state -> string -> unit
+val variable: unlocked switch_state -> string -> unit
 
 (** Substitute files *)
 val subst: 'a global_state -> basename list -> unit
@@ -88,22 +88,22 @@ val set_var_switch:
   rw switch_state -> string -> whole_op -> rw switch_state
 
 (** List switch and/or global fields/sections and their value *)
-val options_list       : ro global_state -> ro switch_state -> unit
-val options_list_global: ro global_state -> unit
-val options_list_switch: ro switch_state -> unit
+val options_list       : unlocked global_state -> unlocked switch_state -> unit
+val options_list_global: unlocked global_state -> unit
+val options_list_switch: unlocked switch_state -> unit
 
 (** List switch and/or global variables and their value *)
-val vars_list       : ro global_state -> ro switch_state -> unit
-val vars_list_global: ro global_state -> unit
-val vars_list_switch: ro switch_state -> unit
+val vars_list       : unlocked global_state -> unlocked switch_state -> unit
+val vars_list_global: unlocked global_state -> unit
+val vars_list_switch: unlocked switch_state -> unit
 
 (** Display [field] name and content in the global or switch configuration *)
-val option_show_global: ro global_state -> string -> unit
-val option_show_switch: ro switch_state -> string -> unit
+val option_show_global: unlocked global_state -> string -> unit
+val option_show_switch: unlocked switch_state -> string -> unit
 
 (** Display [var] name and content in the global or switch configuration *)
-val var_show_global: ro global_state -> string -> unit
-val var_show_switch: ro switch_state -> string -> unit
+val var_show_global: unlocked global_state -> string -> unit
+val var_show_switch: unlocked switch_state -> string -> unit
 
 (** Given an `opam option` field or field-value argument, detect the scope,
     switch, global or inexistent field

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -80,3 +80,7 @@ val options_list_global: ro global_state -> unit
 (** Display [field] name and content in the global or switch configuration *)
 val option_show_switch: ro switch_state -> string -> unit
 val option_show_global: ro global_state -> string -> unit
+
+(** Given an `opam config option` field or field-value argument, detect the
+    scope, switch, global or inexistent field *)
+val get_scope: string -> [> `Switch | `Global | `None of string ]

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -73,10 +73,10 @@ val set_var_global:
 val set_var_switch:
   rw switch_state -> string -> string option -> rw switch_state
 
-(** List switch or global fields/sections and their value *)
+(** List switch and/or global fields/sections and their value *)
+val options_list       : ro global_state -> ro switch_state -> unit
 val options_list_switch: ro switch_state -> unit
 val options_list_global: ro global_state -> unit
-val options_list       : ro global_state -> ro switch_state -> unit
 
 (** Display [field] name and content in the global or switch configuration *)
 val option_show_switch: ro switch_state -> string -> unit

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -35,8 +35,8 @@ val print_eval_env: csh:bool -> sexp:bool -> fish:bool -> env -> unit
 (** Display the content of all available packages variables *)
 val list: ro switch_state -> name list -> unit
 
-(** Display the content of a given variable *)
-val variable: ro global_state -> full_variable -> unit
+(** Display the content of a given variable, deprecated *)
+val variable: ro switch_state -> string -> unit
 
 (** Substitute files *)
 val subst: 'a global_state -> basename list -> unit
@@ -94,12 +94,16 @@ val options_list_switch: ro switch_state -> unit
 
 (** List switch and/or global variables and their value *)
 val vars_list       : ro global_state -> ro switch_state -> unit
-val vars_list_global: ro global_state -> ro switch_state -> unit
+val vars_list_global: ro global_state -> unit
 val vars_list_switch: ro switch_state -> unit
 
 (** Display [field] name and content in the global or switch configuration *)
 val option_show_global: ro global_state -> string -> unit
 val option_show_switch: ro switch_state -> string -> unit
+
+(** Display [var] name and content in the global or switch configuration *)
+val var_show_global: ro global_state -> string -> unit
+val var_show_switch: ro switch_state -> string -> unit
 
 (** Given an `opam option` field or field-value argument, detect the scope,
     switch, global or inexistent field

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -32,10 +32,8 @@ val ensure_env: 'a global_state -> switch -> unit
     compute it from a switch state *)
 val print_eval_env: csh:bool -> sexp:bool -> fish:bool -> env -> unit
 
-(** Display the content of all available variables; global summary if the list
-    is empty, package name "-" is understood as global configuration *)
-val list:
-  ro global_state -> name list -> unit
+(** Display the content of all available packages variables *)
+val list: ro switch_state -> name list -> unit
 
 (** Display the content of a given variable *)
 val variable: ro global_state -> full_variable -> unit
@@ -91,12 +89,17 @@ val set_var_switch:
 
 (** List switch and/or global fields/sections and their value *)
 val options_list       : ro global_state -> ro switch_state -> unit
-val options_list_switch: ro switch_state -> unit
 val options_list_global: ro global_state -> unit
+val options_list_switch: ro switch_state -> unit
+
+(** List switch and/or global variables and their value *)
+val vars_list       : ro global_state -> ro switch_state -> unit
+val vars_list_global: ro global_state -> ro switch_state -> unit
+val vars_list_switch: ro switch_state -> unit
 
 (** Display [field] name and content in the global or switch configuration *)
-val option_show_switch: ro switch_state -> string -> unit
 val option_show_global: ro global_state -> string -> unit
+val option_show_switch: ro switch_state -> string -> unit
 
 (** Given an `opam option` field or field-value argument, detect the scope,
     switch, global or inexistent field

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -143,6 +143,10 @@ module OpamList = struct
     | l when index <= 0 -> value :: l
     | x::l -> x :: insert_at (index - 1) value l
 
+  let rec assoc_opt x = function
+      [] -> None
+    | (a,b)::l -> if compare a x = 0 then Some b else assoc_opt x l
+
   let pick_assoc x l =
     let rec aux acc = function
       | [] -> None, l

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1256,6 +1256,23 @@ module OpamFormat = struct
     | [a;b] -> Printf.sprintf "%s %s %s" a last b
     | h::t  -> Printf.sprintf "%s, %s" h (pretty_list t)
 
+  let as_aligned_table ?(width=OpamSys.terminal_columns ()) l =
+    let itlen =
+      List.fold_left (fun acc s -> max acc (visual_length s))
+        0 l
+    in
+    let by_line = (width + 1) / (itlen + 1) in
+    if by_line <= 1 then
+      List.map (fun x -> [x]) l
+    else
+    let rec aux rline n = function
+      | [] -> [List.rev rline]
+      | x::r ->
+        if n = 0 then List.rev rline :: aux [] by_line r
+        else aux (x :: rline) (n-1) r
+    in
+    align_table (aux [] by_line l)
+
 end
 
 

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -200,6 +200,9 @@ module List : sig
       end if index < 0 or > length respectively). Not tail-recursive *)
   val insert_at: int -> 'a -> 'a list -> 'a list
 
+  (** Like [List.find], but returning option instead of raising *)
+  val assoc_opt: 'a -> ('a * 'b) list -> 'b option
+
   (** Like [List.assoc], but as an option, and also returns the list with the
       binding removed, e.g. equivalent to
       [(List.assoc_opt x l, List.remove_assoc x l)]

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -302,6 +302,10 @@ module Format : sig
   (** Display a pretty list: ["x";"y";"z"] -> "x, y and z".
       "and" can be changed by specifying [last] *)
   val pretty_list: ?last:string -> string list -> string
+
+  (** Splits a list of strings so that it can be printed as a table that should
+      fit on screen *)
+  val as_aligned_table: ?width:int -> string list -> string list list
 end
 
 module Exn : sig

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1124,8 +1124,11 @@ module ConfigSyntax = struct
     default_compiler = OpamFormula.Empty;
   }
 
-  (* When adding a field or section, make sure to add it in
-     [OpamConfigCommand.set_opt_global_t] if it is a user modifiable field *)
+  (* When adding a field, make sure to add it in
+     [OpamConfigCommand.global_allowed_fields] if it is a user modifiable field.
+     When creating sections, make sure to update
+     [OpamConfigCommand.global_allowed_sections] and
+     [OpamConfigCommand.get_scope]. *)
   let fields =
     let with_switch sw t =
       if t.switch = None then with_switch sw t
@@ -1515,7 +1518,9 @@ module Switch_configSyntax = struct
   }
 
   (* When adding a field or section, make sure to add it in
-     [OpamConfigCommand.set_opt_switch] if it is a user modifiable field *)
+     [OpamConfigCommand.switch_allowed_fields] and
+     [OpamConfigCommand.switch_allowed_sections] if it is a user modifiable
+     field *)
   let sections = [
     "paths", Pp.ppacc
       (fun paths t -> {t with paths}) (fun t -> t.paths)

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -183,6 +183,7 @@ module MakeIO (F : IO_Arg) = struct
 
   let write_to_string ?(filename=dummy_file) t =
     F.to_string filename t
+
 end
 
 (** I - Raw text files (no parsing) *)
@@ -864,6 +865,25 @@ module Syntax = struct
       (List.rev_append strs
          (if rem = [] then [""] else [OpamPrinter.items rem;""]))
 
+  let contents pp ?(filename=dummy_file) t =
+    Pp.print pp (filename, t)
+
+  let to_list pp ?(filename=dummy_file) t =
+    let rec aux acc pfx = function
+      | Section (_, {section_kind; section_name=None; section_items}) :: r ->
+        aux (aux acc (section_kind :: pfx) section_items) pfx r
+      | Section (_, {section_kind; section_name=Some n; section_items}) :: r ->
+        aux
+          (aux acc (Printf.sprintf "%s(%s)" section_kind n :: pfx)
+             section_items)
+          pfx r
+      | Variable (_, name, value) :: r ->
+        aux (((name :: pfx), value) :: acc) pfx r
+      | [] -> acc
+    in
+    List.rev_map
+      (fun (pfx, value) -> String.concat "." (List.rev pfx), value)
+      (aux [] [] (contents pp ~filename t).file_contents)
 end
 
 module type SyntaxFileArg = sig
@@ -900,6 +920,7 @@ module SyntaxFile(X: SyntaxFileArg) : IO_FILE with type t := X.t = struct
       include X
       include IO
     end)
+
 end
 
 (** (1) Internal files *)
@@ -1222,6 +1243,7 @@ module ConfigSyntax = struct
     Pp.I.fields ~name ~empty fields -|
     Pp.I.show_errors ~name ~strict:OpamCoreConfig.(not !r.safe_mode) ()
 
+  let to_list = Syntax.to_list pp
 end
 module Config = struct
   include ConfigSyntax
@@ -1582,6 +1604,7 @@ module Switch_configSyntax = struct
 
   let wrappers t = t.wrappers
 
+  let to_list = Syntax.to_list pp
 end
 module Switch_config = struct
   include Switch_configSyntax
@@ -2851,25 +2874,9 @@ module OPAMSyntax = struct
     in
     OpamFilename.write filename s
 
-  let contents ?(filename=dummy_file) t =
-    Pp.print pp (filename, t)
+  let contents = Syntax.contents pp
 
-  let to_list ?filename t =
-    let rec aux acc pfx = function
-      | Section (_, {section_kind; section_name=None; section_items}) :: r ->
-        aux (aux acc (section_kind :: pfx) section_items) pfx r
-      | Section (_, {section_kind; section_name=Some n; section_items}) :: r ->
-        aux
-          (aux acc (Printf.sprintf "%s(%s)" section_kind n :: pfx)
-             section_items)
-          pfx r
-      | Variable (_, name, value) :: r ->
-        aux (((name :: pfx), value) :: acc) pfx r
-      | [] -> acc
-    in
-    List.rev_map
-      (fun (pfx, value) -> String.concat "." (List.rev pfx), value)
-      (aux [] [] (contents ?filename t).file_contents)
+  let to_list = Syntax.to_list pp
 
   let print_field_as_syntax field t =
     let field = try List.assoc field alias_fields with Not_found -> field in

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -189,6 +189,10 @@ module Config: sig
 
   val fields: (string * (t, value) OpamPp.field_parser) list
 
+  (** All file fields as print-AST, Fields within sections are
+      accessed through dot-separated paths *)
+  val to_list: ?filename:'a typed_file -> t -> (string * value) list
+
 end
 
 (** Init config file [/etc/opamrc] *)
@@ -915,6 +919,7 @@ module Switch_config: sig
   val wrappers: t -> Wrappers.t
   val sections: (string * (t, (string option * opamfile_item list) list) OpamPp.field_parser) list
   val fields: (string * (t, value) OpamPp.field_parser) list
+  val to_list: ?filename:'a typed_file -> t -> (string * value) list
   include IO_FILE with type t := t
   val oldest_compatible_format_version: OpamVersion.t
 end

--- a/src/format/opamFormula.ml
+++ b/src/format/opamFormula.ml
@@ -637,9 +637,7 @@ let gen_formula l f =
 let formula_of_version_set set subset =
   let module S = OpamPackage.Version.Set in
   match
-    gen_formula
-      (OpamPackage.Version.Set.elements set)
-      (fun x -> OpamPackage.Version.Set.mem x subset)
+    gen_formula (S.elements set) (fun x -> S.mem x subset)
   with
   | Some f -> f
   | None -> invalid_arg "Empty subset"


### PR DESCRIPTION
This _new_ implementation mainly for UI evolution. The `set-opt` subcommand is replaced by the `option` subcommand:
* `opam config option : list modifiable options and their value (by default switch)
* `opam config option foo`: display `foo` value, available for all fields/sections, not only modifiable ones
* `opam config option foo<=|-=|+=>bar`: update `foo` value
* `opam config option foo=`: revert `foo` value

Options can be given to select scope `--global` or `--switch switch`. If not, `opam option` select by default switch, and other subcommands look at the presence of the field/section name in its internal list to determine the scope. 

`set-var` remain unchanged.

EDIT: update options