### PR TITLE
Handle empty environment variable updates

### DIFF
--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -294,7 +294,12 @@ module LinesBase = struct
       aux acc (i-1) in
     aux ([],0) (len - 1)
 
-  let escape_spaces str =
+  let escape_spaces = function
+  | "" ->
+      "@"
+  | "@" ->
+      "\\@"
+  | str ->
     let len = String.length str in
     match find_escapes str len with
     | [], _ -> str


### PR DESCRIPTION
This is apparently a piece of lost history on my part, but it's resurfaced in #4325. Empty strings cause corrupt environment files, since two tabs are written in a row which are of course lexed as a single piece of whitespace.

For better or worse, my solution in 2016 was to write an empty string as `@`. The ambiguity with the string `"@"` is resolved by writing that as `\@` (since the format already allows `\` to escape _any_ character.

This can go on 2.0 with one caveat - it would mean that any environment updates which intentionally set a value to be `@` will now be empty. That seems unlikely, but it may be reason enough to fix this for 2.1 only.