### PR TITLE
depext: Fix non-interactive mode on opensuse

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -5,3 +5,7 @@ New option/command/subcommand are prefixed with ◈.
 
 Build:
   * Bump to 2.1.0~alpha3 version [#4299 @rjbou]
+
+# External dependencies
+  * Fix non-interactive mode on OpenSuse [#4293 @kit-ty-kate]
+

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -477,7 +477,7 @@ let install_packages_commands_t sys_packages =
     ["port", "install"::packages], (* NOTE: Does not have any interactive mode *)
     None
   | Openbsd -> ["pkg_add", yes ~no:["-i"] ["-I"] packages], None
-  | Suse -> ["zypper", ("install"::yes ["--non-interactive"] packages)], None
+  | Suse -> ["zypper", yes ["--non-interactive"] ("install"::packages)], None
 
 let install_packages_commands sys_packages =
   fst (install_packages_commands_t sys_packages)


### PR DESCRIPTION
It turns out `zypper` doesn't like the `--non-interactive` option if placed after `install` and only recognize it as an option if placed in second position:
```
$ docker run --rm -it ocurrent/opam:opensuse
opam@bd07475f78e2:~> sudo zypper install --non-interactive m4
The flag --non-interactive is not known.
opam@bd07475f78e2:~> sudo zypper --non-interactive install m4
Loading repository data...
Reading installed packages...
'm4' is already installed.
No update candidate for 'm4-1.4.18-lp151.3.70.x86_64'. The highest available version is already installed.
Resolving package dependencies...

Nothing to do.
```