### PR TITLE
Disable recursive & subpath pinning

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -211,9 +211,8 @@ all the packages pinned in the current switch.
 
 `opam install <DIR>` is an automatic way to handle pinning packages whose
 definitions are found in `<DIR>`, synchronise and install them. The `upgrade`,
-`reinstall` and `remove` commands can likewise be used with a directory
-argument to refer to pinned packages. Since `2.1.0~beta`, opam handles lookup
-in subdirectories with `--recurse` and `--subpath` options.
+`reinstall` and `remove` commands can likewise be used with a directory argument
+to refer to pinned packages.
 
 ## Common file format
 
@@ -1105,9 +1104,7 @@ files.
 
 - <a id="opamfield-extra-fields">`x-*: <value>`</a>:
   extra fields prefixed with `x-` can be defined for use by external tools. <span class="opam">opam</span>
-  will ignore them except for some search operations. _Note that_ on 2.1.0, the
-  field `x-subpath` is reserved to specify the subpath of the package (cf.
-  [install manpage](man/opam-install.html#lbAF)).
+  will ignore them except for some search operations.
 
 #### descr
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -50,6 +50,7 @@ New option are prefixed with ◈
 ## Pin
   * Don't keep unpinned package version if it exists in repo [#4073 @rjbou - fix #3630]
   * Fix path resolving when pinning with `file://` [#4209 @rjbou - fix #4208]
+  * ✘ Disable recursive & subpath pinning (only present experimentally in opam 2.1.0~alpha) [#4252 @rjbou]
 
 ## Show
   * ✘ Display error message for all not found packages [#4179 @rjbou - fix #4164]
@@ -108,6 +109,7 @@ New option are prefixed with ◈
   * add badges to install page [#4236 @rjbou]
   * Harden build system against changing the name of the opam binary [#4264 @dra27]
   * Fix typo [#4273 @robz]
+  * Remove recursive & subpath pinning doc [#4252 @rjbou]
 
 ## Var
   * Not found message show scope [#4192 @rjbou]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -476,7 +476,7 @@ let existing_filename_dirname_or_dash =
   in
   parse, print
 
-let subpath_conv =
+let _subpath_conv =
   (fun str -> `Ok (OpamStd.String.remove_prefix ~prefix:"./" str)), pr_str
 
 let package_name =
@@ -1227,18 +1227,24 @@ let assume_built =
      No locally-pinned packages will be skipped."
 
 (* Options common to all path based/related commands, e.g. (un)pin, upgrade,
-   remove, (re)install *)
-let recurse =
+   remove, (re)install.
+   Disabled *)
+let recurse = Term.const false
+
+(*
   mk_flag ["recursive"]
     "Allow recursive lookups of (b,*.opam) files. Cf. $(i,--subpath) also."
+*)
 
-let subpath =
+let subpath = Term.const None
+(*
   mk_opt ["subpath"] "PATH"
     "$(b,*.opam) files are retrieved from the given sub directory instead of \
       top directory. Sources are then taken from the targeted sub directory, \
       internally only this subdirectory is copied/fetched.  It can be combined \
       with $(i,--recursive) to have a recursive lookup on the subpath."
     Arg.(some subpath_conv) None
+*)
 
 let package_selection_section = "PACKAGE SELECTION OPTIONS"
 

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -125,7 +125,8 @@ val build_options: build_options Term.t
 val assume_built: bool Term.t
 
 (* Options common to all path based/related commands, e.g. (un)pin, upgrade,
-   remove, (re)install *)
+   remove, (re)install
+   Disabled *)
 val recurse: bool Term.t
 val subpath: string option Term.t
 


### PR DESCRIPTION
Partial revert of #3499, disable cli options `--recursive` and `--subpath`.