### PR TITLE
Fix a crash in sandbox.sh when the XDG cache directory does not exist

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -80,6 +80,10 @@ New option are prefixed with ◈
 ## Env
   * Fix `OPAMSWITCH` empty string setting, consider as unset [#4237 @rjbou]
 
+## Sandbox
+  * No error when linked directory doesn't exist (e.g. XDG defined) [#4278 @kit-ty-kate]
+  * Add quotew to avoid space unwanted behaviors [#4278 @kit-ty-kate]
+
 ## Remove
   * Fix autoremove env var handling [#4219 @rjbou - fix #4217]
 

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -78,9 +78,9 @@ add_ccache_mount() {
 add_dune_cache_mount() {
   u_cache=${XDG_CACHE_HOME:-$HOME/.cache}
   u_dune_cache=$u_cache/dune
-  cache=$(readlink -f "$u_cache")
+  cache=$(readlink -m "$u_cache")
   dune_cache=$cache/dune
-  dune_cache=$(readlink -f $u_dune_cache)
+  dune_cache=$(readlink -m $u_dune_cache)
   mkdir -p ${dune_cache}
   add_mount rw $u_dune_cache $dune_cache
 }

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -71,7 +71,7 @@ add_ccache_mount() {
       done
       CCACHE_DIR=${CCACHE_DIR-$HOME/.ccache}
       ccache_dir=${ccache_dir-$CCACHE_DIR}
-      add_mounts rw $ccache_dir
+      add_mounts rw "$ccache_dir"
   fi
 }
 
@@ -80,9 +80,9 @@ add_dune_cache_mount() {
   u_dune_cache=$u_cache/dune
   cache=$(readlink -m "$u_cache")
   dune_cache=$cache/dune
-  dune_cache=$(readlink -m $u_dune_cache)
-  mkdir -p ${dune_cache}
-  add_mount rw $u_dune_cache $dune_cache
+  dune_cache=$(readlink -m "$u_dune_cache")
+  mkdir -p "${dune_cache}"
+  add_mount rw "$u_dune_cache" "$dune_cache"
 }
 
 # This case-switch should remain identical between the different sandbox implems
@@ -91,7 +91,7 @@ case "$COMMAND" in
     build)
         # mount unusual path in ro
         if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-           add_mounts ro $(echo ${OPAM_USER_PATH_RO} | sed 's|:| |g')
+           add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
         fi
         add_mounts ro "$OPAM_SWITCH_PREFIX"
         add_mounts rw "$PWD"
@@ -101,7 +101,7 @@ case "$COMMAND" in
     install)
         # mount unusual path in ro
         if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-           add_mounts ro  $(echo ${OPAM_USER_PATH_RO} | sed 's|:| |g')
+           add_mounts ro  $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
         fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"
@@ -110,7 +110,7 @@ case "$COMMAND" in
     remove)
         # mount unusual path in ro
         if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-           add_mounts ro $(echo ${OPAM_USER_PATH_RO} | sed 's|:| |g')
+           add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
         fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -23,11 +23,11 @@ if [ -z ${TMPDIR+x} ]; then
   # directory differently; the latter should be made readable/writable
   # too and getconf seems to be a robust way to get it
   if [ -z /usr/bin/getconf ]; then
-    TMP=`getconf DARWIN_USER_TEMP_DIR`
-    add_mounts rw $TMP
+    TMP=$(getconf DARWIN_USER_TEMP_DIR)
+    add_mounts rw "$TMP"
   fi
 else
-  add_mounts rw $TMPDIR
+  add_mounts rw "$TMPDIR"
 fi
 
 # C compilers using `ccache` will write to a shared cache directory
@@ -44,14 +44,14 @@ add_ccache_mount() {
       done
       CCACHE_DIR=${CCACHE_DIR-$HOME/.ccache}
       ccache_dir=${ccache_dir-$CCACHE_DIR}
-      add_mounts rw $ccache_dir
+      add_mounts rw "$ccache_dir"
   fi
 }
 
 add_dune_cache_mount() {
   DUNE_CACHE=${XDG_CACHE_HOME:-$HOME/.cache}/dune
-  mkdir -p ${DUNE_CACHE}
-  add_mounts rw $DUNE_CACHE
+  mkdir -p "${DUNE_CACHE}"
+  add_mounts rw "$DUNE_CACHE"
  }
 
 # This case-switch should remain identical between the different sandbox implems


### PR DESCRIPTION
Opam 2.1 has support for symlinked cache directory, however currently if the cache directory does not exist, the script will crash with no error message.
```
~/opam-repository$ ls ~/.cache
ls: cannot access '/home/opam/.cache': No such file or directory
~/opam-repository$ OPAM_SWITCH_PREFIX ~/.opam/opam-init/hooks/sandbox.sh build ls
bash: OPAM_SWITCH_PREFIX: command not found
~/opam-repository$ OPAM_SWITCH_PREFIX=blah ~/.opam/opam-init/hooks/sandbox.sh build ls
~/opam-repository$ echo $?
1
~/opam-repository$ sed -i 's/readlink -f/readlink -m/' ~/.opam/opam-init/hooks/sandbox.sh
~/opam-repository$ OPAM_SWITCH_PREFIX=blah ~/.opam/opam-init/hooks/sandbox.sh build ls
CHANGES.md  CONTRIBUTING.md  COPYING  README.md  packages  repo  version
```