### PR TITLE
Add an optional solver relying on opam-0install-cudf

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -62,6 +62,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Solver
   * Allow Z3 backend to return sub-optimal solutions on timeout, add `OPAMSOLVERALLOWSUBOPTIMAL` environment variable [#4289 @AltGr]
+  * Add an optional solver relying on opam-0install-cudf [#4240 @kit-ty-kate]
 
 ## Internal
   *

--- a/opam-solver.opam
+++ b/opam-solver.opam
@@ -27,6 +27,12 @@ depends: [
   "cudf" {>= "0.7"}
   "dune" {>= "1.5.0"}
 ]
-depopts: "z3"
-conflicts: [ "z3" {< "4.8.4"} ]
+depopts: [
+  "z3"
+  "opam-0install-cudf"
+]
+conflicts: [
+  "z3" {< "4.8.4"}
+  "opam-0install-cudf" {< "0.3"}
+]
 available: ocaml-version >= "4.02.3"

--- a/src/solver/dune
+++ b/src/solver/dune
@@ -8,7 +8,10 @@
                  (     -> opamBuiltinMccs.ml.dummy))
                (select opamBuiltinZ3.ml from
                  (z3 -> opamBuiltinZ3.ml.real)
-                 (   -> opamBuiltinZ3.ml.dummy)))
+                 (   -> opamBuiltinZ3.ml.dummy))
+               (select opamBuiltin0install.ml from
+                 (opam-0install-cudf -> opamBuiltin0install.ml.real)
+                 (                   -> opamBuiltin0install.ml.dummy)))
   (flags       (:standard
                (:include ../ocaml-flags-standard.sexp)
                (:include ../ocaml-flags-configure.sexp)

--- a/src/solver/opamBuiltin0install.ml.dummy
+++ b/src/solver/opamBuiltin0install.ml.dummy
@@ -1,0 +1,29 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2019 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+open OpamCudfSolverSig
+
+let name = "builtin-dummy-0install-solver"
+
+let is_present () = false
+
+let ext = ref None
+
+let command_name = None
+
+let default_criteria = {
+  crit_default = "";
+  crit_upgrade = "";
+  crit_fixup = "";
+  crit_best_effort_prefix = None;
+}
+
+let call ~criteria:_ ?timeout:_ _cudf =
+  failwith "This opam was compiled without the opam-0install solver built in"

--- a/src/solver/opamBuiltin0install.ml.dummy
+++ b/src/solver/opamBuiltin0install.ml.dummy
@@ -1,6 +1,6 @@
 (**************************************************************************)
 (*                                                                        *)
-(*    Copyright 2019 OCamlPro                                             *)
+(*    Copyright 2020 Kate Deplaix                                         *)
 (*                                                                        *)
 (*  All rights reserved. This file is distributed under the terms of the  *)
 (*  GNU Lesser General Public License version 2.1, with the special       *)

--- a/src/solver/opamBuiltin0install.ml.real
+++ b/src/solver/opamBuiltin0install.ml.real
@@ -81,7 +81,10 @@ let reconstruct_universe universe selections =
     ) [] |>
   Cudf.load_universe
 
-let call ~criteria:_ ?timeout:_ (preamble, universe, request) =
+let call ~criteria ?timeout:_ (preamble, universe, request) =
+  if not (String.equal criteria default_criteria.crit_default) then begin
+    OpamConsole.warning "Custom CUDF criteria is not supported by the 0install solver";
+  end;
   let timer = OpamConsole.timer () in
   let pkgs, constraints = create_spec universe request in
   let context = Opam_0install_cudf.create ~constraints universe in

--- a/src/solver/opamBuiltin0install.ml.real
+++ b/src/solver/opamBuiltin0install.ml.real
@@ -1,0 +1,92 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2017 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+open OpamCudfSolverSig
+
+let log f = OpamConsole.log "0install" f
+
+let name = "builtin-0install"
+
+let ext = ref None
+
+let is_present () = true
+
+let command_name = None
+
+let default_criteria = {
+  crit_default = "";
+  crit_upgrade = "";
+  crit_fixup = "";
+  crit_best_effort_prefix = None;
+}
+
+let not_relop = function
+  | `Eq -> `Neq
+  | `Neq -> `Eq
+  | `Geq -> `Lt
+  | `Gt -> `Leq
+  | `Leq -> `Gt
+  | `Lt -> `Geq
+
+let if_not_already_in_spec f ((pkgs, _) as spec) ((pkgname, _) as vpkg) =
+  if not (List.exists (fun (pkg, _) -> String.equal pkg pkgname) pkgs)
+  then f spec vpkg
+  else spec
+
+let add_spec pkg req f_relop c (pkgs, constraints) =
+  let pkgs = (pkg, req) :: pkgs in
+  let constraints = match c with
+    | None -> constraints
+    | Some (relop, v) -> (pkg, (f_relop relop, v)) :: constraints
+  in
+  (pkgs, constraints)
+
+let essential spec (pkg, c) = add_spec pkg `Essential (fun x -> x) c spec
+let recommended spec (pkg, c) = add_spec pkg `Recommended (fun x -> x) c spec
+let restricts spec (pkg, c) = add_spec pkg `Restricts not_relop c spec
+
+let create_spec universe request =
+  let spec = ([], []) in
+  let spec = List.fold_left essential spec request.Cudf.install in
+  let spec = List.fold_left essential spec request.Cudf.upgrade in
+  let spec = List.fold_left restricts spec request.Cudf.remove in
+  Cudf.fold_packages_by_name (fun spec pkgname pkgs ->
+      match List.find_opt (fun pkg -> pkg.Cudf.installed) pkgs with
+      | Some {Cudf.keep = `Keep_version; version; _} -> essential spec (pkgname, Some (`Eq, version))
+      | Some {Cudf.keep = `Keep_package; _} -> essential spec (pkgname, None)
+      | Some {Cudf.keep = `Keep_feature; _} -> assert false (* TODO: Is this used? *)
+      | Some {Cudf.keep = `Keep_none; _} -> if_not_already_in_spec recommended spec (pkgname, None)
+      | None -> spec
+    ) spec universe
+
+let reconstruct_universe universe selections =
+  Opam_0install_cudf.packages_of_result selections |>
+  List.fold_left (fun pkgs (pkg, v) ->
+      let pkg = Cudf.lookup_package universe (pkg, v) in
+      {pkg with was_installed = pkg.installed; installed = true} :: pkgs
+    ) [] |>
+  Cudf.load_universe
+
+let call ~criteria:_ ?timeout:_ (preamble, universe, request) =
+  let t0 = Unix.gettimeofday () in
+  let pkgs, constraints = create_spec universe request in
+  let context = Opam_0install_cudf.create ~constraints universe in
+  match Opam_0install_cudf.solve context pkgs with
+  | Ok selections ->
+    let universe = reconstruct_universe universe selections in
+    let t1 = Unix.gettimeofday () in
+    log "Solution found. Solve took %.2f s" (t1 -. t0);
+    (Some preamble, universe)
+  | Error _problem ->
+    let t1 = Unix.gettimeofday () in
+    log "No solution. Solve took %.2f s" (t1 -. t0);
+    (* Diagnostics disabled. Feel free to enable again for debug *)
+    (* print_endline (Opam_0install_cudf.diagnostics problem); *)
+    raise Common.CudfSolver.Unsat

--- a/src/solver/opamBuiltin0install.ml.real
+++ b/src/solver/opamBuiltin0install.ml.real
@@ -10,7 +10,7 @@
 
 open OpamCudfSolverSig
 
-let log f = OpamConsole.log "0install" f
+let log ?level f = OpamConsole.log "0install" ?level f
 
 let name = "builtin-0install"
 
@@ -82,18 +82,15 @@ let reconstruct_universe universe selections =
   Cudf.load_universe
 
 let call ~criteria:_ ?timeout:_ (preamble, universe, request) =
-  let t0 = Unix.gettimeofday () in
+  let timer = OpamConsole.timer () in
   let pkgs, constraints = create_spec universe request in
   let context = Opam_0install_cudf.create ~constraints universe in
   match Opam_0install_cudf.solve context pkgs with
   | Ok selections ->
     let universe = reconstruct_universe universe selections in
-    let t1 = Unix.gettimeofday () in
-    log "Solution found. Solve took %.2f s" (t1 -. t0);
+    log "Solution found. Solve took %.2f s" (timer ());
     (Some preamble, universe)
-  | Error _problem ->
-    let t1 = Unix.gettimeofday () in
-    log "No solution. Solve took %.2f s" (t1 -. t0);
-    (* Diagnostics disabled. Feel free to enable again for debug *)
-    (* print_endline (Opam_0install_cudf.diagnostics problem); *)
+  | Error problem ->
+    log "No solution. Solve took %.2f s" (timer ());
+    log ~level:3 "%a" (OpamConsole.slog Opam_0install_cudf.diagnostics) problem;
     raise Common.CudfSolver.Unsat

--- a/src/solver/opamBuiltin0install.ml.real
+++ b/src/solver/opamBuiltin0install.ml.real
@@ -35,10 +35,10 @@ let not_relop = function
   | `Leq -> `Gt
   | `Lt -> `Geq
 
-let if_not_already_in_spec f ((pkgs, _) as spec) ((pkgname, _) as vpkg) =
-  if not (List.exists (fun (pkg, _) -> String.equal pkg pkgname) pkgs)
-  then f spec vpkg
-  else spec
+let keep_installed request pkgname =
+  not (List.exists (fun (pkg, _) -> String.equal pkg pkgname) request.Cudf.install) &&
+  not (List.exists (fun (pkg, _) -> String.equal pkg pkgname) request.Cudf.upgrade) &&
+  not (List.exists (fun (pkg, _) -> String.equal pkg pkgname) request.Cudf.remove)
 
 let add_spec pkg req c (pkgs, constraints) =
   let pkgs = (pkg, req) :: pkgs in
@@ -51,9 +51,12 @@ let add_spec pkg req c (pkgs, constraints) =
 let essential spec (pkg, c) = add_spec pkg `Essential c spec
 let recommended spec (pkg, c) = add_spec pkg `Recommended c spec
 
-let restricts (pkgs, constraints) = function
-  | (pkg, None) -> ((pkg, `Restricts) :: pkgs, constraints)
-  | (pkg, Some (relop, v)) -> (pkgs, (pkg, (not_relop relop, v)) :: constraints)
+let restricts (pkgs, constraints) (pkg, c) =
+  let constraints = match c with
+    | None -> (pkg, (`Lt, 1)) :: (pkg, (`Gt, 1)) :: constraints (* pkg < 1 & pkg > 1 is always false *)
+    | Some (relop, v) -> (pkg, (not_relop relop, v)) :: constraints
+  in
+  (pkgs, constraints)
 
 let create_spec universe request =
   let spec = ([], []) in
@@ -65,7 +68,8 @@ let create_spec universe request =
       | Some {Cudf.keep = `Keep_version; version; _} -> essential spec (pkgname, Some (`Eq, version))
       | Some {Cudf.keep = `Keep_package; _} -> essential spec (pkgname, None)
       | Some {Cudf.keep = `Keep_feature; _} -> assert false (* TODO: Is this used? *)
-      | Some {Cudf.keep = `Keep_none; _} -> if_not_already_in_spec recommended spec (pkgname, None)
+      | Some {Cudf.keep = `Keep_none; _} when keep_installed request pkgname -> recommended spec (pkgname, None)
+      | Some {Cudf.keep = `Keep_none; _}
       | None -> spec
     ) spec universe
 

--- a/src/solver/opamBuiltin0install.ml.real
+++ b/src/solver/opamBuiltin0install.ml.real
@@ -1,6 +1,6 @@
 (**************************************************************************)
 (*                                                                        *)
-(*    Copyright 2017 OCamlPro                                             *)
+(*    Copyright 2020 Kate Deplaix                                         *)
 (*                                                                        *)
 (*  All rights reserved. This file is distributed under the terms of the  *)
 (*  GNU Lesser General Public License version 2.1, with the special       *)

--- a/src/solver/opamBuiltin0install.ml.real
+++ b/src/solver/opamBuiltin0install.ml.real
@@ -67,7 +67,7 @@ let create_spec universe request =
       match List.find_opt (fun pkg -> pkg.Cudf.installed) pkgs with
       | Some {Cudf.keep = `Keep_version; version; _} -> essential spec (pkgname, Some (`Eq, version))
       | Some {Cudf.keep = `Keep_package; _} -> essential spec (pkgname, None)
-      | Some {Cudf.keep = `Keep_feature; _} -> assert false (* TODO: Is this used? *)
+      | Some {Cudf.keep = `Keep_feature; _} -> assert false (* NOTE: Opam has no support for features *)
       | Some {Cudf.keep = `Keep_none; _} when keep_installed request pkgname -> recommended spec (pkgname, None)
       | Some {Cudf.keep = `Keep_none; _}
       | None -> spec

--- a/src/solver/opamBuiltin0install.ml.real
+++ b/src/solver/opamBuiltin0install.ml.real
@@ -40,17 +40,20 @@ let if_not_already_in_spec f ((pkgs, _) as spec) ((pkgname, _) as vpkg) =
   then f spec vpkg
   else spec
 
-let add_spec pkg req f_relop c (pkgs, constraints) =
+let add_spec pkg req c (pkgs, constraints) =
   let pkgs = (pkg, req) :: pkgs in
   let constraints = match c with
     | None -> constraints
-    | Some (relop, v) -> (pkg, (f_relop relop, v)) :: constraints
+    | Some c -> (pkg, c) :: constraints
   in
   (pkgs, constraints)
 
-let essential spec (pkg, c) = add_spec pkg `Essential (fun x -> x) c spec
-let recommended spec (pkg, c) = add_spec pkg `Recommended (fun x -> x) c spec
-let restricts spec (pkg, c) = add_spec pkg `Restricts not_relop c spec
+let essential spec (pkg, c) = add_spec pkg `Essential c spec
+let recommended spec (pkg, c) = add_spec pkg `Recommended c spec
+
+let restricts (pkgs, constraints) = function
+  | (pkg, None) -> ((pkg, `Restricts) :: pkgs, constraints)
+  | (pkg, Some (relop, v)) -> (pkgs, (pkg, (not_relop relop, v)) :: constraints)
 
 let create_spec universe request =
   let spec = ([], []) in

--- a/src/solver/opamBuiltin0install.mli
+++ b/src/solver/opamBuiltin0install.mli
@@ -1,0 +1,1 @@
+include OpamCudfSolverSig.S

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -1068,10 +1068,12 @@ let get_final_universe ~version_map univ req =
     match r with
     | Some ({Algo.Diagnostic.result = Algo.Diagnostic.Failure _; _} as r) ->
       make_conflicts ~version_map univ r
-    | Some {Algo.Diagnostic.result = Algo.Diagnostic.Success _; _}(*  -> *)
-      (* fail "inconsistent return value." *)
+    | Some {Algo.Diagnostic.result = Algo.Diagnostic.Success _; _}
     | None ->
-      raise (Solver_failure "Unsat")
+      raise (Solver_failure
+        "The current solver could not find a solution but dose3 could. \
+         This is probably a bug in the current solver. Please file a bug-report \
+         on the opam bug tracker: https://github.com/ocaml/opam/issues/")
 
 let diff univ sol =
   let before =

--- a/src/solver/opamCudfSolver.ml
+++ b/src/solver/opamCudfSolver.ml
@@ -230,6 +230,7 @@ let make_custom_solver name args criteria =
 let default_solver_selection =
   OpamBuiltinMccs.all_backends @ [
     (module OpamBuiltinZ3: S);
+    (module OpamBuiltin0install: S);
     (module Aspcud: S);
     (module Mccs: S);
     (module Aspcud_old: S);


### PR DESCRIPTION
A month ago, @talex5 presented a new fast solver for opam in this discourse post: https://discuss.ocaml.org/t/ann-opam-0install-0-1-fast-opam-solver-for-ci-etc/5852

The main goal of the project was to give a fast, CI-oriented external solver without having to use opam.
However for my own CI needs, a builtin solver was more appropriate, thus I started working on a version of this solver which would use the CUDF interface instead of the opam API: opam-0install-cudf (version 0.2 available on opam)

So, after months of testing on [check.ocamllabs.io](http://check.ocamllabs.io) (aka. https://github.com/kit-ty-kate/opam-health-check), where this new solver replaced and outperformed the Z3 builtin solver, I believe the interface in the right one (*) and this is now ready to be included upsteam.

The one change slightly outside of the scope of this PR in the `OpamCudf` module, is here because during the testing phase when the solver wasn't ready yet, the solver would sometime say that there is no solution, but the Dose3 solver used to print the diagnostics succeeded. However the dose3 solution usually includes the removal of most of the packages in the current switch. So for users' sake I'd rather see this outcome be an hard error, asking the user to report it instead, just in case this happens with whichever solver the user is currently using.

~(*): The current PR relies on the next version of `opam-0install-cudf`: `opam-0install-cudf.0.3` which should include https://github.com/talex5/opam-0install-solver/pull/16 for this PR to compile.~
EDIT: `opam-0install-cudf.0.3` has been released a month ago.