### PR TITLE
Show errors: bette error handling

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -703,10 +703,7 @@ let show =
   let sort = mk_flag ["sort"] "Sort opam fields" in
   let opam_files_in_dir d =
     match OpamPinned.files_in_source d with
-    | [] ->
-      OpamConsole.warning "No opam files found in %s"
-        (OpamFilename.Dir.to_string d);
-      []
+    | [] -> []
     | l -> List.map (fun (_,f,_) -> f) l
   in
   let pkg_info global_options fields show_empty raw where
@@ -785,6 +782,17 @@ let show =
             | _ -> acc)
           [] atom_locs
       in
+      if opamfs = [] then
+        let dirnames =
+          OpamStd.List.filter_map (function
+              | `Dirname d -> Some (OpamFilename.Dir.to_string d)
+              | _ -> None)
+            atom_locs
+        in
+        OpamConsole.error_and_exit `Not_found "No opam files found at %s"
+          (OpamStd.List.concat_map ", " ~last_sep:" and "
+             (fun x -> x) dirnames )
+      else
       let errors, opams =
         List.fold_left (fun (errors,opams) opamf ->
             try

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -767,8 +767,11 @@ let show =
         OpamAuxCommands.simulate_autopin ~quiet:no_lint ~for_view:true st
           atom_locs
       in
-      OpamListCommand.info st
-        ~fields ~raw ~where ~normalise ~show_empty ~all_versions atoms;
+      if atoms = [] then
+        OpamConsole.error_and_exit `Not_found "No package found"
+      else
+        OpamListCommand.info st
+          ~fields ~raw ~where ~normalise ~show_empty ~all_versions atoms;
       `Ok ()
     | atom_locs, true ->
       if List.exists (function `Atom _ -> true | _ -> false) atom_locs then

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -795,17 +795,16 @@ let show =
           ([],[]) opamfs
       in
       List.iter (fun (f,o) -> print_just_file f o) opams;
-      if errors = [] then
-        `Ok ()
-      else
-      let sgl = List.length errors = 1 in
-      let files = List.map (OpamFile.filename @> OpamFilename.to_string) errors in
-      OpamConsole.error_and_exit `File_error "%s file%s failed to parse:%s"
-        (if sgl then "A" else "Some")
-        (if sgl then "" else "s")
-        (match files with
-         | [f] -> " "^ f
-         | fs -> "\n"^OpamStd.Format.itemize (fun x -> x) fs)
+      (if errors <> [] then
+        let sgl = List.length errors = 1 in
+        let files = List.map (OpamFile.filename @> OpamFilename.to_string) errors in
+        OpamConsole.error "%s file%s failed to parse:%s"
+          (if sgl then "A" else "Some")
+          (if sgl then "" else "s")
+          (match files with
+           | [f] -> " "^ f
+           | fs -> "\n"^OpamStd.Format.itemize (fun x -> x) fs));
+      `Ok ()
   in
   Term.(ret
           (const pkg_info $global_options $fields $show_empty $raw $where

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -804,15 +804,17 @@ let show =
       in
       List.iter (fun (f,o) -> print_just_file f o) opams;
       (if errors <> [] then
-        let sgl = List.length errors = 1 in
-        let files = List.map (OpamFile.filename @> OpamFilename.to_string) errors in
-        OpamConsole.error "%s file%s failed to parse:%s"
-          (if sgl then "A" else "Some")
-          (if sgl then "" else "s")
-          (match files with
-           | [f] -> " "^ f
-           | fs -> "\n"^OpamStd.Format.itemize (fun x -> x) fs));
-      `Ok ()
+         let sgl = match errors with [_] -> true | _ -> false in
+         let files = List.map (OpamFile.filename @> OpamFilename.to_string) errors in
+         OpamConsole.error "Parsing error on%s:%s"
+           (if sgl then "" else "some opam files")
+           (match files with
+            | [f] -> " " ^ f
+            | fs -> "\n"^OpamStd.Format.itemize (fun x -> x) fs));
+      if opams = [] then
+        OpamStd.Sys.exit_because `File_error
+      else
+        `Ok ()
   in
   Term.(ret
           (const pkg_info $global_options $fields $show_empty $raw $where

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -32,9 +32,11 @@ let read_opam_file_for_pinning ?(quiet=false) name f url =
     let dir = OpamFilename.dirname (OpamFile.filename f) in
     (* don't add aux files for [project/opam] *)
     let add_files = OpamUrl.local_dir url = Some dir in
-    OpamStd.Option.map
+    let opam =
       (OpamFormatUpgrade.opam_file_with_aux ~quiet ~dir ~files:add_files
-         ~filename:f) (OpamFile.OPAM.read_opt f)
+         ~filename:f) (OpamFile.OPAM.safe_read f)
+    in
+    if opam = OpamFile.OPAM.empty then None else Some opam
   in
   (match opam0 with
    | None ->


### PR DESCRIPTION
Fixes #3875
Better handling of:
* Empty file
* `--just-file` errors
* No package found

→ can fail with `Not_found`  (5) or `File_error` (30)