### PR TITLE
Better error handling on switch creation

### DIFF
--- a/src/client/opamSwitchCommand.mli
+++ b/src/client/opamSwitchCommand.mli
@@ -14,15 +14,13 @@
 open OpamTypes
 open OpamStateTypes
 
-(** Creates and configures a new switch. The given [global_state] is unlocked as
-    soon as possible, i.e. after registering the existence of the new switch.
-    [update_config] sets the switch as current globally, unless it is
+(** Creates and configures a new switch. The given [global_state] is unlocked
+    once done. [update_config] sets the switch as current globally, unless it is
     external.
 
     [post] can be used to run guarded operations after the switch creation
     (cleanup will be proposed to the user if they fail). You probably want to
-    call [install_compiler] there.
-*)
+    call [install_compiler] there. *)
 val create:
   rw global_state ->
   rt:'a repos_state ->
@@ -31,7 +29,8 @@ val create:
   update_config:bool ->
   invariant:formula ->
   switch ->
-  (rw switch_state -> 'ret) -> 'ret
+  (rw switch_state -> 'ret * rw switch_state) ->
+  'ret * rw switch_state
 
 (** Used to initially install a compiler's base packages, according to its
     invariant. *)

--- a/src/state/opamSwitchAction.ml
+++ b/src/state/opamSwitchAction.ml
@@ -125,18 +125,18 @@ let add_to_reinstall st ~unpinned_only packages =
     OpamFile.PkgList.write reinstall_file reinstall;
   { st with reinstall = lazy (Lazy.force st.reinstall ++ add_reinst_packages) }
 
-let set_current_switch lock gt ~rt switch =
-  if OpamSwitch.is_external switch then
+let set_current_switch gt st =
+  if OpamSwitch.is_external st.switch then
     OpamConsole.error_and_exit `Bad_arguments
       "Can not set external switch '%s' globally. To set it in the current \
        shell use:\n %s"
-      (OpamSwitch.to_string switch)
-      (OpamEnv.eval_string gt ~set_opamswitch:true (Some switch));
-  let config = OpamFile.Config.with_switch switch gt.config in
+      (OpamSwitch.to_string st.switch)
+      (OpamEnv.eval_string gt ~set_opamswitch:true (Some st.switch));
+  let config = OpamFile.Config.with_switch st.switch gt.config in
   let gt = { gt with config } in
   OpamGlobalState.write gt;
-  let rt = { rt with repos_global = gt } in
-  let st = OpamSwitchState.load lock gt rt switch in
+  let rt = { st.switch_repos with repos_global = gt } in
+  let st = { st with switch_global = gt; switch_repos = rt } in
   OpamEnv.write_dynamic_init_scripts st;
   st
 

--- a/src/state/opamSwitchAction.mli
+++ b/src/state/opamSwitchAction.mli
@@ -25,10 +25,9 @@ val create_empty_switch:
     Unless [OpamStateConfig.(!r.dryrun)] *)
 val write_selections: rw switch_state -> unit
 
-(** Updates the defined default switch and loads its state; fails and exits with
-    a message if the switch is external *)
-val set_current_switch:
-  'a lock -> rw global_state -> rt:'b repos_state -> switch -> 'a switch_state
+(** Updates the global default switch to the one corresponding to the given
+    state; fails and exits with a message if the switch is external *)
+val set_current_switch: rw global_state -> 'a switch_state -> 'a switch_state
 
 (** Create the default global_config structure for a switch, including default
     prefix *)


### PR DESCRIPTION
We used to release the lock on ~/.opam/config as soon as possible, but that is 
not really compatible with the facts that:
- we may want to set the switch as default upon creation (this was done early,
 but could lead to no switch getting selected on error)
- we may want to clear the switch upon error (this was done without proper
locking)

So this keeps the global lock during the switch installation, whith the 
following benefits:
- the selected switch is only changed once installation completes, not just
 after creation
- changes to ~/.opam/config are handled safely

The alternative could be to release the lock, then try to acquire it again if 
needed (on error, or for selecting the switch), but we chose the safer
approach. If the user really needs better lock granularity (e.g. creating many
switches in parallel), they could create all switches empty, then populate
them in parallel.

The last solution would be to remove the option to cleanup a partially
installed switch, and just tell the user with the command to properly remove
it.