### PR TITLE
Implement CLI versioning

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -302,6 +302,8 @@ td.sublib {
   <td>All sub-commands of the "opam admin" command</td></tr>
 <tr><th><a href="opam-client/OpamCommands">opamCommands.ml</a></th>
   <td>Opam CLI commands and their handlers as Cmdliner terms</td></tr>
+<tr><th><a href="opam-client/OpamCLIVersion">opamCLIVersion.ml</a></th>
+  <td>Functions for the CLI versioning</td></tr>
 
 <tr><td colspan="2" class="sublib">Main opam CLI</td></tr>
 <tr><th><a href="opam-client/OpamMain">opamMain.ml</a></th>

--- a/doc/pages/FAQ.md
+++ b/doc/pages/FAQ.md
@@ -411,3 +411,27 @@ you could lose your opam configuration at each reboot.
 You can use the [`nfsopam`](https://github.com/UnixJunkie/nfsopam) script to
 have the best of both worlds: persistence of NFS directories and fast operations
 of local directories.
+
+---
+
+#### 🐫  What does the `--cli` option do? Should I be using it everywhere?
+
+`--cli` was introduced in opam 2.1 to deal with changes in the command line
+interface between releases. It tells opam to interpret the command line as a
+specific version, in particular it means that new options or options which
+have had their meaning altered will not be available, or will be behave as they
+did in that version. It only affects the command-line - it does not, for
+example, stop a root from being upgraded from an older version to the current
+version.
+
+We recommend using it in scripts (and programs which call opam) since they can
+then expect to work seamlessly with future versions of the opam client. It's
+also a good idea to use it in blog posts, or other documentation you may share,
+since it allows copy-and-paste to work reliably (a user with a newer version of
+opam should have no issues and a user with an older opam gets a clearer error
+message).
+
+We don't recommend using it in day-to-day use of opam in the shell, because
+you'll be typing more and you won't get to notice exciting new features! If the
+behaviour of a command or option is altered, and you write something which in no
+longer valid, opam will try to tell you what the new command should look like.

--- a/doc/pages/Usage.md
+++ b/doc/pages/Usage.md
@@ -45,6 +45,14 @@ you find a package there but not on your computer, either it has been recently
 added and you should simply run `opam update`, or it's not available on your
 system or OCaml version — `opam install PACKAGE` will give you the reason.
 
+## `--cli` option
+
+Since opam 2.1, opam is able to be invoked using a previous version of its
+command line. It's recommended that all opam commands in scripts use it, and
+also blog posts and other sources of information, so you may come across
+examples which include it. We don't recommend using it in the shell because it's
+more to type!
+
 ## Details on commands
 
 ### opam init

--- a/master_changes.md
+++ b/master_changes.md
@@ -6,6 +6,7 @@ New option/command/subcommand are prefixed with ◈.
 ## Global CLI
   * --help/--version documented in wrong section for aliases [#4317 @dra27]
   * opam lock --help missing common information {#4317 @dra27]
+  * ◈ --cli / OPAMCLI option added [#4316 @dra27]
 
 ## Init
   *

--- a/master_changes.md
+++ b/master_changes.md
@@ -4,9 +4,10 @@ Possibly scripts breaking changes are prefixed with ✘.
 New option/command/subcommand are prefixed with ◈.
 
 ## Global CLI
-  * --help/--version documented in wrong section for aliases [#4317 @dra27]
-  * opam lock --help missing common information {#4317 @dra27]
-  * ◈ --cli / OPAMCLI option added [#4316 @dra27]
+  * `--help/--version` documented in wrong section for aliases [#4317 @dra27]
+  * `opam lock --help` missing common information {#4317 @dra27]
+  * ◈ `--cli` / `OPAMCLI` option added [#4316 @dra27]
+  * ✘ `--yes` passed to all commands, and plugins [#4316 @dra27]
 
 ## Init
   *

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -1100,7 +1100,7 @@ let default_subcommand =
       \                  [--help]\n\
       \                  <command> [<args>]\n\
        \n\
-       The most commonly used opam commands are:\n\
+       The most commonly used opam admin commands are:\n\
       \    index          %s\n\
       \    cache          %s\n\
       \    upgrade-format %s\n\

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -14,6 +14,8 @@ open OpamProcess.Job.Op
 open OpamStateTypes
 open Cmdliner
 
+type command = unit Cmdliner.Term.t * Cmdliner.Term.info
+
 let checked_repo_root () =
   let repo_root = OpamFilename.cwd () in
   if not (OpamFilename.exists_dir (OpamRepositoryPath.packages_dir repo_root))
@@ -23,6 +25,9 @@ let checked_repo_root () =
        Please make sure there is a \"packages%s\" directory" OpamArg.dir_sep;
   repo_root
 
+let global_options cli =
+  let apply_cli options = {options with OpamArg.cli} in
+  Term.(const apply_cli $ OpamArg.global_options)
 
 let admin_command_doc =
   "Tools for repository administrators"
@@ -41,7 +46,7 @@ let admin_command_man = [
 
 let index_command_doc =
   "Generate an inclusive index file for serving over HTTP."
-let index_command =
+let index_command cli =
   let command = "index" in
   let doc = index_command_doc in
   let man = [
@@ -116,7 +121,7 @@ let index_command =
     OpamHTTP.make_index_tar_gz repo_root;
     OpamConsole.msg "Done.\n";
   in
-  Term.(const cmd $ OpamArg.global_options $ urls_txt_arg),
+  Term.(const cmd $ global_options cli $ urls_txt_arg),
   OpamArg.term_info command ~doc ~man
 
 
@@ -174,7 +179,7 @@ let package_files_to_cache repo_root cache_dir ?link (nv, prefix) =
     OpamProcess.Job.seq urls OpamPackage.Map.empty
 
 let cache_command_doc = "Fills a local cache of package archives"
-let cache_command =
+let cache_command cli =
   let command = "cache" in
   let doc = cache_command_doc in
   let man = [
@@ -251,13 +256,13 @@ let cache_command =
 
       OpamConsole.msg "Done.\n";
   in
-  Term.(const cmd $ OpamArg.global_options $
+  Term.(const cmd $ global_options cli $
         cache_dir_arg $ no_repo_update_arg $ link_arg $ jobs_arg),
   OpamArg.term_info command ~doc ~man
 
 let add_hashes_command_doc =
   "Add archive hashes to an opam repository."
-let add_hashes_command =
+let add_hashes_command cli =
   let command = "add-hashes" in
   let doc = add_hashes_command_doc in
   let cache_dir = OpamFilename.Dir.of_string "~/.cache/opam-hash-cache" in
@@ -479,13 +484,13 @@ let add_hashes_command =
     if has_error then OpamStd.Sys.exit_because `Sync_error
     else OpamStd.Sys.exit_because `Success
   in
-  Term.(const cmd $ OpamArg.global_options $
+  Term.(const cmd $ global_options cli $
         hash_types_arg $ replace_arg $ packages),
   OpamArg.term_info command ~doc ~man
 
 let upgrade_command_doc =
   "Upgrades repository from earlier opam versions."
-let upgrade_command =
+let upgrade_command cli =
   let command = "upgrade" in
   let doc = upgrade_command_doc in
   let man = [
@@ -533,13 +538,13 @@ let upgrade_command =
             \  opam admin index"
       | Some m -> OpamAdminRepoUpgrade.do_upgrade_mirror (OpamFilename.cwd ()) m
   in
-  Term.(const cmd $ OpamArg.global_options $
+  Term.(const cmd $ global_options cli $
         clear_cache_arg $ create_mirror_arg),
   OpamArg.term_info command ~doc ~man
 
 let lint_command_doc =
   "Runs 'opam lint' and reports on a whole repository"
-let lint_command =
+let lint_command cli =
   let command = "lint" in
   let doc = lint_command_doc in
   let man = [
@@ -616,14 +621,14 @@ let lint_command =
     in
     OpamStd.Sys.exit_because (if ret then `Success else `False)
   in
-  Term.(const cmd $ OpamArg.global_options $
+  Term.(const cmd $ global_options cli $
         short_arg $ list_arg $ include_arg $ exclude_arg $ ignore_arg $
         warn_error_arg),
   OpamArg.term_info command ~doc ~man
 
 let check_command_doc =
   "Runs some consistency checks on a repository"
-let check_command =
+let check_command cli =
   let command = "check" in
   let doc = check_command_doc in
   let man = [
@@ -700,7 +705,7 @@ let check_command =
        (pr obsolete "obsolete packages"));
     OpamStd.Sys.exit_because (if all_ok then `Success else `False)
   in
-  Term.(const cmd $ OpamArg.global_options $ ignore_test_arg $ print_short_arg
+  Term.(const cmd $ global_options cli $ ignore_test_arg $ print_short_arg
         $ installability_arg $ cycles_arg $ obsolete_arg),
   OpamArg.term_info command ~doc ~man
 
@@ -796,7 +801,7 @@ let or_arg =
                criteria, select packages that match $(i,any) of them")
 
 let list_command_doc = "Lists packages from a repository"
-let list_command =
+let list_command cli =
   let command = "list" in
   let doc = list_command_doc in
   let man = [
@@ -849,13 +854,13 @@ let list_command =
     in
     OpamListCommand.display st format results
   in
-  Term.(const cmd $ OpamArg.global_options $ OpamArg.package_selection $
+  Term.(const cmd $ global_options cli $ OpamArg.package_selection $
         or_arg $ state_selection_arg $ OpamArg.package_listing $ env_arg $
         pattern_list_arg),
   OpamArg.term_info command ~doc ~man
 
 let filter_command_doc = "Filters a repository to only keep selected packages"
-let filter_command =
+let filter_command cli =
   let command = "filter" in
   let doc = filter_command_doc in
   let man = [
@@ -936,14 +941,14 @@ let filter_command =
              OpamFilename.rmdir_cleanup d))
       pkg_prefixes
   in
-  Term.(const cmd $ OpamArg.global_options $ OpamArg.package_selection $ or_arg $
+  Term.(const cmd $ global_options cli $ OpamArg.package_selection $ or_arg $
         state_selection_arg $ env_arg $ remove_arg $ dryrun_arg $
         pattern_list_arg),
   OpamArg.term_info command ~doc ~man
 
 let add_constraint_command_doc =
   "Adds version constraints on all dependencies towards a given package"
-let add_constraint_command =
+let add_constraint_command cli =
   let command = "add-constraint" in
   let doc = add_constraint_command_doc in
   let man = [
@@ -1044,7 +1049,7 @@ let add_constraint_command =
              |> OpamFile.OPAM.with_conflicts conflicts))
       pkg_prefixes
   in
-  Term.(pure cmd $ OpamArg.global_options $ force_arg $ atom_arg),
+  Term.(pure cmd $ global_options cli $ force_arg $ atom_arg),
   OpamArg.term_info command ~doc ~man
 
 (* HELP *)
@@ -1073,20 +1078,22 @@ let help =
   Term.(ret (const help $Term.man_format $Term.choice_names $topic)),
   Term.info "help" ~doc ~man
 
-let admin_subcommands = [
-  index_command; OpamArg.make_command_alias index_command "make";
-  cache_command;
-  upgrade_command;
-  lint_command;
-  check_command;
-  list_command;
-  filter_command;
-  add_constraint_command;
-  add_hashes_command;
-  help;
-]
+let admin_subcommands cli =
+  let index_command = index_command cli in
+  [
+    index_command; OpamArg.make_command_alias index_command "make";
+    cache_command cli;
+    upgrade_command cli;
+    lint_command cli;
+    check_command cli;
+    list_command cli;
+    filter_command cli;
+    add_constraint_command cli;
+    add_hashes_command cli;
+    help;
+  ]
 
-let default_subcommand =
+let default_subcommand cli =
   let man =
     admin_command_man @ [
       `S Manpage.s_commands;
@@ -1111,9 +1118,12 @@ let default_subcommand =
       cache_command_doc
       upgrade_command_doc
   in
-  Term.(const usage $ OpamArg.global_options),
+  Term.(const usage $ global_options cli),
   Term.info "opam admin"
     ~version:(OpamVersion.to_string OpamVersion.current)
     ~sdocs:OpamArg.global_option_section
     ~doc:admin_command_doc
     ~man
+
+let get_cmdliner_parser cli =
+  default_subcommand cli, admin_subcommands cli

--- a/src/client/opamAdminCommand.mli
+++ b/src/client/opamAdminCommand.mli
@@ -11,6 +11,6 @@
 
 val admin_command_doc: string
 
-val admin_subcommands: (unit Cmdliner.Term.t * Cmdliner.Term.info) list
+type command = unit Cmdliner.Term.t * Cmdliner.Term.info
 
-val default_subcommand: unit Cmdliner.Term.t * Cmdliner.Term.info
+val get_cmdliner_parser: OpamCLIVersion.t -> command * command list

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -102,6 +102,7 @@ type global_options = {
   no_auto_upgrade : bool;
   working_dir : bool;
   ignore_pin_depends : bool;
+  cli : OpamCLIVersion.t;
 }
 
 (** Global options *)

--- a/src/client/opamCLIVersion.ml
+++ b/src/client/opamCLIVersion.ml
@@ -1,0 +1,54 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2020 David Allsopp Ltd.                                   *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+open OpamCompat
+
+type t = int * int
+
+let supported_versions = [(2, 0); (2, 1)]
+
+let is_supported v = List.mem v supported_versions
+
+let of_string s =
+  match String.index s '.' with
+  | i when s.[0] <> '0' && (i >= String.length s - 2 || s.[i + 1] <> '0') ->
+    begin
+      try Scanf.sscanf s "%u.%u%!" (fun major minor -> (major, minor))
+      with Scanf.Scan_failure _ -> failwith "OpamVersion.CLI.of_string"
+    end
+  | exception Not_found -> failwith "OpamVersion.CLI.of_string"
+  | _ -> failwith "OpamVersion.CLI.of_string"
+
+let current = of_string @@ OpamVersion.(to_string current_nopatch)
+
+let of_string_opt s = try Some (of_string s) with Failure _ -> None
+
+let to_string (major, minor) = Printf.sprintf "%d.%d" major minor
+
+let to_json v = `String (to_string v)
+let of_json = function
+| `String x -> of_string_opt x
+| _ -> None
+
+let env = OpamStd.Config.env of_string
+
+let ( >= ) = Stdlib.( >= )
+let ( < ) = Stdlib.( < )
+
+module O = struct
+  type nonrec t = t
+  let to_string = to_string
+  let to_json = to_json
+  let of_json = of_json
+  let compare = compare
+end
+
+module Set = OpamStd.Set.Make(O)
+module Map = OpamStd.Map.Make(O)

--- a/src/client/opamCLIVersion.mli
+++ b/src/client/opamCLIVersion.mli
@@ -1,0 +1,31 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2020 David Allsopp Ltd.                                   *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** CLI Versions *)
+
+include OpamStd.ABSTRACT
+
+(** The current version of the CLI (major and minor of OpamVersion.current *)
+val current : t
+
+(** Tests whether a valid CLI version is supported by the client library *)
+val is_supported : t -> bool
+
+(** Parse the given environment variable as MAJOR.MINOR *)
+val env: OpamStd.Config.env_var -> t option
+
+(** ['a option] version of {!to_string} *)
+val of_string_opt : string -> t option
+
+(** Comparison [>]] with [(major, minor)] *)
+val ( >= ) : t -> int * int -> bool
+
+(** Comparison [<] with [(major, minor)] *)
+val ( < ) : t -> int * int -> bool

--- a/src/client/opamClientConfig.ml
+++ b/src/client/opamClientConfig.ml
@@ -26,6 +26,7 @@ type t = {
   root_is_ok: bool;
   no_auto_upgrade: bool;
   assume_depexts: bool;
+  cli: OpamCLIVersion.t;
 }
 
 let default = {
@@ -46,6 +47,7 @@ let default = {
   root_is_ok = false;
   no_auto_upgrade = false;
   assume_depexts = false;
+  cli = OpamCLIVersion.current;
 }
 
 type 'a options_fun =
@@ -66,6 +68,7 @@ type 'a options_fun =
   ?root_is_ok:bool ->
   ?no_auto_upgrade:bool ->
   ?assume_depexts:bool ->
+  ?cli:OpamCLIVersion.t ->
   'a
 
 let setk k t
@@ -86,6 +89,7 @@ let setk k t
     ?root_is_ok
     ?no_auto_upgrade
     ?assume_depexts
+    ?cli
   =
   let (+) x opt = match opt with Some x -> x | None -> x in
   k {
@@ -106,6 +110,7 @@ let setk k t
     root_is_ok = t.root_is_ok + root_is_ok;
     no_auto_upgrade = t.no_auto_upgrade + no_auto_upgrade;
     assume_depexts = t.assume_depexts + assume_depexts;
+    cli = t.cli + cli;
   }
 
 let set t = setk (fun x () -> x) t
@@ -138,6 +143,7 @@ let initk k =
     ?root_is_ok:(env_bool "ROOTISOK")
     ?no_auto_upgrade:(env_bool "NOAUTOUPGRADE")
     ?assume_depexts:None
+    ?cli:None
 
 let init ?noop:_ = initk (fun () -> ())
 

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -29,6 +29,7 @@ type t = private {
   root_is_ok: bool;
   no_auto_upgrade: bool;
   assume_depexts: bool;
+  cli: OpamCLIVersion.t;
 }
 
 type 'a options_fun =
@@ -50,6 +51,7 @@ type 'a options_fun =
   ?root_is_ok:bool ->
   ?no_auto_upgrade:bool ->
   ?assume_depexts:bool ->
+  ?cli:OpamCLIVersion.t ->
   'a
   (* constraint 'a = 'b -> 'c *)
 
@@ -86,6 +88,7 @@ val opam_init:
   ?root_is_ok:bool ->
   ?no_auto_upgrade:bool ->
   ?assume_depexts:bool ->
+  ?cli:OpamCLIVersion.t ->
   ?current_switch:OpamSwitch.t ->
   ?switch_from:OpamStateTypes.provenance ->
   ?jobs:int Lazy.t ->

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -87,7 +87,7 @@ val opam_init:
   ?no_auto_upgrade:bool ->
   ?assume_depexts:bool ->
   ?current_switch:OpamSwitch.t ->
-  ?switch_from:[ `Command_line | `Default | `Env ] ->
+  ?switch_from:OpamStateTypes.provenance ->
   ?jobs:int Lazy.t ->
   ?dl_jobs:int ->
   ?build_test:bool ->

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3760,3 +3760,8 @@ let commands = [
   admin;
   help;
 ]
+
+let is_builtin_command prefix =
+  List.exists (fun (_,info) ->
+                 OpamStd.String.starts_with ~prefix (Term.name info))
+              commands

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -72,7 +72,7 @@ let switch_to_updated_self debug opamroot =
            updated_self_str
            (OpamVersion.to_string OpamVersion.current)))
 
-let global_options =
+let global_options cli =
   let no_self_upgrade =
     mk_flag ~section:global_option_section ["no-self-upgrade"]
       (Printf.sprintf
@@ -99,7 +99,7 @@ let global_options =
     if not (options.safe_mode || root_is_ok) &&
        Unix.getuid () = 0 then
       OpamConsole.warning "Running as root is not recommended";
-    options, self_upgrade_status
+    {options with cli}, self_upgrade_status
   in
   Term.(const self_upgrade $ no_self_upgrade $ global_options)
 
@@ -166,7 +166,7 @@ let get_init_config ~no_sandboxing ~no_default_config_file ~add_config_file =
 
 (* INIT *)
 let init_doc = "Initialize opam state, or set init options."
-let init =
+let init cli =
   let doc = init_doc in
   let man = [
     `S Manpage.s_description;
@@ -416,7 +416,7 @@ let init =
     OpamSwitchState.drop st
   in
   Term.(const init
-        $global_options $build_options $repo_kind_flag $repo_name $repo_url
+        $global_options cli $build_options $repo_kind_flag $repo_name $repo_url
         $interactive $update_config $setup_completion $env_hook $no_sandboxing
         $shell_opt $dot_profile_flag
         $compiler $no_compiler
@@ -425,7 +425,7 @@ let init =
 
 (* LIST *)
 let list_doc = "Display the list of available packages."
-let list ?(force_search=false) () =
+let list ?(force_search=false) cli =
   let doc = list_doc in
   let selection_docs = OpamArg.package_selection_section in
   let display_docs = OpamArg.package_listing_section in
@@ -664,7 +664,7 @@ let list ?(force_search=false) () =
     else if OpamSysPkg.Set.is_empty results_depexts then
       OpamStd.Sys.exit_because `False
   in
-  Term.(const list $global_options $package_selection $state_selector
+  Term.(const list $global_options cli $package_selection $state_selector
         $no_switch $depexts $vars $repos $owns_file $disjunction $search
         $silent $no_depexts $package_listing $pattern_list),
   term_info "list" ~doc ~man
@@ -672,7 +672,7 @@ let list ?(force_search=false) () =
 
 (* SHOW *)
 let show_doc = "Display information about specific packages."
-let show =
+let show cli =
   let doc = show_doc in
   let man = [
     `S Manpage.s_description;
@@ -866,7 +866,7 @@ let show =
         `Ok ()
   in
   Term.(ret
-          (const pkg_info $global_options $fields $show_empty $raw $where
+          (const pkg_info $global_options cli $fields $show_empty $raw $where
            $list_files $file $normalise $no_lint $just_file $all_versions
            $sort $atom_or_local_list)),
   term_info "show" ~doc ~man
@@ -977,7 +977,7 @@ end
 
 (* VAR *)
 let var_doc = "Display and update the value associated with a given variable"
-let var =
+let var cli =
   let doc = var_doc in
   let man = [
     `S Manpage.s_description;
@@ -1017,13 +1017,13 @@ let var =
                      'pkg:var' instead.")
   in
   Term.ret (
-    Term.(const print_var $global_options $package $varvalue $global)
+    Term.(const print_var $global_options cli $package $varvalue $global)
   ),
   term_info "var" ~doc ~man
 
 (* OPTION *)
 let option_doc = "Global and switch configuration options settings"
-let option =
+let option cli =
   let doc = option_doc in
   let man = [
     `S Manpage.s_description;
@@ -1050,7 +1050,7 @@ let option =
     var_option global global_options `option fieldvalue
   in
   Term.ret (
-    Term.(const option $global_options $fieldvalue $global)
+    Term.(const option $global_options cli $fieldvalue $global)
   ),
   term_info "option" ~doc ~man
 
@@ -1082,7 +1082,7 @@ end
 
 (* CONFIG *)
 let config_doc = "Display configuration options for packages."
-let config =
+let config cli =
   let doc = config_doc in
   let commands = [
     "env", `env, [],
@@ -1371,7 +1371,7 @@ let config =
 
   Term.ret (
     Term.(const config
-          $global_options $command $shell_opt $sexp
+          $global_options cli $command $shell_opt $sexp
           $inplace_path
           $set_opamroot $set_opamswitch
           $params)
@@ -1380,7 +1380,7 @@ let config =
 
 (* EXEC *)
 let exec_doc = "Executes a command in the proper opam environment"
-let exec =
+let exec cli =
   let doc = exec_doc in
   let man = [
     `S Manpage.s_description;
@@ -1402,14 +1402,14 @@ let exec =
       ~set_opamroot ~set_opamswitch ~inplace_path cmd
   in
   let open Common_config_flags in
-  Term.(const exec $global_options $inplace_path
+  Term.(const exec $global_options cli $inplace_path
         $set_opamroot $set_opamswitch
         $cmd),
   term_info "exec" ~doc ~man
 
 (* ENV *)
 let env_doc = "Prints appropriate shell variable assignments to stdout"
-let env =
+let env cli =
   let doc = env_doc in
   let man = [
     `S Manpage.s_description;
@@ -1460,13 +1460,13 @@ let env =
   in
   let open Common_config_flags in
   Term.(const env
-        $global_options $shell_opt $sexp $inplace_path
+        $global_options cli $shell_opt $sexp $inplace_path
         $set_opamroot $set_opamswitch $revert $check),
   term_info "env" ~doc ~man
 
 (* INSTALL *)
 let install_doc = "Install a list of packages."
-let install =
+let install cli =
   let doc = install_doc in
   let man = [
     `S Manpage.s_description;
@@ -1610,7 +1610,7 @@ let install =
       `Ok ()
   in
   Term.ret
-    Term.(const install $global_options $build_options
+    Term.(const install $global_options cli $build_options
           $add_to_roots $deps_only $ignore_conflicts $restore $destdir
           $assume_built $check $recurse $subpath $depext_only
           $atom_or_local_list),
@@ -1618,7 +1618,7 @@ let install =
 
 (* REMOVE *)
 let remove_doc = "Remove a list of packages."
-let remove =
+let remove cli =
   let doc = remove_doc in
   let man = [
     `S Manpage.s_description;
@@ -1694,12 +1694,12 @@ let remove =
       let autoremove = autoremove || OpamClientConfig.(!r.autoremove) in
       OpamSwitchState.drop (OpamClient.remove st ~autoremove ~force atoms)
   in
-  Term.(const remove $global_options $build_options $autoremove $force $destdir
+  Term.(const remove $global_options cli $build_options $autoremove $force $destdir
         $recurse $subpath $atom_or_dir_list),
   term_info "remove" ~doc ~man
 
 (* REINSTALL *)
-let reinstall =
+let reinstall cli =
   let doc = "Reinstall a list of packages." in
   let man = [
     `S Manpage.s_description;
@@ -1782,13 +1782,13 @@ let reinstall =
     | _, _::_ ->
       `Error (true, "Package arguments not allowed with this option")
   in
-  Term.(ret (const reinstall $global_options $build_options $assume_built
+  Term.(ret (const reinstall $global_options cli $build_options $assume_built
              $recurse $subpath $atom_or_dir_list $cmd)),
   term_info "reinstall" ~doc ~man
 
 (* UPDATE *)
 let update_doc = "Update the list of available packages."
-let update =
+let update cli =
   let doc = update_doc in
   let man = [
     `S Manpage.s_description;
@@ -1851,13 +1851,13 @@ let update =
       OpamConsole.msg "Now run 'opam upgrade' to apply any package updates.\n";
     if not success then OpamStd.Sys.exit_because `Sync_error
   in
-  Term.(const update $global_options $jobs_flag $name_list
+  Term.(const update $global_options cli $jobs_flag $name_list
         $repos_only $dev_only $all $check $upgrade),
   term_info "update" ~doc ~man
 
 (* UPGRADE *)
 let upgrade_doc = "Upgrade the installed package to latest version."
-let upgrade =
+let upgrade cli =
   let doc = upgrade_doc in
   let man = [
     `S Manpage.s_description;
@@ -1909,13 +1909,13 @@ let upgrade =
       OpamSwitchState.drop @@ OpamClient.upgrade st ~check ~only_installed ~all atoms;
       `Ok ()
   in
-  Term.(ret (const upgrade $global_options $build_options $fixup $check
+  Term.(ret (const upgrade $global_options cli $build_options $fixup $check
              $installed $all $recurse $subpath $atom_or_dir_list)),
   term_info "upgrade" ~doc ~man
 
 (* REPOSITORY *)
 let repository_doc = "Manage opam repositories."
-let repository =
+let repository cli =
   let doc = repository_doc in
   let scope_section = "SCOPE SPECIFICATION OPTIONS" in
   let commands = [
@@ -2203,7 +2203,7 @@ let repository =
     | command, params -> bad_subcommand commands ("repository", command, params)
   in
   Term.ret
-    Term.(const repository $global_options $command $repo_kind_flag
+    Term.(const repository $global_options cli $command $repo_kind_flag
           $print_short_flag $scope $rank $params),
   term_info "repository" ~doc ~man
 
@@ -2273,7 +2273,7 @@ let with_repos_rt gt repos f =
   f (repos, rt)
 
 let switch_doc = "Manage multiple installation prefixes."
-let switch =
+let switch cli =
   let doc = switch_doc in
   let commands = [
     "create", `install, ["SWITCH"; "[COMPILER]"],
@@ -2743,7 +2743,7 @@ let switch =
     | command, params -> bad_subcommand commands ("switch", command, params)
   in
   Term.(ret (const switch
-             $global_options $build_options $command
+             $global_options cli $build_options $command
              $print_short_flag
              $no_switch
              $packages $formula $empty $descr $full $freeze $no_install
@@ -2753,7 +2753,7 @@ let switch =
 
 (* PIN *)
 let pin_doc = "Pin a given package to a specific version or source."
-let pin ?(unpin_only=false) () =
+let pin ?(unpin_only=false) cli =
   let doc = pin_doc in
   let commands = [
     "list", `list, [], "Lists pinned packages.";
@@ -3097,14 +3097,14 @@ let pin ?(unpin_only=false) () =
   in
   Term.ret
     Term.(const pin
-          $global_options $build_options
+          $global_options cli $build_options
           $kind $edit $no_act $dev_repo $print_short_flag $recurse $subpath
           $command $params),
   term_info "pin" ~doc ~man
 
 (* SOURCE *)
 let source_doc = "Get the source of an opam package."
-let source =
+let source cli =
   let doc = source_doc in
   let man = [
     `S Manpage.s_description;
@@ -3229,12 +3229,12 @@ let source =
         (OpamClient.PIN.pin t nv.name ~version:nv.version target)
   in
   Term.(const source
-        $global_options $atom $dev_repo $pin $dir),
+        $global_options cli $atom $dev_repo $pin $dir),
   term_info "source" ~doc ~man
 
 (* LINT *)
 let lint_doc = "Checks and validate package description ('opam') files."
-let lint =
+let lint cli =
   let doc = lint_doc in
   let man = [
     `S Manpage.s_description;
@@ -3402,13 +3402,13 @@ let lint =
     OpamStd.Option.iter (fun json -> OpamJson.append "lint" (`A json)) json;
     if err then OpamStd.Sys.exit_because `False
   in
-  Term.(const lint $global_options $files $package $normalise $short
+  Term.(const lint $global_options cli $files $package $normalise $short
         $warnings $check_upstream $recurse $subpath),
   term_info "lint" ~doc ~man
 
 (* CLEAN *)
 let clean_doc = "Cleans up opam caches"
-let clean =
+let clean cli =
   let doc = clean_doc in
   let man = [
     `S Manpage.s_description;
@@ -3580,13 +3580,13 @@ let clean =
       (OpamConsole.msg "Clearing logs\n";
        cleandir (OpamPath.log root))
   in
-  Term.(const clean $global_options $dry_run $download_cache $repos $repo_cache
+  Term.(const clean $global_options cli $dry_run $download_cache $repos $repo_cache
         $logs $switch $all_switches),
   term_info "clean" ~doc ~man
 
 (* LOCK *)
 let lock_doc = "Create locked opam files to share build environments across hosts."
-let lock =
+let lock cli =
   let doc = lock_doc in
   let man = [
     `S Manpage.s_description;
@@ -3650,7 +3650,7 @@ let lock =
              (OpamPackage.to_string nv)
              (OpamFilename.to_string file)) pkg_done)
   in
-  Term.(pure lock $global_options $only_direct_flag $lock_suffix
+  Term.(pure lock $global_options cli $only_direct_flag $lock_suffix
         $atom_or_local_list),
   term_info "lock" ~doc ~man
 
@@ -3680,7 +3680,7 @@ let help =
   Term.(ret (const help $Term.man_format $Term.choice_names $topic)),
   Term.info "help" ~doc ~man
 
-let default =
+let default cli =
   let doc = "source-based package management" in
   let man = [
     `S Manpage.s_description;
@@ -3724,7 +3724,7 @@ let default =
       upgrade_doc config_doc repository_doc switch_doc pin_doc
       OpamAdminCommand.admin_command_doc
   in
-  Term.(const usage $global_options),
+  Term.(const usage $global_options cli),
   Term.info "opam"
     ~version:(OpamVersion.to_string OpamVersion.current)
     ~sdocs:global_option_section
@@ -3737,40 +3737,50 @@ let admin =
   Term.(ret (const (`Error (true, doc)))),
   Term.info "admin"
 
-let commands = [
-  init;
-  list ();
-  make_command_alias (list ~force_search:true ()) ~options:" --search" "search";
-  show; make_command_alias show "info";
-  install;
-  remove; make_command_alias remove "uninstall";
-  reinstall;
-  update; upgrade;
-  var; option;
-  config;
-  exec; env;
-  repository; make_command_alias repository "remote";
-  switch;
-  pin (); make_command_alias (pin ~unpin_only:true ()) ~options:" remove" "unpin";
-  source;
-  lint;
-  clean;
-  lock;
-  admin;
-  help;
-]
+let commands cli =
+  let show = show cli in
+  let remove = remove cli in
+  let repository = repository cli in
+  (* This list must always include *all* commands, regardless of cli *)
+  [
+    init cli;
+    list cli;
+    make_command_alias (list ~force_search:true cli) ~options:" --search" "search";
+    show; make_command_alias show "info";
+    install cli;
+    remove; make_command_alias remove "uninstall";
+    reinstall cli;
+    update cli; upgrade cli;
+    var cli; option cli;
+    config cli;
+    exec cli; env cli;
+    repository; make_command_alias repository "remote";
+    switch cli;
+    pin cli; make_command_alias (pin ~unpin_only:true cli) ~options:" remove" "unpin";
+    source cli;
+    lint cli;
+    clean cli;
+    lock cli;
+    admin;
+    help;
+  ]
+
+let current_commands = commands OpamCLIVersion.current
 
 let is_builtin_command prefix =
   List.exists (fun (_,info) ->
                  OpamStd.String.starts_with ~prefix (Term.name info))
-              commands
+              current_commands
 
 let is_admin_subcommand prefix =
   prefix = "admin" ||
   let matches =
     List.filter (fun (_,info) ->
                    OpamStd.String.starts_with ~prefix (Term.name info))
-                commands in
+                current_commands in
   match matches with
   | [(_,info)] when Term.name info = "admin" -> true
   | _ -> false
+
+let get_cmdliner_parser cli =
+  (default cli, commands cli)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3732,11 +3732,10 @@ let default =
     ~man
 
 let admin =
-  let doc = "Use 'opam admin' instead (abbreviation not supported)" in
+  (* cmdliner never sees the admin subcommand, so this "can't happen" *)
+  let doc = "Internal opam error - main admin command invoked" in
   Term.(ret (const (`Error (true, doc)))),
-  Term.info "admin" ~doc:OpamAdminCommand.admin_command_doc
-    ~man:[`S Manpage.s_synopsis;
-          `P doc]
+  Term.info "admin"
 
 let commands = [
   init;
@@ -3765,3 +3764,13 @@ let is_builtin_command prefix =
   List.exists (fun (_,info) ->
                  OpamStd.String.starts_with ~prefix (Term.name info))
               commands
+
+let is_admin_subcommand prefix =
+  prefix = "admin" ||
+  let matches =
+    List.filter (fun (_,info) ->
+                   OpamStd.String.starts_with ~prefix (Term.name info))
+                commands in
+  match matches with
+  | [(_,info)] when Term.name info = "admin" -> true
+  | _ -> false

--- a/src/client/opamCommands.mli
+++ b/src/client/opamCommands.mli
@@ -11,15 +11,10 @@
 
 (** Opam CLI main entry point *)
 
-open Cmdliner
-
 (** {2 Commands} *)
 
 (** Type of commands *)
-type command = unit Term.t * Term.info
-
-(** The default list of commands *)
-val commands: command list
+type command = unit Cmdliner.Term.t * Cmdliner.Term.info
 
 (** [is_builtin_command arg] is [true] if [arg] is a prefix of any built-in
     command *)
@@ -29,44 +24,4 @@ val is_builtin_command: string -> bool
     sub-command. *)
 val is_admin_subcommand: string -> bool
 
-(** opam *)
-val default: command
-
-(** opam init *)
-val init: command
-
-(** opam list *)
-val list: ?force_search:bool -> unit -> command
-
-(** opam show *)
-val show: command
-
-(** opam install *)
-val install: command
-
-(** opam remove *)
-val remove: command
-
-(** opam reinstall *)
-val reinstall: command
-
-(** opam update *)
-val update: command
-
-(** opam upgrade *)
-val upgrade: command
-
-(** opam config *)
-val config: command
-
-(** opam repository *)
-val repository: command
-
-(** opam switch *)
-val switch: command
-
-(** opam pin *)
-val pin: ?unpin_only:bool -> unit -> command
-
-(** opam help *)
-val help: command
+val get_cmdliner_parser: OpamCLIVersion.t -> command * command list

--- a/src/client/opamCommands.mli
+++ b/src/client/opamCommands.mli
@@ -21,6 +21,10 @@ type command = unit Term.t * Term.info
 (** The default list of commands *)
 val commands: command list
 
+(** [is_builtin_command arg] is [true] if [arg] is a prefix of any built-in
+    command *)
+val is_builtin_command: string -> bool
+
 (** opam *)
 val default: command
 

--- a/src/client/opamCommands.mli
+++ b/src/client/opamCommands.mli
@@ -25,6 +25,10 @@ val commands: command list
     command *)
 val is_builtin_command: string -> bool
 
+(** [is_admin_subcommand arg] is [true] if [arg] is a unique prefix of the admin
+    sub-command. *)
+val is_admin_subcommand: string -> bool
+
 (** opam *)
 val default: command
 

--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -190,7 +190,7 @@ let run default commands =
   main_catch_all @@ fun () ->
   check_and_run_external_commands ();
   let admin, argv1 =
-    if Array.length Sys.argv > 1 && Sys.argv.(1) = "admin" then
+    if Array.length Sys.argv > 1 && OpamCommands.is_admin_subcommand Sys.argv.(1) then
       true,
       Array.init (Array.length Sys.argv - 1) (function
           | 0 -> Sys.argv.(0)

--- a/src/client/opamMain.ml
+++ b/src/client/opamMain.ml
@@ -24,9 +24,7 @@ let check_and_run_external_commands () =
   | _ :: name :: args ->
     if
       not (OpamStd.String.starts_with ~prefix:"-" name)
-      && List.for_all (fun (_,info) ->
-          not (OpamStd.String.starts_with ~prefix:name (Term.name info)))
-        OpamCommands.commands
+      && not (OpamCommands.is_builtin_command name)
     then
       (* No such command, check if there is a matching plugin *)
       let command = plugin_prefix ^ name in

--- a/src/core/opamCompat.ml
+++ b/src/core/opamCompat.ml
@@ -110,6 +110,19 @@ struct
 end
 #endif
 
+module Result =
+#if OCAML_VERSION >= (4, 8, 0)
+  Result
+#else
+struct
+  type ('a, 'e) t
+#if OCAML_VERSION >= (4, 3, 0)
+    = ('a, 'e) result
+#endif
+    = Ok of 'a | Error of 'e
+end
+#endif
+
 #if OCAML_VERSION < (4, 7, 0)
 module Stdlib = Pervasives
 #endif

--- a/src/core/opamCompat.mli
+++ b/src/core/opamCompat.mli
@@ -90,6 +90,19 @@ module Filename
 end
 #endif
 
+module Result
+#if OCAML_VERSION >= (4, 8, 0)
+= Result
+#else
+: sig
+  type ('a, 'e) t
+#if OCAML_VERSION >= (4, 3, 0)
+    = ('a, 'e) result
+#endif
+    = Ok of 'a | Error of 'e
+end
+#endif
+
 #if OCAML_VERSION < (4, 7, 0)
 module Stdlib = Pervasives
 #endif

--- a/src/core/opamConsole.mli
+++ b/src/core/opamConsole.mli
@@ -43,7 +43,7 @@ type text_style =
 val colorise : text_style -> string -> string
 val colorise' : text_style list -> string -> string
 val acolor : text_style -> unit -> string -> string
-val acolor_w : int -> text_style -> out_channel -> string -> unit
+val acolor_w : int -> text_style -> Format.formatter -> string -> unit
 
 module Symbols : sig
   val rightwards_arrow : OpamCompat.Uchar.t
@@ -79,12 +79,12 @@ val timer : unit -> unit -> float
 
 (** [log section ~level fmt args]. Used for debug messages, default
     level is 1 *)
-val log : string -> ?level:int -> ('a, out_channel, unit) format -> 'a
+val log : string -> ?level:int -> ('a, Format.formatter, unit) format -> 'a
 
 (** Helper to pass stringifiers to log (use [log "%a" (slog to_string) x]
     rather than [log "%s" (to_string x)] to avoid costly unneeded
     stringifications *)
-val slog : ('a -> string) -> out_channel -> 'a -> unit
+val slog : ('a -> string) -> Format.formatter -> 'a -> unit
 
 val error : ('a, unit, string, unit) format4 -> 'a
 val warning : ('a, unit, string, unit) format4 -> 'a

--- a/src/core/opamCoreConfig.ml
+++ b/src/core/opamCoreConfig.ml
@@ -27,6 +27,7 @@ type t = {
   merged_output: bool;
   use_openssl: bool;
   precise_tracking: bool;
+  set: bool;
 }
 
 type 'a options_fun =
@@ -64,6 +65,7 @@ let default = {
   merged_output = true;
   use_openssl = true;
   precise_tracking = false;
+  set = false;
 }
 
 let setk k t
@@ -98,6 +100,7 @@ let setk k t
     merged_output = t.merged_output + merged_output;
     use_openssl = t.use_openssl + use_openssl;
     precise_tracking = t.precise_tracking + precise_tracking;
+    set = true;
   }
 
 let set t = setk (fun x () -> x) t

--- a/src/core/opamCoreConfig.mli
+++ b/src/core/opamCoreConfig.mli
@@ -50,6 +50,8 @@ type t = private {
   precise_tracking : bool;
   (** If set, will take full md5 of all files when checking diffs (to track
       installations), rather than rely on just file size and mtime *)
+  set : bool;
+  (** Options have not yet been initialised (i.e. defaults are active) *)
 }
 
 type 'a options_fun =

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -536,6 +536,8 @@ module Config : sig
 
   type env_var = string
 
+  val env: (string -> 'a) -> string -> 'a option
+
   val env_bool: env_var -> bool option
 
   val env_int: env_var -> int option

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -1513,7 +1513,7 @@ let register_printer () =
     | Unix.Unix_error (e, fn, msg) ->
       let msg = if msg = "" then "" else " on " ^ msg in
       let error = Printf.sprintf "%s: %S failed%s: %s"
-          Sys.argv.(0) fn msg (Unix.error_message e) in
+          Sys.executable_name fn msg (Unix.error_message e) in
       Some error
     | _ -> None
   )

--- a/src/core/opamVersion.ml
+++ b/src/core/opamVersion.ml
@@ -69,7 +69,7 @@ let message () =
     \n\
     This is free software; see the source for copying conditions.  There is NO\n\
     warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n"
-    Sys.argv.(0) current_raw;
+    Sys.executable_name current_raw;
   exit 0
 
 let gitversion = ref None

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -38,7 +38,7 @@ let inferred_from_system = "Inferred from system"
 
 let load lock_kind =
   let root = OpamStateConfig.(!r.root_dir) in
-  log "LOAD-GLOBAL-STATE @ %a" (slog OpamFilename.Dir.to_string) root;
+  log "LOAD-GLOBAL-STATE %@ %a" (slog OpamFilename.Dir.to_string) root;
   (* Always take a global read lock, this is only used to prevent concurrent
      ~/.opam format changes *)
   let has_root = OpamFilename.exists_dir root in

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -200,7 +200,7 @@ let get_repo_root rt repo =
   get_root_raw rt.repos_global.root rt.repos_tmp repo.repo_name
 
 let load lock_kind gt =
-  log "LOAD-REPOSITORY-STATE @ %a" (slog OpamFilename.Dir.to_string) gt.root;
+  log "LOAD-REPOSITORY-STATE %@ %a" (slog OpamFilename.Dir.to_string) gt.root;
   let lock = OpamFilename.flock lock_kind (OpamPath.repos_lock gt.root) in
   let repos_map =
     OpamFile.Repos_config.safe_read (OpamPath.repos_config gt.root)

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -9,11 +9,12 @@
 (**************************************************************************)
 
 open OpamTypes
+open OpamStateTypes
 
 type t = {
   root_dir: OpamFilename.Dir.t;
   current_switch: OpamSwitch.t option;
-  switch_from: [ `Env | `Command_line | `Default ];
+  switch_from: provenance;
   jobs: int Lazy.t;
   dl_jobs: int;
   build_test: bool;
@@ -53,7 +54,7 @@ let default = {
 type 'a options_fun =
   ?root_dir:OpamFilename.Dir.t ->
   ?current_switch:OpamSwitch.t ->
-  ?switch_from:[ `Env | `Command_line | `Default ] ->
+  ?switch_from:provenance ->
   ?jobs:(int Lazy.t) ->
   ?dl_jobs:int ->
   ?build_test:bool ->

--- a/src/state/opamStateConfig.mli
+++ b/src/state/opamStateConfig.mli
@@ -12,11 +12,12 @@
     initialisation) *)
 
 open OpamTypes
+open OpamStateTypes
 
 type t = private {
   root_dir: OpamFilename.Dir.t;
   current_switch: OpamSwitch.t option;
-  switch_from: [ `Env | `Command_line | `Default ];
+  switch_from: provenance;
   jobs: int Lazy.t;
   dl_jobs: int;
   build_test: bool;
@@ -33,7 +34,7 @@ type t = private {
 type 'a options_fun =
   ?root_dir:OpamFilename.Dir.t ->
   ?current_switch:OpamSwitch.t ->
-  ?switch_from:[ `Env | `Command_line | `Default ] ->
+  ?switch_from:provenance ->
   ?jobs:(int Lazy.t) ->
   ?dl_jobs:int ->
   ?build_test:bool ->

--- a/src/state/opamStateTypes.mli
+++ b/src/state/opamStateTypes.mli
@@ -160,3 +160,9 @@ type +'lock switch_state = {
      - switch-global and package variables
      - the solver universe? *)
 } constraint 'lock = 'lock lock
+
+(** Command-line setting provenance *)
+type provenance = [ `Env          (** Environment variable *)
+                  | `Command_line (** Command line *)
+                  | `Default      (** Default value *)
+                  ]

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -208,7 +208,7 @@ let depexts_unavailable_raw sys_packages nv =
 
 let load lock_kind gt rt switch =
   let chrono = OpamConsole.timer () in
-  log "LOAD-SWITCH-STATE @ %a" (slog OpamSwitch.to_string) switch;
+  log "LOAD-SWITCH-STATE %@ %a" (slog OpamSwitch.to_string) switch;
   if not (OpamGlobalState.switch_exists gt switch) then
     (log "The switch %a does not appear to be installed according to %a"
        (slog OpamSwitch.to_string) switch

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -1101,14 +1101,14 @@ let do_backup lock st = match lock with
                (Printf.sprintf
                   "\nThe former state can be restored with:\n\
                   \    %s switch import %S\n"
-                  Sys.argv.(0) (OpamFile.to_string file) ^
+                  Sys.executable_name (OpamFile.to_string file) ^
                 if OpamPackage.Set.is_empty
                     (new_selections.sel_roots -- new_selections.sel_installed)
                 then "" else
                   Printf.sprintf
                     "Or you can retry to install your package selection with:\n\
                     \    %s install --restore\n"
-                  Sys.argv.(0))))
+                  Sys.executable_name)))
   | _ -> fun _ -> ()
 
 let with_ lock ?rt ?(switch=OpamStateConfig.get_switch ()) gt f =


### PR DESCRIPTION
Implements the [CLI Versioning spec](https://github.com/ocaml/opam/wiki/Spec-for-opam-CLI-versioning)

Fundamentally, this PR allows the user/author to select backwards-compatibility with the opam 2.0 CLI by setting `OPAMCLI` to `2.0` and forwards-compatibility with future releases of the opam client by passing `--cli=2.1` _anywhere_ on the command line.

This is implemented by increasing the pre-processing which is done to `Sys.argv` before `Cmdliner.Term.eval` is invoked. Various things to note:

- While refactoring, I noticed that there's no reason for not supporting `opam adm` as an abbreviation for `opam admin` so this is now implemented (see `OpamCommands.is_admin_subcommand`).
- I've converted `OpamConsole.log` to use `Format.fprintf` instead of `Printf.fprintf` which has been on my TODO-list for a while. This actually improves the Windows story ever-so-slightly and it turns out with only tiny alterations to a couple of messages which included `@` signs. In future, it will allow the formatting to be applied using tags which will be better in terms of the code and also better for Windows (since `Format` will do the heavy lifting instead of my horrendous VT100 parser). I've done it here because I wanted to be able to debug the CLI parsing process, and its hard to set `OpamCoreConfig.!r.debug_level` _before_ you've parsed the command-line!
- opam already included pre-processing of `Sys.argv` in order to allow `opam --yes plugin args` to mean "automatically build and install plugin and then call it with args". I've extracted this pre-processing and included the `--cli` processing with it.
- I have changed the processing of `--yes` to allow *all* commands to benefit from it. This means that `opam --yes list` now works, where before it was a syntax error. This is necessary to allow plugins to become built-in commands compatibly. At the moment this has a slight change of semantics in that `opam --yes lock` now means `opam lock --yes` where before the plugin would not have been invoked with `--yes`. I think this is acceptable and consistent to do universally, rather than tying that handling to CLI version (although we could...).
- `--yes` is transformed - that is, `opam --yes list` is still handled by Cmdliner, it just sees `opam list --yes` instead. `--cli` is completely extracted since it affects the generation of the Cmdliner parser - `--cli` itself is included in the parser only so that it's included in `--help` (in particular, this is why parsing the prefix `--cl` is important or `opam --cli=2.0 --cl=2.1` would be a contradiction).