### PR TITLE
Fix resolve name for orphan packages

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -20,6 +20,7 @@ note.
 
 ## Switch
   * Fix Not_found with `opam switch create . --deps` [#4151 @AltGr]
+  * Package Var: resolve self `name` variable for orphan packages [#4228 @rjbou - fix #4224]
 
 ## Pin
   * Don't keep unpinned package version if it exists in repo [#4073 @rjbou - fix #3630]

--- a/src/state/opamPackageVar.ml
+++ b/src/state/opamPackageVar.ml
@@ -260,8 +260,11 @@ let resolve st ?opam:opam_arg ?(local=OpamVariable.Map.empty) v =
       Some (bool false)
     | "pinned", _ ->
       Some (bool (OpamPackage.has_name st.pinned name))
-    | "name", _ ->
-      if OpamPackage.has_name st.packages name
+    | "name", opam ->
+      (* On reinstall, orphan packages are not present in the state, and we
+         need to resolve their internal name variable *)
+      if OpamStd.Option.map OpamFile.OPAM.name opam = Some name
+      || OpamPackage.has_name st.packages name
       then Some (string (OpamPackage.Name.to_string name))
       else None
     | _, None -> None


### PR DESCRIPTION
Fix #4224 
If a package is no more available in a repository, and a recompile is trigered, opam can't resolve its name because it is restrained to known packages `st.packages`. Release this constraint.