### PR TITLE
Fix missing conflict message when trying to remove required packages

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -72,7 +72,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Solver
-  *
+  * Fix missing conflict message when trying to remove required packages [#4362 @AltGr]
 
 ## Client
   *

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -731,6 +731,7 @@ let extract_explanations packages cudfnv2opam unav_reasons reasons =
           if Set.exists is_opam_invariant pkgs then
             Printf.sprintf "(invariant)"
             :: aux vpkgl1 r
+          else if r = [] then ["(request)"]
           else aux vpkgl1 r (* request *)
         else if vpkgl = [] then
           print_set pkgs :: aux vpkgl1 r
@@ -772,9 +773,12 @@ let extract_explanations packages cudfnv2opam unav_reasons reasons =
     reasons;
   (* Get paths from the conflicts to requested or invariant packages *)
   let roots =
-    Hashtbl.fold (fun p _ acc ->
-        if is_artefact p then Set.add p acc else acc)
-      deps Set.empty
+    let add_artefacts set =
+      Hashtbl.fold (fun p _ acc ->
+          if is_artefact p then Set.add p acc else acc)
+        set
+    in
+    Set.empty |> add_artefacts deps |> add_artefacts missing |> add_artefacts ct
   in
   let conflicting =
     Hashtbl.fold (fun p _ -> Set.add p) ct Set.empty

--- a/tests/reftests/conflict-badversion.test
+++ b/tests/reftests/conflict-badversion.test
@@ -20,6 +20,9 @@ Done.
 
 No solution found, exiting
 ### opam remove ocaml --show
-Sorry, no solution found: there seems to be a problem with your request.
+  * Incompatible packages:
+    - (invariant) → ocaml-base-compiler = 4.02.3
+    - (request)
+    You can temporarily relax the switch invariant with `--update-invariant'
 
 No solution found, exiting

--- a/tests/reftests/conflict-badversion.test
+++ b/tests/reftests/conflict-badversion.test
@@ -19,3 +19,7 @@ Done.
     - core != 112.17.00
 
 No solution found, exiting
+### opam remove ocaml --show
+Sorry, no solution found: there seems to be a problem with your request.
+
+No solution found, exiting


### PR DESCRIPTION
We were missing some roots when the chain of dependencies ended up of
length 0!