### PR TITLE
Remove m4 from the list of recommended tools

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -1,6 +1,9 @@
 Working version changelog, used as a base for the changelog and the release
 note.
 
+## Init
+  * Remove m4 from the list of recommended tools [#4184 @kit-ty-kate]
+
 ## Switch
   * Fix Not_found with `opam switch create . --deps` [#4151 @AltGr]
 

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -112,7 +112,6 @@ let recommended_tools () =
   let make = OpamStateConfig.(Lazy.force !r.makecmd) in
   [
     [make], None, None;
-    ["m4"], None, None;
     ["cc"], None, None;
   ]
 


### PR DESCRIPTION
With depext now builtin part of opam in opam 2.1 and `ocamlfind` (which uses `m4`) being less and less used, I'm not sure it feels necessary to have a warning recommending to install this package anymore:
```
[WARNING] Recommended dependencies -- most packages rely on these:
  - m4
```