### PR TITLE
Opam root light upgrade

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -10,8 +10,8 @@ New option/command/subcommand are prefixed with ◈.
 ## Init
   *
 
-## Upgrade
-  *
+## Config Upgrade
+  * config upgrade: on the fly upgrade if no write lock required [#4313 @rjbou]
 
 ## Install
   *

--- a/src/state/opamFormatUpgrade.mli
+++ b/src/state/opamFormatUpgrade.mli
@@ -25,7 +25,7 @@ val latest_version: OpamVersion.t
 (** Runs the upgrade from its current format to the latest compatible version
     for the opam root at the given directory. A global write lock must be supplied.
     If an upgrade has been done, raises [Upgrade_done updated_config]. *)
-val as_necessary: OpamSystem.lock -> dirname -> OpamFile.Config.t -> unit
+val as_necessary: OpamSystem.lock -> dirname -> OpamFile.Config.t -> OpamFile.Config.t
 
 (** Converts the opam file format, including rewriting availability conditions
     based on OCaml-related variables into dependencies. The filename is used to

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -31,7 +31,7 @@ let load_config global_lock root =
            argument"
           (OpamFilename.Dir.to_string root)
   in
-  OpamFormatUpgrade.as_necessary global_lock root config;
+  let config = OpamFormatUpgrade.as_necessary global_lock root config in
   config
 
 let inferred_from_system = "Inferred from system"
@@ -44,7 +44,12 @@ let load lock_kind =
   let has_root = OpamFilename.exists_dir root in
   let global_lock =
     if has_root then
-      OpamFilename.flock `Lock_read (OpamPath.lock root)
+      let lock = (* needed for on-the-fly upgrade config file *)
+        match lock_kind with
+        | `Lock_none | `Lock_read -> `Lock_read
+        | `Lock_write -> `Lock_write
+      in
+      OpamFilename.flock lock (OpamPath.lock root)
     else OpamSystem.lock_none
   in
   (* The global_state lock actually concerns the global config file only (and


### PR DESCRIPTION
When a read lock is acquired, upgrade config file _on-the-fly_ instead of the blocking process.