### PR TITLE
Depext: handle virtual packages on Debian

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -44,6 +44,7 @@ Possibly scripts breaking changes are prefixed with ✘
   * Homebrew: add no auto update env var for install, accept `pkgname` and `pkgnam@version` on query [#4200 @rjbou]
   * Force LC_ALL=C for query commands [#4200 @rjbou]
   * Fix install command dryrun [#4200 @rjbou]
+  * Handle debian virtual packages [#4267 @rjbou - fix #4251]
 
 
 ## Env


### PR DESCRIPTION
Change querying method to `apt-cache showpkg` to retrieve available and virtual packages (and the concrete packages they provide).
This is the most efficient. Other tested methods:
- `apt-cache depends` for available (concrete and virtual) packages + `apt-cache search` for each virtual package -> 1.824s
- `apt-cache search` for available packages + `apt-cache showpkg` on all not found for virtual ones -> 0.235
- `apt-cache showpkg` for available (concrete and virtual) packages, and their mapping (+ regexp optim) -> 0.178s
For reference, on this run, the old version takes 0.151s.
Fix #4251
