### PR TITLE
Ignore `_build`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -8,6 +8,10 @@ note.
   * Opam file build using dune, removal of opam-%.install makefile target [#4178 @rjbou - fix #4173]
   * Use version var in opam file instead of equal current version number in opamlib dependencies [#4178 @rjbou]
 
+## Install
+  * Add `_build` to rsync exclusion list [#4230 @rjobou - fix #4195]
+  * Recursive opam file lookup: ignore `_build` [#4230 @rjbou]
+
 ## Switch
   * Fix Not_found with `opam switch create . --deps` [#4151 @AltGr]
 

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -65,7 +65,7 @@ let rsync ?(args=[]) ?(exclude_vcdirs=true) src dst =
     not (OpamStd.String.contains ~sub:OpamSwitch.external_dirname (norm dst)) ||
     OpamStd.String.starts_with ~prefix:(norm dst) (norm src)
   in
-  (* See also OpamVCS.sync_dirty *)
+  (* See also [OpamVCS.sync_dirty] *)
   let exclude_args =
     (if not exclude_vcdirs then [] else
        [ "--exclude"; ".git";
@@ -75,6 +75,7 @@ let rsync ?(args=[]) ?(exclude_vcdirs=true) src dst =
     @ [
       "--exclude"; ".#*";
       "--exclude"; OpamSwitch.external_dirname ^ "*";
+      "--exclude"; "_build";
     ]
   in
   if not(remote || Sys.file_exists src) then

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -133,13 +133,16 @@ module Make (VCS: VCS) = struct
           (OpamFilename.rec_files repo_root)
       in
       List.iter OpamFilename.remove rm_list;
-      (* We do the list cleaning here becuse of rsync options: `--exclude` need
-         to be explicitely given directory descendants, e.g `--exclude
-         _build/**`
+      (* We do the list cleaning here because of rsync options: with
+         `--files-from`, `--exclude` need to be explicitly given directory
+         descendants, e.g `--exclude _build/**`
       *)
       let excluded =
-        (* from [OpamGit.rsync] exclude list *)
-        let exc = [ "_opam"; "_build"; ".git"; "_darcs"; ".hg" ] in
+        (* from [OpamLocal.rsync] exclude list *)
+        let exc =
+          [ OpamSwitch.external_dirname ^ "*"; "_build";
+            ".git"; "_darcs"; ".hg" ]
+        in
         OpamStd.String.Set.filter (fun f ->
             List.exists (fun prefix ->
                 OpamStd.String.starts_with ~prefix f)
@@ -147,7 +150,9 @@ module Make (VCS: VCS) = struct
           fset
       in
       let vcset = OpamStd.String.Set.of_list (filter_subpath vc_files) in
-      let vc_dirty_set = OpamStd.String.Set.of_list (filter_subpath vc_dirty_files) in
+      let vc_dirty_set =
+        OpamStd.String.Set.of_list (filter_subpath vc_dirty_files)
+      in
       let final_set =
         OpamStd.String.Set.Op.(fset -- vcset ++ vc_dirty_set -- excluded)
       in

--- a/src/state/opamPinned.ml
+++ b/src/state/opamPinned.ml
@@ -200,8 +200,9 @@ let files_in_source ?(recurse=false) ?subpath d =
            let base_dir = OpamFilename.basename_dir d in
            let basename = OpamFilename.Base.to_string base_dir in
            if recurse &&
-              base_dir <> OpamFilename.Base.of_string OpamSwitch.external_dirname &&
-              not (OpamStd.String.starts_with ~prefix:"." basename)
+              not (base_dir = OpamFilename.Base.of_string OpamSwitch.external_dirname ||
+                   base_dir = OpamFilename.Base.of_string "_build" ||
+                   OpamStd.String.starts_with ~prefix:"." basename)
            then
              let base = match base with
                | None -> Some basename


### PR DESCRIPTION
On syncing (`assume-built`) and for opam file lookup (`recursive`)
fix #4195 