### PR TITLE
CLI help updates

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -3,6 +3,9 @@ note.
 Possibly scripts breaking changes are prefixed with ✘.
 New option/command/subcommand are prefixed with ◈.
 
+## Global CLI
+  * --help/--version documented in wrong section for aliases [#4317 @dra27]
+
 ## Init
   *
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -5,6 +5,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Global CLI
   * --help/--version documented in wrong section for aliases [#4317 @dra27]
+  * opam lock --help missing common information {#4317 @dra27]
 
 ## Init
   *

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -28,7 +28,7 @@ let admin_command_doc =
   "Tools for repository administrators"
 
 let admin_command_man = [
-  `S "DESCRIPTION";
+  `S Manpage.s_description;
   `P (Printf.sprintf
        "This command can perform various actions on repositories in the opam \
         format. It is expected to be run from the root of a repository, i.e. a \
@@ -45,7 +45,7 @@ let index_command =
   let command = "index" in
   let doc = index_command_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "An opam repository can be served over HTTP or HTTPS using any web \
         server. To that purpose, an inclusive index needs to be generated \
         first: this command generates the files the opam client will expect \
@@ -178,7 +178,7 @@ let cache_command =
   let command = "cache" in
   let doc = cache_command_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "Downloads the archives for all packages to fill a local cache, that \
         can be used when serving the repository."
   ]
@@ -262,7 +262,7 @@ let add_hashes_command =
   let doc = add_hashes_command_doc in
   let cache_dir = OpamFilename.Dir.of_string "~/.cache/opam-hash-cache" in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P (Printf.sprintf
           "This command scans through package definitions, and add hashes as \
            requested (fetching the archives if required). A cache is generated \
@@ -489,7 +489,7 @@ let upgrade_command =
   let command = "upgrade" in
   let doc = upgrade_command_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P (Printf.sprintf
          "This command reads repositories from earlier opam versions, and \
           converts them to repositories suitable for the current opam version. \
@@ -543,7 +543,7 @@ let lint_command =
   let command = "lint" in
   let doc = lint_command_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "This command gathers linting results on all files in a repository. The \
         warnings and errors to show or hide can be selected"
   ]
@@ -627,7 +627,7 @@ let check_command =
   let command = "check" in
   let doc = check_command_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "This command runs consistency checks on a repository, and prints a \
         report to stdout. Checks include packages that are not installable \
         (due e.g. to a missing dependency) and dependency cycles. The \
@@ -800,12 +800,12 @@ let list_command =
   let command = "list" in
   let doc = list_command_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "This command is similar to 'opam list', but allows listing packages \
         directly from a repository instead of what is available in a given \
         opam installation.";
-    `S "ARGUMENTS";
-    `S "OPTIONS";
+    `S Manpage.s_arguments;
+    `S Manpage.s_options;
     `S OpamArg.package_selection_section;
     `S OpamArg.package_listing_section;
   ]
@@ -859,12 +859,12 @@ let filter_command =
   let command = "filter" in
   let doc = filter_command_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "This command removes all package definitions that don't match the \
         search criteria (specified similarly to 'opam admin list') from a \
         repository.";
-    `S "ARGUMENTS";
-    `S "OPTIONS";
+    `S Manpage.s_arguments;
+    `S Manpage.s_options;
     `S OpamArg.package_selection_section;
   ]
   in
@@ -947,15 +947,15 @@ let add_constraint_command =
   let command = "add-constraint" in
   let doc = add_constraint_command_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "This command searches to all dependencies towards a given package, and \
         adds a version constraint to them. It is particularly useful to add \
         upper bounds to existing dependencies when a new, incompatible major \
         version of a library is added to a repository. The new version \
         constraint is merged with the existing one, and simplified if \
         possible (e.g. $(b,>=3 & >5) becomes $(b,>5)).";
-    `S "ARGUMENTS";
-    `S "OPTIONS";
+    `S Manpage.s_arguments;
+    `S Manpage.s_options;
   ]
   in
   let atom_arg =
@@ -1051,7 +1051,7 @@ let add_constraint_command =
 let help =
   let doc = "Display help about opam admin and opam admin subcommands." in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "Prints help about opam admin commands.";
     `P "Use `$(mname) help topics' to get the full list of help topics.";
   ] in
@@ -1089,7 +1089,7 @@ let admin_subcommands = [
 let default_subcommand =
   let man =
     admin_command_man @ [
-      `S "COMMANDS";
+      `S Manpage.s_commands;
       `S "COMMAND ALIASES";
     ] @ OpamArg.help_sections
   in

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -216,7 +216,7 @@ let apply_build_options b =
 let when_enum = [ "always", `Always; "never", `Never; "auto", `Auto ]
 
 (* Help sections common to all commands *)
-let global_option_section = "COMMON OPTIONS"
+let global_option_section = Manpage.s_common_options
 let help_sections = [
   `S global_option_section;
   `P "These options are common to all commands.";
@@ -342,7 +342,7 @@ let help_sections = [
   `P "$(i,OPAMWORKINGDIR) see option `--working-dir`";
   `P "$(i,OPAMYES) see option `--yes'.";
 
-  `S "EXIT STATUS";
+  `S Manpage.s_exit_status;
   `P "As an exception to the following, the `exec' command returns 127 if the \
       command was not found or couldn't be executed, and the command's exit \
       value otherwise."
@@ -396,7 +396,7 @@ let help_sections = [
   `S "FURTHER DOCUMENTATION";
   `P (Printf.sprintf "See https://opam.ocaml.org/doc.");
 
-  `S "AUTHORS";
+  `S Manpage.s_authors;
   `P "Vincent Bernardoff <vb@luminar.eu.org>"; `Noblank;
   `P "Raja Boujbel       <raja.boujbel@ocamlpro.com>"; `Noblank;
   `P "Roberto Di Cosmo   <roberto@dicosmo.org>"; `Noblank;
@@ -408,7 +408,7 @@ let help_sections = [
   `P "Ralf Treinen       <ralf.treinen@pps.jussieu.fr>"; `Noblank;
   `P "Frederic Tuong     <tuong@users.gforge.inria.fr>";
 
-  `S "BUGS";
+  `S Manpage.s_bugs;
   `P "Check bug reports at https://github.com/ocaml/opam/issues.";
 ]
 
@@ -773,7 +773,7 @@ type 'a subcommands = 'a subcommand list
 let mk_subdoc ?(defaults=[]) commands =
   let bold s = Printf.sprintf "$(b,%s)" s in
   let it s = Printf.sprintf "$(i,%s)" s in
-  `S "COMMANDS" ::
+  `S Manpage.s_commands ::
   (List.map (function
        | "", name ->
          `P (Printf.sprintf "Without argument, defaults to %s."
@@ -811,12 +811,12 @@ let make_command_alias cmd ?(options="") name =
   let orig = Term.name info in
   let doc = Printf.sprintf "An alias for $(b,%s%s)." orig options in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P (Printf.sprintf "$(mname)$(b, %s) is an alias for $(mname)$(b, %s%s)."
           name orig options);
     `P (Printf.sprintf "See $(mname)$(b, %s --help) for details."
           orig);
-    `S "OPTIONS";
+    `S Manpage.s_options;
   ] @ help_sections
   in
   term,
@@ -850,7 +850,7 @@ let bad_subcommand subcommands (command, usersubcommand, userparams) =
 
 let term_info title ~doc ~man =
   let man = man @ help_sections in
-  Term.info ~sdocs:global_option_section ~docs:"COMMANDS" ~doc ~man title
+  Term.info ~sdocs:global_option_section ~docs:Manpage.s_commands ~doc ~man title
 
 let arg_list name doc kind =
   let doc = Arg.info ~docv:name ~doc [] in

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -821,7 +821,7 @@ let make_command_alias cmd ?(options="") name =
   in
   term,
   Term.info name
-    ~docs:"COMMAND ALIASES"
+    ~docs:"COMMAND ALIASES" ~sdocs:global_option_section
     ~doc ~man
 
 let bad_subcommand subcommands (command, usersubcommand, userparams) =

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -221,7 +221,7 @@ let help_sections = [
   `S global_option_section;
   `P "These options are common to all commands.";
 
-  `S "ENVIRONMENT VARIABLES";
+  `S Manpage.s_environment;
   `P "Opam makes use of the environment variables listed here. Boolean \
       variables should be set to \"0\", \"no\", \"false\" or the empty  string \
       to disable, \"1\", \"yes\" or \"true\" to enable.";

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3600,7 +3600,7 @@ let lock =
     `P "If paths (filename or directory) are given, those opam files are locked. \
         If package is given, installed one is locked, otherwise its latest version.";
     `P "Fails if all mandatory dependencies are not installed in the switch.";
-    `S "What is changed in the locked file?";
+    `S "LOCK FILE CHANGED FIELDS";
     `P "- $(i,depends) are fixed to their specific versions, with all filters \
         removed (except for the exceptions below";
     `P "- $(i,depopts) that are installed in the current switch are turned into \

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -169,7 +169,7 @@ let init_doc = "Initialize opam state, or set init options."
 let init =
   let doc = init_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "Initialise the opam state, or update opam init options";
     `P (Printf.sprintf
          "The $(b,init) command initialises a local \"opam root\" (by default, \
@@ -187,8 +187,8 @@ let init =
     `P "Additionally, this command allows one to customise some aspects of opam's \
         shell integration, when run initially (avoiding the interactive \
         dialog), but also at any later time.";
-    `S "ARGUMENTS";
-    `S "OPTIONS";
+    `S Manpage.s_arguments;
+    `S Manpage.s_options;
     `S "CONFIGURATION FILE";
     `P (Printf.sprintf
          "Any field from the built-in initial configuration can be overridden \
@@ -430,7 +430,7 @@ let list ?(force_search=false) () =
   let selection_docs = OpamArg.package_selection_section in
   let display_docs = OpamArg.package_listing_section in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "List selections of opam packages.";
     `P "Without argument, the command displays the list of currently installed \
         packages. With pattern arguments, lists all available packages \
@@ -446,7 +446,7 @@ let list ?(force_search=false) () =
     `P "For a more detailed description of packages, see $(b,opam show). For \
         extended search capabilities within the packages' metadata, see \
         $(b,opam search).";
-    `S "ARGUMENTS";
+    `S Manpage.s_arguments;
     `S selection_docs;
     `S display_docs;
   ] in
@@ -675,7 +675,7 @@ let show_doc = "Display information about specific packages."
 let show =
   let doc = show_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "This command displays the information block for the selected \
         package(s).";
     `P "The information block consists of the name of the package, \
@@ -980,7 +980,7 @@ let var_doc = "Display and update the value associated with a given variable"
 let var =
   let doc = var_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "Without argument, lists the opam variables currently defined. With a \
         $(i,VAR) argument, prints the value associated with $(i,VAR). \
         Otherwise, sets or updates $(i,VAR)'s value. \
@@ -1026,7 +1026,7 @@ let option_doc = "Global and switch configuration options settings"
 let option =
   let doc = option_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "Without argument, list all configurable fields. If a field name \
         $(i,FIELD) is given, display its content. Otherwise, sets or updates \
         the given field in the global/switch configuration file. \
@@ -1132,7 +1132,7 @@ let config =
     "Deprecated, see $(b,set-var).";
   ] in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "This command uses opam state to output information on how to use \
         installed libraries, update the $(b,PATH), and substitute \
         variables used in opam packages.";
@@ -1140,7 +1140,7 @@ let config =
         by opam internally, and are of limited interest for the casual \
         user.";
   ] @ mk_subdoc commands
-    @ [`S "OPTIONS"]
+    @ [`S Manpage.s_options]
   in
 
   let command, params = mk_subcommands commands in
@@ -1383,7 +1383,7 @@ let exec_doc = "Executes a command in the proper opam environment"
 let exec =
   let doc = exec_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "Execute $(i,COMMAND) with the correct environment variables. This \
         command can be used to cross-compile between switches using $(b,opam \
         config exec --switch=SWITCH -- COMMAND ARG1 ... ARGn). Opam expansion \
@@ -1412,7 +1412,7 @@ let env_doc = "Prints appropriate shell variable assignments to stdout"
 let env =
   let doc = env_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "Returns the bindings for the environment variables set in the current \
         switch, e.g. PATH, in a format intended to be evaluated by a shell. \
         With $(i,-v), add comments documenting the reason or package of origin \
@@ -1469,7 +1469,7 @@ let install_doc = "Install a list of packages."
 let install =
   let doc = install_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "This command installs one or more packages inside the currently \
         selected switch (see $(b,opam switch)). Once installed, you can remove \
         packages with $(b,opam remove), upgrade them with $(b,opam upgrade), \
@@ -1487,8 +1487,8 @@ let install =
         $(i,opam) files. Then the corresponding packages will be pinned to \
         their local directory and installed (unless $(b,--deps-only) was \
         specified).";
-    `S "ARGUMENTS";
-    `S "OPTIONS";
+    `S Manpage.s_arguments;
+    `S Manpage.s_options;
   ] @ OpamArg.man_build_option_section
    in
   let add_to_roots =
@@ -1621,7 +1621,7 @@ let remove_doc = "Remove a list of packages."
 let remove =
   let doc = remove_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "This command uninstalls one or more packages currently \
         installed in the currently selected compiler switch. To remove packages \
         installed in another compiler, you need to switch compilers using \
@@ -1629,8 +1629,8 @@ let remove =
         inverse of $(b,opam-install).";
     `P "If a directory name is specified as package, packages pinned to that \
         directory are both unpinned and removed.";
-    `S "ARGUMENTS";
-    `S "OPTIONS";
+    `S Manpage.s_arguments;
+    `S Manpage.s_options;
   ] @ OpamArg.man_build_option_section
   in
   let autoremove =
@@ -1702,14 +1702,14 @@ let remove =
 let reinstall =
   let doc = "Reinstall a list of packages." in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "This command removes the given packages and the ones that depend on \
         them, and reinstalls the same versions. Without arguments, assume \
         $(b,--pending) and reinstall any package with upstream changes.";
     `P "If a directory is specified as argument, anything that is pinned to \
         that directory is selected for reinstall.";
-    `S "ARGUMENTS";
-    `S "OPTIONS";
+    `S Manpage.s_arguments;
+    `S Manpage.s_options;
   ] @ OpamArg.man_build_option_section
   in
   let cmd =
@@ -1791,7 +1791,7 @@ let update_doc = "Update the list of available packages."
 let update =
   let doc = update_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "Update the package definitions. This fetches the newest version of the \
         repositories configured through $(b, opam repository), and the sources \
         of installed development packages and packages pinned in the current \
@@ -1860,15 +1860,15 @@ let upgrade_doc = "Upgrade the installed package to latest version."
 let upgrade =
   let doc = upgrade_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "This command upgrades the installed packages to their latest available \
         versions. More precisely, this command calls the dependency solver to \
         find a consistent state where $(i,most) of the installed packages are \
         upgraded to their latest versions.";
     `P "If a directory is specified as argument, anything that is pinned to \
         that directory is selected for upgrade.";
-    `S "ARGUMENTS";
-    `S "OPTIONS";
+    `S Manpage.s_arguments;
+    `S Manpage.s_options;
   ] @ OpamArg.man_build_option_section
   in
   let fixup =
@@ -1956,7 +1956,7 @@ let repository =
     "Synonym to $(b,add NAME --rank RANK)";
   ] in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "This command is used to manage package repositories. Repositories can \
         be registered through subcommands $(b,add), $(b,remove) and \
         $(b,set-url), and are updated from their URLs using $(b,opam update). \
@@ -1973,7 +1973,7 @@ let repository =
           $(b,remove), $(b,set-repos). If no flag in this section is specified \
           the updated selections default to the current switch. Multiple scopes \
           can be selected, e.g. $(b,--this-switch --set-default).";
-      `S "OPTIONS";
+      `S Manpage.s_options;
     ]
   in
   let command, params = mk_subcommands commands in
@@ -2324,7 +2324,7 @@ let switch =
     "Deprecated alias for 'set-invariant'.";
   ] in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "This command is used to manage \"switches\", which are independent \
         installation prefixes with their own compiler and sets of installed \
         and pinned packages. This is typically useful to have different \
@@ -2350,7 +2350,7 @@ let switch =
         --switch=SWITCH --set-switch\\)).";
   ] @ mk_subdoc ~defaults:["","list";"SWITCH","set"] commands
     @ [
-      `S "EXAMPLES";
+      `S Manpage.s_examples;
       `Pre "    opam switch create 4.08.0";
       `P "Create a new switch called \"4.08.0\" and select it, with a compiler \
           automatically selected at version 4.08.0 (note that this can fail in \
@@ -2367,7 +2367,7 @@ let switch =
           $(b,ocaml-variants.4.10.0+trunk) as compiler, with a new $(i,beta) \
           repository bound to the given URL selected besides the default one."
     ]
-    @ [`S "OPTIONS"]
+    @ [`S Manpage.s_options]
     @ OpamArg.man_build_option_section
   in
 
@@ -2788,7 +2788,7 @@ let pin ?(unpin_only=false) () =
      order.";
   ] in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "This command allows local customisation of the packages in a given \
         switch. A pinning can either just enforce a given version, or provide \
         a local, editable version of the definition of the package. It is also \
@@ -2811,7 +2811,7 @@ let pin ?(unpin_only=false) () =
     `P "The default subcommand is $(i,list) if there are no further arguments, \
         and $(i,add) otherwise if unambiguous.";
   ] @ mk_subdoc ~defaults:["","list"] commands @ [
-      `S "OPTIONS";
+      `S Manpage.s_options;
     ] @ OpamArg.man_build_option_section
   in
   let command, params =
@@ -3107,7 +3107,7 @@ let source_doc = "Get the source of an opam package."
 let source =
   let doc = source_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "Downloads the source for a given package to a local directory \
         for development, bug fixing or documentation purposes."
   ] in
@@ -3237,11 +3237,11 @@ let lint_doc = "Checks and validate package description ('opam') files."
 let lint =
   let doc = lint_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "Given an $(i,opam) file, performs several quality checks on it and \
         outputs recommendations, warnings or errors on stderr.";
-    `S "ARGUMENTS";
-    `S "OPTIONS";
+    `S Manpage.s_arguments;
+    `S Manpage.s_options;
     `S "LINT CODES"
   ] @
     List.map (fun (c,t,s) ->
@@ -3252,7 +3252,7 @@ let lint =
   in
   let files =
     Arg.(value & pos_all (existing_filename_dirname_or_dash) [] &
-         info ~docv:"FILES" []
+         info ~docv:Manpage.s_files []
            ~doc:"Name of the opam files to check, or directory containing \
                  them. Current directory if unspecified")
   in
@@ -3411,7 +3411,7 @@ let clean_doc = "Cleans up opam caches"
 let clean =
   let doc = clean_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "Cleans up opam caches, reclaiming some disk space. If no options are \
         specified, the default is $(b,--logs --download-cache \
         --switch-cleanup)."
@@ -3589,7 +3589,7 @@ let lock_doc = "Create locked opam files to share build environments across host
 let lock =
   let doc = lock_doc in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "Generates a lock file of a package: checks the current \
         state of their installed dependencies, and outputs modified versions of \
         the opam file with a $(i,.locked) suffix, where all the (transitive) \
@@ -3613,15 +3613,15 @@ let lock =
         dependencies some packages are pinned ";
     `P "- pins are resolved: if a package is locally pinned, opam tries to get \
         its remote url and branch, and sets this as the target URL";
-    `S "ARGUMENTS";
-    `S "OPTIONS";
+    `S Manpage.s_arguments;
+    `S Manpage.s_options;
   ]
   in
   let only_direct_flag =
     mk_flag ["direct-only"]
       "Only lock direct dependencies, rather than the whole dependency tree."
   in
-  let lock_suffix = OpamArg.lock_suffix "OPTIONS" in
+  let lock_suffix = OpamArg.lock_suffix Manpage.s_options in
   let lock global_options only_direct lock_suffix atom_locs =
     apply_global_options global_options;
     OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -3658,7 +3658,7 @@ let lock =
 let help =
   let doc = "Display help about opam and opam commands." in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "Prints help about opam commands.";
     `P "Use `$(mname) help topics' to get the full list of help topics.";
   ] in
@@ -3683,7 +3683,7 @@ let help =
 let default =
   let doc = "source-based package management" in
   let man = [
-    `S "DESCRIPTION";
+    `S Manpage.s_description;
     `P "Opam is a package manager. It uses the powerful mancoosi tools to \
         handle dependencies, including support for version constraints, \
         optional dependencies, and conflict management. The default \
@@ -3694,7 +3694,7 @@ let default =
         different sets of intalled packages.";
     `P "Use either $(b,opam <command> --help) or $(b,opam help <command>) \
         for more information on a specific command.";
-    `S "COMMANDS";
+    `S Manpage.s_commands;
     `S "COMMAND ALIASES";
   ] @  help_sections
   in
@@ -3735,7 +3735,7 @@ let admin =
   let doc = "Use 'opam admin' instead (abbreviation not supported)" in
   Term.(ret (const (`Error (true, doc)))),
   Term.info "admin" ~doc:OpamAdminCommand.admin_command_doc
-    ~man:[`S "SYNOPSIS";
+    ~man:[`S Manpage.s_synopsis;
           `P doc]
 
 let commands = [

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3652,7 +3652,7 @@ let lock =
   in
   Term.(pure lock $global_options $only_direct_flag $lock_suffix
         $atom_or_local_list),
-  Term.info "lock" ~doc ~man
+  term_info "lock" ~doc ~man
 
 (* HELP *)
 let help =


### PR DESCRIPTION
Best checked commit-by-commit:

- Use `Cmdliner.Manpage.s_` constants instead of hard-coded section names (small tidy-up, although possibly one "bug" found)
- Aliases put the `--help` and `--version` options in `OPTIONS` instead of `COMMON OPTIONS`
- `opam lock --help` was missing all the common information (`ENVIRONMENT`, `BUGS`, etc.)

There are two other things to consider/fix:
- We call the section `ENVIRONMENT VARIABLES` (`OpamArg.help_sections`) but the standard name is `ENVIRONMENT` ([`Cmdliner.Manpage.s_environment`](https://erratique.ch/software/cmdliner/doc/Cmdliner.Manpage.html#VALs_environment)) - any reason not to change this?
- opam lock has a section `What is changed in the lock file?` - this should be in capitals and re-worded. Perhaps `LOCK PROCEDURE`, perhaps?