### PR TITLE
Consistently have -n as alias of --no-action

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -16,7 +16,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Switch
-  *
+  * Support -n as an alias of --no-action (to match opam-pin) [#4324 @dra27]
 
 ## Pin
   *

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2436,7 +2436,7 @@ let switch =
        consistency checks."
   in
   let no_action =
-    mk_flag ["no-action"]
+    mk_flag ["n"; "no-action"]
       "Only for $(i,set-invariant): set the invariant, but don't enforce it \
        right away: wait for the next $(i,install), $(i,upgrade) or similar \
        command."


### PR DESCRIPTION
`opam pin` has `-n` as an alias of `--no-action` (cf. `-n` meaning `--no-setup` in `opam init` as well)