### PR TITLE
config exec: error message if command not found

### DIFF
--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -244,7 +244,9 @@ let exec gt ?set_opamroot ?set_opamswitch ~inplace_path command =
   in
   match OpamSystem.resolve_command ~env cmd with
   | Some cmd -> raise (OpamStd.Sys.Exec (cmd, args, env))
-  | None -> raise (OpamStd.Sys.Exit 127)
+  | None ->
+    OpamConsole.error "Command not found '%s'" cmd;
+    raise (OpamStd.Sys.Exit 127)
 
 
 (** Options and Variables settings *)


### PR DESCRIPTION
fixes #4131 