### PR TITLE
Update opam file with dune, remove `opam-%-install` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,6 @@ opam-devel.install: $(DUNE_DEP)
 	$(DUNE) build $(DUNE_ARGS) -p opam opam.install
 	sed -e "s/bin:/libexec:/" opam.install > $@
 
-opam-%.install: $(DUNE_DEP)
-	$(DUNE) build $(DUNE_ARGS) -p opam-$* $@
-
 .PHONY: build-opam-installer
 build-opam-installer: $(DUNE_DEP) 
 	$(DUNE) build --profile=$(DUNE_PROFILE) $(DUNE_ARGS)$(DUNE_PROMOTE_ARG) opam-installer.install

--- a/master_changes.md
+++ b/master_changes.md
@@ -4,6 +4,10 @@ note.
 ## Init
   * Remove m4 from the list of recommended tools [#4184 @kit-ty-kate]
 
+## Build
+  * Opam file build using dune, removal of opam-%.install makefile target [#4178 @rjbou - fix #4173]
+  * Use version var in opam file instead of equal current version number in opamlib dependencies [#4178 @rjbou]
+
 ## Switch
   * Fix Not_found with `opam switch create . --deps` [#4151 @AltGr]
 

--- a/opam-client.opam
+++ b/opam-client.opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
-  [make "%{name}%.install"]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "opam-state" {= "2.1.0~alpha"}

--- a/opam-client.opam
+++ b/opam-client.opam
@@ -21,10 +21,10 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "opam-state" {= "2.1.0~alpha"}
-  "opam-solver" {= "2.1.0~alpha"}
+  "opam-state" {= version}
+  "opam-solver" {= version}
   "extlib"
-  "opam-repository" {= "2.1.0~alpha"}
+  "opam-repository" {= version}
   "re" {>= "1.9.0"}
   "cmdliner" {>= "0.9.8"}
   "dune" {build & >= "1.2.1"}

--- a/opam-core.opam
+++ b/opam-core.opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
-  [make "%{name}%.install"]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "base-unix"

--- a/opam-devel.opam
+++ b/opam-devel.opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
-  [make "%{name}%.install"]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 build-test: [make "tests"]
 depends: [

--- a/opam-devel.opam
+++ b/opam-devel.opam
@@ -22,7 +22,7 @@ build: [
 ]
 build-test: [make "tests"]
 depends: [
-  "opam-client" {= "2.1.0~alpha"}
+  "opam-client" {= version}
   "cmdliner" {>= "0.9.8"}
   "dune" {build & >= "1.2.1"}
 ]

--- a/opam-format.opam
+++ b/opam-format.opam
@@ -21,7 +21,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "opam-core" {= "2.1.0~alpha"}
+  "opam-core" {= version}
   "opam-file-format" {>= "2.0.0~rc2"}
   "dune" {build & >= "1.2.1"}
 ]

--- a/opam-format.opam
+++ b/opam-format.opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
-  [make "%{name}%.install"]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "opam-core" {= "2.1.0~alpha"}

--- a/opam-installer.opam
+++ b/opam-installer.opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
-  [make "%{name}%.install"]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "opam-format" {= "2.1.0~alpha"}

--- a/opam-installer.opam
+++ b/opam-installer.opam
@@ -21,7 +21,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "opam-format" {= "2.1.0~alpha"}
+  "opam-format" {= version}
   "cmdliner" {>= "0.9.8"}
   "dune" {build & >= "1.2.1"}
 ]

--- a/opam-repository.opam
+++ b/opam-repository.opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
-  [make "%{name}%.install"]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "opam-format" {= "2.1.0~alpha"}

--- a/opam-repository.opam
+++ b/opam-repository.opam
@@ -21,7 +21,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "opam-format" {= "2.1.0~alpha"}
+  "opam-format" {= version}
   "dune" {build & >= "1.2.1"}
 ]
 available: ocaml-version >= "4.02.3"

--- a/opam-solver.opam
+++ b/opam-solver.opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
-  [make "%{name}%.install"]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "opam-format" {= "2.1.0~alpha"}

--- a/opam-solver.opam
+++ b/opam-solver.opam
@@ -21,7 +21,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "opam-format" {= "2.1.0~alpha"}
+  "opam-format" {= version}
   "mccs" {>= "1.1+9"}
   "dose3" {>= "5"}
   "cudf" {>= "0.7"}

--- a/opam-state.opam
+++ b/opam-state.opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
-  [make "%{name}%.install"]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "opam-repository" {= "2.1.0~alpha"}

--- a/opam-state.opam
+++ b/opam-state.opam
@@ -21,7 +21,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "opam-repository" {= "2.1.0~alpha"}
+  "opam-repository" {= version}
   "dune" {build & >= "1.2.1"}
 ]
 available: ocaml-version >= "4.02.3"


### PR DESCRIPTION
`opam-%s.install` target was only used by opam files, there is no occurrence of their call in the opam source. Are they used in other projects ? @samoht @avsm @dra27

Fix #4173 