### PR TITLE
Update opam files

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -61,7 +61,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Build
-  *
+  * Update opam file to 2.0 [#4371 @AltGr]
 
 ## Infrastructure
   *

--- a/opam-client.opam
+++ b/opam-client.opam
@@ -1,5 +1,9 @@
-opam-version: "1.2"
+opam-version: "2.0"
 version: "2.1.0~beta3"
+synopsis: "opam 2.1 development libraries (client)"
+description: """
+Actions on the opam root, switches, installations, and front-end.
+"""
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"
@@ -15,12 +19,13 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
+  "ocaml" {>= "4.02.3"}
   "opam-state" {= version}
   "opam-solver" {= version}
   "extlib"
@@ -29,4 +34,3 @@ depends: [
   "cmdliner" {>= "0.9.8"}
   "dune" {>= "1.5.0"}
 ]
-available: ocaml-version >= "4.02.3"

--- a/opam-core.opam
+++ b/opam-core.opam
@@ -1,5 +1,9 @@
-opam-version: "1.2"
+opam-version: "2.0"
 version: "2.1.0~beta3"
+synopsis: "opam 2.1 development libraries (core)"
+description: """
+Small standard library extensions, and generic system interaction modules used by opam.
+"""
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"
@@ -15,12 +19,13 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
+  "ocaml" {>= "4.02.3"}
   "base-unix"
   "base-bigarray"
   "ocamlgraph"
@@ -29,4 +34,3 @@ depends: [
   "cppo" {build}
 ]
 conflicts: "extlib-compat"
-available: ocaml-version >= "4.02.3"

--- a/opam-devel.opam
+++ b/opam-devel.opam
@@ -1,5 +1,9 @@
-opam-version: "1.2"
+opam-version: "2.0"
 version: "2.1.0~beta3"
+synopsis: "opam 2.1 bootstrapped binary"
+description: """
+This package compiles (bootstraps) opam. For consistency and safety of the installation, the binaries are not installed into the PATH, but into lib/opam-devel, from where the user can manually install them system-wide.
+"""
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"
@@ -15,13 +19,14 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
+  [make "tests"] {with-test}
 ]
-build-test: [make "tests"]
 depends: [
+  "ocaml" {>= "4.02.3"}
   "opam-client" {= version}
   "cmdliner" {>= "0.9.8"}
   "dune" {>= "1.5.0"}
@@ -34,4 +39,3 @@ If you just want to give it a try without altering your current installation, yo
     alias opam2=\"OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""
   {success}
 ]
-available: ocaml-version >= "4.02.3"

--- a/opam-format.opam
+++ b/opam-format.opam
@@ -1,5 +1,9 @@
-opam-version: "1.2"
+opam-version: "2.0"
 version: "2.1.0~beta3"
+synopsis: "opam 2.1 development libraries (format)"
+description: """
+Definition of opam datastructures and its file interface.
+"""
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"
@@ -15,14 +19,14 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
+  "ocaml" {>= "4.02.3"}
   "opam-core" {= version}
   "opam-file-format" {>= "2.0.0~rc2"}
   "dune" {>= "1.5.0"}
 ]
-available: ocaml-version >= "4.02.3"

--- a/opam-installer.opam
+++ b/opam-installer.opam
@@ -1,5 +1,11 @@
-opam-version: "1.2"
+opam-version: "2.0"
 version: "2.1.0~beta3"
+synopsis: "Installation of files to a prefix, following opam conventions"
+description: """
+opam-installer is a small tool that can read *.install files, as defined by opam [1], and execute them to install or remove package files without going through opam.
+
+[1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install
+"""
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"
@@ -15,14 +21,14 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
+  "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
   "cmdliner" {>= "0.9.8"}
   "dune" {>= "1.5.0"}
 ]
-available: ocaml-version >= "4.02.3"

--- a/opam-repository.opam
+++ b/opam-repository.opam
@@ -1,5 +1,9 @@
-opam-version: "1.2"
+opam-version: "2.0"
 version: "2.1.0~beta3"
+synopsis: "opam 2.1 development libraries (repository)"
+description: """
+This library includes repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends.
+"""
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"
@@ -15,13 +19,13 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
+  "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
   "dune" {>= "1.5.0"}
 ]
-available: ocaml-version >= "4.02.3"

--- a/opam-solver.opam
+++ b/opam-solver.opam
@@ -1,5 +1,9 @@
-opam-version: "1.2"
+opam-version: "2.0"
 version: "2.1.0~beta3"
+synopsis: "opam 2.1 development libraries (solver)"
+description: """
+Solver and Cudf interaction. This library is based on the Cudf and Dose libraries, and handles calls to the external solver from opam.
+"""
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"
@@ -15,12 +19,13 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
+  "ocaml" {>= "4.02.3"}
   "opam-format" {= version}
   "mccs" {>= "1.1+9"}
   "dose3" {>= "5"}
@@ -35,4 +40,3 @@ conflicts: [
   "z3" {< "4.8.4"}
   "opam-0install-cudf" {< "0.3"}
 ]
-available: ocaml-version >= "4.02.3"

--- a/opam-state.opam
+++ b/opam-state.opam
@@ -1,5 +1,9 @@
-opam-version: "1.2"
+opam-version: "2.0"
 version: "2.1.0~beta3"
+synopsis: "opam 2.1 development libraries (state)"
+description: """
+Handling of the ~/.opam hierarchy, repository and switch states.
+"""
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"
@@ -15,13 +19,13 @@ authors: [
 ]
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
-dev-repo: "https://github.com/ocaml/opam.git"
+dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
+  "ocaml" {>= "4.02.3"}
   "opam-repository" {= version}
   "dune" {>= "1.5.0"}
 ]
-available: ocaml-version >= "4.02.3"


### PR DESCRIPTION
They were referring to the `version` variable already anyway, so I
guess there is no point in keeping them locked to the very obsolete
1.2: you'll probably prefer to use the bootstrap scripts if yiy are in
this case anyway?