### PR TITLE
Fix to output a correct note by changing to the --global flag instead

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -39,7 +39,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Option
-  *
+  * Fix to output a correct note by changing to the `--global` flag instead of `global` [#4334 @smorimoto]
 
 ## Lint
   *

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -192,7 +192,7 @@ let depexts_status_of_packages_raw ~depexts global_config switch_config packages
         ) syspkg_map
     | exception (Failure msg) ->
       OpamConsole.note "%s\nYou can disable this check using 'opam \
-                        option global depext=false'"
+                        option --global depext=false'"
         msg;
       OpamPackage.Map.empty
   in


### PR DESCRIPTION
This is probably wrong.