### PR TITLE
Revert "Add missing Cmdliner.Manpage.escape calls"

### DIFF
--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -36,7 +36,7 @@ let admin_command_man = [
         holding package definition within subdirectories. A 'compilers%s' \
         subdirectory (opam repository format version < 2) will also be used by \
         the $(b,upgrade-format) subcommand."
-       Filename.dir_sep Filename.dir_sep |> Cmdliner.Manpage.escape)
+       Filename.dir_sep Filename.dir_sep)
 ]
 
 let index_command_doc =
@@ -198,7 +198,7 @@ let cache_command =
          info ["link"] ~docv:"DIR" ~doc:
            (Printf.sprintf
              "Create reverse symbolic links to the archives within $(i,DIR), in \
-              the form $(b,DIR%sPKG.VERSION%sFILENAME)." Filename.dir_sep Filename.dir_sep |> Cmdliner.Manpage.escape))
+              the form $(b,DIR%sPKG.VERSION%sFILENAME)." Filename.dir_sep Filename.dir_sep))
   in
   let jobs_arg =
     Arg.(value & opt OpamArg.positive_integer 8 &
@@ -266,7 +266,7 @@ let add_hashes_command =
           "This command scans through package definitions, and add hashes as \
            requested (fetching the archives if required). A cache is generated \
            in %s for subsequent runs."
-          (OpamFilename.Dir.to_string cache_dir |> Cmdliner.Manpage.escape));
+          (OpamFilename.Dir.to_string cache_dir));
   ]
   in
   let hash_kinds = [`MD5; `SHA256; `SHA512] in
@@ -494,7 +494,7 @@ let upgrade_command =
           converts them to repositories suitable for the current opam version. \
           Packages might be created or renamed, and any compilers defined in the \
           old format ('compilers%s' directory) will be turned into packages, \
-          using a pre-defined hierarchy that assumes OCaml compilers." Filename.dir_sep |> Cmdliner.Manpage.escape)
+          using a pre-defined hierarchy that assumes OCaml compilers." Filename.dir_sep)
   ]
   in
   let clear_cache_arg =
@@ -502,7 +502,7 @@ let upgrade_command =
       Printf.sprintf
        "Instead of running the upgrade, clear the cache of archive hashes (held \
         in ~%s.cache), that is used to avoid re-downloading files to obtain \
-        their hashes at every run." Filename.dir_sep |> Cmdliner.Manpage.escape
+        their hashes at every run." Filename.dir_sep
     in
     Arg.(value & flag & info ["clear-cache"] ~doc)
   in
@@ -718,7 +718,7 @@ let env_arg =
            resolved purely from globally defined variables. Note that, unless \
            overridden, variables like 'root' or 'opam-version' may be taken \
            from the current opam installation. What is defined in \
-           $(i,~%s.opam%sconfig) is always ignored." Filename.dir_sep Filename.dir_sep |> Cmdliner.Manpage.escape))
+           $(i,~%s.opam%sconfig) is always ignored." Filename.dir_sep Filename.dir_sep))
 
 let state_selection_arg =
   let docs = OpamArg.package_selection_section in

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -20,7 +20,7 @@ let checked_repo_root () =
   then
     OpamConsole.error_and_exit `Bad_arguments
       "No repository found in current directory.\n\
-       Please make sure there is a \"packages%s\" directory" Filename.dir_sep;
+       Please make sure there is a \"packages%s\" directory" OpamArg.dir_sep;
   repo_root
 
 
@@ -36,7 +36,7 @@ let admin_command_man = [
         holding package definition within subdirectories. A 'compilers%s' \
         subdirectory (opam repository format version < 2) will also be used by \
         the $(b,upgrade-format) subcommand."
-       Filename.dir_sep Filename.dir_sep)
+       OpamArg.dir_sep OpamArg.dir_sep)
 ]
 
 let index_command_doc =
@@ -198,7 +198,8 @@ let cache_command =
          info ["link"] ~docv:"DIR" ~doc:
            (Printf.sprintf
              "Create reverse symbolic links to the archives within $(i,DIR), in \
-              the form $(b,DIR%sPKG.VERSION%sFILENAME)." Filename.dir_sep Filename.dir_sep))
+              the form $(b,DIR%sPKG.VERSION%sFILENAME)."
+             OpamArg.dir_sep OpamArg.dir_sep))
   in
   let jobs_arg =
     Arg.(value & opt OpamArg.positive_integer 8 &
@@ -266,7 +267,7 @@ let add_hashes_command =
           "This command scans through package definitions, and add hashes as \
            requested (fetching the archives if required). A cache is generated \
            in %s for subsequent runs."
-          (OpamFilename.Dir.to_string cache_dir));
+          (OpamArg.escape_path (OpamFilename.Dir.to_string cache_dir)));
   ]
   in
   let hash_kinds = [`MD5; `SHA256; `SHA512] in
@@ -494,7 +495,8 @@ let upgrade_command =
           converts them to repositories suitable for the current opam version. \
           Packages might be created or renamed, and any compilers defined in the \
           old format ('compilers%s' directory) will be turned into packages, \
-          using a pre-defined hierarchy that assumes OCaml compilers." Filename.dir_sep)
+          using a pre-defined hierarchy that assumes OCaml compilers."
+         OpamArg.dir_sep)
   ]
   in
   let clear_cache_arg =
@@ -502,7 +504,7 @@ let upgrade_command =
       Printf.sprintf
        "Instead of running the upgrade, clear the cache of archive hashes (held \
         in ~%s.cache), that is used to avoid re-downloading files to obtain \
-        their hashes at every run." Filename.dir_sep
+        their hashes at every run." OpamArg.dir_sep
     in
     Arg.(value & flag & info ["clear-cache"] ~doc)
   in
@@ -718,7 +720,8 @@ let env_arg =
            resolved purely from globally defined variables. Note that, unless \
            overridden, variables like 'root' or 'opam-version' may be taken \
            from the current opam installation. What is defined in \
-           $(i,~%s.opam%sconfig) is always ignored." Filename.dir_sep Filename.dir_sep))
+           $(i,~%s.opam%sconfig) is always ignored."
+          OpamArg.dir_sep OpamArg.dir_sep))
 
 let state_selection_arg =
   let docs = OpamArg.package_selection_section in

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -406,6 +406,18 @@ let help_sections = [
 ]
 
 (* Converters *)
+
+(* Windows directory separator need to be escaped for manpage *)
+let dir_sep, escape_path =
+  match Filename.dir_sep with
+  | "\\" ->
+    let esc = "\\\\" in
+    esc,
+    fun p ->
+      OpamStd.List.concat_map esc (fun x -> x)
+        (OpamStd.String.split_delim p '\\')
+  | ds -> ds, fun x -> x
+
 let pr_str = Format.pp_print_string
 
 let repository_name =
@@ -442,7 +454,7 @@ let existing_filename_or_dash =
 
 let dirname =
   let parse str = `Ok (OpamFilename.Dir.of_string str) in
-  let print ppf dir = pr_str ppf (OpamFilename.prettify_dir dir) in
+  let print ppf dir = pr_str ppf (escape_path (OpamFilename.prettify_dir dir)) in
   parse, print
 
 let existing_filename_dirname_or_dash =
@@ -871,7 +883,7 @@ let dot_profile_flag =
     (Printf.sprintf
       "Name of the configuration file to update instead of \
        $(i,~%s.profile) or $(i,~%s.zshrc) based on shell detection."
-      Filename.dir_sep Filename.dir_sep)
+      dir_sep dir_sep)
     (Arg.some filename) None
 
 let repo_kind_flag =
@@ -913,7 +925,7 @@ let atom_or_local_list =
     (Printf.sprintf
       "List of package names, with an optional version or constraint, e.g `pkg', \
        `pkg.1.0' or `pkg>=0.5' ; or files or directory names containing package \
-       description, with explicit directory (e.g. `.%sfoo.opam' or `.')" Filename.dir_sep)
+       description, with explicit directory (e.g. `.%sfoo.opam' or `.')" dir_sep)
     atom_or_local
 
 let atom_or_dir_list =
@@ -921,7 +933,7 @@ let atom_or_dir_list =
     (Printf.sprintf
       "List of package names, with an optional version or constraint, e.g `pkg', \
        `pkg.1.0' or `pkg>=0.5' ; or directory names containing package \
-       description, with explicit directory (e.g. `.%ssrcdir' or `.')" Filename.dir_sep)
+       description, with explicit directory (e.g. `.%ssrcdir' or `.')" dir_sep)
     atom_or_dir
 
 let nonempty_atom_list =

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -871,7 +871,7 @@ let dot_profile_flag =
     (Printf.sprintf
       "Name of the configuration file to update instead of \
        $(i,~%s.profile) or $(i,~%s.zshrc) based on shell detection."
-      Filename.dir_sep Filename.dir_sep |> Cmdliner.Manpage.escape)
+      Filename.dir_sep Filename.dir_sep)
     (Arg.some filename) None
 
 let repo_kind_flag =
@@ -913,7 +913,7 @@ let atom_or_local_list =
     (Printf.sprintf
       "List of package names, with an optional version or constraint, e.g `pkg', \
        `pkg.1.0' or `pkg>=0.5' ; or files or directory names containing package \
-       description, with explicit directory (e.g. `.%sfoo.opam' or `.')" Filename.dir_sep |> Cmdliner.Manpage.escape)
+       description, with explicit directory (e.g. `.%sfoo.opam' or `.')" Filename.dir_sep)
     atom_or_local
 
 let atom_or_dir_list =
@@ -921,7 +921,7 @@ let atom_or_dir_list =
     (Printf.sprintf
       "List of package names, with an optional version or constraint, e.g `pkg', \
        `pkg.1.0' or `pkg>=0.5' ; or directory names containing package \
-       description, with explicit directory (e.g. `.%ssrcdir' or `.')" Filename.dir_sep |> Cmdliner.Manpage.escape)
+       description, with explicit directory (e.g. `.%ssrcdir' or `.')" Filename.dir_sep)
     atom_or_dir
 
 let nonempty_atom_list =

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -27,6 +27,13 @@ val mk_opt_all:
   string list -> string -> string ->
   'a Arg.converter -> 'a list Term.t
 
+(* Escaped Windows directory separator. To use instead of [Filename.dir_sep] for
+   manpage strings *)
+val dir_sep: string
+
+(* Escape Windows path *)
+val escape_path: string -> string
+
 (** {2 Flags} *)
 
 (** --short *)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -77,7 +77,8 @@ let global_options =
     mk_flag ~section:global_option_section ["no-self-upgrade"]
       (Printf.sprintf
         "Opam will replace itself with a newer binary found \
-         at $(b,OPAMROOT%sopam) if present. This disables this behaviour." Filename.dir_sep) in
+         at $(b,OPAMROOT%sopam) if present. This disables this behaviour."
+        OpamArg.dir_sep) in
   let self_upgrade no_self_upgrade options =
     let self_upgrade_status =
       if OpamStd.Config.env_string "NOSELFUPGRADE" =
@@ -178,11 +179,11 @@ let init =
           installed, according to the configuration and options. These can be \
           afterwards configured using $(b,opam switch) and $(b,opam \
           repository)."
-         Filename.dir_sep Filename.dir_sep);
+         OpamArg.dir_sep OpamArg.dir_sep);
     `P (Printf.sprintf
          "The initial repository and defaults can be set through a \
           configuration file found at $(i,~%s.opamrc) or $(i,/etc/opamrc)."
-         Filename.dir_sep);
+         OpamArg.dir_sep);
     `P "Additionally, this command allows one to customise some aspects of opam's \
         shell integration, when run initially (avoiding the interactive \
         dialog), but also at any later time.";
@@ -194,7 +195,7 @@ let init =
           through $(i,~%s.opamrc), $(i,/etc/opamrc), or a file supplied with \
           $(i,--config). The default configuration for this version of opam \
           can be obtained using $(b,--show-default-opamrc)."
-         Filename.dir_sep);
+         OpamArg.dir_sep);
   ] @ OpamArg.man_build_option_section
   in
   let compiler =
@@ -274,7 +275,7 @@ let init =
     mk_flag ["no-opamrc"]
       (Printf.sprintf
       "Don't read `/etc/opamrc' or `~%s.opamrc': use the default settings and \
-       the files specified through $(b,--config) only" Filename.dir_sep)
+       the files specified through $(b,--config) only" OpamArg.dir_sep)
   in
   let reinit =
     mk_flag ["reinit"]
@@ -2277,7 +2278,7 @@ let switch =
          package definitions are found locally, the user is automatically \
          prompted to install them after the switch is created unless \
          $(b,--no-install) is specified."
-        Filename.dir_sep OpamSwitch.external_dirname);
+        OpamArg.dir_sep OpamSwitch.external_dirname);
     `P "$(b,opam switch set) sets the default switch globally, but it is also \
         possible to select a switch in a given shell session, using the \
         environment. For that, use $(i,eval \\$(opam env \
@@ -3347,7 +3348,8 @@ let clean =
     mk_flag ["c"; "download-cache"]
       (Printf.sprintf
         "Clear the cache of downloaded files (\\$OPAMROOT%sdownload-cache), as \
-         well as the obsolete \\$OPAMROOT%sarchives, if that exists." Filename.dir_sep Filename.dir_sep)
+         well as the obsolete \\$OPAMROOT%sarchives, if that exists."
+        OpamArg.dir_sep OpamArg.dir_sep)
   in
   let repos =
     mk_flag ["unused-repositories"]

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -77,7 +77,7 @@ let global_options =
     mk_flag ~section:global_option_section ["no-self-upgrade"]
       (Printf.sprintf
         "Opam will replace itself with a newer binary found \
-         at $(b,OPAMROOT%sopam) if present. This disables this behaviour." Filename.dir_sep |> Cmdliner.Manpage.escape) in
+         at $(b,OPAMROOT%sopam) if present. This disables this behaviour." Filename.dir_sep) in
   let self_upgrade no_self_upgrade options =
     let self_upgrade_status =
       if OpamStd.Config.env_string "NOSELFUPGRADE" =
@@ -178,11 +178,11 @@ let init =
           installed, according to the configuration and options. These can be \
           afterwards configured using $(b,opam switch) and $(b,opam \
           repository)."
-         Filename.dir_sep Filename.dir_sep |> Cmdliner.Manpage.escape);
+         Filename.dir_sep Filename.dir_sep);
     `P (Printf.sprintf
          "The initial repository and defaults can be set through a \
           configuration file found at $(i,~%s.opamrc) or $(i,/etc/opamrc)."
-         Filename.dir_sep |> Cmdliner.Manpage.escape);
+         Filename.dir_sep);
     `P "Additionally, this command allows one to customise some aspects of opam's \
         shell integration, when run initially (avoiding the interactive \
         dialog), but also at any later time.";
@@ -194,7 +194,7 @@ let init =
           through $(i,~%s.opamrc), $(i,/etc/opamrc), or a file supplied with \
           $(i,--config). The default configuration for this version of opam \
           can be obtained using $(b,--show-default-opamrc)."
-         Filename.dir_sep |> Cmdliner.Manpage.escape);
+         Filename.dir_sep);
   ] @ OpamArg.man_build_option_section
   in
   let compiler =
@@ -274,7 +274,7 @@ let init =
     mk_flag ["no-opamrc"]
       (Printf.sprintf
       "Don't read `/etc/opamrc' or `~%s.opamrc': use the default settings and \
-       the files specified through $(b,--config) only" Filename.dir_sep |> Cmdliner.Manpage.escape)
+       the files specified through $(b,--config) only" Filename.dir_sep)
   in
   let reinit =
     mk_flag ["reinit"]
@@ -2277,7 +2277,7 @@ let switch =
          package definitions are found locally, the user is automatically \
          prompted to install them after the switch is created unless \
          $(b,--no-install) is specified."
-        Filename.dir_sep OpamSwitch.external_dirname |> Cmdliner.Manpage.escape);
+        Filename.dir_sep OpamSwitch.external_dirname);
     `P "$(b,opam switch set) sets the default switch globally, but it is also \
         possible to select a switch in a given shell session, using the \
         environment. For that, use $(i,eval \\$(opam env \
@@ -3347,7 +3347,7 @@ let clean =
     mk_flag ["c"; "download-cache"]
       (Printf.sprintf
         "Clear the cache of downloaded files (\\$OPAMROOT%sdownload-cache), as \
-         well as the obsolete \\$OPAMROOT%sarchives, if that exists." Filename.dir_sep Filename.dir_sep |> Cmdliner.Manpage.escape)
+         well as the obsolete \\$OPAMROOT%sarchives, if that exists." Filename.dir_sep Filename.dir_sep)
   in
   let repos =
     mk_flag ["unused-repositories"]


### PR DESCRIPTION
This reverts commit 888351728e1e28ddd13ee4de5828e348b6a0bbfa.

This patch makes the cmdliner escapes `$(i,xxx)` appear verbatim in the
man-page. Probably the solution is to replace the file_sep used, or use
another escaping function instead. @dra27 ?