### PR TITLE
Harden doc/man/dune

### DIFF
--- a/doc/man/dune
+++ b/doc/man/dune
@@ -35,3 +35,7 @@
 (include opam-topics.inc)
 
 (include opam-admin-topics.inc)
+
+; This ensures that no opam command run will block asking for input
+(env
+  (_ (env-vars ("OPAMYES" "no"))))

--- a/doc/man/dune
+++ b/doc/man/dune
@@ -1,3 +1,7 @@
+; opam must always be invoked as %{bin:opam} to ensure that the manifested runtime on mingw is
+; assembled, if it was selected at configure-time (%{exe:opamMain.exe} is not executable in this
+; case.
+
 (rule
   (targets opam.1)
   (deps opam-topics.inc opam-admin-topics.inc)
@@ -22,13 +26,13 @@
 
 (rule
   (targets opam-topics.inc)
-  (deps %{bin:opam})
+  (deps %{bin:opam} using-built-opam)
   (mode promote)
   (action (with-stdout-to %{targets} (run %{exe:dune_man.exe} opam))))
 
 (rule
   (targets opam-admin-topics.inc)
-  (deps %{bin:opam})
+  (deps %{bin:opam} using-built-opam)
   (mode promote)
   (action (with-stdout-to %{targets} (run %{exe:dune_man.exe} opam admin))))
 
@@ -39,3 +43,12 @@
 ; This ensures that no opam command run will block asking for input
 (env
   (_ (env-vars ("OPAMYES" "no"))))
+
+; This ensure that %{bin:opam} really refers to the opam built in the tree
+(rule
+  (with-stdout-to check_local_build.ml
+    (echo "let s = Sys.argv.(1) in exit (if not (Filename.is_implicit s) && Filename.is_relative s then 0 else 1)")))
+
+(rule
+  (with-stdout-to using-built-opam (run ocaml %{dep:check_local_build.ml} %{bin:opam})))
+

--- a/doc/man/dune_man.ml
+++ b/doc/man/dune_man.ml
@@ -4,6 +4,7 @@ let gen_topic target_basename dline t =
                 \  (with-stdout-to %s-%s.0 (echo \"\")))\n\
                  (rule\n\
                 \  (targets %s-%s.1 %s-%s.err)\n\
+                \  (deps using-built-opam)\n\
                 \  (action (progn (with-stderr-to %s-%s.err\n\
                 \                   (with-stdout-to %s-%s.1 (run %s %s --help=groff)))\n\
                 \                 (diff %s-%s.err %%{dep:%s-%s.0}))))\n\

--- a/doc/man/opam-admin-topics.inc
+++ b/doc/man/opam-admin-topics.inc
@@ -4,6 +4,7 @@
   (with-stdout-to opam-admin-help.0 (echo "")))
 (rule
   (targets opam-admin-help.1 opam-admin-help.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-help.err
                    (with-stdout-to opam-admin-help.1 (run %{bin:opam} admin help --help=groff)))
                  (diff opam-admin-help.err %{dep:opam-admin-help.0}))))
@@ -12,6 +13,7 @@
   (with-stdout-to opam-admin-add-hashes.0 (echo "")))
 (rule
   (targets opam-admin-add-hashes.1 opam-admin-add-hashes.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-add-hashes.err
                    (with-stdout-to opam-admin-add-hashes.1 (run %{bin:opam} admin add-hashes --help=groff)))
                  (diff opam-admin-add-hashes.err %{dep:opam-admin-add-hashes.0}))))
@@ -20,6 +22,7 @@
   (with-stdout-to opam-admin-add-constraint.0 (echo "")))
 (rule
   (targets opam-admin-add-constraint.1 opam-admin-add-constraint.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-add-constraint.err
                    (with-stdout-to opam-admin-add-constraint.1 (run %{bin:opam} admin add-constraint --help=groff)))
                  (diff opam-admin-add-constraint.err %{dep:opam-admin-add-constraint.0}))))
@@ -28,6 +31,7 @@
   (with-stdout-to opam-admin-filter.0 (echo "")))
 (rule
   (targets opam-admin-filter.1 opam-admin-filter.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-filter.err
                    (with-stdout-to opam-admin-filter.1 (run %{bin:opam} admin filter --help=groff)))
                  (diff opam-admin-filter.err %{dep:opam-admin-filter.0}))))
@@ -36,6 +40,7 @@
   (with-stdout-to opam-admin-list.0 (echo "")))
 (rule
   (targets opam-admin-list.1 opam-admin-list.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-list.err
                    (with-stdout-to opam-admin-list.1 (run %{bin:opam} admin list --help=groff)))
                  (diff opam-admin-list.err %{dep:opam-admin-list.0}))))
@@ -44,6 +49,7 @@
   (with-stdout-to opam-admin-check.0 (echo "")))
 (rule
   (targets opam-admin-check.1 opam-admin-check.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-check.err
                    (with-stdout-to opam-admin-check.1 (run %{bin:opam} admin check --help=groff)))
                  (diff opam-admin-check.err %{dep:opam-admin-check.0}))))
@@ -52,6 +58,7 @@
   (with-stdout-to opam-admin-lint.0 (echo "")))
 (rule
   (targets opam-admin-lint.1 opam-admin-lint.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-lint.err
                    (with-stdout-to opam-admin-lint.1 (run %{bin:opam} admin lint --help=groff)))
                  (diff opam-admin-lint.err %{dep:opam-admin-lint.0}))))
@@ -60,6 +67,7 @@
   (with-stdout-to opam-admin-upgrade.0 (echo "")))
 (rule
   (targets opam-admin-upgrade.1 opam-admin-upgrade.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-upgrade.err
                    (with-stdout-to opam-admin-upgrade.1 (run %{bin:opam} admin upgrade --help=groff)))
                  (diff opam-admin-upgrade.err %{dep:opam-admin-upgrade.0}))))
@@ -68,6 +76,7 @@
   (with-stdout-to opam-admin-cache.0 (echo "")))
 (rule
   (targets opam-admin-cache.1 opam-admin-cache.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-cache.err
                    (with-stdout-to opam-admin-cache.1 (run %{bin:opam} admin cache --help=groff)))
                  (diff opam-admin-cache.err %{dep:opam-admin-cache.0}))))
@@ -76,6 +85,7 @@
   (with-stdout-to opam-admin-make.0 (echo "")))
 (rule
   (targets opam-admin-make.1 opam-admin-make.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-make.err
                    (with-stdout-to opam-admin-make.1 (run %{bin:opam} admin make --help=groff)))
                  (diff opam-admin-make.err %{dep:opam-admin-make.0}))))
@@ -84,6 +94,7 @@
   (with-stdout-to opam-admin-index.0 (echo "")))
 (rule
   (targets opam-admin-index.1 opam-admin-index.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-index.err
                    (with-stdout-to opam-admin-index.1 (run %{bin:opam} admin index --help=groff)))
                  (diff opam-admin-index.err %{dep:opam-admin-index.0}))))

--- a/doc/man/opam-topics.inc
+++ b/doc/man/opam-topics.inc
@@ -4,6 +4,7 @@
   (with-stdout-to opam-help.0 (echo "")))
 (rule
   (targets opam-help.1 opam-help.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-help.err
                    (with-stdout-to opam-help.1 (run %{bin:opam} help --help=groff)))
                  (diff opam-help.err %{dep:opam-help.0}))))
@@ -12,6 +13,7 @@
   (with-stdout-to opam-admin.0 (echo "")))
 (rule
   (targets opam-admin.1 opam-admin.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin.err
                    (with-stdout-to opam-admin.1 (run %{bin:opam} admin --help=groff)))
                  (diff opam-admin.err %{dep:opam-admin.0}))))
@@ -20,6 +22,7 @@
   (with-stdout-to opam-lock.0 (echo "")))
 (rule
   (targets opam-lock.1 opam-lock.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-lock.err
                    (with-stdout-to opam-lock.1 (run %{bin:opam} lock --help=groff)))
                  (diff opam-lock.err %{dep:opam-lock.0}))))
@@ -28,6 +31,7 @@
   (with-stdout-to opam-clean.0 (echo "")))
 (rule
   (targets opam-clean.1 opam-clean.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-clean.err
                    (with-stdout-to opam-clean.1 (run %{bin:opam} clean --help=groff)))
                  (diff opam-clean.err %{dep:opam-clean.0}))))
@@ -36,6 +40,7 @@
   (with-stdout-to opam-lint.0 (echo "")))
 (rule
   (targets opam-lint.1 opam-lint.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-lint.err
                    (with-stdout-to opam-lint.1 (run %{bin:opam} lint --help=groff)))
                  (diff opam-lint.err %{dep:opam-lint.0}))))
@@ -44,6 +49,7 @@
   (with-stdout-to opam-source.0 (echo "")))
 (rule
   (targets opam-source.1 opam-source.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-source.err
                    (with-stdout-to opam-source.1 (run %{bin:opam} source --help=groff)))
                  (diff opam-source.err %{dep:opam-source.0}))))
@@ -52,6 +58,7 @@
   (with-stdout-to opam-unpin.0 (echo "")))
 (rule
   (targets opam-unpin.1 opam-unpin.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-unpin.err
                    (with-stdout-to opam-unpin.1 (run %{bin:opam} unpin --help=groff)))
                  (diff opam-unpin.err %{dep:opam-unpin.0}))))
@@ -60,6 +67,7 @@
   (with-stdout-to opam-pin.0 (echo "")))
 (rule
   (targets opam-pin.1 opam-pin.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-pin.err
                    (with-stdout-to opam-pin.1 (run %{bin:opam} pin --help=groff)))
                  (diff opam-pin.err %{dep:opam-pin.0}))))
@@ -68,6 +76,7 @@
   (with-stdout-to opam-switch.0 (echo "")))
 (rule
   (targets opam-switch.1 opam-switch.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-switch.err
                    (with-stdout-to opam-switch.1 (run %{bin:opam} switch --help=groff)))
                  (diff opam-switch.err %{dep:opam-switch.0}))))
@@ -76,6 +85,7 @@
   (with-stdout-to opam-remote.0 (echo "")))
 (rule
   (targets opam-remote.1 opam-remote.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-remote.err
                    (with-stdout-to opam-remote.1 (run %{bin:opam} remote --help=groff)))
                  (diff opam-remote.err %{dep:opam-remote.0}))))
@@ -84,6 +94,7 @@
   (with-stdout-to opam-repository.0 (echo "")))
 (rule
   (targets opam-repository.1 opam-repository.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-repository.err
                    (with-stdout-to opam-repository.1 (run %{bin:opam} repository --help=groff)))
                  (diff opam-repository.err %{dep:opam-repository.0}))))
@@ -92,6 +103,7 @@
   (with-stdout-to opam-env.0 (echo "")))
 (rule
   (targets opam-env.1 opam-env.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-env.err
                    (with-stdout-to opam-env.1 (run %{bin:opam} env --help=groff)))
                  (diff opam-env.err %{dep:opam-env.0}))))
@@ -100,6 +112,7 @@
   (with-stdout-to opam-exec.0 (echo "")))
 (rule
   (targets opam-exec.1 opam-exec.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-exec.err
                    (with-stdout-to opam-exec.1 (run %{bin:opam} exec --help=groff)))
                  (diff opam-exec.err %{dep:opam-exec.0}))))
@@ -108,6 +121,7 @@
   (with-stdout-to opam-config.0 (echo "")))
 (rule
   (targets opam-config.1 opam-config.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-config.err
                    (with-stdout-to opam-config.1 (run %{bin:opam} config --help=groff)))
                  (diff opam-config.err %{dep:opam-config.0}))))
@@ -116,6 +130,7 @@
   (with-stdout-to opam-option.0 (echo "")))
 (rule
   (targets opam-option.1 opam-option.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-option.err
                    (with-stdout-to opam-option.1 (run %{bin:opam} option --help=groff)))
                  (diff opam-option.err %{dep:opam-option.0}))))
@@ -124,6 +139,7 @@
   (with-stdout-to opam-var.0 (echo "")))
 (rule
   (targets opam-var.1 opam-var.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-var.err
                    (with-stdout-to opam-var.1 (run %{bin:opam} var --help=groff)))
                  (diff opam-var.err %{dep:opam-var.0}))))
@@ -132,6 +148,7 @@
   (with-stdout-to opam-upgrade.0 (echo "")))
 (rule
   (targets opam-upgrade.1 opam-upgrade.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-upgrade.err
                    (with-stdout-to opam-upgrade.1 (run %{bin:opam} upgrade --help=groff)))
                  (diff opam-upgrade.err %{dep:opam-upgrade.0}))))
@@ -140,6 +157,7 @@
   (with-stdout-to opam-update.0 (echo "")))
 (rule
   (targets opam-update.1 opam-update.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-update.err
                    (with-stdout-to opam-update.1 (run %{bin:opam} update --help=groff)))
                  (diff opam-update.err %{dep:opam-update.0}))))
@@ -148,6 +166,7 @@
   (with-stdout-to opam-reinstall.0 (echo "")))
 (rule
   (targets opam-reinstall.1 opam-reinstall.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-reinstall.err
                    (with-stdout-to opam-reinstall.1 (run %{bin:opam} reinstall --help=groff)))
                  (diff opam-reinstall.err %{dep:opam-reinstall.0}))))
@@ -156,6 +175,7 @@
   (with-stdout-to opam-uninstall.0 (echo "")))
 (rule
   (targets opam-uninstall.1 opam-uninstall.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-uninstall.err
                    (with-stdout-to opam-uninstall.1 (run %{bin:opam} uninstall --help=groff)))
                  (diff opam-uninstall.err %{dep:opam-uninstall.0}))))
@@ -164,6 +184,7 @@
   (with-stdout-to opam-remove.0 (echo "")))
 (rule
   (targets opam-remove.1 opam-remove.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-remove.err
                    (with-stdout-to opam-remove.1 (run %{bin:opam} remove --help=groff)))
                  (diff opam-remove.err %{dep:opam-remove.0}))))
@@ -172,6 +193,7 @@
   (with-stdout-to opam-install.0 (echo "")))
 (rule
   (targets opam-install.1 opam-install.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-install.err
                    (with-stdout-to opam-install.1 (run %{bin:opam} install --help=groff)))
                  (diff opam-install.err %{dep:opam-install.0}))))
@@ -180,6 +202,7 @@
   (with-stdout-to opam-info.0 (echo "")))
 (rule
   (targets opam-info.1 opam-info.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-info.err
                    (with-stdout-to opam-info.1 (run %{bin:opam} info --help=groff)))
                  (diff opam-info.err %{dep:opam-info.0}))))
@@ -188,6 +211,7 @@
   (with-stdout-to opam-show.0 (echo "")))
 (rule
   (targets opam-show.1 opam-show.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-show.err
                    (with-stdout-to opam-show.1 (run %{bin:opam} show --help=groff)))
                  (diff opam-show.err %{dep:opam-show.0}))))
@@ -196,6 +220,7 @@
   (with-stdout-to opam-search.0 (echo "")))
 (rule
   (targets opam-search.1 opam-search.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-search.err
                    (with-stdout-to opam-search.1 (run %{bin:opam} search --help=groff)))
                  (diff opam-search.err %{dep:opam-search.0}))))
@@ -204,6 +229,7 @@
   (with-stdout-to opam-list.0 (echo "")))
 (rule
   (targets opam-list.1 opam-list.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-list.err
                    (with-stdout-to opam-list.1 (run %{bin:opam} list --help=groff)))
                  (diff opam-list.err %{dep:opam-list.0}))))
@@ -212,6 +238,7 @@
   (with-stdout-to opam-init.0 (echo "")))
 (rule
   (targets opam-init.1 opam-init.err)
+  (deps using-built-opam)
   (action (progn (with-stderr-to opam-init.err
                    (with-stdout-to opam-init.1 (run %{bin:opam} init --help=groff)))
                  (diff opam-init.err %{dep:opam-init.0}))))

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.2)
+(lang dune 1.5)
 (name opam)

--- a/master_changes.md
+++ b/master_changes.md
@@ -71,6 +71,7 @@ Possibly scripts breaking changes are prefixed with ✘
 ## Doc
   * add doc/warning for  Filename.rmdir_cleanup [#4197 @rjbou]
   * add badges to install page [#4236 @rjbou]
+  * Harden build system against changing the name of the opam binary [#4264 @dra27]
 
 ## Var
   * Not found message show scope [#4192 @rjbou]

--- a/opam-client.opam
+++ b/opam-client.opam
@@ -27,6 +27,6 @@ depends: [
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
   "cmdliner" {>= "0.9.8"}
-  "dune" {>= "1.2.1"}
+  "dune" {>= "1.5.0"}
 ]
 available: ocaml-version >= "4.02.3"

--- a/opam-core.opam
+++ b/opam-core.opam
@@ -25,7 +25,7 @@ depends: [
   "base-bigarray"
   "ocamlgraph"
   "re" {>= "1.9.0"}
-  "dune" {>= "1.2.1"}
+  "dune" {>= "1.5.0"}
   "cppo" {build}
 ]
 conflicts: "extlib-compat"

--- a/opam-devel.opam
+++ b/opam-devel.opam
@@ -24,7 +24,7 @@ build-test: [make "tests"]
 depends: [
   "opam-client" {= version}
   "cmdliner" {>= "0.9.8"}
-  "dune" {>= "1.2.1"}
+  "dune" {>= "1.5.0"}
 ]
 post-messages: [
 "The development version of opam has been successfully compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with

--- a/opam-format.opam
+++ b/opam-format.opam
@@ -23,6 +23,6 @@ build: [
 depends: [
   "opam-core" {= version}
   "opam-file-format" {>= "2.0.0~rc2"}
-  "dune" {>= "1.2.1"}
+  "dune" {>= "1.5.0"}
 ]
 available: ocaml-version >= "4.02.3"

--- a/opam-installer.opam
+++ b/opam-installer.opam
@@ -23,6 +23,6 @@ build: [
 depends: [
   "opam-format" {= version}
   "cmdliner" {>= "0.9.8"}
-  "dune" {>= "1.2.1"}
+  "dune" {>= "1.5.0"}
 ]
 available: ocaml-version >= "4.02.3"

--- a/opam-repository.opam
+++ b/opam-repository.opam
@@ -22,6 +22,6 @@ build: [
 ]
 depends: [
   "opam-format" {= version}
-  "dune" {>= "1.2.1"}
+  "dune" {>= "1.5.0"}
 ]
 available: ocaml-version >= "4.02.3"

--- a/opam-solver.opam
+++ b/opam-solver.opam
@@ -25,7 +25,7 @@ depends: [
   "mccs" {>= "1.1+9"}
   "dose3" {>= "5"}
   "cudf" {>= "0.7"}
-  "dune" {>= "1.2.1"}
+  "dune" {>= "1.5.0"}
 ]
 depopts: "z3"
 conflicts: [ "z3" {< "4.8.4"} ]

--- a/opam-state.opam
+++ b/opam-state.opam
@@ -22,6 +22,6 @@ build: [
 ]
 depends: [
   "opam-repository" {= version}
-  "dune" {>= "1.2.1"}
+  "dune" {>= "1.5.0"}
 ]
 available: ocaml-version >= "4.02.3"

--- a/src/client/dune
+++ b/src/client/dune
@@ -12,6 +12,7 @@
 
 (executable
   (name        opamMain)
+  ; This name needs to be updated in doc/man/dune if changed
   (public_name opam)
   (package     opam)
   (modules     opamMain)


### PR DESCRIPTION
Two fixes:

- Building the man pages should never inexplicably block the build
- There's a check to ensure that `%{bin:opam}` refers to something that's just been built and not something in `PATH`

cc @kit-ty-kate (replaces commit in #4229)