### PR TITLE
Fix config file solver ignored at init

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -7,6 +7,7 @@ Possibly scripts breaking changes are prefixed with ✘
 
 ## Init
   * Remove m4 from the list of recommended tools [#4184 @kit-ty-kate]
+  * Fix config solver field ignored [#4243 @rjbou - fix #4241]
 
 ## Upgrade
   * Fix atoms formula restriction with `--all` [#4221 @rjbou - fix #4218]

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -65,6 +65,7 @@ val search_files: string list
 val opam_init:
   ?root_dir:OpamTypes.dirname ->
   ?strict:bool ->
+  ?solver:(module OpamCudfSolver.S) Lazy.t ->
   ?skip_version_checks:bool ->
   ?all_parens:bool ->
   ?log_dir:OpamTypes.dirname ->
@@ -99,7 +100,6 @@ val opam_init:
   ?locked:string option ->
   ?no_depexts:bool ->
   ?cudf_file:string option ->
-  ?solver:(module OpamCudfSolver.S) Lazy.t ->
   ?best_effort:bool ->
   ?solver_preferences_default:string option Lazy.t ->
   ?solver_preferences_upgrade:string option Lazy.t ->


### PR DESCRIPTION
Same as for `OPAMLOGDIR`, as the default value is defined, the init mechanism ignores its update.
Fix #4241
