### PR TITLE
Store depext exceptions in switch with `--assume-depexts` and `--no-depexts`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -7,7 +7,12 @@ note.
 ## Switch
   * Fix Not_found with `opam switch create . --deps` [#4151 @AltGr]
 
+
+## Config
+  * Add switch depext-bypass as modifiable field [#4191 @rjbou]
+
 ## Depext
+  * Update switch depext-bypass with --assume-depext and --no-depexts [#4191 @rjbou - fix #4177]
   * Fix performance issue of depext under Docker/debian [#4165 @AltGr]
   * Refactor package status [#4152 @rjbou]
   * Add Macport support [#4152 @rjbou]

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -502,6 +502,13 @@ let switch_allowed_fields, switch_allowed_sections =
                  in
                  { c with env })),
            fun t -> { t with env = empty.env });
+          "depext-bypass", OpamSysPkg.Set.Op.(Modifiable (
+              (fun nc c ->
+                 { c with depext_bypass = nc.depext_bypass ++ c.depext_bypass }),
+              (fun nc c ->
+                 { c with depext_bypass = nc.depext_bypass -- c.depext_bypass })
+            )),
+          (fun t -> { t with depext_bypass = empty.depext_bypass });
         ] @ allwd_wrappers empty.wrappers wrappers
           (fun wrappers t -> { t with wrappers })))
   in

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1139,6 +1139,11 @@ let apply ?ask t ~requested ?add_roots ?(assume_built=false) ?force_remove
           let depext_bypass =
             OpamSysPkg.Set.Op.(t.switch_config.depext_bypass ++ sys_packages)
           in
+          OpamConsole.note "Add system packages %s to switch 'depext-bypass' field"
+            (OpamStd.Format.pretty_list
+               (List.map (fun s ->
+                    OpamConsole.colorise `underline (OpamSysPkg.to_string s))
+                   (OpamSysPkg.Set.elements sys_packages)));
           { t with switch_config = { t.switch_config with depext_bypass }}
         else t
       in

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1133,6 +1133,15 @@ let apply ?ask t ~requested ?add_roots ?(assume_built=false) ?force_remove
           action_graph
       in
       let success = match r with | OK _ -> true | _ -> false in
+      let t =
+        if success && (OpamClientConfig.(!r.assume_depexts) ||
+                       OpamStateConfig.(!r.no_depexts)) then
+          let depext_bypass =
+            OpamSysPkg.Set.Op.(t.switch_config.depext_bypass ++ sys_packages)
+          in
+          { t with switch_config = { t.switch_config with depext_bypass }}
+        else t
+      in
       let post_session =
         let open OpamPackage.Set.Op in
         let local = [


### PR DESCRIPTION
& add `depext-bypass`  as a modifiable field in switch config
Fix #4177