### PR TITLE
Bootstrap Opam with OCaml 4.11.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,6 @@
 
 # Shell scripts, autoconf, etc. must have LF endings, even on Windows
 *.sh text eol=lf
-*.zsh text eol=lf
 configure text eol=lf -diff
 configure.ac text eol=lf
 msvs-detect text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@ msvs-detect text eol=lf
 check_linker text eol=lf
 *.m4 text eol=lf
 changelog_checker text eol=lf
+*.cmd text eol=crlf
 
 # For diffing simplicity, the patch re-write test uses LF endings on Windows
 tests/patcher-test.reference text eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
+os: linux
 dist: focal
 language: c
-sudo: false
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
   global:
   - OPAMBSVERSION=2.1.0-alpha2
     # This should be identical to the value in appveyor.yml
-  - OPAM_REPO_SHA=8c45759d4
+  - OPAM_REPO_SHA=6877131f0
 
 jobs:
   include:
@@ -61,15 +61,18 @@ jobs:
       env: OCAML_VERSION=4.09.1
       stage: Build
     - os: linux
-      env: OCAML_VERSION=4.10.0
+      env: OCAML_VERSION=4.10.1
+      stage: Build
+    - os: linux
+      env: OCAML_VERSION=4.11.1
       stage: Build
     - os: linux
       stage: Hygiene
     - os: osx
-      env: OCAML_VERSION=4.09.1 OPAM_TEST=1
+      env: OCAML_VERSION=4.11.1 OPAM_TEST=1
       stage: Test
     - os: linux
-      env: OCAML_VERSION=4.09.1 OPAM_TEST=1
+      env: OCAML_VERSION=4.11.1 OPAM_TEST=1
       stage: Test
 #    - os: linux
 #      env: OCAML_VERSION=4.07.1 OPAM_TEST=1 EXTERNAL_SOLVER=aspcud
@@ -78,7 +81,7 @@ jobs:
       env: COLD=1
       stage: Test
     - os: linux
-      env: OCAML_VERSION=4.09.1
+      env: OCAML_VERSION=4.11.1
       stage: Upgrade
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
     CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
     DEP_MODE: lib-ext
     # This should be identical to the value in .travis.yml
-    OPAM_REPO_SHA: 8c45759d4
+    OPAM_REPO_SHA: 6877131f0
   matrix:
     - CYG_ROOT: cygwin
       CYG_ARCH: x86

--- a/appveyor_test.sh
+++ b/appveyor_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-opam init -y -a --compiler=ocaml.4.09.1 git+https://github.com/ocaml/opam-repository#$OPAM_REPO_SHA
+opam init -y -a --compiler=ocaml.4.11.1 git+https://github.com/ocaml/opam-repository#$OPAM_REPO_SHA
 eval $(opam config env)
 opam install -y -v ocamlfind

--- a/master_changes.md
+++ b/master_changes.md
@@ -46,10 +46,13 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## External dependencies
-  * Upgrade bootstrap OCaml compiler from 4.09.1 to 4.11.1 [#4234 @avsm]
+  * Upgrade bootstrap OCaml compiler from 4.09.1 to 4.11.1 [#4242 @avsm @dra27 @MisterDA @rjbou]
 
 ## Sandbox
   *
+
+## Test
+  * Update and expand Travis and AppVeyor test matrices [#4242 @MisterDA]
 
 ## Repository management
   *

--- a/master_changes.md
+++ b/master_changes.md
@@ -46,7 +46,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## External dependencies
-  *
+  * Upgrade bootstrap OCaml compiler from 4.09.1 to 4.11.1 [#4234 @avsm]
 
 ## Sandbox
   *

--- a/shell/bootstrap-ocaml.sh
+++ b/shell/bootstrap-ocaml.sh
@@ -125,8 +125,13 @@ if [ -n "$1" -a -n "${COMSPEC}" -a -x "${COMSPEC}" ] ; then
   PREFIX=`cd .. ; pwd`/ocaml
   WINPREFIX=`echo ${PREFIX} | cygpath -f - -m`
   if [ ${GEN_CONFIG_ONLY} -eq 0 ] ; then
-    # --disable-ocamldoc can change to --disable-stdlib-manpages when bumped to 4.11
-    PATH="${PATH_PREPEND}${PREFIX}/bin:${PATH}" Lib="${LIB_PREPEND}${Lib}" Include="${INC_PREPEND}${Include}" ./configure --prefix "$WINPREFIX" --build=$BUILD --host=$HOST --disable-ocamldoc $BOOTSTRAP_EXTRA_OPTS
+    PATH="${PATH_PREPEND}${PREFIX}/bin:${PATH}" \
+    Lib="${LIB_PREPEND}${Lib}" \
+    Include="${INC_PREPEND}${Include}" \
+      ./configure --prefix "$WINPREFIX" \
+                  --build=$BUILD --host=$HOST \
+                  --disable-stdlib-manpages \
+                  $BOOTSTRAP_EXTRA_OPTS
   fi
   cd ..
   if [ ! -e ${FLEXDLL} ]; then

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -11,8 +11,8 @@ endif
 
 PATCH ?= patch
 
-URL_ocaml = https://caml.inria.fr/pub/distrib/ocaml-4.09/ocaml-4.09.1.tar.gz
-MD5_ocaml = 1a7fc32aebbad6cb821ef26a396f78e7
+URL_ocaml = https://caml.inria.fr/pub/distrib/ocaml-4.11/ocaml-4.11.1.tar.gz
+MD5_ocaml = 3bee0ea50ed28b9cf0e8a35233f61480
 
 URL_flexdll = https://github.com/alainfrisch/flexdll/archive/0.38.tar.gz
 MD5_flexdll = dca52bce081c8f19e9cd78219458a816


### PR DESCRIPTION
This PR builds on https://github.com/ocaml/opam/pull/4234 to fix the little things that are missing and completely replaces 4.07.1 with 4.10.0 for bootstrapping.
Updating findlib to 1.8.1 is mandatory because 1.8.0 checks for the `-vmthread` flag of `ocamlc` which has been removed in 4.10.0.
EDIT: I removed the 'flexdll appveyor patch' in favor of using the latest flexdll commit available at the time of writing.
I have also updated and expanded Travis test matrix.