### PR TITLE
Ensure that a cold `dune runtest` works

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -82,7 +82,7 @@ New option/command/subcommand are prefixed with ◈.
   * ActionGraph: removal postponing, protect against addition of cycles [#4358 @AltGr - fix #4357]
 
 ## Test
-  *
+  * Ensure that a cold `dune runtest` works [#4375 @emillon]
 
 ## Doc
   *

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -23,7 +23,7 @@ PACKAGES  = P1-0 P1-1 P1-2 P2 P3 P4 P5
 unexport OCAMLLIB
 
 ifndef OPAM
-  OPAM = $(firstword $(realpath ../../install/default/bin/opam$(EXE) ../_build/install/default/bin/opamMain.exe))
+  OPAM = $(firstword $(realpath ../../install/default/bin/opam$(EXE) ../_build/install/default/bin/opamMain.exe ../../default/src/client/opamMain.exe))
 endif
 ENV   = PATH="$(PATH)" $(DEBUG) OPAMKEEPBUILDDIR=1 OPAMROOT=$(OPAM_ROOT) OPAMSWITCH= OPAMNOBASEPACKAGES=1 OPAMYES=1 OPAM=$(OPAM)
 OPAMBIN  = $(ENV) $(OPAM)

--- a/tests/patcher.ml
+++ b/tests/patcher.ml
@@ -90,7 +90,7 @@ let generate_patch () =
 let tests () =
   set_debug_level 0 [];
   let cwd = Sys.getcwd () in
-  setup_directory test_dir;
+  setup_directory ~dir:test_dir;
   pattern1 "a";
   pattern2 "b";
   pattern1 "c";


### PR DESCRIPTION
When running through the Makefile, the install binary is picked up and
the tests are run using the default profile. These tweaks ensure that it
is possible to run `dune runtest` directly after `dune clean`.
