### PR TITLE
build cold bootstrap with OCaml 4.10 to fix gcc10 compilation

### DIFF
--- a/appveyor.patch
+++ b/appveyor.patch
@@ -14,8 +14,8 @@ index 1a350068..964a818c 100644
 --- a/src_ext/Makefile
 +++ b/src_ext/Makefile
 @@ -12,8 +12,8 @@ endif
- URL_ocaml = http://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.1.tar.gz
- MD5_ocaml = 0b180b273ce5cc2ac68f347c9b06d06f
+ URL_ocaml = http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10.0.tar.gz
+ MD5_ocaml = 34de3225e40d92a6a8b03f1626a01dd3
  
 -URL_flexdll = https://github.com/alainfrisch/flexdll/archive/0.37.tar.gz
 -MD5_flexdll = cc456a89382e60d84130cddd53977486

--- a/master_changes.md
+++ b/master_changes.md
@@ -14,6 +14,7 @@ Possibly scripts breaking changes are prefixed with ✘
 ## Build
   * Opam file build using dune, removal of opam-%.install makefile target [#4178 @rjbou - fix #4173]
   * Use version var in opam file instead of equal current version number in opamlib dependencies [#4178 @rjbou]
+  * Upgrade bootstrap OCaml compiler from 4.07.1 to 4.10.0 [#4234 @avsm]
 
 ## Install
   * Add `_build` to rsync exclusion list [#4230 @rjobou - fix #4195]
@@ -29,7 +30,6 @@ Possibly scripts breaking changes are prefixed with ✘
   * ✘ Display error message for all not found packages [#4179 @rjbou - fix #4164]
   * ✘ Keep package order given via cli [#4179 @rjbou - fix #4163]
   * `--sort`` apply to with all options, not only `--just-file` [#4179 @rjbou]
-
 
 ## Depext
   * Fix performance issue of depext under Docker/debian [#4165 @AltGr]

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -11,8 +11,8 @@ endif
 
 PATCH ?= patch
 
-URL_ocaml = http://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.1.tar.gz
-MD5_ocaml = 0b180b273ce5cc2ac68f347c9b06d06f
+URL_ocaml = http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10.0.tar.gz
+MD5_ocaml = 34de3225e40d92a6a8b03f1626a01dd3
 
 URL_flexdll = https://github.com/alainfrisch/flexdll/archive/0.37.tar.gz
 MD5_flexdll = cc456a89382e60d84130cddd53977486


### PR DESCRIPTION
This is because gcc10 defaults to -fcommon which causes
compatibility carnage.  See ocaml/opam-repository#16583.

Reported by @Misterda