### PR TITLE
Copy files instead of rsync when they are in a local cache

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -20,6 +20,9 @@ Possibly scripts breaking changes are prefixed with ✘
   * Add `_build` to rsync exclusion list [#4230 @rjobou - fix #4195]
   * Recursive opam file lookup: ignore `_build` [#4230 @rjbou]
 
+## Archives fetch
+  * Copy instead of calling rsync when archives are in a local cache [#4270 @kit-ty-kate]
+
 ## Switch
   * Fix Not_found with `opam switch create . --deps` [#4151 @AltGr]
   * Package Var: resolve self `name` variable for orphan packages [#4228 @rjbou - fix #4224]


### PR DESCRIPTION
This PR is just to upstream a change I've been using in https://github.com/kit-ty-kate/opam-health-check.
This change improves slightly the time it takes to retrieve archives from a local cache by avoiding a rather unnecessary call to `rsync` from the cache to a temporary file (which is then going to be moved to the global download cache in `~/.opam/download-cache`), and replacing it by the `OpamSystem.copy_file` function improved in this wonderful PR: https://github.com/ocaml/opam/pull/4064

This PR approximatively improves the time it takes to retrieve archive by 0.02s per archive in cache on my test server. In my use-case (CI), opam is repetitively called and thus repetitively retrieve archive from the cache.
On a typical medium sized-example: `core.v0.14.0` for instance pulls 59 archives, so in total this PR make us gain 1.13s in this build. Multiply by 10_000 packages and this is now significant.

This was tested and timed with master + https://github.com/ocaml/opam/pull/4071 for simplicity and to avoid noise in the timing. (cc @Armael in case you want a simple-to-use commit to rebase #4071 you can use this one: https://github.com/kit-ty-kate/opam/commit/ac20d2f56fcd3befbb0032db6238137ac2962212)

Just to avoid confusion, I know I could directly move (or link) the entire cache to `~/.opam/download-cache` for an extra second of gain per 50 archives, but this is less composable and this PR is still an improvement nonetheless.