### PR TITLE
[WIP] Cudf request preprocessing

### DIFF
--- a/.ocamlinit
+++ b/.ocamlinit
@@ -1,4 +1,5 @@
 #use "topfind";;
+#use "down.top";;
 #require "opam-client";;
 
 OpamClientConfig.opam_init ();;

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ endif
 endif
 
 ifneq ($(LIBINSTALL_DIR),)
-    OPAMINSTALLER_FLAGS += --libdir "$(LIBINSTALL_DIR)"
+    OPAMINSTALLER_FLAGS += --libdir "$(LIBINSTALL_DIR)" --docdir "$(LIBINSTALL_DIR)/../doc"
 endif
 
 opam-devel.install: $(DUNE_DEP)

--- a/master_changes.md
+++ b/master_changes.md
@@ -19,7 +19,8 @@ New option/command/subcommand are prefixed with ◈.
   * The stdout of `pre-` and `post-session` hooks is now propagated to the user [#4382 @AltGr - fix #4359]
 
 ## Remove
-  *
+  * Fix `opam remove --autoremove <PKG>` to not autoremove unrelated packages
+  * Fix cases where `opam remove -a` could trigger conflicts in the presence of orphan packages
 
 ## Switch
   * Fix `--update-invariant` when removing or changing package name [#4360 @AltGr - fix #4353]

--- a/master_changes.md
+++ b/master_changes.md
@@ -19,8 +19,8 @@ New option/command/subcommand are prefixed with ◈.
   * The stdout of `pre-` and `post-session` hooks is now propagated to the user [#4382 @AltGr - fix #4359]
 
 ## Remove
-  * Fix `opam remove --autoremove <PKG>` to not autoremove unrelated packages
-  * Fix cases where `opam remove -a` could trigger conflicts in the presence of orphan packages
+  * Fix `opam remove --autoremove <PKG>` to not autoremove unrelated packages [#4369 @AltGr - fix #4250 #4332]
+  * Fix cases where `opam remove -a` could trigger conflicts in the presence of orphan packages [#4369 @AltGr - fix #4250 #4332]
 
 ## Switch
   * Fix `--update-invariant` when removing or changing package name [#4360 @AltGr - fix #4353]

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -291,8 +291,9 @@ let upgrade_t
       OpamConsole.warning
         "Upgrade is not possible because of conflicts or packages that \
          are no longer available:";
-      OpamConsole.errmsg "%s"
-        (OpamStd.Format.itemize (OpamCudf.string_of_conflict ~indent:4) reasons);
+      OpamConsole.errmsg "  %s"
+        (OpamStd.Format.itemize (OpamCudf.string_of_conflict ~start_column:2)
+           reasons);
       OpamConsole.errmsg
         "\nYou may run \"opam upgrade --fixup\" to let opam fix the \
          current state.\n"

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -232,7 +232,6 @@ let apply_selector ~base st = function
       ~installed:false ~unavailable:true
       (get_universe st tog)
       (packages_of_atoms st atoms)
-    |> OpamPackage.Set.of_list
   | Required_by (tog, atoms) ->
     atom_dependencies st tog atoms |>
     OpamFormula.packages base
@@ -664,14 +663,8 @@ let display st format packages =
           ~requested:(OpamPackage.names_of_packages packages)
           Query
       in
-      let deps_packages =
-        OpamSolver.dependencies
-          ~depopts:true ~installed:false ~unavailable:true
-          ~build:true ~post:false
-          universe packages
-      in
-      List.filter (fun nv -> OpamPackage.Set.mem nv packages) deps_packages |>
-      List.rev
+      OpamSolver.dependency_sort ~depopts:true ~build:true ~post:false
+        universe packages
     else match format.order with
       | `Custom o -> List.sort o (OpamPackage.Set.elements packages)
       | _ -> OpamPackage.Set.elements packages

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -1093,7 +1093,10 @@ let preprocess_cudf_request (props, univ, creq) criteria =
     let installed =
       Set.of_list (Cudf.get_packages ~filter:(fun p -> p.Cudf.installed) univ)
     in
-    let to_install = vpkg2set creq.Cudf.install in
+    let to_install =
+      vpkg2set creq.Cudf.install
+      ++ Set.of_list (Cudf.lookup_packages univ opam_invariant_package_name)
+    in
     let packages =
       if do_trimming then
         Set.fixpoint deps

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -1124,7 +1124,11 @@ let preprocess_cudf_request (props, univ, creq) =
     in
     let cache = Hashtbl.create 513 in
     (* Don't explore deeper than that for transitive conflicts *)
-    let max_dig_depth = 2 in
+    let max_dig_depth =
+      match OpamStd.Config.env_int "DIGDEPTH" with
+      | None -> 2
+      | Some i -> i
+    in
     let rec transitive_conflicts seen p =
       (* OpamConsole.msg "%s\n" (Package.to_string p); *)
       try Hashtbl.find cache p with Not_found ->

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -1142,8 +1142,14 @@ let preprocess_cudf_request (props, univ, creq) =
       conflicts
     in
     let conflicts =
-      Set.fold (fun p acc -> transitive_conflicts Set.empty acc p)
-        to_install Set.empty
+      OpamStd.String.Map.fold (fun _ ps acc ->
+          acc ++
+          Set.map_reduce ~default:Set.empty
+            (transitive_conflicts Set.empty Set.empty)
+            Set.inter
+            ps)
+        (to_map to_install)
+        Set.empty
     in
     log "Conflicts: %a pkgs to remove"
       (slog OpamStd.Op.(string_of_int @* Set.cardinal)) conflicts;

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -910,12 +910,13 @@ let extract_explanations packages cudfnv2opam unav_reasons reasons =
 let strings_of_cycles cycles =
   List.map arrow_concat cycles
 
-let string_of_conflict ?(indent=0) (msg1, msg2, msg3) =
-  OpamStd.Format.reformat ~start_column:indent ~indent msg1 ^
+let string_of_conflict ?(start_column=0) (msg1, msg2, msg3) =
+  let width = OpamStd.Sys.terminal_columns () - start_column - 2 in
+  OpamStd.Format.reformat ~start_column ~indent:2 msg1 ^
   OpamStd.List.concat_map ~left:"\n- " ~nil:"" "\n- "
-    (fun s -> OpamStd.Format.reformat ~indent s) msg2 ^
+    (fun s -> OpamStd.Format.reformat ~indent:2 ~width s) msg2 ^
   OpamStd.List.concat_map ~left:"\n" ~nil:"" "\n"
-    (fun s -> OpamStd.Format.reformat ~indent s) msg3
+    (fun s -> OpamStd.Format.reformat ~indent:2 ~width s) msg3
 
 let conflict_explanations packages unav_reasons = function
   | univ, version_map, Conflict_dep reasons ->
@@ -942,7 +943,7 @@ let string_of_conflicts packages unav_reasons conflict =
   if cflts <> [] then
     Buffer.add_string b
       (OpamStd.Format.itemize ~bullet:(OpamConsole.colorise `red "  * ")
-         (string_of_conflict ~indent:4) cflts);
+         (string_of_conflict ~start_column:4) cflts);
   if cflts = [] && cycles = [] then (* No explanation found *)
     Printf.bprintf b
       "Sorry, no solution found: \

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -1280,22 +1280,22 @@ let get_final_universe ~version_map univ req =
     Success (Cudf.load_universe [])
   | Algo.Depsolver.Error str -> fail str
   | Algo.Depsolver.Unsat r   ->
-    OpamConsole.error
-      "The solver (%s) pretends there is no solution while that's apparently \
-       false.\n\
-       This is likely an issue with the solver interface, please try a \
-       different solver and report if you were using a supported one."
-      (let module Solver = (val OpamSolverConfig.(Lazy.force !r.solver)) in
-       Solver.name);
+    let msg =
+      Printf.sprintf
+        "The solver (%s) pretends there is no solution while that's apparently \
+         false.\n\
+         This is likely an issue with the solver interface, please try a \
+         different solver and report if you were using a supported one."
+        (let module Solver = (val OpamSolverConfig.(Lazy.force !r.solver)) in
+         Solver.name)
+    in
     match r with
     | Some ({Algo.Diagnostic.result = Algo.Diagnostic.Failure _; _} as r) ->
+      OpamConsole.error "%s" msg;
       make_conflicts ~version_map univ r
     | Some {Algo.Diagnostic.result = Algo.Diagnostic.Success _; _}
     | None ->
-      raise (Solver_failure
-        "The current solver could not find a solution but dose3 could. \
-         This is probably a bug in the current solver. Please file a bug-report \
-         on the opam bug tracker: https://github.com/ocaml/opam/issues/")
+      raise (Solver_failure msg)
 
 let diff univ sol =
   let before =

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -1180,9 +1180,8 @@ let call_external_solver ~version_map univ req =
     in
     try
       let cudf_request =
-        if OpamStd.Config.env_bool "PREPRO" = Some true then
-          preprocess_cudf_request cudf_request
-        else  cudf_request
+        if OpamStd.Config.env_bool "PREPRO" = Some false then cudf_request
+        else preprocess_cudf_request cudf_request
       in
       let r =
         check_request_using

--- a/src/solver/opamCudf.mli
+++ b/src/solver/opamCudf.mli
@@ -42,10 +42,6 @@ module Graph: sig
   (** Return the transitive closure of [g] *)
   val transitive_closure: t -> t
 
-  (** Return the transitive closure of dependencies of [set],
-      sorted in topological order. *)
-  val close_and_linearize: t -> Set.t -> Cudf.package list
-
   (** Reverse the direction of all edges *)
   val mirror: t -> t
 end
@@ -62,13 +58,15 @@ module ActionGraph: OpamActionGraph.SIG with type package = Package.t
 (** Abstract type that may be returned in case of conflicts *)
 type conflict
 
-(** Return the transitive closure of dependencies of [set],
-    sorted in topological order *)
-val dependencies: Cudf.universe -> Cudf.package list -> Cudf.package list
+(** Return the transitive closure of dependencies of [set] *)
+val dependencies: Cudf.universe -> Set.t -> Set.t
 
-(** Return the transitive closure of dependencies of [set],
-    sorted in topological order *)
-val reverse_dependencies: Cudf.universe -> Cudf.package list -> Cudf.package list
+(** Return the transitive closure of reverse dependencies of [set] *)
+val reverse_dependencies: Cudf.universe -> Set.t -> Set.t
+
+(** Sorts the given packages topolgically (be careful if there are cycles, e.g.
+   if the universe was loaded with [post] dependencies enabled) *)
+val dependency_sort: Cudf.universe -> Set.t -> Cudf.package list
 
 (** Check if a request is satisfiable and return the reasons why not unless
     [explain] is set to [false] *)

--- a/src/solver/opamCudf.mli
+++ b/src/solver/opamCudf.mli
@@ -221,7 +221,7 @@ val conflict_explanations:
 (** Properly concat a single conflict as returned by [conflict_explanations] for
    display *)
 val string_of_conflict:
-  ?indent:int -> string * string list * string list -> string
+  ?start_column:int -> string * string list * string list -> string
 
 (** Dumps the given cudf universe to the given channel *)
 val dump_universe: out_channel -> Cudf.universe -> unit

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -102,6 +102,8 @@ let constraint_to_cudf version_map name (op,v) =
        (this shouldn't happen for any constraint in the universe, now that we
        compute a full version map, but may still happen for user-provided
        constraints) *)
+    log "Warn: fallback constraint for %s"
+      (OpamFormula.string_of_atom (name, Some (op,v)));
     let all_versions =
       OpamPackage.Map.filter (fun nv _ -> nv.name = name)
         version_map in

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -570,7 +570,7 @@ let dependency_graph
 let filter_dependencies
     f_direction ~depopts ~build ~post ~installed
     ?(unavailable=false) universe packages =
-  if OpamPackage.Set.is_empty packages then [] else
+  if OpamPackage.Set.is_empty packages then OpamPackage.Set.empty else
   let u_packages =
     packages ++
     if installed then universe.u_installed else
@@ -583,18 +583,34 @@ let filter_dependencies
     load_cudf_universe ~depopts ~build ~post universe ~version_map
       u_packages () in
   let cudf_packages =
-    opam2cudf universe ~depopts ~build ~post version_map packages
+    OpamCudf.Set.of_list
+      (opam2cudf universe ~depopts ~build ~post version_map packages)
   in
   log ~level:3 "filter_dependencies: dependency";
-  let topo_packages = f_direction cudf_universe cudf_packages in
-  let result = List.rev_map OpamCudf.cudf2opam topo_packages in
+  let clos_packages = f_direction cudf_universe cudf_packages in
+  let result =
+    OpamCudf.Set.fold (fun cp -> OpamPackage.Set.add (OpamCudf.cudf2opam cp))
+      clos_packages OpamPackage.Set.empty
+  in
   log "filter_dependencies result=%a"
-    (slog (OpamStd.List.to_string OpamPackage.to_string)) result;
+    (slog OpamPackage.Set.to_string) result;
   result
 
 let dependencies = filter_dependencies OpamCudf.dependencies
 
 let reverse_dependencies = filter_dependencies OpamCudf.reverse_dependencies
+
+let dependency_sort ~depopts ~build ~post universe packages =
+  let version_map = cudf_versions_map universe universe.u_packages in
+  let cudf_universe =
+    load_cudf_universe ~depopts ~build ~post universe ~version_map
+      universe.u_packages () in
+  let cudf_packages =
+    OpamCudf.Set.of_list
+      (opam2cudf universe ~depopts ~build ~post version_map packages)
+  in
+  List.map OpamCudf.cudf2opam
+    (OpamCudf.dependency_sort cudf_universe cudf_packages)
 
 let coinstallability_check universe packages =
   let version_map = cudf_versions_map universe universe.u_packages in

--- a/src/solver/opamSolver.mli
+++ b/src/solver/opamSolver.mli
@@ -92,7 +92,7 @@ val installable: universe -> package_set
 (** Like [installable], but within a subset and potentially much faster *)
 val installable_subset: universe -> package_set -> package_set
 
-(** Return the topological sort of the transitive dependency closures
+(** Return the transitive dependency closures
     of a collection of packages.*)
 val dependencies :
   depopts:bool -> build:bool -> post:bool ->
@@ -100,13 +100,21 @@ val dependencies :
   ?unavailable:bool ->
   universe ->
   package_set ->
-  package list
+  package_set
 
 (** Same as [dependencies] but for reverse dependencies *)
 val reverse_dependencies :
   depopts:bool -> build:bool -> post:bool ->
   installed:bool ->
   ?unavailable:bool ->
+  universe ->
+  package_set ->
+  package_set
+
+(** Sorts the given package set in topological order (as much as possible,
+    beware of cycles in particular if [post] is [true]) *)
+val dependency_sort :
+  depopts:bool -> build:bool -> post:bool ->
   universe ->
   package_set ->
   package list

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -314,7 +314,6 @@ let load lock_kind gt rt switch =
   let opams =
     OpamPackage.Map.union (fun _ x -> x) repos_package_index pinned_opams
   in
-  let packages = OpamPackage.keys opams in
   let available_packages =
     lazy (compute_available_packages gt switch switch_config
             ~pinned ~opams)
@@ -324,6 +323,7 @@ let load lock_kind gt rt switch =
        computing availability *)
     OpamPackage.Map.union (fun _ x -> x) installed_opams opams
   in
+  let packages = OpamPackage.keys opams in
   let installed_without_def =
     OpamPackage.Set.fold (fun nv nodef ->
         if OpamPackage.Map.mem nv installed_opams then nodef else


### PR DESCRIPTION
This adds a resolution of conflicts at low-level (directly on the CUDF
that is sent to the solver, but after the satisfiability check so that
it doesn't have an impact on the error messages).

It might be a better replacement for the high-level preprocessing that
tried to remove conflicting compilers in OpamSwitchState, when
computing the universe. Preliminary tests have shown it can be very
efficient for local switch creation cases where the OCaml version is
constrained.