### PR TITLE
opam show small fixes

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -1,5 +1,6 @@
 Working version changelog, used as a base for the changelog and the release
 note.
+Possibly scripts breaking changes are prefixed with ✘
 
 ## Admin
   * Fix admin cache synchronisation message [#4193 @rjbou - fix #4167]
@@ -23,6 +24,12 @@ note.
 
 ## Pin
   * Don't keep unpinned package version if it exists in repo [#4073 @rjbou - fix #3630]
+
+## Show
+  * ✘ Display error message for all not found packages [#4179 @rjbou - fix #4164]
+  * ✘ Keep package order given via cli [#4179 @rjbou - fix #4163]
+  * `--sort`` apply to with all options, not only `--just-file` [#4179 @rjbou]
+
 
 ## Depext
   * Fix performance issue of depext under Docker/debian [#4165 @AltGr]

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -774,7 +774,7 @@ let show =
         OpamConsole.error_and_exit `Not_found "No package found"
       else
         OpamListCommand.info st
-          ~fields ~raw ~where ~normalise ~show_empty ~all_versions atoms;
+          ~fields ~raw ~where ~normalise ~show_empty ~all_versions ~sort atoms;
       `Ok ()
     | atom_locs, true ->
       if List.exists (function `Atom _ -> true | _ -> false) atom_locs then

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -716,9 +716,8 @@ let info st ~fields ~raw ~where ?normalise ?(show_empty=false)
     OpamFormula.packages_of_atoms ~disj:all_versions
       (st.packages ++ st.installed) atoms
   in
-  let missing_atoms =
-    OpamStd.List.filter_map (fun ((n,_) as atom) ->
-        if OpamPackage.has_name packages n then None else Some atom) atoms
+  let atoms, missing_atoms =
+    List.partition (fun (n,_) -> OpamPackage.has_name packages n) atoms
   in
   if missing_atoms <> [] then
     (OpamConsole.error "No package matching %s found"
@@ -807,8 +806,7 @@ let info st ~fields ~raw ~where ?normalise ?(show_empty=false)
     | [f] -> OpamConsole.msg "%s\n" (detail_printer ?normalise st pkg f)
     | fields -> output_table fields pkg
   in
-  OpamPackage.names_of_packages packages |>
-  OpamPackage.Name.Set.iter (fun name ->
+  List.iter (fun (name,_) ->
       (* Like OpamSwitchState.get_package, but restricted to [packages] *)
       let nvs = OpamPackage.packages_of_name packages name in
       if all_versions then
@@ -824,4 +822,4 @@ let info st ~fields ~raw ~where ?normalise ?(show_empty=false)
          in
          header choose;
          output_package choose)
-    )
+    ) atoms

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -716,10 +716,16 @@ let info st ~fields ~raw ~where ?normalise ?(show_empty=false)
     OpamFormula.packages_of_atoms ~disj:all_versions
       (st.packages ++ st.installed) atoms
   in
-  if OpamPackage.Set.is_empty packages then
+  let missing_atoms =
+    OpamStd.List.filter_map (fun ((n,_) as atom) ->
+        if OpamPackage.has_name packages n then None else Some atom) atoms
+  in
+  if missing_atoms <> [] then
     (OpamConsole.error "No package matching %s found"
-       (OpamStd.List.concat_map " or " OpamFormula.short_string_of_atom atoms);
-     OpamStd.Sys.exit_because `Not_found);
+       (OpamStd.List.concat_map " or " OpamFormula.short_string_of_atom
+          missing_atoms);
+     if OpamPackage.Set.is_empty packages then
+       OpamStd.Sys.exit_because `Not_found);
   let fields = List.map (field_of_string ~raw) fields in
   let all_versions_fields = [
     Name;

--- a/src/client/opamListCommand.mli
+++ b/src/client/opamListCommand.mli
@@ -141,7 +141,7 @@ val display: 'a switch_state -> package_listing_format -> package_set -> unit
 val info:
   'a switch_state ->
   fields:string list -> raw:bool -> where:bool ->
-  ?normalise:bool -> ?show_empty:bool -> ?all_versions:bool ->
+  ?normalise:bool -> ?show_empty:bool -> ?all_versions:bool -> ?sort:bool ->
   atom list -> unit
 
 (** Prints the value of an opam field in a shortened way (with [prettify] -- the


### PR DESCRIPTION
* Display error message for not found packages (not only when no one is found) fix #4164 
* Keep package order given via cli fix #4163 
* Don't restrict apply option to `--just-file`