### PR TITLE
Fix --columns advertised options

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -22,7 +22,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## List
-  *
+  * <field> form no longer advertised as valid for --columns [#4322 @dra27]
 
 ## Show
   *
@@ -55,7 +55,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Admin
-  *
+  * <field> form no longer advertised as valid for --columns in list [#4322 @dra27]
 
 ## Opam installer
   *

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1417,7 +1417,7 @@ let package_listing =
                        The default is $(b,name) when $(i,--short) is present \
                        and %s otherwise."
          (OpamStd.List.concat_map ", " (fun (_,f) -> Printf.sprintf "$(b,%s)" f)
-            OpamListCommand.field_names)
+            OpamListCommand.raw_field_names)
          (OpamStd.List.concat_map ", "
             (fun f -> Printf.sprintf "$(b,%s)" (OpamListCommand.string_of_field f))
             OpamListCommand.default_list_format))

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -442,6 +442,9 @@ let field_names = [
   Depexts, "depexts";
 ]
 
+let raw_field_names =
+  List.filter (function Field _, _ -> false | _ -> true) field_names
+
 let string_of_field ?(raw=false) = function
   | Field s -> if raw then s ^":" else s
   | Raw_field s -> s ^":"

--- a/src/client/opamListCommand.mli
+++ b/src/client/opamListCommand.mli
@@ -111,7 +111,12 @@ val default_list_format: output_format list
     state corresponding to the configured repos *)
 val get_switch_state: 'a global_state -> 'a repos_state -> unlocked switch_state
 
-(** For documentation, includes a dummy '<field>:' for the [Field] format *)
+(** For documentation, includes a dummy '<field>:' for the [Field] format.
+    Used for the --columns argument. *)
+val raw_field_names: (output_format * string) list
+
+(** For documentation, includes a dummy '<field>:' and '<field>' for the
+    [Field] format. Used for the --field argument. *)
 val field_names: (output_format * string) list
 
 val string_of_field: ?raw:bool -> output_format -> string


### PR DESCRIPTION
#3931 allows `<field>` to refer directly to a raw opam field and so added an entry to `OpamListCommand.field_names`. This list is also used for the `--columns` argument to `opam list` and `opam admin list` which still requires the trailing colon at all times.

This PR removes the spurious `<field>` from the help for `--columns` - this is correct (I think) since `--raw` can't be used here as `--columns` is a list of fields.