### PR TITLE
Fix the opam-devel package + various fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,9 @@ opam-devel.install: $(DUNE_DEP)
 	$(DUNE) build $(DUNE_ARGS) -p opam opam.install
 	sed -e "s/bin:/libexec:/" opam.install > $@
 
+opam-%.install: $(DUNE_DEP)
+	$(DUNE) build $(DUNE_ARGS) -p opam-$* $@
+
 .PHONY: build-opam-installer
 build-opam-installer: $(DUNE_DEP) 
 	$(DUNE) build --profile=$(DUNE_PROFILE) $(DUNE_ARGS)$(DUNE_PROMOTE_ARG) opam-installer.install

--- a/master_changes.md
+++ b/master_changes.md
@@ -12,7 +12,7 @@ Possibly scripts breaking changes are prefixed with ✘
   * Fix atoms formula restriction with `--all` [#4221 @rjbou - fix #4218]
 
 ## Build
-  * Opam file build using dune, removal of opam-%.install makefile target [#4178 @rjbou - fix #4173]
+  * Opam file build using dune, removal of opam-%.install makefile target [#4178 @rjbou #4229 @kit-ty-kate - fix #4173]
   * Use version var in opam file instead of equal current version number in opamlib dependencies [#4178 @rjbou]
   * ext: fix extlib url [#4248 @rjbou]
 

--- a/opam-client.opam
+++ b/opam-client.opam
@@ -27,6 +27,6 @@ depends: [
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
   "cmdliner" {>= "0.9.8"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 available: ocaml-version >= "4.02.3"

--- a/opam-core.opam
+++ b/opam-core.opam
@@ -25,7 +25,7 @@ depends: [
   "base-bigarray"
   "ocamlgraph"
   "re" {>= "1.9.0"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
   "cppo" {build}
 ]
 conflicts: "extlib-compat"

--- a/opam-devel.opam
+++ b/opam-devel.opam
@@ -24,7 +24,7 @@ build-test: [make "tests"]
 depends: [
   "opam-client" {= version}
   "cmdliner" {>= "0.9.8"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 post-messages: [
 "The development version of opam has been successfully compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with

--- a/opam-devel.opam
+++ b/opam-devel.opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 dev-repo: "https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
-  ["dune" "build" "-p" name "-j" jobs]
+  [make "%{name}%.install"]
 ]
 build-test: [make "tests"]
 depends: [

--- a/opam-format.opam
+++ b/opam-format.opam
@@ -23,6 +23,6 @@ build: [
 depends: [
   "opam-core" {= version}
   "opam-file-format" {>= "2.0.0~rc2"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 available: ocaml-version >= "4.02.3"

--- a/opam-installer.opam
+++ b/opam-installer.opam
@@ -23,6 +23,6 @@ build: [
 depends: [
   "opam-format" {= version}
   "cmdliner" {>= "0.9.8"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 available: ocaml-version >= "4.02.3"

--- a/opam-repository.opam
+++ b/opam-repository.opam
@@ -22,6 +22,6 @@ build: [
 ]
 depends: [
   "opam-format" {= version}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 available: ocaml-version >= "4.02.3"

--- a/opam-solver.opam
+++ b/opam-solver.opam
@@ -25,7 +25,7 @@ depends: [
   "mccs" {>= "1.1+9"}
   "dose3" {>= "5"}
   "cudf" {>= "0.7"}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 depopts: "z3"
 conflicts: [ "z3" {< "4.8.4"} ]

--- a/opam-state.opam
+++ b/opam-state.opam
@@ -22,6 +22,6 @@ build: [
 ]
 depends: [
   "opam-repository" {= version}
-  "dune" {build & >= "1.2.1"}
+  "dune" {>= "1.2.1"}
 ]
 available: ocaml-version >= "4.02.3"


### PR DESCRIPTION
Following the merge of https://github.com/ocaml/opam/pull/4178, the `opam-devel` package now doesn't install anything anymore (see the special `opam-devel.install` makefile rule). 1471a27 should fix that.

Otherwise the rest is more of a collection of various fixes that can be taken independently:
* 8d4ae0d is here because the `opam-%.install` rule is still used in the makefile (see the `installlib-%` rule for instance)
* 5429c09 fixes an issue that happens when an external archive is not available to download and the script tries to get it from the cache but the url does not exist anymore.
* 9f3dacf is a preventive fix in case someone changes the name of the opam binary (in the src/client/dune) it will not try to use the `opam` binary from the PATH (which, if it is not opam 2.1 already is going to hang up forever trying to get `opam lock --help=groff`
* 866fbc7 fixes an issue in the opam file as dune is not compatible with the `{build}` tag anymore (see https://github.com/ocaml/dune/issues/2147)