### PR TITLE
Update Dune to 1.11.4

### DIFF
--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -48,8 +48,8 @@ MD5_result = d3162dbc501a2af65c8c71e0866541da
 
 $(call PKG_SAME,result)
 
-URL_dune-local = https://github.com/ocaml/dune/releases/download/1.10.0/dune-1.10.0.tbz
-MD5_dune-local = 36c5cdffdf4db63022b3b05ee1a0251e
+URL_dune-local = https://github.com/ocaml/dune/archive/1.11.4.tar.gz
+MD5_dune-local = 3c04b502b0b17d60b805b730eefe61a6
 
 $(call PKG_SAME,dune-local)
 


### PR DESCRIPTION
Update Dune to the latest 1.x, after that the build slightly process changes.
For the patch, see https://github.com/ocaml/dune/pull/3325. If the executable path contains spaces, the build process stops. The bug also happens with the current bundled version of Dune.