### PR TITLE
Add `opam install --depext-only` option

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -1,6 +1,7 @@
 Working version changelog, used as a base for the changelog and the release
 note.
 Possibly scripts breaking changes are prefixed with ✘
+New option are prefixed with ◈
 
 ## Admin
   * Fix admin cache synchronisation message [#4193 @rjbou - fix #4167]
@@ -60,7 +61,9 @@ Possibly scripts breaking changes are prefixed with ✘
   * Homebrew: add no auto update env var for install, accept `pkgname` and `pkgnam@version` on query [#4200 @rjbou]
   * Force LC_ALL=C for query commands [#4200 @rjbou]
   * Fix install command dryrun [#4200 @rjbou]
-
+  * ◈ Add --depext-only to install only external dependencies, regardless of config depext status [#4238 @rjbou]
+  * Move confirmation message after opam packages install [#4238 @rjbou]
+  * Error if '--depext-only' is given with '--assume-depexts' or '--no-depexts'
 
 ## Env
   * Fix `OPAMSWITCH` empty string setting, consider as unset [#4237 @rjbou]

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1151,7 +1151,7 @@ let install_t t ?ask ?(ignore_conflicts=false) ?(depext_only=false)
             solution
         else solution in
       if depext_only then
-        (OpamSolution.install_depexts ~confirm:false t
+        (OpamSolution.install_depexts ~force_depext:true ~confirm:false t
            (OpamSolver.all_packages solution)), None
       else
       let add_roots =

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -49,13 +49,14 @@ val reinit:
 val install:
   rw switch_state ->
   ?autoupdate:atom list -> ?add_to_roots:bool -> ?deps_only:bool ->
-  ?ignore_conflicts:bool -> ?assume_built:bool -> atom list ->
+  ?ignore_conflicts:bool -> ?assume_built:bool -> ?depext_only:bool ->
+  atom list ->
   rw switch_state
 
 (** Low-level version of [reinstall], bypassing the package name sanitization
     and dev package update, and offering more control *)
 val install_t:
-  rw switch_state -> ?ask:bool -> ?ignore_conflicts:bool ->
+  rw switch_state -> ?ask:bool -> ?ignore_conflicts:bool -> ?depext_only:bool ->
   atom list -> bool option -> deps_only:bool -> assume_built:bool ->
   rw switch_state
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1545,6 +1545,14 @@ let install =
     if atoms_or_locals = [] && not restore then
       `Error (true, "required argument PACKAGES is missing")
     else
+    if depext_only
+    && (OpamClientConfig.(!r.assume_depexts)
+        || OpamStateConfig.(!r.no_depexts)) then
+      `Error (true,
+              Printf.sprintf "--depext-only and --%s can't be used together"
+                (if OpamClientConfig.(!r.assume_depexts) then "assume-depexts"
+                 else "no-depexts"))
+    else
     OpamGlobalState.with_ `Lock_none @@ fun gt ->
     OpamSwitchState.with_ `Lock_write gt @@ fun st ->
     let pure_atoms =

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1530,9 +1530,16 @@ let install =
        installed. If not, output the names of the missing dependencies to \
        stdout, and exits with 1."
   in
+  let depext_only =
+    mk_flag ["depext-only"]
+      "Resolves the package installation normally, but only installs the required \
+       system dependencies, without affecting the opam switch state or installing \
+       opam packages."
+  in
   let install
       global_options build_options add_to_roots deps_only ignore_conflicts
-      restore destdir assume_built check recurse subpath atoms_or_locals =
+      restore destdir assume_built check recurse subpath depext_only
+      atoms_or_locals =
     apply_global_options global_options;
     apply_build_options build_options;
     if atoms_or_locals = [] && not restore then
@@ -1561,7 +1568,7 @@ let install =
     if atoms_or_locals = [] then `Ok () else
     let st, atoms =
       OpamAuxCommands.autopin
-        st ~recurse ?subpath ~quiet:check ~simulate:(deps_only||check)
+        st ~recurse ?subpath ~quiet:check ~simulate:(deps_only||check||depext_only)
         atoms_or_locals
     in
     if atoms = [] then
@@ -1585,7 +1592,7 @@ let install =
     let st =
       OpamClient.install st atoms
         ~autoupdate:pure_atoms ?add_to_roots ~deps_only ~ignore_conflicts
-        ~assume_built
+        ~assume_built ~depext_only
     in
     match destdir with
     | None -> `Ok ()
@@ -1597,7 +1604,8 @@ let install =
   Term.ret
     Term.(const install $global_options $build_options
           $add_to_roots $deps_only $ignore_conflicts $restore $destdir
-          $assume_built $check $recurse $subpath $atom_or_local_list),
+          $assume_built $check $recurse $subpath $depext_only
+          $atom_or_local_list),
   term_info "install" ~doc ~man
 
 (* REMOVE *)

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -939,7 +939,7 @@ let get_depexts t packages =
   print_depext_msg (avail, nf);
   avail
 
-let install_depexts ?(noconfirm=false) t packages =
+let install_depexts ?(confirm=true) t packages =
   let sys_packages =
     if not (OpamFile.Config.depext t.switch_global.config) then
       OpamSysPkg.Set.empty
@@ -1017,7 +1017,7 @@ let install_depexts ?(noconfirm=false) t packages =
        sys_packages)
   else if OpamClientConfig.(!r.fake) then (print (); t)
   else if
-    noconfirm || OpamConsole.confirm
+    not confirm || OpamConsole.confirm
       "Let opam run your package manager to install the required system \
        packages?"
   then
@@ -1026,7 +1026,7 @@ let install_depexts ?(noconfirm=false) t packages =
       map_sysmap (fun _ -> OpamSysPkg.Set.empty) t
     with Failure msg ->
       OpamConsole.error "%s" msg;
-      if noconfirm then (print (); t) else
+      if not confirm then (print (); t) else
         wait "You can now try to get them installed manually."
           sys_packages
   else

--- a/src/client/opamSolution.mli
+++ b/src/client/opamSolution.mli
@@ -65,10 +65,10 @@ val check_solution:
   unit
 
 (* Install external dependencies of the given package set, according the depext
-   configuration. If [noconfirm] is given, install commands are directly
+   configuration. If [confirm] is false, install commands are directly
    launched, without asking user (used by the `--depext-only` option). *)
 val install_depexts:
-  ?noconfirm:bool -> rw switch_state -> package_set -> rw switch_state
+  ?confirm:bool -> rw switch_state -> package_set -> rw switch_state
 
 (** {2 Atoms} *)
 

--- a/src/client/opamSolution.mli
+++ b/src/client/opamSolution.mli
@@ -64,6 +64,12 @@ val check_solution:
   (solution_result, 'conflict) result ->
   unit
 
+(* Install external dependencies of the given package set, according the depext
+   configuration. If [noconfirm] is given, install commands are directly
+   launched, without asking user (used by the `--depext-only` option). *)
+val install_depexts:
+  ?noconfirm:bool -> rw switch_state -> package_set -> rw switch_state
+
 (** {2 Atoms} *)
 
 (** Return an atom with a strict version constraint *)

--- a/src/client/opamSolution.mli
+++ b/src/client/opamSolution.mli
@@ -66,9 +66,10 @@ val check_solution:
 
 (* Install external dependencies of the given package set, according the depext
    configuration. If [confirm] is false, install commands are directly
-   launched, without asking user (used by the `--depext-only` option). *)
+   launched, without asking user (used by the `--depext-only` option). If
+   [force_depext] is true, it overrides [OpamFile.Config.depext] value. *)
 val install_depexts:
-  ?confirm:bool -> rw switch_state -> package_set -> rw switch_state
+  ?force_depext:bool -> ?confirm:bool -> rw switch_state -> package_set -> rw switch_state
 
 (** {2 Atoms} *)
 


### PR DESCRIPTION
to install only external dependencies required by the install of targeted package(s).