### PR TITLE
`opam pin scan'

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -23,7 +23,9 @@ New option/command/subcommand are prefixed with ◈.
   * Support -n as an alias of --no-action (to match opam-pin) [#4324 @dra27]
 
 ## Pin
-  *
+  * ◈ Add `pin scan` subcommand to list available pins [#4285 @rjbou]
+  * ◈ Add `--normalise` option to print a normalised list when scanning, that can be taken by `opam pin add` [#4285 @rjbou]
+  * `OpamCommand.pin` refactor, including adding `OpamClient.PIN.pin_url_list` to pin a list of package with url  [#4285 @rjbou]
 
 ## List
   * <field> form no longer advertised as valid for --columns [#4322 @dra27]
@@ -67,13 +69,12 @@ New option/command/subcommand are prefixed with ◈.
 ## Opam installer
   *
 
-## Opam file
-  *
 
 ## Solver
   * Don't penalise packages with more recent 'hidden-versions' [#4312 @AltGr]
 
 ## Internal
+  * Process: don't display status line if not verbose, and status line disabled [#4285 @rjbou]
   * Optimise package name comparison [#4328 @AltGr - fix #4245]
 
 ## Test

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1478,6 +1478,33 @@ module PIN = struct
     | OpamPinCommand.Aborted -> OpamStd.Sys.exit_because `Aborted
     | OpamPinCommand.Nothing_to_do -> st
 
+  let url_pins st ?edit ?(action=true) ?(pre=fun _ -> ()) pins =
+    let names = List.map (fun (n,_,_,_) -> n) pins in
+    (match names with
+    | _::_::_ ->
+      if not (OpamConsole.confirm
+                "This will pin the following packages: %s. Continue?"
+                (OpamStd.List.concat_map ", " OpamPackage.Name.to_string names))
+      then
+        OpamStd.Sys.exit_because `Aborted
+    | _ -> ());
+    let pinned = st.pinned in
+    let st =
+      List.fold_left (fun st (name, version, url, subpath as pin) ->
+          pre pin;
+          try
+            OpamPinCommand.source_pin st name ?version
+              ?edit ?subpath (Some url)
+          with
+          | OpamPinCommand.Aborted -> OpamStd.Sys.exit_because `Aborted
+          | OpamPinCommand.Nothing_to_do -> st)
+        st pins
+    in
+    if action then
+      (OpamConsole.msg "\n";
+       post_pin_action st pinned names)
+    else st
+
   let edit st ?(action=true) ?version name =
     let pinned = st.pinned in
     let st =

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -126,6 +126,12 @@ module PIN: sig
     rw switch_state -> ?action:bool -> ?version:version -> OpamPackage.Name.t ->
     rw switch_state
 
+  val url_pins:
+    rw switch_state ->  ?edit:bool -> ?action:bool ->
+    ?pre:((name * version option * url * string option) -> unit) ->
+    (name * version option * url * string option) list ->
+    rw switch_state
+
   val unpin:
     rw switch_state ->
     ?action:bool -> OpamPackage.Name.t list -> rw switch_state

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2865,10 +2865,10 @@ let pin ?(unpin_only=false) () =
     mk_flag ["normalise"]
       (Printf.sprintf
          "Print list of available package to pin in format \
-          `name.version%curl%csubpath`, that is comprehensible by `opam pin \
+          `name.version%curl`, that is comprehensible by `opam pin \
           add`. Available only with the scan subcommand. An example of use is \
           `opam pin scan . --normalise | grep foo | xargs opam pin add`"
-         OpamPinCommand.scan_sep OpamPinCommand.scan_sep)
+         OpamPinCommand.scan_sep)
   in
   let guess_names kind ~recurse ?subpath url k =
     let found, cleanup =

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -766,12 +766,12 @@ let scan ~normalise ~recurse ?subpath url =
                    (String.make 1 scan_sep) ^ sb) sb))
          pins)
   else
-    ["# Name"; "# Version"; "# Url" ; "# Subpath"] ::
-    List.map (fun (name, version, sb) ->
+    ["# Name"; "# Version"; "# Url" (*; "# Subpath"*)] ::
+    List.map (fun (name, version, _sb) ->
         [ OpamPackage.Name.to_string name;
           (version >>| OpamPackage.Version.to_string) +! "-";
           OpamUrl.to_string url;
-          sb +! "-" ]) pins
+          (*sb +! "-"*) ]) pins
     |> OpamStd.Format.align_table
     |> OpamConsole.print_table stdout ~sep:"  "
 

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -702,3 +702,75 @@ let list st ~short =
   in
   let table = List.map lines (OpamPackage.Set.elements st.pinned) in
   OpamConsole.print_table stdout ~sep:"  " (OpamStd.Format.align_table table)
+
+(* Must not be contained in a package name, version, nor url *)
+let scan_sep = '^'
+
+let scan ~normalise ~recurse ?subpath url =
+  let open OpamStd.Option.Op in
+  let pins_of_dir dir =
+    OpamPinned.files_in_source ~recurse ?subpath dir
+    |> OpamStd.List.filter_map (fun (nf, opamf, sb) ->
+        let opam = OpamFile.OPAM.safe_read opamf in
+        match (nf ++ OpamFile.OPAM.name_opt opam) with
+        | Some name ->
+          Some (name, (OpamFile.OPAM.version_opt opam), sb)
+        | None ->
+          OpamConsole.warning "Can not retrieve a package name from %s"
+            (OpamFilename.to_string (OpamFile.filename opamf));
+          None)
+  in
+  let pins, cleanup =
+    match OpamUrl.local_dir url with
+    | Some dir -> pins_of_dir dir, None
+    | None ->
+      let pin_cache_dir = OpamRepositoryPath.pin_cache url in
+      let cleanup = fun () ->
+        OpamFilename.rmdir @@ OpamRepositoryPath.pin_cache_dir ()
+      in
+      let basename =
+        match OpamStd.String.split (OpamUrl.basename url) '.' with
+        | [] ->
+          OpamConsole.error_and_exit `Bad_arguments
+            "Can not retrieve a path from '%s'"
+            (OpamUrl.to_string url)
+        | b::_ -> b
+      in
+      try
+        let open OpamProcess.Job.Op in
+        OpamProcess.Job.run @@
+        OpamRepository.pull_tree
+          ~cache_dir:(OpamRepositoryPath.download_cache
+                        OpamStateConfig.(!r.root_dir))
+          basename pin_cache_dir [] [url] @@| function
+        | Not_available (_,u) ->
+          OpamConsole.error_and_exit `Sync_error
+            "Could not retrieve %s" u
+        | Result _ | Up_to_date _ ->
+          pins_of_dir pin_cache_dir, Some cleanup
+      with e -> OpamStd.Exn.finalise e cleanup
+  in
+  let finalise = OpamStd.Option.default (fun () -> ()) cleanup in
+  OpamStd.Exn.finally finalise @@ fun () ->
+  if normalise then
+    OpamConsole.msg "%s"
+      (OpamStd.List.concat_map "\n"
+         (fun (name, version, sb) ->
+            Printf.sprintf "%s%s%c%s%s"
+              (OpamPackage.Name.to_string name)
+              (OpamStd.Option.to_string
+                 (fun v -> "." ^OpamPackage.Version.to_string v) version)
+              scan_sep
+              (OpamUrl.to_string url)
+              (OpamStd.Option.to_string (fun sb ->
+                   (String.make 1 scan_sep) ^ sb) sb))
+         pins)
+  else
+    ["# Name"; "# Version"; "# Url" ; "# Subpath"] ::
+    List.map (fun (name, version, sb) ->
+        [ OpamPackage.Name.to_string name;
+          (version >>| OpamPackage.Version.to_string) +! "-";
+          OpamUrl.to_string url;
+          sb +! "-" ]) pins
+    |> OpamStd.Format.align_table
+    |> OpamConsole.print_table stdout ~sep:"  "

--- a/src/client/opamPinCommand.mli
+++ b/src/client/opamPinCommand.mli
@@ -65,6 +65,13 @@ val scan_sep: char
     [normalise] is true, displays it's normalised format
     `name.version[scan_sep]curl[scan_sep]subpath`. *)
 val scan: normalise:bool -> recurse:bool -> ?subpath: string -> url -> unit
+
+(** Detect if a string is a normalised format of [scan]. *)
+val looks_like_normalised: string list -> bool
+
+(** Parse the normalised form of [scan], and returns pinning informations. *)
+val parse_pins: string list -> (name * version option * url * string option) list
+
 (** Lints the given opam file, prints warnings or errors accordingly (unless
     [quiet]), upgrades it to current format, adds references to files below the
     'files/' subdir (unless the file is directly below the specified, local

--- a/src/client/opamPinCommand.mli
+++ b/src/client/opamPinCommand.mli
@@ -57,6 +57,14 @@ val unpin_one: 'a switch_state -> package -> 'a switch_state
 (** List the pinned packages to the user. *)
 val list: 'a switch_state -> short:bool -> unit
 
+(** Scan pinning separator, used for printing and parsing by [scna] and
+    [parse_pins]. *)
+val scan_sep: char
+
+(** Scan for available packages to pin, and display it on stdout. If
+    [normalise] is true, displays it's normalised format
+    `name.version[scan_sep]curl[scan_sep]subpath`. *)
+val scan: normalise:bool -> recurse:bool -> ?subpath: string -> url -> unit
 (** Lints the given opam file, prints warnings or errors accordingly (unless
     [quiet]), upgrades it to current format, adds references to files below the
     'files/' subdir (unless the file is directly below the specified, local

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -866,7 +866,9 @@ module Job = struct
         OpamStd.Option.iter
           (if OpamConsole.disp_status_line () then
              OpamConsole.status_line "Processing: %s"
-           else OpamConsole.msg "%s\n")
+           else if OpamConsole.verbose () then
+             OpamConsole.msg "%s\n"
+           else fun _ -> ())
           (text_of_command cmd);
         let r = run cmd in
         let k =


### PR DESCRIPTION
`opam pin scan url` lists available package to pin in the given directory
```
$ opam pin scan git+https://github.com/ocaml/opam
# Name           # Version     # Url
opam-state       2.1.0~alpha2  git+https://github.com/ocaml/opam
opam-solver      2.1.0~alpha2  git+https://github.com/ocaml/opam
opam-repository  2.1.0~alpha2  git+https://github.com/ocaml/opam
opam-installer   2.1.0~alpha2  git+https://github.com/ocaml/opam
opam-format      2.1.0~alpha2  git+https://github.com/ocaml/opam
opam-devel       2.1.0~alpha2  git+https://github.com/ocaml/opam
opam-core        2.1.0~alpha2  git+https://github.com/ocaml/opam
opam-client      2.1.0~alpha2  git+https://github.com/ocaml/opam
```

Used with `--normalise`, displays a parseable output
```
$ opam pin scan git+https://github.com/ocaml/opam --normalise
opam-state.2.1.0~alpha2^git+https://github.com/ocaml/opam
opam-solver.2.1.0~alpha2^git+https://github.com/ocaml/opam
opam-repository.2.1.0~alpha2^git+https://github.com/ocaml/opam
opam-installer.2.1.0~alpha2^git+https://github.com/ocaml/opam
opam-format.2.1.0~alpha2^git+https://github.com/ocaml/opam
opam-devel.2.1.0~alpha2^git+https://github.com/ocaml/opam
opam-core.2.1.0~alpha2^git+https://github.com/ocaml/opam
opam-client.2.1.0~alpha2^git+https://github.com/ocaml/opam
```

This output is understandable by `opam pin [add]`, e.g. to select only a subset of packages to pin
```
$ opam pin scan git+https://github.com/ocaml/opam --normalise | grep core | xargs ./opam pin add -n
[opam-core.2.1.0~alpha2] synchronised (git+https://github.com/ocaml/opam)
opam-core is now pinned to git+https://github.com/ocaml/opam (version 2.1.0~alpha2)

$ OPAMSTATUSLINE=never ./opam pin scan git+https://github.com/ocaml/opam --normalise  | xargs ./opam pin -y -n
This will pin the following packages: opam-state, opam-solver, opam-repository, opam-installer, opam-format, opam-devel, opam-core, opam-client. Continue? [Y/n] y
[opam-state.2.1.0~alpha2] synchronised (git+https://github.com/ocaml/opam)
opam-state is now pinned to git+https://github.com/ocaml/opam (version 2.1.0~alpha2)
[opam-solver.2.1.0~alpha2] synchronised (git+https://github.com/ocaml/opam)
opam-solver is now pinned to git+https://github.com/ocaml/opam (version 2.1.0~alpha2)
[opam-repository.2.1.0~alpha2] synchronised (git+https://github.com/ocaml/opam)
opam-repository is now pinned to git+https://github.com/ocaml/opam (version 2.1.0~alpha2)
[opam-installer.2.1.0~alpha2] synchronised (git+https://github.com/ocaml/opam)
opam-installer is now pinned to git+https://github.com/ocaml/opam (version 2.1.0~alpha2)
[opam-format.2.1.0~alpha2] synchronised (git+https://github.com/ocaml/opam)
opam-format is now pinned to git+https://github.com/ocaml/opam (version 2.1.0~alpha2)
[opam-devel.2.1.0~alpha2] synchronised (git+https://github.com/ocaml/opam)
opam-devel is now pinned to git+https://github.com/ocaml/opam (version 2.1.0~alpha2)
[opam-core.2.1.0~alpha2] synchronised (git+https://github.com/ocaml/opam)
opam-core is now pinned to git+https://github.com/ocaml/opam (version 2.1.0~alpha2)
[opam-client.2.1.0~alpha2] synchronised (git+https://github.com/ocaml/opam)
opam-client is now pinned to git+https://github.com/ocaml/opam (version 2.1.0~alpha2)
```