### PR TITLE
On init, check and propose to disable sandboxing if tool present & not working (docker, chroot, WLS1, etc.)

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -112,19 +112,6 @@ case "$TARGET" in
     git config --global gc.autoDetach false
 
   # Disable bubblewrap wrapping, it's not available within Docker
-  cat <<EOF >>~/.opamrc
-required-tools: [
-  ["curl" "wget"]
-    {"A download tool is required, check env variables OPAMCURL or OPAMFETCH"}
-  "diff"
-  "patch"
-  "tar"
-  "unzip"
-]
-wrap-build-commands: []
-wrap-install-commands: []
-wrap-remove-commands: []
-EOF
 
     if [[ $COLD -ne 1 ]] ; then
       if [[ $TRAVIS_OS_NAME = "osx" && -n $EXTERNAL_SOLVER ]] ; then
@@ -355,10 +342,6 @@ export OCAMLRUNPARAM=b
         echo -e "\e[31mBad return code $rcode, should be 10\e[0m";
         exit $rcode
       fi
-      # Disable sandbox because of the init done in the forced upgrade
-      opam option --global 'wrap-build-commands=[]'
-      opam option --global 'wrap-install-commands=[]'
-      opam option --global 'wrap-remove-commands=[]'
     fi
     set -e
     make distclean

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
     - aspcud
     - libglpk-dev
     - busybox
+    - bubblewrap
 
 before_install:
     - bash -exu .travis-ci.sh prepare

--- a/master_changes.md
+++ b/master_changes.md
@@ -10,7 +10,7 @@ New option/command/subcommand are prefixed with ◈.
   * ✘ `--yes` passed to all commands, and plugins [#4316 @dra27]
 
 ## Init
-  *
+  * On init, check availability of sandbox and propose to disable [#4284 @rjbou - fix #4089]
 
 ## Upgrade
   *

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -446,12 +446,11 @@ let get_wrappers t =
     ~inner:(OpamFile.Switch_config.wrappers t.switch_config)
 
 let get_wrapper t opam wrappers ?local getter =
-  let root = t.switch_global.root in
-  let hook_vnam = OpamVariable.of_string "hooks" in
-  let hook_vval = Some (OpamVariable.dirname (OpamPath.hooks_dir root)) in
-  let local_env = match local with
-    | Some e -> OpamVariable.Map.add hook_vnam hook_vval e
-    | None ->OpamVariable.Map.singleton hook_vnam hook_vval
+  let local_env =
+    let hook_env = OpamEnv.hook_env t.switch_global.root in
+    match local with
+    | Some e -> OpamVariable.Map.merge (fun _ _ v -> v) e hook_env
+    | None -> hook_env
   in
   OpamFilter.commands (OpamPackageVar.resolve ~local:local_env ~opam t)
     (getter wrappers) |>

--- a/src/client/opamAuxCommands.mli
+++ b/src/client/opamAuxCommands.mli
@@ -103,3 +103,11 @@ val simulate_autopin:
   ?subpath:string ->
   [ `Atom of atom | `Filename of filename | `Dirname of dirname ] list ->
   'a switch_state * atom list
+
+(* Check sandboxing script call. If it errors or unattended output, disable
+   sandboxing by removing [OpamInitDefaults.sandbox_wrappers] commands in
+   config file.
+   Only one script is checked (init script default one), and tested on an
+   `echo SUCCESS' call. *)
+val check_and_revert_sandboxing:
+  OpamPath.t -> OpamFile.Config.t -> OpamFile.Config.t

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -25,6 +25,7 @@ val init:
   ?update_config:bool ->
   ?env_hook:bool ->
   ?completion:bool ->
+  ?check_sandbox:bool ->
   shell ->
   rw global_state * unlocked repos_state * formula
 
@@ -40,6 +41,7 @@ val init:
 val reinit:
   ?init_config:OpamFile.InitConfig.t -> interactive:bool -> ?dot_profile:filename ->
   ?update_config:bool -> ?env_hook:bool -> ?completion:bool -> ?inplace:bool ->
+  ?check_sandbox:bool ->
   OpamFile.Config.t -> shell -> unit
 
 (** Install the given list of packages. [add_to_roots], if given, specifies that

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -365,8 +365,9 @@ let init cli =
             ~no_default_config_file:no_config_file ~add_config_file:config_file
         in
         OpamClient.reinit ~init_config ~interactive ~dot_profile
-          ?update_config ?env_hook ?completion ~inplace
-          (OpamFile.Config.safe_read config_f) shell
+           ?update_config ?env_hook ?completion ~inplace
+           ~check_sandbox:(not no_sandboxing)
+           (OpamFile.Config.safe_read config_f) shell;
       else
         OpamEnv.setup root ~interactive ~dot_profile ?update_config ?env_hook
           ?completion ~inplace shell
@@ -385,7 +386,9 @@ let init cli =
       OpamClient.init
         ~init_config ~interactive
         ?repo ~bypass_checks ~dot_profile
-        ?update_config ?env_hook ?completion shell
+        ?update_config ?env_hook ?completion
+        ~check_sandbox:(not no_sandboxing)
+        shell
     in
     OpamStd.Exn.finally (fun () -> OpamRepositoryState.drop rt)
     @@ fun () ->

--- a/src/client/opamInitDefaults.mli
+++ b/src/client/opamInitDefaults.mli
@@ -21,6 +21,11 @@ val default_compiler: formula
 
 val eval_variables: (OpamVariable.t * string list * string) list
 
+val sandbox_wrappers:
+  [> `build of command list
+  | `install of command list
+  | `remove of command list ] list
+
 (** Default initial configuration file for use by [opam init] if nothing is
     supplied. *)
 val init_config: ?sandboxing:bool -> unit -> OpamFile.InitConfig.t

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -736,3 +736,8 @@ let setup
   in
   update_user_setup root ?dot_profile:update_dot_profile shell;
   write_static_init_scripts root ?completion ?env_hook ?inplace ()
+
+let hook_env root =
+  let hook_vnam = OpamVariable.of_string "hooks" in
+  let hook_vval = Some (OpamVariable.dirname (OpamPath.hooks_dir root)) in
+  OpamVariable.Map.singleton hook_vnam hook_vval

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -121,3 +121,7 @@ val clear_dynamic_init_scripts: rw global_state -> unit
 (** Print a warning if the environment is not set-up properly.
     (General message) *)
 val check_and_print_env_warning: 'a switch_state -> unit
+
+(** Hook directory environment *)
+val hook_env:
+  OpamPath.t -> OpamVariable.variable_contents option OpamVariable.Map.t


### PR DESCRIPTION
The check is done by calling the sandbox script with `sandbox <action> sh -c "echo SUCCESS >/tmp/t && cat /tmp/t"`, and checking that stdout is `SUCCESS`.
Disabling is done by removing from global config sandboxing wrappers, default ones, defined in `OpamInitDefaults.sandbox_wrappers`.