### PR TITLE
`opam pin --with-version'

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -27,7 +27,9 @@ New option/command/subcommand are prefixed with ◈.
 ## Pin
   * ◈ Add `pin scan` subcommand to list available pins [#4285 @rjbou]
   * ◈ Add `--normalise` option to print a normalised list when scanning, that can be taken by `opam pin add` [#4285 @rjbou]
-  * `OpamCommand.pin` refactor, including adding `OpamClient.PIN.pin_url_list` to pin a list of package with url  [#4285 @rjbou]
+  * `OpamCommand.pin` refactor, including adding `OpamClient.PIN.url_pins` to pin a list of package with url  [#4285 #4301 @rjbou]
+  * ◈ Add `with-version` option to set the pinned package version [#4301 @rjbou]
+  * `OpamPinCommand.source_pin', for new package confirmation, don't check that no opam file is given as argument [#4301 @rjbou]
 
 ## List
   * <field> form no longer advertised as valid for --columns [#4322 @dra27]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -518,6 +518,14 @@ let package_name =
   let print ppf pkg = pr_str ppf (OpamPackage.Name.to_string pkg) in
   parse, print
 
+let package_version =
+  let parse str =
+    try `Ok (OpamPackage.Version.of_string str)
+    with Failure msg -> `Error msg
+  in
+  let print ppf ver = pr_str ppf (OpamPackage.Version.to_string ver) in
+  parse, print
+
 let positive_integer : int Arg.converter =
   let (parser, printer) = Arg.int in
   let parser s =

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -179,6 +179,9 @@ val positive_integer: int Arg.converter
 (** Package name converter *)
 val package_name: name Arg.converter
 
+(** Package version converter *)
+val package_version: version Arg.converter
+
 (** [name{.version}] (or [name=version]) *)
 val package: (name * version option) Arg.converter
 

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1479,7 +1479,7 @@ module PIN = struct
     | OpamPinCommand.Nothing_to_do -> st
 
   let url_pins st ?edit ?(action=true) ?(pre=fun _ -> ()) pins =
-    let names = List.map (fun (n,_,_,_) -> n) pins in
+    let names = List.map (fun (n,_,_,_,_) -> n) pins in
     (match names with
     | _::_::_ ->
       if not (OpamConsole.confirm
@@ -1490,10 +1490,10 @@ module PIN = struct
     | _ -> ());
     let pinned = st.pinned in
     let st =
-      List.fold_left (fun st (name, version, url, subpath as pin) ->
+      List.fold_left (fun st (name, version, opam, url, subpath as pin) ->
           pre pin;
           try
-            OpamPinCommand.source_pin st name ?version
+            OpamPinCommand.source_pin st name ?version ?opam
               ?edit ?subpath (Some url)
           with
           | OpamPinCommand.Aborted -> OpamStd.Sys.exit_because `Aborted

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -119,7 +119,10 @@ module PIN: sig
     rw switch_state ->
     OpamPackage.Name.t ->
     ?edit:bool -> ?version:version -> ?action:bool -> ?subpath:string ->
-    [< `Source of url | `Version of version | `Dev_upstream | `None ] ->
+    [< `Source of url | `Version of version | `Dev_upstream
+    | `Source_version of version * version
+    (* the first version is the source one, the second the package one *)
+    | `None ] ->
     rw switch_state
 
   val edit:

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -128,8 +128,9 @@ module PIN: sig
 
   val url_pins:
     rw switch_state ->  ?edit:bool -> ?action:bool ->
-    ?pre:((name * version option * url * string option) -> unit) ->
-    (name * version option * url * string option) list ->
+    ?pre:((name * version option * OpamFile.OPAM.t option * url * string option)
+          -> unit) ->
+    (name * version option * OpamFile.OPAM.t option * url * string option) list ->
     rw switch_state
 
   val unpin:

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2875,8 +2875,9 @@ let pin ?(unpin_only=false) cli =
       "Set the pinning version to $(b,VERSION) for named $(b,PACKAGES) or \
        retrieved packagesi fro $(b,TARGET). It has priority to any other \
        version specification (opam file version field, $(i,name.vers) \
-       argument). It is equivalent to editing pinned package opam file to set \
-       its version."
+       argument)). With version pin, package source is version pin one and \
+       package version is the one specified with this option. It is equivalent \
+       to editing pinned package opam file to set its version."
       Arg.(some package_version) None
   in
   let guess_names kind ~recurse ?subpath url k =
@@ -3123,7 +3124,11 @@ let pin ?(unpin_only=false) cli =
     | `add_wtarget (n, target) ->
       (match (fst package) n with
        | `Ok (name,version) ->
-         let pin = pin_target kind target in
+         let pin =
+           match pin_target kind target, with_version with
+           | `Version v, Some v' -> `Source_version (v, v')
+           | p, _ -> p
+         in
          let version = OpamStd.Option.Op.(with_version ++ version) in
          OpamGlobalState.with_ `Lock_none @@ fun gt ->
          OpamSwitchState.with_ `Lock_write gt @@ fun st ->

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2808,7 +2808,7 @@ let pin ?(unpin_only=false) cli =
     `P "If $(i,PACKAGE) has the form $(i,name.version), the pinned package \
         will be considered as version $(i,version) by opam. Beware that this \
         doesn't relate with the version of the source actually used for the \
-        package.";
+        package. See also $(i,--with-version) option.";
     `P "The default subcommand is $(i,list) if there are no further arguments, \
         and $(i,add) otherwise if unambiguous.";
   ] @ mk_subdoc ~defaults:["","list"] commands @ [
@@ -2869,6 +2869,15 @@ let pin ?(unpin_only=false) cli =
           add`. Available only with the scan subcommand. An example of use is \
           `opam pin scan . --normalise | grep foo | xargs opam pin add`"
          OpamPinCommand.scan_sep)
+  in
+  let with_version =
+    mk_opt ["with-version"] "VERSION"
+      "Set the pinning version to $(b,VERSION) for named $(b,PACKAGES) or \
+       retrieved packagesi fro $(b,TARGET). It has priority to any other \
+       version specification (opam file version field, $(i,name.vers) \
+       argument). It is equivalent to editing pinned package opam file to set \
+       its version."
+      Arg.(some package_version) None
   in
   let guess_names kind ~recurse ?subpath url k =
     let found, cleanup =
@@ -2966,6 +2975,7 @@ let pin ?(unpin_only=false) cli =
   let pin
       global_options build_options
       kind edit no_act dev_repo print_short recurse subpath normalise
+      with_version
       command params =
     apply_global_options global_options;
     apply_build_options build_options;
@@ -3069,6 +3079,7 @@ let pin ?(unpin_only=false) cli =
        | `Ok (name, version) ->
          OpamGlobalState.with_ `Lock_none @@ fun gt ->
          OpamSwitchState.with_ `Lock_write gt @@ fun st ->
+         let version = OpamStd.Option.Op.(with_version ++ version) in
          OpamSwitchState.drop @@ OpamClient.PIN.edit st ~action ?version name;
          `Ok ()
        | `Error e -> `Error (false, e))
@@ -3077,7 +3088,8 @@ let pin ?(unpin_only=false) cli =
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
       OpamSwitchState.with_ `Lock_write gt @@ fun st ->
       OpamSwitchState.drop @@
-      OpamClient.PIN.url_pins st ~edit ~action pins;
+      OpamClient.PIN.url_pins st ~edit ~action
+        (List.map (fun (n,v,u,sb) -> n,v,None,u,sb) pins);
       `Ok ()
     | `add_dev nv ->
       (match (fst package) nv with
@@ -3085,6 +3097,7 @@ let pin ?(unpin_only=false) cli =
          OpamGlobalState.with_ `Lock_none @@ fun gt ->
          OpamSwitchState.with_ `Lock_write gt @@ fun st ->
          let name = OpamSolution.fuzzy_name st name in
+         let version = OpamStd.Option.Op.(with_version ++ version) in
          OpamSwitchState.drop @@ OpamClient.PIN.pin st name ~edit ?version ~action
            `Dev_upstream;
          `Ok ()
@@ -3103,31 +3116,15 @@ let pin ?(unpin_only=false) cli =
          guess_names kind ~recurse ?subpath url @@ fun names ->
          OpamGlobalState.with_ `Lock_none @@ fun gt ->
          OpamSwitchState.with_ `Lock_write gt @@ fun st ->
-         let pins, opams =
-           List.fold_left (fun (pins, opams) (name, opam_opt, subpath, url) ->
-               (name, None, url, subpath)::pins,
-               match opam_opt with
-               | None -> opams
-               | Some opam -> OpamPackage.Name.Map.add name opam opams)
-             ([], OpamPackage.Name.Map.empty) names
-         in
-         let pre (name, _, _, _) =
-           OpamPackage.Name.Map.find_opt name opams
-           |> OpamStd.Option.iter (fun opam ->
-               let opam_localf =
-                 OpamPath.Switch.Overlay.tmp_opam
-                   st.switch_global.root st.switch name
-               in
-               if not (OpamFilename.exists (OpamFile.filename opam_localf))
-               then OpamFile.OPAM.write opam_localf opam)
-         in
          OpamSwitchState.drop @@
-         OpamClient.PIN.url_pins st ~edit ~action ~pre (List.rev pins);
+         OpamClient.PIN.url_pins st ~edit ~action
+           (List.map (fun (n,o,u,sb) -> n,None,o,sb,u) names);
          `Ok ())
     | `add_wtarget (n, target) ->
       (match (fst package) n with
        | `Ok (name,version) ->
          let pin = pin_target kind target in
+         let version = OpamStd.Option.Op.(with_version ++ version) in
          OpamGlobalState.with_ `Lock_none @@ fun gt ->
          OpamSwitchState.with_ `Lock_write gt @@ fun st ->
          OpamSwitchState.drop @@
@@ -3140,7 +3137,7 @@ let pin ?(unpin_only=false) cli =
     Term.(const pin
           $global_options cli $build_options
           $kind $edit $no_act $dev_repo $print_short_flag $recurse $subpath
-          $normalise
+          $normalise $with_version
           $command $params),
   term_info "pin" ~doc ~man
 

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -411,6 +411,8 @@ and source_pin
     with Not_found -> None
   in *)
 
+  let open OpamStd.Option.Op in
+
   let cur_version, cur_urlf =
     try
       let cur_version = OpamPinned.version st name in
@@ -466,11 +468,11 @@ and source_pin
        (OpamPath.Switch.pinned_package st.switch_global.root st.switch name)
    | _ -> ());
 
-  let pin_version = OpamStd.Option.Op.(version +! cur_version) in
+  let pin_version = version +! cur_version in
 
   let nv = OpamPackage.create name pin_version in
 
-  let urlf = OpamStd.Option.Op.(target_url >>| OpamFile.URL.create ?subpath) in
+  let urlf = target_url >>| OpamFile.URL.create ?subpath in
 
   let temp_file =
     OpamPath.Switch.Overlay.tmp_opam st.switch_global.root st.switch name
@@ -478,17 +480,15 @@ and source_pin
 
   let opam_local =
     OpamFile.OPAM.read_opt temp_file
-    |> OpamStd.Option.map (OpamFormatUpgrade.opam_file)
+    >>| OpamFormatUpgrade.opam_file
   in
   OpamFilename.remove (OpamFile.filename temp_file);
 
   let opam_opt =
     try
-      OpamStd.Option.Op.(
-        opam_opt >>+ fun () ->
-        urlf >>= fun url ->
-        OpamProcess.Job.run @@ get_source_definition ?version ?subpath st nv url
-      )
+      opam_opt >>+ fun () ->
+      urlf >>= fun url ->
+      OpamProcess.Job.run @@ get_source_definition ?version ?subpath st nv url
     with Fetch_Fail err ->
       if force then None else
         (OpamConsole.error_and_exit `Sync_error
@@ -501,16 +501,15 @@ and source_pin
     match version with
     | Some _ -> nv
     | None ->
-      OpamPackage.create name OpamStd.Option.Op.(
-          (opam_opt >>= OpamFile.OPAM.version_opt)
-          +! cur_version)
+      OpamPackage.create name
+        ((opam_opt >>= OpamFile.OPAM.version_opt)
+         +! cur_version)
   in
 
   let opam_opt =
-    OpamStd.Option.Op.(
-      opam_opt >>+ fun () ->
-      OpamPackage.Map.find_opt nv st.installed_opams >>+ fun () ->
-      OpamSwitchState.opam_opt st nv)
+    opam_opt >>+ fun () ->
+    OpamPackage.Map.find_opt nv st.installed_opams >>+ fun () ->
+    OpamSwitchState.opam_opt st nv
   in
 
   let opam_opt =
@@ -551,11 +550,10 @@ and source_pin
          OpamFile.OPAM.write_with_preserved_format
            ?format_from:(OpamPinned.orig_opam_file st name opam_base)
            temp_file opam_base;
-       OpamStd.Option.Op.(
-         edit_raw name temp_file >>|
-         (* Preserve metadata_dir so that copy_files below works *)
-         OpamFile.OPAM.(with_metadata_dir (metadata_dir opam_base))
-       ))
+       edit_raw name temp_file >>|
+       (* Preserve metadata_dir so that copy_files below works *)
+       OpamFile.OPAM.(with_metadata_dir (metadata_dir opam_base))
+      )
     else
       Some opam_base
   in
@@ -569,9 +567,7 @@ and source_pin
       | Some _ -> opam
       | None -> OpamFile.OPAM.with_url_opt urlf opam
     in
-    let version =
-      OpamStd.Option.Op.(OpamFile.OPAM.version_opt opam +! nv.version)
-    in
+    let version = version +! (OpamFile.OPAM.version_opt opam +! nv.version) in
     let nv = OpamPackage.create nv.name version in
     let st =
       if ignore_extra_pins then st

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -451,7 +451,6 @@ and source_pin
   in
 
   if not (OpamPackage.has_name st.packages name) &&
-     opam_opt = None &&
      not (OpamConsole.confirm
             "Package %s does not exist, create as a %s package?"
             (OpamPackage.Name.to_string name)


### PR DESCRIPTION
Add `--with-version` pin option to permit to specify the version of the pinned package.
```
$ opam pin add git+https://github.com/ocaml/opam --with-version 3.0 -n -y
This will pin the following packages: opam-client, opam-core, opam-devel, opam-format, opam-installer, opam-repository, opam-solver, opam-state. Continue?
[Y/n] y
opam-client is now pinned to git+https://github.com/ocaml/opam (version 3.0)
opam-core is now pinned to git+https://github.com/ocaml/opam (version 3.0)
opam-devel is now pinned to git+https://github.com/ocaml/opam (version 3.0)
opam-format is now pinned to git+https://github.com/ocaml/opam (version 3.0)
opam-installer is now pinned to git+https://github.com/ocaml/opam (version 3.0)
opam-repository is now pinned to git+https://github.com/ocaml/opam (version 3.0)
opam-solver is now pinned to git+https://github.com/ocaml/opam (version 3.0)
opam-state is now pinned to git+https://github.com/ocaml/opam (version 3.0)

$ opam pin
opam-client.3.0      (uninstalled)  git  git+https://github.com/ocaml/opam
opam-core.3.0        (uninstalled)  git  git+https://github.com/ocaml/opam
opam-devel.3.0       (uninstalled)  git  git+https://github.com/ocaml/opam
opam-format.3.0      (uninstalled)  git  git+https://github.com/ocaml/opam
opam-installer.3.0   (uninstalled)  git  git+https://github.com/ocaml/opam
opam-repository.3.0  (uninstalled)  git  git+https://github.com/ocaml/opam
opam-solver.3.0      (uninstalled)  git  git+https://github.com/ocaml/opam
opam-state.3.0       (uninstalled)  git  git+https://github.com/ocaml/opam
```