### PR TITLE
'opam admin cache': use the configured caches for update

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -67,7 +67,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Admin
-  *
+  * Use the archive caches when running `opam admin cache` [#4384 @AltGr - fix #4352]
 
 ## Opam installer
   *


### PR DESCRIPTION
Caches are taken from the local `repo` file `archive-mirrors` field, then from 
the global opam configuration, if any.

Interestingly, the former (only) was already used by `opam admin add-hashes`, 
but not by `opam admin cache`.

Closes #4352