### PR TITLE
Tag packages with missing depexts to the solver

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -40,6 +40,7 @@ Possibly scripts breaking changes are prefixed with ✘
   * Add environment variables handling [#4200 @rjbou]
   * Add Macport support [#4152 @rjbou]
   * Homebrew: add no auto update env var for install, accept `pkgname` and `pkgnam@version` on query [#4200 @rjbou]
+  * Tag packages with missing depexts in Cudf [#4235 @AltGr]
   * Force LC_ALL=C for query commands [#4200 @rjbou]
   * Fix install command dryrun [#4200 @rjbou]
 

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -858,6 +858,14 @@ let universe st
     | Some set -> set
     | None -> OpamPackage.Set.empty
   in
+  let missing_depexts =
+    OpamPackage.Map.fold (fun nv status acc ->
+        if OpamSysPkg.Set.is_empty status.OpamSysPkg.s_available
+        then acc
+        else OpamPackage.Set.add nv acc)
+      (Lazy.force st.sys_packages)
+      OpamPackage.Set.empty
+  in
   let u =
 {
   u_packages  = st.packages;
@@ -872,7 +880,8 @@ let universe st
   u_base      = base;
   u_invariant;
   u_reinstall;
-  u_attrs     = ["opam-query", requested_allpkgs];
+  u_attrs     = ["opam-query", requested_allpkgs;
+                 "missing-depexts", missing_depexts];
 }
   in
   u


### PR DESCRIPTION
to allow playing with criteria and seeing if we can solve the
mariadb/mysql dilemma.

With this patch, you can add a `-count[missing-depexts,solution]`
criterion (putting it before the main `version-lag` criteria would be a
bad idea though).