### PR TITLE
depext: fail hard for BSD distributions that are not supported

### DIFF
--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -129,7 +129,10 @@ let packages_status packages =
             |> OpamSysPkg.Set.of_list
           in
           packages %% installed
-        | _ -> OpamSysPkg.Set.empty
+        | distribution ->
+          Printf.ksprintf failwith
+            "External dependency handling not supported for BSD distribution '%s'."
+            distribution
       in
       installed, packages -- installed, OpamSysPkg.Set.empty
     | "debian" ->


### PR DESCRIPTION
earlier code failed soft by returning the empty set

the same function ends with the following pattern:
```OCaml
    | family ->
      Printf.ksprintf failwith
        "External dependency handling not supported for OS family '%s'."
        family
```

this PR unifies the behaviour for unsupported BSD distributions.