### PR TITLE
Opam file with preserved format more precise

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -97,6 +97,7 @@ New option/command/subcommand are prefixed with ◈.
 
 # Opam file format
   * Update opam-format lib to opam-file-format end position and new type definition [#4298 @rjbou]
+  * `with_preserved_format` preserves in fields also, don't drop comments, etc. [#4302 @rjbou - fix #3993]
 
 ## Solver
   * Fix missing conflict message when trying to remove required packages [#4362 @AltGr]


### PR DESCRIPTION
Fixes #3993. To not merge before #4298
To take the same example, with `opam admin add-constraint dune>=1.11` : 
```diff
diff --git a/packages/hardcaml/hardcaml.v0.12.0/opam b/packages/hardcaml/hardcaml.v0.12.0/opam
index ca3c8171bf..87f513d55c 100644
--- a/packages/hardcaml/hardcaml.v0.12.0/opam
+++ b/packages/hardcaml/hardcaml.v0.12.0/opam
@@ -10,13 +10,13 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"            {>= "4.07.0"}
-  "base"             {>= "v0.12" & < "v0.13"}
-  "ppx_jane"         {>= "v0.12" & < "v0.13"}
-  "stdio"            {>= "v0.12" & < "v0.13"}
+  "ocaml" {>= "4.07.0"}
+  "base" {>= "v0.12" & < "v0.13"}
+  "ppx_jane" {>= "v0.12" & < "v0.13"}
+  "stdio" {>= "v0.12" & < "v0.13"}
   "topological_sort" {>= "v0.12" & < "v0.13"}
-  "dune"             {>= "1.5.1"}
-  "zarith"           {>= "1.5"}
+  "dune" {>= "1.11"}
+  "zarith" {>= "1.5"}
 ]
 synopsis: "RTL Hardware Design in OCaml"
 description: "
diff --git a/packages/lwt/lwt.4.2.1/opam b/packages/lwt/lwt.4.2.1/opam
index 6c4fb5e040..431af99ad7 100644
--- a/packages/lwt/lwt.4.2.1/opam
+++ b/packages/lwt/lwt.4.2.1/opam
@@ -20,12 +20,11 @@ dev-repo: "git+https://github.com/ocsigen/lwt.git"
 
 depends: [
   "cppo" {build & >= "1.1.0"}
-  "dune"
-  "mmap"  # mmap is needed as long as Lwt supports OCaml < 4.06.0.
+  "dune" {>= "1.11"}
+  "mmap"
   "ocaml" {>= "4.02.0"}
-  "result" # result is needed as long as Lwt supports OCaml 4.02.
-  "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
-
+  "result"
+  "seq"
   "bisect_ppx" {dev & >= "1.3.0"}
   "ocamlfind" {dev & >= "1.7.3-1"}
 ]
```
to
```diff
diff --git a/packages/hardcaml/hardcaml.v0.12.0/opam b/packages/hardcaml/hardcaml.v0.12.0/opam
index ca3c8171bf..83cdbee304 100644
--- a/packages/hardcaml/hardcaml.v0.12.0/opam
+++ b/packages/hardcaml/hardcaml.v0.12.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_jane"         {>= "v0.12" & < "v0.13"}
   "stdio"            {>= "v0.12" & < "v0.13"}
   "topological_sort" {>= "v0.12" & < "v0.13"}
-  "dune"             {>= "1.5.1"}
+  "dune" {>= "1.11"}
   "zarith"           {>= "1.5"}
 ]
 synopsis: "RTL Hardware Design in OCaml"
diff --git a/packages/lwt/lwt.4.2.1/opam b/packages/lwt/lwt.4.2.1/opam
index 6c4fb5e040..91781964df 100644
--- a/packages/lwt/lwt.4.2.1/opam
+++ b/packages/lwt/lwt.4.2.1/opam
@@ -20,7 +20,7 @@ dev-repo: "git+https://github.com/ocsigen/lwt.git"
 
 depends: [
   "cppo" {build & >= "1.1.0"}
-  "dune"
+  "dune" {>= "1.11"}
   "mmap"  # mmap is needed as long as Lwt supports OCaml < 4.06.0.
   "ocaml" {>= "4.02.0"}
   "result" # result is needed as long as Lwt supports OCaml 4.02.
```