### PR TITLE
src-ext: fix extlib url

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -14,6 +14,7 @@ Possibly scripts breaking changes are prefixed with ✘
 ## Build
   * Opam file build using dune, removal of opam-%.install makefile target [#4178 @rjbou - fix #4173]
   * Use version var in opam file instead of equal current version number in opamlib dependencies [#4178 @rjbou]
+  * ext: fix extlib url [#4248 @rjbou]
 
 ## Install
   * Add `_build` to rsync exclusion list [#4230 @rjobou - fix #4195]

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -3,7 +3,7 @@ MD5_cppo = b13afeea6631d7c9b61f95bfd984a542
 
 $(call PKG_SAME,cppo)
 
-URL_extlib = https://ygrek.org.ua/p/release/ocaml-extlib/extlib-1.7.6.tar.gz
+URL_extlib = https://ygrek.org/p/release/ocaml-extlib/extlib-1.7.6.tar.gz
 MD5_extlib = b976093ef23b7d60fc1c8f0380c4f76a
 
 $(call PKG_SAME,extlib)


### PR DESCRIPTION
Seems that ygreg.org.ua is no more reachable and  the [package](https://opam.ocaml.org/packages/extlib/extlib.1.7.6/) redirects to ygrek.org.