### PR TITLE
Switch name check

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -23,6 +23,7 @@ Possibly scripts breaking changes are prefixed with ✘
 ## Switch
   * Fix Not_found with `opam switch create . --deps` [#4151 @AltGr]
   * Package Var: resolve self `name` variable for orphan packages [#4228 @rjbou - fix #4224]
+  * ✘ Reject (shell) character on switch names [#4237 @rjbou - fix #4231]
 
 ## Pin
   * Don't keep unpinned package version if it exists in repo [#4073 @rjbou - fix #3630]
@@ -44,16 +45,23 @@ Possibly scripts breaking changes are prefixed with ✘
   * Fix install command dryrun [#4200 @rjbou]
 
 
+## Env
+  * Fix `OPAMSWITCH` empty string setting, consider as unset [#4237 @rjbou]
+
 ## Remove
   * Fix autoremove env var handling [#4219 @rjbou - fix #4217]
 
 ## Repository management
   * Fix temp files repository cleaning [#4197 @rjbou]
 
+## Opam installer
+  * For paths, remove use of empty switch in favor of a context-less module [#4237 @rjbou]
+
 ## Internal
   * Disable chrono when timestamps are disables [#4206 @rjbou]
   * Expose some functionality in the `OpamAction`, `OpamPath` and `OpamSwitchState`
-    modules for use without a `switch` value [#4147]
+    modules for use without a `switch` value [#4147 @timberston]
+    *Path: introduce a functor to permit replicating switch layout in different contexts
 
 ## Test
   * Add show cram test [#4206 @rjbou]

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -182,7 +182,7 @@ let env gt switch ?(set_opamroot=false) ?(set_opamswitch=false)
         (OpamFile.Config.switch gt.config)
     in
     match OpamStd.Config.env_string "SWITCH" with
-    | None ->
+    | None | Some "" ->
       Some (OpamStateConfig.resolve_local_switch gt.root switch) <> default
     | Some s ->
       OpamStateConfig.resolve_local_switch gt.root (OpamSwitch.of_string s) <>

--- a/src/format/opamSwitch.ml
+++ b/src/format/opamSwitch.ml
@@ -20,17 +20,18 @@ let is_external s =
 let external_dirname = "_opam"
 
 let check s =
-  let re =
-    Re.(compile @@
-        seq [
-          bol;
-          opt @@ seq [ wordc ; char ':'; set "/\\" ];
-          rep @@ diff any @@ set "<>!`$():";
-          eol
-        ])
-  in
-  (try ignore @@ Re.exec re s with Not_found ->
-     failwith (Printf.sprintf "Invalid character in switch name %S" s));
+  if String.compare s "" = 0 &&
+    let re =
+      Re.(compile @@
+          seq [
+            bol;
+            opt @@ seq [ wordc ; char ':'; set "/\\" ];
+            rep @@ diff any @@ set "<>!`$():";
+            eol
+          ])
+    in
+    (try ignore @@ Re.exec re s; true with Not_found -> false) then
+    failwith (Printf.sprintf "Invalid character in switch name %S" s);
   s
 
 let of_string s =

--- a/src/format/opamSwitch.ml
+++ b/src/format/opamSwitch.ml
@@ -19,12 +19,28 @@ let is_external s =
 
 let external_dirname = "_opam"
 
+let check s =
+  let re =
+    Re.(compile @@
+        seq [
+          bol;
+          opt @@ seq [ wordc ; char ':'; set "/\\" ];
+          rep @@ diff any @@ set "<>!`$():";
+          eol
+        ])
+  in
+  (try ignore @@ Re.exec re s with Not_found ->
+     failwith (Printf.sprintf "Invalid character in switch name %S" s));
+  s
+
 let of_string s =
+  check @@
   if is_external s then OpamFilename.Dir.(to_string (of_string s))
   else s
 
 let of_dirname d =
   let s = OpamFilename.Dir.to_string d in
+  check @@
   try
     let swdir = Unix.readlink (Filename.concat s external_dirname) in
     let swdir =


### PR DESCRIPTION
* Switch names (global or local directories) containing  `| '<' | '>' | '!' | '<backquote>' | '$' | '(' | ')' | ':'`, or empty are rejected. For windows compatibility, switch names that begin with `\w:/` & `\w:\` are allowed.  Empty switche names are forbidden.
  * Compliance regexp is `^(\w:/\\)?[^<>!$():]+$` (missing the backquote because of markdown) cf. [code](https://github.com/ocaml/opam/pull/4237/files#diff-69b74e9ec849a48241d3e03d0196540bR25)
* Update opam installer to not use an empty switch to retrieve needed paths
* Cherry-picked context-free switch paths from #4147 
* fix opam env `OPAMSWITCH` setting: if empty string, consider it as unset

fix #4231 

@rjbou edit: update content