### PR TITLE
depexts: Make package system behaviour consistent accross platforms

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -67,6 +67,8 @@ New option are prefixed with ◈
   * Homebrew: add no auto update env var for install, accept `pkgname` and `pkgnam@version` on query [#4200 @rjbou]
   * Tag packages with missing depexts in Cudf [#4235 @AltGr]
   * Force LC_ALL=C for query commands [#4200 @rjbou]
+  * Put back opam-depext-2.0's behaviour with regards to asking users' consent before installing system packages [#4168 @kit-ty-kate @rjbou]
+  * Add OPAMDEPEXTYES env variable to pass --yes options to system package manaer [#4168 @kit-ty-kate @rjbou]
   * Fix install command dryrun [#4200 @rjbou]
   * ◈ Add --depext-only to install only external dependencies, regardless of config depext status [#4238 @rjbou]
   * Move confirmation message after opam packages install [#4238 @rjbou]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -240,6 +240,7 @@ let help_sections = [
        report` to know the current setting. See also option --criteria";
   `P "$(i,OPAMCUDFFILE file) save the cudf graph to \
       $(i,file)-actions-explicit.dot";
+  `P "$(i,OPAMDEPEXTYES) launch system package managers in non-interactive mode";
   `P "$(i,OPAMCURL) can be used to select a given 'curl' program. See \
       $(i,OPAMFETCH) for more options.";
   `P "$(i,OPAMDEBUG) see options `--debug' and `--debug-level'.";

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -474,7 +474,7 @@ let install_packages_commands_t sys_packages =
   | Macports ->
     ["port", "install"::packages], (* NOTE: Does not have any interactive mode *)
     None
-  | Openbsd -> ["pkg_add", yes ~no:["-I"] ["-i"] packages], None
+  | Openbsd -> ["pkg_add", yes ~no:["-i"] ["-I"] packages], None
   | Suse -> ["zypper", ("install"::yes ["--non-interactive"] packages)], None
 
 let install_packages_commands sys_packages =

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -440,7 +440,8 @@ let packages_status packages =
 
 let install_packages_commands_t sys_packages =
   let yes ?(no=[]) yes r =
-    if OpamCoreConfig.(!r.answer) = Some true then yes @ r else no @ r
+    if OpamStd.Config.env_bool "DEPEXTYES" = Some true then
+      yes @ r else no @ r
   in
   let packages =
     List.map OpamSysPkg.to_string (OpamSysPkg.Set.elements sys_packages)


### PR DESCRIPTION
The new depext system in opam 2.1 has several issues:
* `opam install -y` does not mean `apt-get` will be called with `-yy` anymore, which breaks every CI.
* It's behaviour regarding to whether or not package systems were to ask the user before installing packages has changed from opam-depext 2.0 (see https://github.com/ocaml/opam-depext/blob/2.0/depext.ml#L129)
* This behaviour is not consistent accross platfrom. Meaning some platforms will ask an input from their users by default, and others don't and install anything without any acknowledgement from the user.

What I've done here is the following:
* By default, always ask for user to interactively accept the installation. There are some differences from before: on Gentoo and Alpine, the user was never asked for input on opam-depext2.0.
* If `-y, --yes or OPAMYES=1` is given, never ask the user for any input. There is a minor difference from before on Archlinux (for sure) and BSDs (not quite sure because I don't have any BSD machine)
* The two exceptions are `homebrew` and `macports` which don't have any way of asking the user before installing the packages (at least that I could fine, I don't own any Mac).

Here are the man-pages for all the package systems by order in the code:
* Homebrew: https://docs.brew.sh/Manpage#install-options-formula
* Macports: https://guide.macports.org/chunked/using.html (I couldn't find better docs online)
* Apt-get: https://linux.die.net/man/8/apt-get
* Yum: https://linux.die.net/man/8/yum
* Pkg: https://www.freebsd.org/cgi/man.cgi?query=pkg-install
* Pkg_add: https://man.openbsd.org/pkg_add
* Pacman: https://www.archlinux.org/pacman/pacman.8.html
* Emerge: https://dev.gentoo.org/~zmedico/portage/doc/man/emerge.1.html
* Apk: https://git.alpinelinux.org/apk-tools/tree/doc/apk.8.scd
* Zypper: https://en.opensuse.org/SDB:Zypper_manual_%28plain%29
* https://man.openbsd.org/pkg_add

Can someone with a Mac confirm there is no way of asking for user input before installation a package? cc @mseri 

*Side-note: this PR seems to require https://github.com/ocaml/opam/pull/4152 to be rebased afterwards* cc @rjbou 