### PR TITLE
depext fixes: unavailable reason, pin, depext-bypass, list

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -1265,8 +1265,8 @@ shouldn't be edited except by <span class="opam">opam</span>.
 #### config
 
 This file is stored as `~/.opam/config` and defines global configuration options
-for <span class="opam">opam</span>. Fields value can be displayed and some of
-them modified with [`opam config option --global`](man/opam-config.html).
+for <span class="opam">opam</span>. Field values can be displayed and some of
+them modified with [`opam option --global`](man/opam-option.html).
 
 - <a id="configfield-opam-version">`opam-version: <string>`</a>:
   the version of the format of this opam root, used in particular to trigger
@@ -1501,8 +1501,8 @@ contains configuration options specific to that switch:
 - <a id="switchconfigsection-variables">`variables "{" { <ident>: ( <string> | [ <string> ... ] | <bool> ) ... } "}"`</a>:
   allows the definition of variables local to the switch.
 
-As [config](#config), fields value can be displayed and some of them modified
-with [`opam config option`](man/opam-config.html).
+As [config](#config), field values can be displayed and some of them modified
+with [`opam option`](man/opam-option.html).
 
 #### switch-state
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -25,6 +25,21 @@ Possibly scripts breaking changes are prefixed with ✘
   * Fix Not_found with `opam switch create . --deps` [#4151 @AltGr]
   * Package Var: resolve self `name` variable for orphan packages [#4228 @rjbou - fix #4224]
   * ✘ Reject (shell) character on switch names [#4237 @rjbou - fix #4231]
+  * Add missing depext to unavailable reasons [#4194 @rjbou - fix #4176]
+
+
+## Pin
+  * Add depext handling on new pinned packages [#4194 @rjbou - fix #4189]
+
+## Option
+  * Fix messages advertising a command in an obsolete format [#4194 @rjbou]
+
+## Config
+  * Add switch depext-bypass as modifiable field [#4194 @rjbou - fix #4177]
+
+## List
+  * Add --no-depexts option to disable depexts packages unavailability [#4194 @rjbou - fix #4205]
+  * Warn if packages are not listed because of depexts unavailaibilty [#4194 @rjbou - fix #4205]
 
 ## Pin
   * Don't keep unpinned package version if it exists in repo [#4073 @rjbou - fix #3630]
@@ -37,6 +52,7 @@ Possibly scripts breaking changes are prefixed with ✘
 
 ## Depext
   * Fix arch query [#4200 @rjbou]
+  * Add message when adding a package to `depext-bypass` [#4194 @rjbou]
   * Fix performance issue of depext under Docker/debian [#4165 @AltGr]
   * Refactor package status [#4152 #4200 @rjbou]
   * Add environment variables handling [#4200 @rjbou]

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1378,16 +1378,39 @@ module PIN = struct
   open OpamPinCommand
 
   let post_pin_action st was_pinned names =
-    let names =
-      OpamPackage.Set.Op.(st.pinned -- was_pinned)
-      |> OpamPackage.names_of_packages
-      |> (fun s ->
-          List.fold_left
-            (fun s p -> OpamPackage.Name.Set.add p s)
-            s names)
-      |> OpamPackage.Name.Set.elements
+    let pkgs =
+      let newly = st.pinned -- was_pinned in
+      let old =
+        OpamPackage.packages_of_names was_pinned
+          OpamPackage.Name.Set.Op.(
+            OpamPackage.Name.Set.of_list names
+            -- OpamPackage.names_of_packages newly)
+      in
+      newly ++ old
+    in
+    let no_depexts =
+      not (OpamFile.Config.depext st.switch_global.config)
+      || OpamSysPkg.Set.is_empty
+        ((OpamPackage.Set.fold (fun pkg acc ->
+             OpamSysPkg.Set.union acc (OpamSwitchState.depexts st pkg)))
+           pkgs OpamSysPkg.Set.empty)
     in
     try
+      let st =
+        if no_depexts then st else
+        let st =
+          { st with sys_packages =  lazy (
+                OpamPackage.Map.union (fun _ n -> n)
+                  (Lazy.force st.sys_packages)
+                  (OpamSwitchState.depexts_status_of_packages st pkgs)
+              )}
+        in
+        { st with available_packages = lazy (
+              OpamPackage.Set.filter (fun nv ->
+                  OpamSwitchState.depexts_unavailable st nv = None)
+                (Lazy.force st.available_packages)
+            )}
+      in
       upgrade_t
         ~strict_upgrade:false ~auto_install:true ~ask:true ~terse:true
         ~all:false

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -532,9 +532,15 @@ let list ?(force_search=false) () =
       "Don't write anything in the output, exit with return code 0 if the list \
        is not empty, 1 otherwise."
   in
+  let no_depexts =
+    mk_flag ["no-depexts"]
+      "Disable external dependencies handling for the query. This can be used \
+       to include packages that are marked as unavailable because of an unavailable \
+       system dependency."
+  in
   let list
       global_options selection state_selector no_switch depexts vars repos
-      owns_file disjunction search silent format packages =
+      owns_file disjunction search silent no_depexts format packages =
     apply_global_options global_options;
     let no_switch =
       no_switch || OpamStateConfig.get_switch_opt () = None
@@ -590,6 +596,7 @@ let list ?(force_search=false) () =
     in
     OpamGlobalState.with_ `Lock_none @@ fun gt ->
     OpamRepositoryState.with_ `Lock_none gt @@ fun rt ->
+    if no_depexts then OpamStateConfig.update ~no_depexts:true ();
     let st =
       if no_switch then OpamSwitchState.load_virtual ?repos_list:repos gt rt
       else OpamSwitchState.load `Lock_none gt rt (OpamStateConfig.get_switch ())
@@ -626,7 +633,7 @@ let list ?(force_search=false) () =
   in
   Term.(const list $global_options $package_selection $state_selector
         $no_switch $depexts $vars $repos $owns_file $disjunction $search
-        $silent $package_listing $pattern_list),
+        $silent $no_depexts $package_listing $pattern_list),
   term_info "list" ~doc ~man
 
 

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -502,6 +502,13 @@ let switch_allowed_fields, switch_allowed_sections =
                  in
                  { c with env })),
            fun t -> { t with env = empty.env });
+          "depext-bypass", OpamSysPkg.Set.Op.(Modifiable (
+              (fun nc c ->
+                 { c with depext_bypass = nc.depext_bypass ++ c.depext_bypass }),
+              (fun nc c ->
+                 { c with depext_bypass = nc.depext_bypass -- c.depext_bypass })
+            )),
+          (fun t -> { t with depext_bypass = empty.depext_bypass });
         ] @ allwd_wrappers empty.wrappers wrappers
           (fun wrappers t -> { t with wrappers })))
   in

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -980,7 +980,7 @@ let install_depexts t packages sys_packages =
     let give_up () =
       OpamConsole.formatted_msg
         "You can retry with '--assume-depexts' to skip this check, or run \
-         'opam config option global depext=false' to permanently disable handling of \
+         'opam option depext=false' to permanently disable handling of \
          system packages altogether.\n";
       OpamStd.Sys.exit_because `Aborted
     in
@@ -1023,9 +1023,8 @@ let install_depexts t packages sys_packages =
       wait "You can now try to get them installed manually."
         sys_packages
   else
-    (OpamConsole.note "Use 'opam config option global \
-                       depext-run-installs=false' if you don't want to be \
-                       prompted again.";
+    (OpamConsole.note "Use 'opam option depext-run-installs=false' \
+                       if you don't want to be prompted again.";
      print ();
      wait
        "You may now install the packages manually on your system."

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -157,7 +157,7 @@ let depexts_raw ~env nv opams =
       (OpamFile.OPAM.depexts opam)
   with Not_found -> OpamSysPkg.Set.empty
 
-let get_sysdeps_map ~depexts global_config switch_config packages =
+let depexts_status_of_packages_raw ~depexts global_config switch_config packages =
   let open OpamSysPkg.Set.Op in
   let syspkg_set, syspkg_map =
     OpamPackage.Set.fold (fun nv (set, map) ->
@@ -445,7 +445,8 @@ let load lock_kind gt rt switch =
     || OpamStateConfig.(!r.no_depexts) then
       lazy OpamPackage.Map.empty
     else lazy (
-      get_sysdeps_map gt.config switch_config (Lazy.force available_packages)
+      depexts_status_of_packages_raw gt.config switch_config
+        (Lazy.force available_packages)
         ~depexts:(fun package ->
             let env =
               OpamPackageVar.resolve_switch_raw ~package gt switch switch_config
@@ -684,6 +685,10 @@ let source_dir st nv =
 let depexts st nv =
   let env v = OpamPackageVar.resolve_switch ~package:nv st v in
  depexts_raw ~env nv st.opams
+
+let depexts_status_of_packages st set =
+  depexts_status_of_packages_raw st.switch_global.config st.switch_config set
+    ~depexts:(depexts st)
 
 let depexts_unavailable st nv =
   depexts_unavailable_raw (Lazy.force st.sys_packages) nv

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -170,6 +170,9 @@ val get_sysdeps_map:
   package_set ->
   OpamSysPkg.status package_map
 
+(** Returns not found depexts for the package *)
+val depexts_unavailable: 'a switch_state -> package -> OpamSysPkg.Set.t option
+
 (** [conflicts_with st subset pkgs] returns all packages declared in conflict
     with at least one element of [subset] within [pkgs], through forward or
     backward conflict definition or common conflict-class. Packages in [subset]

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -163,12 +163,8 @@ val depexts: 'a switch_state -> package -> OpamSysPkg.Set.t
 
 (** Returns required system packages of each of the given packages (elements are
     not added to the map  if they don't have system dependencies) *)
-val get_sysdeps_map:
-  depexts:(package -> OpamSysPkg.Set.t) ->
-  OpamFile.Config.t ->
-  OpamFile.Switch_config.t ->
-  package_set ->
-  OpamSysPkg.status package_map
+val depexts_status_of_packages:
+  'a switch_state -> package_set -> OpamSysPkg.status package_map
 
 (** Returns not found depexts for the package *)
 val depexts_unavailable: 'a switch_state -> package -> OpamSysPkg.Set.t option


### PR DESCRIPTION
* add depext check to unavailable reason, on the same behavior as in `check_availability`, by displaying the max element depexts. fix #4176
* add depext handling on new pinned packages fix #4189 
* add `depext-bypass`  as a modifiable field in switch config fix #4177
* fix old opam option format in messages
* fix opam list depext handling fix #4205