### PR TITLE
depext/debian: restore support for virtual packages with minimal cost

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -75,6 +75,7 @@ New option are prefixed with ◈
   * ◈ Add --depext-only to install only external dependencies, regardless of config depext status [#4238 @rjbou]
   * Move confirmation message after opam packages install [#4238 @rjbou]
   * Error if '--depext-only' is given with '--assume-depexts' or '--no-depexts'
+  * Handle debian virtual packages [#4269 @AltGr @rjbou - fix #4251]
 
 ## Env
   * Fix `OPAMSWITCH` empty string setting, consider as unset [#4237 @rjbou]

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -505,14 +505,16 @@ module OpamString = struct
   let starts_with ~prefix s =
     let x = String.length prefix in
     let n = String.length s in
-    n >= x
-    && String.sub s 0 x = prefix
+    n >= x &&
+    let rec chk i = i >= x || prefix.[i] = s.[i] && chk (i+1) in
+    chk 0
 
   let ends_with ~suffix s =
     let x = String.length suffix in
     let n = String.length s in
-    n >= x
-    && String.sub s (n - x) x = suffix
+    n >= x &&
+    let rec chk i = i >= x || suffix.[i] = s.[i+n-x] && chk (i+1) in
+    chk 0
 
   let contains_char s c =
     try let _ = String.index s c in true


### PR DESCRIPTION
we must juggle a bit between the limited interfaces provided to access
the apt database (e.g. `search` returns virtual pkg matches, but not
their origin package; other queries either don't handle them or don't
have regexps or options...), but it works.

So we call `apt-cache search --full` to retrieve the "provides" data,
then filter just the info we need, and reinterpret just the "provides"
info.