### PR TITLE
Switch AppVeyor back to stable Cygwin

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,8 @@ environment:
     # This should be identical to the value in .travis.yml
     OPAM_REPO_SHA: 8c45759d4
   matrix:
-    - CYG_ROOT: cygwin
+    - appveyor_build_worker_image: Visual Studio 2019
+      CYG_ROOT: cygwin
       CYG_ARCH: x86
 #    - CYG_ROOT: cygwin64
 #      CYG_ARCH: x86_64
@@ -31,10 +32,6 @@ environment:
 cache:
   - C:\projects\opam\bootstrap
   - C:\projects\opam\src_ext\archives
-
-init:
-  - systeminfo 2>nul | findstr /B /C:"OS Name" /C:"OS Version"
-  - "echo System architecture: %PLATFORM%"
 
 install:
   - call "%APPVEYOR_BUILD_FOLDER%\appveyor_build.cmd" install

--- a/appveyor_build.cmd
+++ b/appveyor_build.cmd
@@ -48,12 +48,12 @@ set CYG_ROOT=C:\%CYG_ROOT%
 
 cd "%APPVEYOR_BUILD_FOLDER%"
 
-if "%OCAML_PORT%" equ "" (
-  rem Need unreleased Cygwin 3.1.7 for bugfix in acl_get_tag_type and acl_get_permset
-  appveyor DownloadFile "https://cygwin.com/snapshots/x86/cygwin1-20200710.dll.xz" -FileName "cygwin1.dll.xz" || exit /b 1
-  "%CYG_ROOT%\bin\bash.exe" -lc "cd $APPVEYOR_BUILD_FOLDER ; unxz cygwin1.dll.xz ; chmod +x cygwin1.dll"
-  move cygwin1.dll %CYG_ROOT%\bin\cygwin1.dll
-)
+:: if "%OCAML_PORT%" equ "" (
+::   rem Need unreleased Cygwin 3.1.7 for bugfix in acl_get_tag_type and acl_get_permset
+::   appveyor DownloadFile "https://cygwin.com/snapshots/x86/cygwin1-20200710.dll.xz" -FileName "cygwin1.dll.xz" || exit /b 1
+::   "%CYG_ROOT%\bin\bash.exe" -lc "cd $APPVEYOR_BUILD_FOLDER ; unxz cygwin1.dll.xz ; chmod +x cygwin1.dll"
+::   move cygwin1.dll %CYG_ROOT%\bin\cygwin1.dll
+:: )
 
 rem CYGWIN_PACKAGES is the list of required Cygwin packages (cygwin is included
 rem in the list just so that the Cygwin version is always displayed on the log).

--- a/appveyor_build.cmd
+++ b/appveyor_build.cmd
@@ -33,14 +33,21 @@ if %ERRORLEVEL% equ 1 (
 goto :EOF
 
 :UpgradeCygwin
-if "%CYGWIN_INSTALL_PACKAGES%" neq "" "%CYG_ROOT%\setup-%CYG_ARCH%.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --packages %CYGWIN_INSTALL_PACKAGES:~1% > nul
-for %%P in (%CYGWIN_COMMANDS%) do "%CYG_ROOT%\bin\bash.exe" -lc "%%P --help" > nul || set CYGWIN_UPGRADE_REQUIRED=1
-"%CYG_ROOT%\bin\bash.exe" -lc "cygcheck -dc %CYGWIN_PACKAGES%"
 if %CYGWIN_UPGRADE_REQUIRED% equ 1 (
   echo Cygwin package upgrade required - please go and drink coffee
-  "%CYG_ROOT%\setup-%CYG_ARCH%.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --upgrade-also > nul
-  "%CYG_ROOT%\bin\bash.exe" -lc "cygcheck -dc %CYGWIN_PACKAGES%"
+  set CYGWIN_UPGRADE_FLAG=--upgrade-also
+  SET CYGWIN_UPGRADE_REQUIRED=0
+) else (
+  set CYGWIN_UPGRADE_FLAG=
 )
+if "%CYGWIN_INSTALL_PACKAGES%" neq "" set CYGWIN_INSTALL_PACKAGES=--packages %CYGWIN_INSTALL_PACKAGES:~1%
+if "%CYGWIN_INSTALL_PACKAGES%%FLAG%" equ "" goto UpgradeCygwin_next
+"%CYG_ROOT%\setup-%CYG_ARCH%.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" %CYGWIN_INSTALL_PACKAGES% %CYGWIN_UPGRADE_FLAG% > nul
+set CYGWIN_INSTALL_PACKAGES=
+:UpgradeCygwin_next
+if "%CYGWIN_UPGRADE_FLAG%" equ "" for %%P in (%CYGWIN_COMMANDS%) do "%CYG_ROOT%\bin\bash.exe" -lc "%%P --help" > nul || set CYGWIN_UPGRADE_REQUIRED=1
+"%CYG_ROOT%\bin\bash.exe" -lc "cygcheck -dc %CYGWIN_PACKAGES%"
+if "%CYGWIN_UPGRADE_REQUIRED%%CYGWIN_UPGRADE_FLAG%" equ "1" call :UpgradeCygwin
 goto :EOF
 
 :install
@@ -79,7 +86,24 @@ if "%OCAML_PORT%" equ "" (
 set CYGWIN_INSTALL_PACKAGES=
 set CYGWIN_UPGRADE_REQUIRED=0
 
+rem Check that all packages are installed
 for %%P in (%CYGWIN_PACKAGES%) do call :CheckPackage %%P
+
+rem Check that Cygwin is at least 3.1.7
+for /f "tokens=2,3,4 delims=-. " %%a in ('%CYG_ROOT%\bin\bash.exe -lc "cygcheck -dc cygwin" ^| findstr cygwin') do (
+  set CYG_MAJOR=%%a
+  set CYG_MINOR=%%b
+  set CYG_REV=%%c
+)
+set /a CYG_VER=%CYG_MAJOR%*10000+%CYG_MINOR%*100+%CYG_REV%
+if %CYG_VER% lss 30107 (
+  if "%OCAML_PORT%" equ "" (
+    echo Cygwin version %CYG_MAJOR%.%CYG_MINOR%.%CYG_REV% installed; opam requires 3.1.7 or later
+    set CYGWIN_UPGRADE_REQUIRED=1
+  )
+)
+
+rem Upgrade/install packages as necessary
 call :UpgradeCygwin
 
 set INSTALLED_URL=

--- a/appveyor_build.cmd
+++ b/appveyor_build.cmd
@@ -51,6 +51,9 @@ if "%CYGWIN_UPGRADE_REQUIRED%%CYGWIN_UPGRADE_FLAG%" equ "1" call :UpgradeCygwin
 goto :EOF
 
 :install
+echo Build Worker Image: %APPVEYOR_BUILD_WORKER_IMAGE%
+systeminfo 2>nul | findstr /B /C:"OS Name" /C:"OS Version"
+echo System architecture: %PLATFORM%
 set CYG_ROOT=C:\%CYG_ROOT%
 
 cd "%APPVEYOR_BUILD_FOLDER%"

--- a/master_changes.md
+++ b/master_changes.md
@@ -73,7 +73,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Internal
-  *
+  * Switch AppVeyor Cygwin from snapshot back to main repository [#4338 @dra27]
 
 ## Test
   *


### PR DESCRIPTION
Cygwin 3.1.7 was released last week, so AppVeyor no longer needs to use a development snapshot for the Cygwin port's test.

The AppVeyor script now checks the installed version of Cygwin and forces an upgrade if necessary. AppVeyor is on 3.1.2 so for now this is necessary - when the AppVeyor base image is next upgraded, this will go back to installing packages only.