### PR TITLE
depext: fix arch/brew, use regexp, environment variable handling, etc.

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -32,9 +32,15 @@ Possibly scripts breaking changes are prefixed with ✘
 
 
 ## Depext
+  * Fix arch query [#4200 @rjbou]
   * Fix performance issue of depext under Docker/debian [#4165 @AltGr]
-  * Refactor package status [#4152 @rjbou]
+  * Refactor package status [#4152 #4200 @rjbou]
+  * Add environment variables handling [#4200 @rjbou]
   * Add Macport support [#4152 @rjbou]
+  * Homebrew: add no auto update env var for install, accept `pkgname` and `pkgnam@version` on query [#4200 @rjbou]
+  * Force LC_ALL=C for query commands [#4200 @rjbou]
+  * Fix install command dryrun [#4200 @rjbou]
+
 
 
 ## Remove

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -12,6 +12,7 @@ let log fmt = OpamConsole.log "XSYS" fmt
 
 (* Run commands *)
 (* Always call this function to run a command, as it handles `dryrun` option *)
+
 let run_command
     ?vars ?(discard_err=false) ?allow_stdin ?verbose cmd args =
   let clean_output =
@@ -65,7 +66,8 @@ let run_command
   Done (code, out)
 
 let run_query_command ?vars cmd args =
-  let code,out = run_command ?vars cmd args in
+  let vars = (`set, ("LC_ALL","C"))::OpamStd.Option.to_list vars in
+  let code,out = run_command ~vars cmd args in
   if code = 0 then out
   else []
 

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -455,7 +455,9 @@ let install_packages_commands_t sys_packages =
   | Debian -> ["apt-get", "install"::packages], None
   | Freebsd -> ["pkg", "install"::packages], None
   | Gentoo -> ["emerge", packages], None
-  | Homebrew -> ["brew", "install"::packages], None
+  | Homebrew ->
+    ["brew", "install"::packages],
+    Some (["HOMEBREW_NO_AUTO_UPDATE","yes"])
   | Macports -> ["port", "install"::packages], None
   | Openbsd -> ["pkg_add", packages], None
   | Suse -> ["zypper", ("install"::packages)], None

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -309,10 +309,19 @@ let packages_status packages =
     in
     compute_sets sys_installed
   | Homebrew ->
+    (* accept 'pkgname' and 'pkgname@version'
+       exampe output
+       >openssl@1.1
+       >bmake
+    *)
     let sys_installed =
       run_query_command "brew" ["list"]
-      |> List.map (fun s -> OpamStd.String.split s ' ')
-      |> List.flatten
+      |> List.fold_left (fun res s ->
+          List.fold_left (fun res spkg ->
+              match OpamStd.String.cut_at spkg '@' with
+              | Some (n,_v) -> n::spkg::res
+              | None -> spkg::res)
+            res (OpamStd.String.split s ' ')) []
       |> List.map OpamSysPkg.of_string
       |> OpamSysPkg.Set.of_list
     in


### PR DESCRIPTION
* arch: use `pacman -Ss <packages regexp>` to have only one exec call. fix #4199
* regexp: transform list string manipulation into regexp to treat sys package manager outputs
* add some example outputs
* fix homebrew package name check, allow `package` and `package@version`
* add environment variabe handling for `OpamSysInteract` commands (addition and overriding)
* force `LC_ALL=C` for query commands
* fix dry run for install commands