### PR TITLE
Temporarily disable appveyor mingw32 runs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ environment:
       DEP_MODE: lib-pkg
       GIT_FOR_WINDOWS: 1
     - OCAML_PORT: msvc64
-    - OCAML_PORT: mingw
+#    - OCAML_PORT: mingw
     - OCAML_PORT: mingw64
       DEP_MODE: lib-pkg
       GIT_FOR_WINDOWS: 1


### PR DESCRIPTION
Ref. https://github.com/ocaml/ocaml/pull/9939 for the underlying issue, this 
should be re-enabled once fixed upstream.