### PR TITLE
Optimise package name comparison

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -74,7 +74,7 @@ New option/command/subcommand are prefixed with ◈.
   * Don't penalise packages with more recent 'hidden-versions' [#4312 @AltGr]
 
 ## Internal
-  *
+  * Optimise package name comparison [#4328 @AltGr - fix #4245]
 
 ## Test
   *

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -639,6 +639,26 @@ module OpamString = struct
     for i = 0 to String.length s - 1 do acc := f !acc s.[i] done;
     !acc
 
+  let compare_case s1 s2 =
+    let l1 = String.length s1 and l2 = String.length s2 in
+    let len = min l1 l2 in
+    let rec aux i =
+      if i < len then
+        let c1 = s1.[i] and c2 = s2.[i] in
+        match Char.compare (Char.lowercase_ascii c1) (Char.lowercase_ascii c2)
+        with
+        | 0 ->
+          (match Char.compare c1 c2 with
+           | 0 -> aux (i+1)
+           | c -> c)
+        | c -> c
+      else
+        if l1 < l2 then -1
+        else if l1 > l2 then 1
+        else 0
+    in
+    aux 0
+
 end
 
 type warning_printer =

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -254,6 +254,10 @@ module String : sig
   val exact_match: Re.re -> string -> bool
   val find_from: (char -> bool) -> string -> int -> int
 
+  (** Like [String.compare], but with lowercase/uppercase variants ordered next
+      to each other (still considered not equal though) *)
+  val compare_case: string -> string -> int
+
   (** {3 Manipulation} *)
 
   val map: (char -> char) -> string -> string

--- a/src/format/opamPackage.ml
+++ b/src/format/opamPackage.ml
@@ -83,10 +83,7 @@ module Name = struct
     | Some true ->
       x
 
-  let compare n1 n2 =
-    match compare (String.lowercase_ascii n1) (String.lowercase_ascii n2) with
-    | 0 -> compare n1 n2
-    | i -> i
+  let compare = OpamStd.String.compare_case
 
   let equal n1 n2 =
     compare n1 n2 = 0

--- a/src/format/opamSysPkg.ml
+++ b/src/format/opamSysPkg.ml
@@ -14,11 +14,8 @@ type t = string
 
 let of_string s = s
 let to_string s = s
-let compare s s' =
-  let open OpamCompat in
-  match compare (String.lowercase_ascii s) (String.lowercase_ascii s') with
-  | 0 -> compare s s'
-  | i -> i
+let compare = OpamStd.String.compare_case
+
 let to_json s =
   `O [ ("sys_package", `String s) ]
 let of_json = function


### PR DESCRIPTION
Removing unneeded string allocations can possibly have a big impact due
to the large number of set/map operations we have.

Fixes #4245, thanks for the suggestion