### PR TITLE
Fix pin kind consistency

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -19,7 +19,9 @@ New option/command/subcommand are prefixed with ◈.
   * Confirmation on non-compiler switch invariant: not on dryrun, Y by default [#4289 @AltGr]
 
 ## Pin
-  *
+  * Fix pin kind automatic detection consistency [#4300 @rjbou]
+    * With `opam pin target`, when opam file is not versioned and at root, vcs-pin the package instead of path-pin
+    * With `opam pin add nv target`, take opam file even if not versioned
 
 ## List
   *

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -70,6 +70,15 @@ let get_source_definition ?version ?subpath st nv url =
     opam
   in
   let open OpamProcess.Job.Op in
+  let url =
+    let u = OpamFile.URL.url url in
+    match OpamUrl.local_dir u, u.OpamUrl.backend with
+    | Some dir, #OpamUrl.version_control ->
+      OpamFile.URL.with_url
+        (OpamUrl.of_string (OpamFilename.Dir.to_string dir))
+        url
+    | _, _ -> url
+  in
   OpamUpdate.fetch_dev_package url srcdir ?subpath nv @@| function
   | Not_available (_,s) -> raise (Fetch_Fail s)
   | Up_to_date _ | Result _ ->


### PR DESCRIPTION
* With `opam pin target`, when opam file is not versioned and at root, vcs-pin the package instead of path-pin
* With `opam pin add nv target`, take opam file even if not versioned