### PR TITLE
2.0: Changes required to build on the 2.0 branch with gcc10

### DIFF
--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -9,8 +9,8 @@ else
 CAN_PKG=0
 endif
 
-URL_ocaml = http://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.1.tar.gz
-MD5_ocaml = 0b180b273ce5cc2ac68f347c9b06d06f
+URL_ocaml = http://caml.inria.fr/pub/distrib/ocaml-4.09/ocaml-4.09.1.tar.gz
+MD5_ocaml = 1a7fc32aebbad6cb821ef26a396f78e7
 
 URL_flexdll = https://github.com/alainfrisch/flexdll/archive/0.37.tar.gz
 MD5_flexdll = cc456a89382e60d84130cddd53977486

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -3,7 +3,7 @@ MD5_cppo = 1cd25741d31417995b0973fe0b6f6c82
 
 $(call PKG_SAME,cppo)
 
-URL_extlib = http://ygrek.org.ua/p/release/ocaml-extlib/extlib-1.7.5.tar.gz
+URL_extlib = https://github.com/ygrek/ocaml-extlib/releases/download/1.7.5/extlib-1.7.5.tar.gz
 MD5_extlib = d989951536077563bf4c5e3479c3866f
 
 $(call PKG_SAME,extlib)


### PR DESCRIPTION
These are the minimal changes the CI container images are using to continue building opam with Fedora 32 and other gcc10 arches.

- Change bootstrap compiler to 4.09.1
- Change distfile of extlib to a site that isnt down