### PR TITLE
repo: remove temp directory instead of clean_dir

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -27,3 +27,10 @@ note.
 
 ## Remove
   * Fix autoremove env var handling [#4219 @rjbou - fix #4217]
+
+## Repository management
+  * Fix temp files repository cleaning [#4197 @rjbou]
+
+
+## Doc
+  * add doc/warning for  Filename.rmdir_cleanup [#4197 @rjbou]

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -35,7 +35,9 @@ val rmdir: Dir.t -> unit
 (** Cleans the contents of a directory, but keeps the directory in place. *)
 val cleandir: Dir.t -> unit
 
-(** Removes an empty directory, as well as any empty leading path components *)
+(** Removes an empty directory, as well as any empty leading path components.
+    Must be called only on a directory that is known to not have empty parents,
+    only internal opam directory (and not tmp dir). *)
 val rmdir_cleanup: Dir.t -> unit
 
 (** Create a directory *)


### PR DESCRIPTION
supersede #4166, see discussions full there.
> When removing temporary stuff, a directory cleaning is done, to remove all intermediate temporary directories. The process is upward: if directory is empty, removes it, and check its on parent, ... On some new containers, when cleaning a temporary repository (new repo mechanism) it reaches `/tmp`, as its only content was those opam repo temporary files.