### PR TITLE
Config file - opam root bump to format-version '2.1' + travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ autom4te.cache
 src/ocaml-flags-configure.sexp
 src/**/.merlin
 src/client/linking.sexp
+src/client/no-git-version
 src/core/developer
 src/manifest/dune
 src/manifest/install.inc

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -94,8 +94,8 @@ please run make configure and fixup the commit"
 }
 
 unset-dev-version () {
-  # unset git versioning to allow OPAMYES use for upgrade
-  sed -i  -e 's/\(.*with-stdout-to get_git_version.ml.*@@\).*/\1 \\"let version = None\\"")))/' src/client/dune
+  # disable git versioning to allow OPAMYES use for upgrade
+  touch src/client/no-git-version
 }
 
 case "$TARGET" in

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -322,8 +322,8 @@ export OCAMLRUNPARAM=b
     make lib-ext
   fi
   if [ "$TRAVIS_BUILD_STAGE_NAME" = "Upgrade" ]; then
-    # unset git versionning to allow OPAMYES use for upgrade
-    sed -i  -e 's/\(.*with-stdout-to get-git-version.ml.*@@\).*/\1 \\"let version = None\\"")))/' src/client/dune
+    # unset git versioning to allow OPAMYES use for upgrade
+    sed -i  -e 's/\(.*with-stdout-to get_git_version.ml.*@@\).*/\1 \\"let version = None\\"")))/' src/client/dune
   fi
   make all admin
 

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -62,7 +62,7 @@ init-bootstrap () {
     eval $(opam env)
     # extlib is installed, since UChar.cmi causes problems with the search
     # order. See also the removal of uChar and uTF8 in src_ext/jbuild-extlib-src
-    opam install ssl cmdliner dose3 cudf.0.9 opam-file-format re extlib dune 'mccs>=1.1+5' --yes
+    opam install . --deps-only --yes
   fi
   rm -f "$OPAMBSROOT"/log/*
 }

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -380,6 +380,12 @@ if [ "$TRAVIS_BUILD_STAGE_NAME" = "Upgrade" ]; then
     echo "[31mBad return code $rcode, should be 10[0m";
     exit $rcode
   fi
+  opam_version=$(sed -ne 's/opam-version: *//p' $OPAMROOT/config)
+  if [ "$opam_version" = '"1.2"' ]; then
+    echo -e "\e[31mUpgrade failed, opam-root is still 1.2\e[0m";
+    cat $OPAMROOT/config
+    exit 2
+  fi
   exit 0
 fi
 

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -319,6 +319,8 @@ export OCAMLRUNPARAM=b
   (set +x ; echo -en "travis_fold:start:build\r") 2>/dev/null
   if [[ $OPAM_TEST -eq 1 ]] ; then
     export OPAMROOT=$OPAMBSROOT
+    # If the cached root is newer, regenerate a binary compatible root
+    opam env || { rm -rf $OPAMBSROOT; init-bootstrap; }
     eval $(opam env)
   fi
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -33,6 +33,7 @@ New option are prefixed with ◈
   * ✘ Reject (shell) character on switch names [#4237 @rjbou - fix #4231]
   * Add missing depext to unavailable reasons [#4194 @rjbou - fix #4176]
     * Fix not found error [#4279 @rjbou]
+  * ✘ Bump config file version to 2.1 (new depext fields) [#4280 @rjbou - fix #4266]
 
 
 ## Pin

--- a/src/client/dune
+++ b/src/client/dune
@@ -42,8 +42,13 @@
   (action  (ignore-stderr (with-stdout-to %{targets} (system "git rev-parse --quiet --verify HEAD || echo .")))))
 
 (rule
+  (targets no-git-version)
+  (mode fallback)
+  (action (copy git-sha %{targets})))
+
+(rule
   ; Travis Upgrade job rely on this line. If changed, update travis-ci.sh too.
-  (with-stdout-to get_git_version.ml (echo "print_string @@ let v = \"%{read-lines:git-sha}\" in if v = \".\" then \"let version = None\" else \"let version = Some \\\"\" ^ v ^ \"\\\"\"")))
+  (with-stdout-to get_git_version.ml (echo "print_string @@ let v = \"%{read-lines:no-git-version}\" in if v = \"\" || v = \".\" then \"let version = None\" else \"let version = Some \\\"\" ^ v ^ \"\\\"\"")))
 
 (rule
   (with-stdout-to opamGitVersion.ml (run ocaml %{dep:get_git_version.ml})))

--- a/src/client/dune
+++ b/src/client/dune
@@ -42,6 +42,7 @@
   (action  (ignore-stderr (with-stdout-to %{targets} (system "git rev-parse --quiet --verify HEAD || echo .")))))
 
 (rule
+  ; Travis Upgrade job rely on this line. If changed, update travis-ci.sh too.
   (with-stdout-to get_git_version.ml (echo "print_string @@ let v = \"%{read-lines:git-sha}\" in if v = \".\" then \"let version = None\" else \"let version = Some \\\"\" ^ v ^ \"\\\"\"")))
 
 (rule

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1055,7 +1055,7 @@ module ConfigSyntax = struct
   let internal = "config"
   (* This version is used as a marker for the whole opam root, so it's not
      strictly speaking the actual format of the config file *)
-  let format_version = OpamVersion.of_string "2.0"
+  let format_version = OpamVersion.of_string "2.1"
 
   type t = {
     opam_version : opam_version;

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -1046,9 +1046,9 @@ let from_2_0_beta_to_2_0_beta5 root conf =
 
 let from_2_0_beta5_to_2_0 _ conf = conf
 
-let _v2_1 = OpamVersion.of_string "2.1"
+let v2_1 = OpamVersion.of_string "2.1"
 
-let _from_2_0_to_2_1 _ conf = conf
+let from_2_0_to_2_1 _ conf = conf
 
 let latest_version = OpamFile.Config.format_version
 
@@ -1111,7 +1111,8 @@ let as_necessary global_lock root config =
         update_to v2_0_alpha3 from_2_0_alpha2_to_2_0_alpha3 |>
         update_to v2_0_beta  from_2_0_alpha3_to_2_0_beta |>
         update_to v2_0_beta5 from_2_0_beta_to_2_0_beta5 |>
-        update_to v2_0       from_2_0_beta5_to_2_0
+        update_to v2_0       from_2_0_beta5_to_2_0 |>
+        update_to v2_1       from_2_0_to_2_1
       in
       OpamConsole.msg "Format upgrade done.\n";
       raise (Upgrade_done config)


### PR DESCRIPTION
As new fields was added (depext ones), we need to upgrade to avoid syntax errors with an opam 2.0 bnary
fix #4266