### PR TITLE
Cli versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ checker:
 tests: $(DUNE_DEP)
 	$(DUNE) build --profile=$(DUNE_PROFILE) $(DUNE_ARGS) opam.install src/tools/opam_check.exe tests/patcher.exe
 	$(DUNE) build --profile=$(DUNE_PROFILE) $(DUNE_ARGS) doc/man/opam-topics.inc doc/man/opam-admin-topics.inc
-	$(DUNE) runtest --force --no-buffer --profile=$(DUNE_PROFILE) $(DUNE_ARGS) src/ tests/
+	OPAMCLI=2.0 $(DUNE) runtest --force --no-buffer --profile=$(DUNE_PROFILE) $(DUNE_ARGS) src/ tests/
 
 .PHONY: crowbar
 # only run the quickcheck-style tests, not very covering

--- a/master_changes.md
+++ b/master_changes.md
@@ -9,6 +9,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Global CLI
   * Fix hooks broken by 371963a6b [#4386 @lefessan]
+  * CLI versioning usage [#4385 @rjbou]
 
 ## Init
   * Fix sandbox check with not yet set opam environment variables [#4370 @rjbou - fix #4368]
@@ -123,6 +124,7 @@ New option/command/subcommand are prefixed with ◈.
   * Add github actions [#4463 @rjbou]
   * Add reftests to github actions [#4466 @rjbou]
   * Add opam file 1.2 -> 2.0 upgrade test [#4466 @rjbou]
+  * Add cli versioning test [#4385 @rjbou]
 
 ## Shell
   * Update completion scripts with `opam var` instead of `opam config list` [#4428 @rjbou]

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -299,8 +299,8 @@ let add_hashes_command cli =
             hash_kinds))
   in
   let packages =
-    OpamArg.mk_opt ~cli OpamArg.valid_cli_legacy ["p";"packages"] "PACKAGES"
-      "Only add hashes for the given packages"
+    OpamArg.mk_opt ~cli OpamArg.(Valid_since cli2_1) ["p";"packages"]
+      "PACKAGES" "Only add hashes for the given packages"
       Arg.(list OpamArg.package) []
   in
   let replace_arg =

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -74,7 +74,7 @@ let index_command cli =
        of failing. This is the default.";
     ]
   in
-  let cmd global_options urls_txt =
+  let cmd global_options urls_txt () =
     OpamArg.apply_global_options global_options;
     let repo_root = checked_repo_root ()  in
     let repo_file = OpamRepositoryPath.repo repo_root in
@@ -121,8 +121,8 @@ let index_command cli =
     OpamHTTP.make_index_tar_gz repo_root;
     OpamConsole.msg "Done.\n";
   in
-  Term.(const cmd $ global_options cli $ urls_txt_arg cli),
-  OpamArg.term_info command ~doc ~man
+  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
+    Term.(const cmd $ global_options cli $ urls_txt_arg cli)
 
 let cache_urls repo_root repo_def =
   let global_dl_cache =
@@ -226,7 +226,7 @@ let cache_command cli =
       "JOBS" "Number of parallel downloads"
       OpamArg.positive_integer 8
   in
-  let cmd global_options cache_dir no_repo_update link jobs =
+  let cmd global_options cache_dir no_repo_update link jobs () =
     OpamArg.apply_global_options global_options;
     let repo_root = checked_repo_root () in
     let repo_file = OpamRepositoryPath.repo repo_root in
@@ -272,9 +272,9 @@ let cache_command cli =
 
     OpamConsole.msg "Done.\n";
   in
-  Term.(const cmd $ global_options cli $
-        cache_dir_arg $ no_repo_update_arg $ link_arg $ jobs_arg),
-  OpamArg.term_info command ~doc ~man
+  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
+    Term.(const cmd $ global_options cli $
+          cache_dir_arg $ no_repo_update_arg $ link_arg $ jobs_arg)
 
 let add_hashes_command_doc =
   "Add archive hashes to an opam repository."
@@ -389,7 +389,7 @@ let add_hashes_command cli =
        | None -> ());
       h
   in
-  let cmd global_options hash_types replace packages =
+  let cmd global_options hash_types replace packages () =
     OpamArg.apply_global_options global_options;
     let repo_root = checked_repo_root () in
     let cache_urls =
@@ -491,9 +491,9 @@ let add_hashes_command cli =
     if has_error then OpamStd.Sys.exit_because `Sync_error
     else OpamStd.Sys.exit_because `Success
   in
-  Term.(const cmd $ global_options cli $
-        hash_types_arg $ replace_arg $ packages),
-  OpamArg.term_info command ~doc ~man
+  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
+    Term.(const cmd $ global_options cli $
+          hash_types_arg $ replace_arg $ packages)
 
 let upgrade_command_doc =
   "Upgrades repository from earlier opam versions."
@@ -526,7 +526,7 @@ let upgrade_command cli =
        of opam don't understand relative redirects)."
       Arg.(some OpamArg.url) None
   in
-  let cmd global_options clear_cache create_mirror =
+  let cmd global_options clear_cache create_mirror () =
     OpamArg.apply_global_options global_options;
     if clear_cache then OpamAdminRepoUpgrade.clear_cache ()
     else match create_mirror with
@@ -541,9 +541,9 @@ let upgrade_command cli =
             \  opam admin index"
       | Some m -> OpamAdminRepoUpgrade.do_upgrade_mirror (OpamFilename.cwd ()) m
   in
-  Term.(const cmd $ global_options cli $
-        clear_cache_arg $ create_mirror_arg),
-  OpamArg.term_info command ~doc ~man
+  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
+    Term.(const cmd $ global_options cli $
+          clear_cache_arg $ create_mirror_arg)
 
 let lint_command_doc =
   "Runs 'opam lint' and reports on a whole repository"
@@ -582,7 +582,7 @@ let lint_command cli =
     OpamArg.mk_flag ~cli OpamArg.cli_original ["warn-error";"W"]
       "Return failure on any warnings, not only on errors"
   in
-  let cmd global_options short list incl excl ign warn_error =
+  let cmd global_options short list incl excl ign warn_error () =
     OpamArg.apply_global_options global_options;
     let repo_root = OpamFilename.cwd () in
     if not (OpamFilename.exists_dir OpamFilename.Op.(repo_root / "packages"))
@@ -624,10 +624,10 @@ let lint_command cli =
     in
     OpamStd.Sys.exit_because (if ret then `Success else `False)
   in
-  Term.(const cmd $ global_options cli $
-        short_arg $ list_arg $ include_arg $ exclude_arg $ ignore_arg $
-        warn_error_arg),
-  OpamArg.term_info command ~doc ~man
+  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
+    Term.(const cmd $ global_options cli $
+          short_arg $ list_arg $ include_arg $ exclude_arg $ ignore_arg $
+          warn_error_arg)
 
 let check_command_doc =
   "Runs some consistency checks on a repository"
@@ -665,7 +665,7 @@ let check_command cli =
       "Analyse for obsolete packages"
   in
   let cmd global_options ignore_test print_short
-      installability cycles obsolete =
+      installability cycles obsolete () =
     OpamArg.apply_global_options global_options;
     let repo_root = checked_repo_root () in
     let installability, cycles, obsolete =
@@ -708,9 +708,9 @@ let check_command cli =
        (pr obsolete "obsolete packages"));
     OpamStd.Sys.exit_because (if all_ok then `Success else `False)
   in
+  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
   Term.(const cmd $ global_options cli $ ignore_test_arg $ print_short_arg
-        $ installability_arg $ cycles_arg $ obsolete_arg),
-  OpamArg.term_info command ~doc ~man
+        $ installability_arg $ cycles_arg $ obsolete_arg)
 
 let pattern_list_arg =
   OpamArg.arg_list "PATTERNS"
@@ -822,7 +822,7 @@ let list_command cli =
   in
   let cmd
       global_options package_selection disjunction state_selection
-      package_listing env packages =
+      package_listing env packages () =
     OpamArg.apply_global_options global_options;
     let format =
       let force_all_versions =
@@ -859,10 +859,10 @@ let list_command cli =
     in
     OpamListCommand.display st format results
   in
+  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
   Term.(const cmd $ global_options cli $ OpamArg.package_selection cli $
         or_arg cli $ state_selection_arg cli $ OpamArg.package_listing cli $
-        env_arg cli $ pattern_list_arg),
-  OpamArg.term_info command ~doc ~man
+        env_arg cli $ pattern_list_arg)
 
 let filter_command_doc = "Filters a repository to only keep selected packages"
 let filter_command cli =
@@ -889,7 +889,7 @@ let filter_command cli =
   in
   let cmd
       global_options package_selection disjunction state_selection env
-      remove dryrun packages =
+      remove dryrun packages () =
     OpamArg.apply_global_options global_options;
     let repo_root = OpamFilename.cwd () in
     let pattern_selector = OpamListCommand.pattern_selector packages in
@@ -946,11 +946,11 @@ let filter_command cli =
              OpamFilename.rmdir_cleanup d))
       pkg_prefixes
   in
+  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
   Term.(const cmd $ global_options cli $ OpamArg.package_selection cli $
         or_arg cli $ state_selection_arg cli $ env_arg cli $ remove_arg $
         dryrun_arg $
-        pattern_list_arg),
-  OpamArg.term_info command ~doc ~man
+        pattern_list_arg)
 
 let add_constraint_command_doc =
   "Adds version constraints on all dependencies towards a given package"
@@ -984,7 +984,7 @@ let add_constraint_command cli =
        $(b,<2)). The default in this case is to print a warning and keep \
        the existing constraint unchanged."
   in
-  let cmd global_options force atom =
+  let cmd global_options force atom () =
     OpamArg.apply_global_options global_options;
     let repo_root = checked_repo_root () in
     let pkg_prefixes = OpamRepository.packages_with_prefixes repo_root in
@@ -1055,8 +1055,8 @@ let add_constraint_command cli =
              |> OpamFile.OPAM.with_conflicts conflicts))
       pkg_prefixes
   in
-  Term.(pure cmd $ global_options cli $ force_arg $ atom_arg),
-  OpamArg.term_info command ~doc ~man
+  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
+  Term.(pure cmd $ global_options cli $ force_arg $ atom_arg)
 
 (* HELP *)
 let help =

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -59,20 +59,20 @@ let index_command cli =
   ]
   in
   let urls_txt_arg =
-    Arg.(value & vflag `minimal_urls_txt [
-        `no_urls_txt, info ["no-urls-txt"] ~doc:
-          "Don't generate a 'urls.txt' file. That index file is no longer \
-           needed from opam 2.0 on, but is still used by older versions.";
-        `full_urls_txt, info ["full-urls-txt"] ~doc:
-          "Generate an inclusive 'urls.txt', for a repository that will be \
-           used by opam versions earlier than 2.0.";
-        `minimal_urls_txt, info ["minimal-urls-txt"] ~doc:
-          "Generate a minimal 'urls.txt' file, that only includes the 'repo' \
-           file. This allows opam versions earlier than 2.0 to read that file, \
-           and be properly redirected to a repository dedicated to their \
-           version, assuming a suitable 'redirect:' field is defined, instead \
-           of failing. This is the default.";
-      ])
+    OpamArg.mk_vflag `minimal_urls_txt [
+      `no_urls_txt, ["no-urls-txt"],
+      "Don't generate a 'urls.txt' file. That index file is no longer \
+       needed from opam 2.0 on, but is still used by older versions.";
+      `full_urls_txt, ["full-urls-txt"],
+      "Generate an inclusive 'urls.txt', for a repository that will be \
+       used by opam versions earlier than 2.0.";
+      `minimal_urls_txt, ["minimal-urls-txt"],
+      "Generate a minimal 'urls.txt' file, that only includes the 'repo' \
+       file. This allows opam versions earlier than 2.0 to read that file, \
+       and be properly redirected to a repository dedicated to their \
+       version, assuming a suitable 'redirect:' field is defined, instead \
+       of failing. This is the default.";
+    ]
   in
   let cmd global_options urls_txt =
     OpamArg.apply_global_options global_options;
@@ -209,22 +209,21 @@ let cache_command cli =
            "Name of the cache directory to use.")
   in
   let no_repo_update_arg =
-    Arg.(value & flag & info ["no-repo-update";"n"] ~doc:
-           "Don't check, create or update the 'repo' file to point to the \
-            generated cache ('archive-mirrors:' field).")
+    OpamArg.mk_flag ["no-repo-update";"n"]
+      "Don't check, create or update the 'repo' file to point to the \
+       generated cache ('archive-mirrors:' field)."
   in
   let link_arg =
-    Arg.(value & opt (some OpamArg.dirname) None &
-         info ["link"] ~docv:"DIR" ~doc:
-           (Printf.sprintf
-             "Create reverse symbolic links to the archives within $(i,DIR), in \
-              the form $(b,DIR%sPKG.VERSION%sFILENAME)."
-             OpamArg.dir_sep OpamArg.dir_sep))
+    OpamArg.mk_opt ["link"] "DIR"
+      (Printf.sprintf
+         "Create reverse symbolic links to the archives within $(i,DIR), in \
+          the form $(b,DIR%sPKG.VERSION%sFILENAME)."
+         OpamArg.dir_sep OpamArg.dir_sep)
+      Arg.(some OpamArg.dirname) None
   in
   let jobs_arg =
-    Arg.(value & opt OpamArg.positive_integer 8 &
-         info ["jobs"; "j"] ~docv:"JOBS" ~doc:
-           "Number of parallel downloads")
+    OpamArg.mk_opt ["jobs"; "j"] "JOBS" "Number of parallel downloads"
+      OpamArg.positive_integer 8
   in
   let cmd global_options cache_dir no_repo_update link jobs =
     OpamArg.apply_global_options global_options;
@@ -293,23 +292,19 @@ let add_hashes_command cli =
   in
   let hash_kinds = [`MD5; `SHA256; `SHA512] in
   let hash_types_arg =
-    let hash_kind_conv =
-      Arg.enum
-        (List.map (fun k -> OpamHash.string_of_kind k, k)
-           hash_kinds)
-    in
-    Arg.(non_empty & pos_all hash_kind_conv [] & info [] ~docv:"HASH_ALGO" ~doc:
-           "The hash, or hashes to be added")
+    OpamArg.nonempty_arg_list "HASH_ALGO" "The hash, or hashes to be added"
+      (Arg.enum
+         (List.map (fun k -> OpamHash.string_of_kind k, k)
+            hash_kinds))
   in
   let packages =
-    Arg.(value & opt (list OpamArg.package) [] & info
-           ~docv:"PACKAGES"
-           ~doc:"Only add hashes for the given packages"
-           ["p";"packages"])
+    OpamArg.mk_opt ["p";"packages"] "PACKAGES"
+      "Only add hashes for the given packages"
+      Arg.(list OpamArg.package) []
   in
   let replace_arg =
-    Arg.(value & flag & info ["replace"] ~doc:
-           "Replace the existing hashes rather than adding to them")
+    OpamArg.mk_flag ["replace"]
+      "Replace the existing hashes rather than adding to them"
   in
   let hash_tables =
     let t = Hashtbl.create (List.length hash_kinds) in
@@ -507,32 +502,28 @@ let upgrade_command cli =
   let man = [
     `S Manpage.s_description;
     `P (Printf.sprintf
-         "This command reads repositories from earlier opam versions, and \
-          converts them to repositories suitable for the current opam version. \
-          Packages might be created or renamed, and any compilers defined in the \
-          old format ('compilers%s' directory) will be turned into packages, \
-          using a pre-defined hierarchy that assumes OCaml compilers."
-         OpamArg.dir_sep)
+          "This command reads repositories from earlier opam versions, and \
+           converts them to repositories suitable for the current opam version. \
+           Packages might be created or renamed, and any compilers defined in the \
+           old format ('compilers%s' directory) will be turned into packages, \
+           using a pre-defined hierarchy that assumes OCaml compilers."
+          OpamArg.dir_sep)
   ]
   in
   let clear_cache_arg =
-    let doc =
-      Printf.sprintf
-       "Instead of running the upgrade, clear the cache of archive hashes (held \
-        in ~%s.cache), that is used to avoid re-downloading files to obtain \
-        their hashes at every run." OpamArg.dir_sep
-    in
-    Arg.(value & flag & info ["clear-cache"] ~doc)
+    OpamArg.mk_flag ["clear-cache"]
+      (Printf.sprintf
+         "Instead of running the upgrade, clear the cache of archive hashes (held \
+          in ~%s.cache), that is used to avoid re-downloading files to obtain \
+          their hashes at every run." OpamArg.dir_sep)
   in
   let create_mirror_arg =
-    let doc =
+    OpamArg.mk_opt ["m"; "mirror"] "URL"
       "Don't overwrite the current repository, but put an upgraded mirror in \
        place in a subdirectory, with proper redirections. Needs the URL the \
        repository will be served from to put in the redirects (older versions \
        of opam don't understand relative redirects)."
-    in
-    Arg.(value & opt (some OpamArg.url) None &
-         info ~docv:"URL" ["m"; "mirror"] ~doc)
+      Arg.(some OpamArg.url) None
   in
   let cmd global_options clear_cache create_mirror =
     OpamArg.apply_global_options global_options;
@@ -727,34 +718,35 @@ let pattern_list_arg =
     Arg.string
 
 let env_arg =
-  Arg.(value & opt (list string) [] & info ["environment"] ~doc:(
-         Printf.sprintf
-          "Use the given opam environment, in the form of a list of \
-           comma-separated 'var=value' bindings, when resolving variables. This \
-           is used e.g. when computing available packages: if undefined, \
-           availability of packages will be assumed as soon as it can not be \
-           resolved purely from globally defined variables. Note that, unless \
-           overridden, variables like 'root' or 'opam-version' may be taken \
-           from the current opam installation. What is defined in \
-           $(i,~%s.opam%sconfig) is always ignored."
-          OpamArg.dir_sep OpamArg.dir_sep))
+  OpamArg.mk_opt ["environment"] "VAR=VALUE[;VAR=VALUE]"
+    (Printf.sprintf
+       "Use the given opam environment, in the form of a list of \
+        comma-separated 'var=value' bindings, when resolving variables. This \
+        is used e.g. when computing available packages: if undefined, \
+        availability of packages will be assumed as soon as it can not be \
+        resolved purely from globally defined variables. Note that, unless \
+        overridden, variables like 'root' or 'opam-version' may be taken \
+        from the current opam installation. What is defined in \
+        $(i,~%s.opam%sconfig) is always ignored."
+       OpamArg.dir_sep OpamArg.dir_sep)
+    Arg.(list string) []
 
 let state_selection_arg =
-  let docs = OpamArg.package_selection_section in
-  Arg.(value & vflag OpamListCommand.Available [
-      OpamListCommand.Any, info ~docs ["A";"all"]
-        ~doc:"Include all, even uninstalled or unavailable packages";
-      OpamListCommand.Available, info ~docs ["a";"available"]
-        ~doc:"List only packages that are available according to the defined \
-              $(b,environment). Without $(b,--environment), this will include \
-              any packages for which availability is not resolvable at this \
-              point.";
-      OpamListCommand.Installable, info ~docs ["installable"]
-        ~doc:"List only packages that are installable according to the defined \
-              $(b,environment) (this calls the solver and may be more costly; \
-              a package depending on an unavailable one may be available, but \
-              is never installable)";
-    ])
+  OpamArg.mk_vflag ~section:OpamArg.package_selection_section
+    OpamListCommand.Available [
+    OpamListCommand.Any, ["A";"all"],
+    "Include all, even uninstalled or unavailable packages";
+    OpamListCommand.Available, ["a";"available"],
+    "List only packages that are available according to the defined \
+     $(b,environment). Without $(b,--environment), this will include \
+     any packages for which availability is not resolvable at this \
+     point.";
+    OpamListCommand.Installable, ["installable"],
+    "List only packages that are installable according to the defined \
+     $(b,environment) (this calls the solver and may be more costly; \
+     a package depending on an unavailable one may be available, but \
+     is never installable)";
+  ]
 
 let get_virtual_switch_state repo_root env =
   let env =
@@ -807,9 +799,9 @@ let get_virtual_switch_state repo_root env =
     gt rt
 
 let or_arg =
-  Arg.(value & flag & info ~docs:OpamArg.package_selection_section ["or"]
-         ~doc:"Instead of selecting packages that match $(i,all) the \
-               criteria, select packages that match $(i,any) of them")
+  OpamArg.mk_flag ~section:OpamArg.package_selection_section ["or"]
+    "Instead of selecting packages that match $(i,all) the \
+     criteria, select packages that match $(i,any) of them"
 
 let list_command_doc = "Lists packages from a repository"
 let list_command cli =
@@ -983,11 +975,11 @@ let add_constraint_command cli =
             package.")
   in
   let force_arg =
-    Arg.(value & flag & info ["force"] ~doc:
-           "Force updating of constraints even if the resulting constraint is \
-            unsatisfiable (e.g. when adding $(b,>3) to the constraint \
-            $(b,<2)). The default in this case is to print a warning and keep \
-            the existing constraint unchanged.")
+    OpamArg.mk_flag ["force"]
+      "Force updating of constraints even if the resulting constraint is \
+       unsatisfiable (e.g. when adding $(b,>3) to the constraint \
+       $(b,<2)). The default in this case is to print a warning and keep \
+       the existing constraint unchanged."
   in
   let cmd global_options force atom =
     OpamArg.apply_global_options global_options;

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -60,13 +60,13 @@ let index_command cli =
   in
   let urls_txt_arg cli =
     OpamArg.mk_vflag ~cli `minimal_urls_txt [
-      OpamArg.valid_cli_legacy, `no_urls_txt, ["no-urls-txt"],
+      OpamArg.cli_original, `no_urls_txt, ["no-urls-txt"],
       "Don't generate a 'urls.txt' file. That index file is no longer \
        needed from opam 2.0 on, but is still used by older versions.";
-      OpamArg.valid_cli_legacy, `full_urls_txt, ["full-urls-txt"],
+      OpamArg.cli_original, `full_urls_txt, ["full-urls-txt"],
       "Generate an inclusive 'urls.txt', for a repository that will be \
        used by opam versions earlier than 2.0.";
-      OpamArg.valid_cli_legacy, `minimal_urls_txt, ["minimal-urls-txt"],
+      OpamArg.cli_original, `minimal_urls_txt, ["minimal-urls-txt"],
       "Generate a minimal 'urls.txt' file, that only includes the 'repo' \
        file. This allows opam versions earlier than 2.0 to read that file, \
        and be properly redirected to a repository dedicated to their \
@@ -209,12 +209,12 @@ let cache_command cli =
            "Name of the cache directory to use.")
   in
   let no_repo_update_arg =
-    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["no-repo-update";"n"]
+    OpamArg.mk_flag ~cli OpamArg.cli_original ["no-repo-update";"n"]
       "Don't check, create or update the 'repo' file to point to the \
        generated cache ('archive-mirrors:' field)."
   in
   let link_arg =
-    OpamArg.mk_opt ~cli OpamArg.valid_cli_legacy ["link"] "DIR"
+    OpamArg.mk_opt ~cli OpamArg.cli_original ["link"] "DIR"
       (Printf.sprintf
          "Create reverse symbolic links to the archives within $(i,DIR), in \
           the form $(b,DIR%sPKG.VERSION%sFILENAME)."
@@ -222,7 +222,7 @@ let cache_command cli =
       Arg.(some OpamArg.dirname) None
   in
   let jobs_arg =
-    OpamArg.mk_opt ~cli OpamArg.valid_cli_legacy ["jobs"; "j"]
+    OpamArg.mk_opt ~cli OpamArg.cli_original ["jobs"; "j"]
       "JOBS" "Number of parallel downloads"
       OpamArg.positive_integer 8
   in
@@ -299,12 +299,12 @@ let add_hashes_command cli =
             hash_kinds))
   in
   let packages =
-    OpamArg.mk_opt ~cli OpamArg.(Valid_since cli2_1) ["p";"packages"]
+    OpamArg.mk_opt ~cli OpamArg.(cli_from cli2_1) ["p";"packages"]
       "PACKAGES" "Only add hashes for the given packages"
       Arg.(list OpamArg.package) []
   in
   let replace_arg =
-    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["replace"]
+    OpamArg.mk_flag ~cli OpamArg.cli_original ["replace"]
       "Replace the existing hashes rather than adding to them"
   in
   let hash_tables =
@@ -512,14 +512,14 @@ let upgrade_command cli =
   ]
   in
   let clear_cache_arg =
-    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["clear-cache"]
+    OpamArg.mk_flag ~cli OpamArg.cli_original ["clear-cache"]
       (Printf.sprintf
          "Instead of running the upgrade, clear the cache of archive hashes (held \
           in ~%s.cache), that is used to avoid re-downloading files to obtain \
           their hashes at every run." OpamArg.dir_sep)
   in
   let create_mirror_arg =
-    OpamArg.mk_opt ~cli OpamArg.valid_cli_legacy ["m"; "mirror"] "URL"
+    OpamArg.mk_opt ~cli OpamArg.cli_original ["m"; "mirror"] "URL"
       "Don't overwrite the current repository, but put an upgraded mirror in \
        place in a subdirectory, with proper redirections. Needs the URL the \
        repository will be served from to put in the redirects (older versions \
@@ -557,11 +557,11 @@ let lint_command cli =
   ]
   in
   let short_arg =
-    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["s";"short"]
+    OpamArg.mk_flag ~cli OpamArg.cli_original ["s";"short"]
       "Print only packages and warning/error numbers, without explanations"
   in
   let list_arg =
-    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["list";"l"]
+    OpamArg.mk_flag ~cli OpamArg.cli_original ["list";"l"]
       "Only list package names, without warning details"
   in
   let include_arg =
@@ -569,17 +569,17 @@ let lint_command cli =
       OpamArg.positive_integer
   in
   let exclude_arg =
-    OpamArg.mk_opt_all ~cli OpamArg.valid_cli_legacy ["exclude";"x"] "INT"
+    OpamArg.mk_opt_all ~cli OpamArg.cli_original ["exclude";"x"] "INT"
       "Exclude the given warnings or errors"
       OpamArg.positive_integer
   in
   let ignore_arg =
-    OpamArg.mk_opt_all ~cli OpamArg.valid_cli_legacy ["ignore-packages";"i"] "INT"
+    OpamArg.mk_opt_all ~cli OpamArg.cli_original ["ignore-packages";"i"] "INT"
       "Ignore any packages having one of these warnings or errors"
       OpamArg.positive_integer
   in
   let warn_error_arg =
-    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["warn-error";"W"]
+    OpamArg.mk_flag ~cli OpamArg.cli_original ["warn-error";"W"]
       "Return failure on any warnings, not only on errors"
   in
   let cmd global_options short list incl excl ign warn_error =
@@ -644,24 +644,24 @@ let check_command cli =
   ]
   in
   let ignore_test_arg =
-    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["ignore-test-doc";"i"]
+    OpamArg.mk_flag ~cli OpamArg.cli_original ["ignore-test-doc";"i"]
       "By default, $(b,{with-test}) and $(b,{with-doc}) dependencies are \
        included. This ignores them, and makes the test more tolerant."
   in
   let print_short_arg =
-    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["s";"short"]
+    OpamArg.mk_flag ~cli OpamArg.cli_original ["s";"short"]
       "Only output a list of uninstallable packages"
   in
   let installability_arg =
-    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["installability"]
+    OpamArg.mk_flag ~cli OpamArg.cli_original ["installability"]
       "Do the installability check (and disable the others by default)"
   in
   let cycles_arg =
-    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["cycles"]
+    OpamArg.mk_flag ~cli OpamArg.cli_original ["cycles"]
       "Do the cycles check (and disable the others by default)"
   in
   let obsolete_arg =
-    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["obsolete"]
+    OpamArg.mk_flag ~cli OpamArg.cli_original ["obsolete"]
       "Analyse for obsolete packages"
   in
   let cmd global_options ignore_test print_short
@@ -719,7 +719,7 @@ let pattern_list_arg =
     Arg.string
 
 let env_arg cli =
-  OpamArg.mk_opt ~cli OpamArg.valid_cli_legacy ["environment"]
+  OpamArg.mk_opt ~cli OpamArg.cli_original ["environment"]
     "VAR=VALUE[;VAR=VALUE]"
     (Printf.sprintf
        "Use the given opam environment, in the form of a list of \
@@ -736,14 +736,14 @@ let env_arg cli =
 let state_selection_arg cli =
   OpamArg.mk_vflag ~cli ~section:OpamArg.package_selection_section
     OpamListCommand.Available [
-    OpamArg.valid_cli_legacy, OpamListCommand.Any, ["A";"all"],
+    OpamArg.cli_original, OpamListCommand.Any, ["A";"all"],
     "Include all, even uninstalled or unavailable packages";
-    OpamArg.valid_cli_legacy, OpamListCommand.Available, ["a";"available"],
+    OpamArg.cli_original, OpamListCommand.Available, ["a";"available"],
     "List only packages that are available according to the defined \
      $(b,environment). Without $(b,--environment), this will include \
      any packages for which availability is not resolvable at this \
      point.";
-    OpamArg.valid_cli_legacy, OpamListCommand.Installable, ["installable"],
+    OpamArg.cli_original, OpamListCommand.Installable, ["installable"],
     "List only packages that are installable according to the defined \
      $(b,environment) (this calls the solver and may be more costly; \
      a package depending on an unavailable one may be available, but \
@@ -801,7 +801,7 @@ let get_virtual_switch_state repo_root env =
     gt rt
 
 let or_arg cli =
-  OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ~section:OpamArg.package_selection_section ["or"]
+  OpamArg.mk_flag ~cli OpamArg.cli_original ~section:OpamArg.package_selection_section ["or"]
     "Instead of selecting packages that match $(i,all) the \
      criteria, select packages that match $(i,any) of them"
 
@@ -879,12 +879,12 @@ let filter_command cli =
   ]
   in
   let remove_arg =
-    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["remove"]
+    OpamArg.mk_flag ~cli OpamArg.cli_original ["remove"]
       "Invert the behaviour and remove the matching packages, keeping the ones \
        that don't match."
   in
   let dryrun_arg =
-    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["dry-run"]
+    OpamArg.mk_flag ~cli OpamArg.cli_original ["dry-run"]
       "List the removal commands, without actually performing them"
   in
   let cmd
@@ -978,7 +978,7 @@ let add_constraint_command cli =
             package.")
   in
   let force_arg =
-    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["force"]
+    OpamArg.mk_flag ~cli OpamArg.cli_original ["force"]
       "Force updating of constraints even if the resulting constraint is \
        unsatisfiable (e.g. when adding $(b,>3) to the constraint \
        $(b,<2)). The default in this case is to print a warning and keep \

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -27,7 +27,7 @@ let checked_repo_root () =
 
 let global_options cli =
   let apply_cli options = {options with OpamArg.cli} in
-  Term.(const apply_cli $ OpamArg.global_options)
+  Term.(const apply_cli $ OpamArg.global_options cli)
 
 let admin_command_doc =
   "Tools for repository administrators"
@@ -58,15 +58,15 @@ let index_command cli =
         are done to the contents of the repository."
   ]
   in
-  let urls_txt_arg =
-    OpamArg.mk_vflag `minimal_urls_txt [
-      `no_urls_txt, ["no-urls-txt"],
+  let urls_txt_arg cli =
+    OpamArg.mk_vflag ~cli `minimal_urls_txt [
+      OpamArg.valid_cli_legacy, `no_urls_txt, ["no-urls-txt"],
       "Don't generate a 'urls.txt' file. That index file is no longer \
        needed from opam 2.0 on, but is still used by older versions.";
-      `full_urls_txt, ["full-urls-txt"],
+      OpamArg.valid_cli_legacy, `full_urls_txt, ["full-urls-txt"],
       "Generate an inclusive 'urls.txt', for a repository that will be \
        used by opam versions earlier than 2.0.";
-      `minimal_urls_txt, ["minimal-urls-txt"],
+      OpamArg.valid_cli_legacy, `minimal_urls_txt, ["minimal-urls-txt"],
       "Generate a minimal 'urls.txt' file, that only includes the 'repo' \
        file. This allows opam versions earlier than 2.0 to read that file, \
        and be properly redirected to a repository dedicated to their \
@@ -121,7 +121,7 @@ let index_command cli =
     OpamHTTP.make_index_tar_gz repo_root;
     OpamConsole.msg "Done.\n";
   in
-  Term.(const cmd $ global_options cli $ urls_txt_arg),
+  Term.(const cmd $ global_options cli $ urls_txt_arg cli),
   OpamArg.term_info command ~doc ~man
 
 let cache_urls repo_root repo_def =
@@ -209,12 +209,12 @@ let cache_command cli =
            "Name of the cache directory to use.")
   in
   let no_repo_update_arg =
-    OpamArg.mk_flag ["no-repo-update";"n"]
+    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["no-repo-update";"n"]
       "Don't check, create or update the 'repo' file to point to the \
        generated cache ('archive-mirrors:' field)."
   in
   let link_arg =
-    OpamArg.mk_opt ["link"] "DIR"
+    OpamArg.mk_opt ~cli OpamArg.valid_cli_legacy ["link"] "DIR"
       (Printf.sprintf
          "Create reverse symbolic links to the archives within $(i,DIR), in \
           the form $(b,DIR%sPKG.VERSION%sFILENAME)."
@@ -222,7 +222,8 @@ let cache_command cli =
       Arg.(some OpamArg.dirname) None
   in
   let jobs_arg =
-    OpamArg.mk_opt ["jobs"; "j"] "JOBS" "Number of parallel downloads"
+    OpamArg.mk_opt ~cli OpamArg.valid_cli_legacy ["jobs"; "j"]
+      "JOBS" "Number of parallel downloads"
       OpamArg.positive_integer 8
   in
   let cmd global_options cache_dir no_repo_update link jobs =
@@ -298,12 +299,12 @@ let add_hashes_command cli =
             hash_kinds))
   in
   let packages =
-    OpamArg.mk_opt ["p";"packages"] "PACKAGES"
+    OpamArg.mk_opt ~cli OpamArg.valid_cli_legacy ["p";"packages"] "PACKAGES"
       "Only add hashes for the given packages"
       Arg.(list OpamArg.package) []
   in
   let replace_arg =
-    OpamArg.mk_flag ["replace"]
+    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["replace"]
       "Replace the existing hashes rather than adding to them"
   in
   let hash_tables =
@@ -511,14 +512,14 @@ let upgrade_command cli =
   ]
   in
   let clear_cache_arg =
-    OpamArg.mk_flag ["clear-cache"]
+    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["clear-cache"]
       (Printf.sprintf
          "Instead of running the upgrade, clear the cache of archive hashes (held \
           in ~%s.cache), that is used to avoid re-downloading files to obtain \
           their hashes at every run." OpamArg.dir_sep)
   in
   let create_mirror_arg =
-    OpamArg.mk_opt ["m"; "mirror"] "URL"
+    OpamArg.mk_opt ~cli OpamArg.valid_cli_legacy ["m"; "mirror"] "URL"
       "Don't overwrite the current repository, but put an upgraded mirror in \
        place in a subdirectory, with proper redirections. Needs the URL the \
        repository will be served from to put in the redirects (older versions \
@@ -556,11 +557,11 @@ let lint_command cli =
   ]
   in
   let short_arg =
-    OpamArg.mk_flag ["s";"short"]
+    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["s";"short"]
       "Print only packages and warning/error numbers, without explanations"
   in
   let list_arg =
-    OpamArg.mk_flag ["list";"l"]
+    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["list";"l"]
       "Only list package names, without warning details"
   in
   let include_arg =
@@ -568,17 +569,17 @@ let lint_command cli =
       OpamArg.positive_integer
   in
   let exclude_arg =
-    OpamArg.mk_opt_all ["exclude";"x"] "INT"
+    OpamArg.mk_opt_all ~cli OpamArg.valid_cli_legacy ["exclude";"x"] "INT"
       "Exclude the given warnings or errors"
       OpamArg.positive_integer
   in
   let ignore_arg =
-    OpamArg.mk_opt_all ["ignore-packages";"i"] "INT"
+    OpamArg.mk_opt_all ~cli OpamArg.valid_cli_legacy ["ignore-packages";"i"] "INT"
       "Ignore any packages having one of these warnings or errors"
       OpamArg.positive_integer
   in
   let warn_error_arg =
-    OpamArg.mk_flag ["warn-error";"W"]
+    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["warn-error";"W"]
       "Return failure on any warnings, not only on errors"
   in
   let cmd global_options short list incl excl ign warn_error =
@@ -643,24 +644,24 @@ let check_command cli =
   ]
   in
   let ignore_test_arg =
-    OpamArg.mk_flag ["ignore-test-doc";"i"]
+    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["ignore-test-doc";"i"]
       "By default, $(b,{with-test}) and $(b,{with-doc}) dependencies are \
        included. This ignores them, and makes the test more tolerant."
   in
   let print_short_arg =
-    OpamArg.mk_flag ["s";"short"]
+    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["s";"short"]
       "Only output a list of uninstallable packages"
   in
   let installability_arg =
-    OpamArg.mk_flag ["installability"]
+    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["installability"]
       "Do the installability check (and disable the others by default)"
   in
   let cycles_arg =
-    OpamArg.mk_flag ["cycles"]
+    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["cycles"]
       "Do the cycles check (and disable the others by default)"
   in
   let obsolete_arg =
-    OpamArg.mk_flag ["obsolete"]
+    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["obsolete"]
       "Analyse for obsolete packages"
   in
   let cmd global_options ignore_test print_short
@@ -717,8 +718,9 @@ let pattern_list_arg =
      $(b,NAME.VERSION)"
     Arg.string
 
-let env_arg =
-  OpamArg.mk_opt ["environment"] "VAR=VALUE[;VAR=VALUE]"
+let env_arg cli =
+  OpamArg.mk_opt ~cli OpamArg.valid_cli_legacy ["environment"]
+    "VAR=VALUE[;VAR=VALUE]"
     (Printf.sprintf
        "Use the given opam environment, in the form of a list of \
         comma-separated 'var=value' bindings, when resolving variables. This \
@@ -731,17 +733,17 @@ let env_arg =
        OpamArg.dir_sep OpamArg.dir_sep)
     Arg.(list string) []
 
-let state_selection_arg =
-  OpamArg.mk_vflag ~section:OpamArg.package_selection_section
+let state_selection_arg cli =
+  OpamArg.mk_vflag ~cli ~section:OpamArg.package_selection_section
     OpamListCommand.Available [
-    OpamListCommand.Any, ["A";"all"],
+    OpamArg.valid_cli_legacy, OpamListCommand.Any, ["A";"all"],
     "Include all, even uninstalled or unavailable packages";
-    OpamListCommand.Available, ["a";"available"],
+    OpamArg.valid_cli_legacy, OpamListCommand.Available, ["a";"available"],
     "List only packages that are available according to the defined \
      $(b,environment). Without $(b,--environment), this will include \
      any packages for which availability is not resolvable at this \
      point.";
-    OpamListCommand.Installable, ["installable"],
+    OpamArg.valid_cli_legacy, OpamListCommand.Installable, ["installable"],
     "List only packages that are installable according to the defined \
      $(b,environment) (this calls the solver and may be more costly; \
      a package depending on an unavailable one may be available, but \
@@ -798,8 +800,8 @@ let get_virtual_switch_state repo_root env =
     ~avail_default:(env = [])
     gt rt
 
-let or_arg =
-  OpamArg.mk_flag ~section:OpamArg.package_selection_section ["or"]
+let or_arg cli =
+  OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ~section:OpamArg.package_selection_section ["or"]
     "Instead of selecting packages that match $(i,all) the \
      criteria, select packages that match $(i,any) of them"
 
@@ -857,9 +859,9 @@ let list_command cli =
     in
     OpamListCommand.display st format results
   in
-  Term.(const cmd $ global_options cli $ OpamArg.package_selection $
-        or_arg $ state_selection_arg $ OpamArg.package_listing $ env_arg $
-        pattern_list_arg),
+  Term.(const cmd $ global_options cli $ OpamArg.package_selection cli $
+        or_arg cli $ state_selection_arg cli $ OpamArg.package_listing cli $
+        env_arg cli $ pattern_list_arg),
   OpamArg.term_info command ~doc ~man
 
 let filter_command_doc = "Filters a repository to only keep selected packages"
@@ -877,12 +879,12 @@ let filter_command cli =
   ]
   in
   let remove_arg =
-    OpamArg.mk_flag ["remove"]
+    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["remove"]
       "Invert the behaviour and remove the matching packages, keeping the ones \
        that don't match."
   in
   let dryrun_arg =
-    OpamArg.mk_flag ["dry-run"]
+    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["dry-run"]
       "List the removal commands, without actually performing them"
   in
   let cmd
@@ -944,8 +946,9 @@ let filter_command cli =
              OpamFilename.rmdir_cleanup d))
       pkg_prefixes
   in
-  Term.(const cmd $ global_options cli $ OpamArg.package_selection $ or_arg $
-        state_selection_arg $ env_arg $ remove_arg $ dryrun_arg $
+  Term.(const cmd $ global_options cli $ OpamArg.package_selection cli $
+        or_arg cli $ state_selection_arg cli $ env_arg cli $ remove_arg $
+        dryrun_arg $
         pattern_list_arg),
   OpamArg.term_info command ~doc ~man
 
@@ -975,7 +978,7 @@ let add_constraint_command cli =
             package.")
   in
   let force_arg =
-    OpamArg.mk_flag ["force"]
+    OpamArg.mk_flag ~cli OpamArg.valid_cli_legacy ["force"]
       "Force updating of constraints even if the resulting constraint is \
        unsatisfiable (e.g. when adding $(b,>3) to the constraint \
        $(b,<2)). The default in this case is to print a warning and keep \

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1256,10 +1256,6 @@ let make_command_alias cmd ?(options="") name =
     ~docs:"COMMAND ALIASES" ~sdocs:global_option_section
     ~doc ~man
 
-let term_info title ~doc ~man =
-  let man = man @ help_sections in
-  Term.info ~sdocs:global_option_section ~docs:Manpage.s_commands ~doc ~man title
-
 let arg_list name doc kind =
   let doc = Arg.info ~docv:name ~doc [] in
   Arg.(value & pos_all kind [] & doc)

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -183,6 +183,7 @@ let create_build_options
   }
 
 let apply_build_options b =
+  let open OpamStd.Option.Op in
   let flag f = if f then Some true else None in
   OpamRepositoryConfig.update
     (* ?download_tool:(OpamTypes.arg list * dl_tool_kind) Lazy.t *)
@@ -193,16 +194,16 @@ let apply_build_options b =
     ();
   OpamStateConfig.update
     (* ?root: -- handled globally *)
-    ?jobs:OpamStd.Option.Op.(b.jobs >>| fun j -> lazy j)
+    ?jobs:(b.jobs >>| fun j -> lazy j)
     (* ?dl_jobs:int *)
     (* ?no_base_packages:(flag o.no_base_packages) -- handled globally *)
     ?build_test:(flag b.build_test)
     ?build_doc:(flag b.build_doc)
     ?dryrun:(flag b.dryrun)
-    ?makecmd:OpamStd.Option.Op.(b.make >>| fun m -> lazy m)
+    ?makecmd:(b.make >>| fun m -> lazy m)
     ?ignore_constraints_on:
-      OpamStd.Option.Op.(b.ignore_constraints_on >>|
-                         OpamPackage.Name.Set.of_list)
+      (b.ignore_constraints_on >>|
+       OpamPackage.Name.Set.of_list)
     ?unlock_base:(flag b.unlock_base)
     ?locked:(if b.locked then Some (Some b.lock_suffix) else None)
     ?no_depexts:(flag b.no_depexts)
@@ -800,6 +801,20 @@ let mk_opt_all ?section ?vopt ?(default=[]) flags value doc kind =
 let mk_tristate_opt ?section flags value doc =
   let doc = Arg.info ?docs:section ~docv:value ~doc flags in
   Arg.(value & opt (some (enum when_enum)) None & doc)
+
+let mk_vflag ?section default flags =
+  let flags =
+    List.map (fun (content, flag, doc) ->
+        content, Arg.info ?docs:section flag ~doc) flags
+  in
+  Arg.(value & vflag default flags)
+
+let mk_vflag_all ?section ?(default=[]) flags =
+  let flags =
+    List.map (fun (content, flag, doc) ->
+        content, Arg.info ?docs:section flag ~doc) flags
+  in
+  Arg.(value & vflag_all default flags)
 
 type 'a subcommand = string * 'a * string list * string
 

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -44,7 +44,11 @@ let create_global_options
     opt_root external_solver use_internal_solver
     cudf_file solver_preferences best_effort safe_mode json no_auto_upgrade
     working_dir ignore_pin_depends
-    _d_no_aspcud _ =
+    d_no_aspcud _ =
+  if d_no_aspcud then
+    OpamConsole.warning
+      "Option %s is deprecated, ignoring it."
+      (OpamConsole.colorise `bold "--no-aspcud");
   let debug_level = OpamStd.Option.Op.(
       debug_level >>+ fun () -> if debug then Some 1 else None
     ) in
@@ -1353,7 +1357,7 @@ let global_options cli =
               This is equivalent to setting $(b,\\$OPAMROOT) to $(i,ROOT)."
       Arg.(some dirname) None in
   let d_no_aspcud =
-    mk_flag ~cli (cli_between cli2_0 cli2_0) ~section ["no-aspcud"] ""
+    mk_flag ~cli (cli_between cli2_0 cli2_1) ~section ["no-aspcud"] "Deprecated"
   in
   let use_internal_solver =
     mk_flag ~cli cli_original ~section ["use-internal-solver"]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -785,6 +785,8 @@ type flag_validity =
 
 let cli2_0 = OpamCLIVersion.of_string "2.0"
 let cli2_1 = OpamCLIVersion.of_string "2.1"
+let cli2_3 = OpamCLIVersion.of_string "2.3"
+let cli3_0 = OpamCLIVersion.of_string "3.0"
 let valid_cli_legacy = Valid_since cli2_0
 
 let update_doc_w_cli doc ~cli = function
@@ -1287,8 +1289,7 @@ let global_options cli =
               This is equivalent to setting $(b,\\$OPAMROOT) to $(i,ROOT)."
       Arg.(some dirname) None in
   let d_no_aspcud =
-    mk_flag ~cli valid_cli_legacy ~section ["no-aspcud"]
-    "Deprecated."
+    mk_flag ~cli (Deprecated (cli2_0, cli2_1, None)) ~section ["no-aspcud"] ""
   in
   let use_internal_solver =
     mk_flag ~cli valid_cli_legacy ~section ["use-internal-solver"]
@@ -1391,7 +1392,7 @@ let locked cli section =
      to setting the $(b,\\$OPAMLOCKED) environment variable. Note that this \
      option doesn't generally affect already pinned packages."
 let lock_suffix cli section =
-  mk_opt ~cli valid_cli_legacy ~section ["lock-suffix"] "SUFFIX"
+  mk_opt ~cli (Valid_since cli2_1) ~section ["lock-suffix"] "SUFFIX"
     "Set locked files suffix to $(i,SUFFIX)."
     Arg.(string) ("locked")
 
@@ -1481,21 +1482,26 @@ let build_options cli =
        to setting $(b,\\$OPAMIGNORECONSTRAINTS)."
       Arg.(some (list package_name)) None ~vopt:(Some []) in
   let unlock_base =
-    mk_flag ~cli valid_cli_legacy ~section ["update-invariant"; "unlock-base"]
-      "Allow changes to the packages set as switch base (typically, the main \
-       compiler). Use with caution. This is equivalent to setting the \
-       $(b,\\$OPAMUNLOCKBASE) environment variable" in
+    mk_vflag ~cli ~section false ([
+        Deprecated (cli2_1, cli2_3, Some "--update-invariant"), true, ["unlock-base"] ;
+        Valid_since cli2_1, true, ["update-invariant"]
+      ] |> List.map (fun (c,v,f) ->
+        c,v,f,
+        "Allow changes to the packages set as switch base (typically, the main \
+         compiler). Use with caution. This is equivalent to setting the \
+         $(b,\\$OPAMUNLOCKBASE) environment variable"))
+  in
   let locked = locked cli section in
   let lock_suffix = lock_suffix cli section in
   let assume_depexts =
-    mk_flag ~cli valid_cli_legacy ~section ["assume-depexts"]
+    mk_flag ~cli (Valid_since cli2_1) ~section ["assume-depexts"]
       "Skip the installation step for any missing system packages, and attempt \
        to proceed with compilation of the opam packages anyway. If the \
        installation is successful, opam won't prompt again about these system \
        packages. Only meaningful if external dependency handling is enabled."
   in
   let no_depexts =
-    mk_flag ~cli valid_cli_legacy ~section ["no-depexts"]
+    mk_flag ~cli (Valid_since cli2_1) ~section ["no-depexts"]
       "Temporarily disables handling of external dependencies. This can be \
        used if a package is not available on your system package manager, but \
        you installed the required dependency by hand. Implies \

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -33,6 +33,8 @@ type flag_validity =
 val valid_cli_legacy: flag_validity
 val cli2_0: OpamCLIVersion.t
 val cli2_1: OpamCLIVersion.t
+val cli2_3: OpamCLIVersion.t
+val cli3_0: OpamCLIVersion.t
 
 val mk_flag:
   cli:OpamCLIVersion.t -> flag_validity ->
@@ -52,8 +54,8 @@ val mk_opt_all:
   'a Arg.converter -> 'a list Term.t
 
 val mk_vflag:
-  cli:OpamCLIVersion.t -> ?section:string -> 'a ->
-  (flag_validity * 'a * string list * string) list ->
+  cli:OpamCLIVersion.t ->
+  ?section:string -> 'a -> (flag_validity * 'a * string list * string) list ->
   'a Term.t
 
 val mk_vflag_all:

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -285,13 +285,6 @@ val mk_subcommands_with_default:
 (** Same as {!mk_subcommand} but use the default value if no
     sub-command is selected. *)
 
-val make_command_alias:
-  'a Term.t * Term.info -> ?options:string -> string ->
-  'a Term.t * Term.info
-(** Create an alias for an existing command. [options] can be used to add extra
-    options after the original command in the doc (eg like `unpin` is an alias
-    for `pin remove`). *)
-
 val bad_subcommand:
   cli:OpamCLIVersion.t ->
   'a default subcommands -> (string * 'a option * string list) -> 'b Term.ret
@@ -302,6 +295,33 @@ val mk_subdoc :
   cli:OpamCLIVersion.t ->
   ?defaults:(string * string) list -> 'a subcommands -> Manpage.block list
 (** [mk_subdoc cmds] is the documentation block for [cmds]. *)
+
+val make_command_alias:
+  'a Term.t * Term.info -> ?options:string -> string ->
+  'a Term.t * Term.info
+(** Create an alias for an existing command. [options] can be used to add extra
+    options after the original command in the doc (eg like `unpin` is an alias
+    for `pin remove`). *)
+
+(** {2 Commands} *)
+
+(* All commands must be defined using [mk_command] and [mk_command_ret] for
+   prior cli validation. *)
+
+type command = unit Term.t * Term.info
+
+val mk_command:
+  OpamCLIVersion.t -> validity -> string -> doc:string ->
+  man:Manpage.block list -> (unit -> unit) Term.t -> command
+  (* [mk_command cli validity name doc man term] is the command [name] with its
+     [doc] and [man], and using [term]. Its [validity] is checked at runtime
+     against requested [cli], updates its documentation and errors if not
+     valid. *)
+
+val mk_command_ret:
+  OpamCLIVersion.t -> validity -> string -> doc:string ->
+  man:Manpage.block list -> (unit -> unit Term.ret) Term.t -> command
+  (* Same as {!mk_command} but [term] returns a [Cmdliner.Term.ret] *)
 
 (** {2 Documentation} *)
 

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -327,4 +327,3 @@ val mk_command_ret:
 
 val global_option_section: string
 val help_sections: Manpage.block list
-val term_info: string -> doc:string -> man:Manpage.block list -> Term.info

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -27,6 +27,13 @@ val mk_opt_all:
   string list -> string -> string ->
   'a Arg.converter -> 'a list Term.t
 
+val mk_vflag:
+  ?section:string -> 'a -> ('a * string list * string) list -> 'a Term.t
+
+val mk_vflag_all:
+  ?section:string -> ?default:'a list -> ('a * string list * string) list
+  -> 'a list Term.t
+
 (* Escaped Windows directory separator. To use instead of [Filename.dir_sep] for
    manpage strings *)
 val dir_sep: string

--- a/src/client/opamCLIVersion.ml
+++ b/src/client/opamCLIVersion.ml
@@ -42,6 +42,15 @@ let env = OpamStd.Config.env of_string
 let ( >= ) = Stdlib.( >= )
 let ( < ) = Stdlib.( < )
 
+let previous cli =
+  let f previous version =
+    if version > previous && cli > version then version else previous
+  in
+  let zero = (0, 0) in
+  let previous = List.fold_left f zero supported_versions in
+  if previous = zero then raise Not_found
+  else previous
+
 module O = struct
   type nonrec t = t
   let to_string = to_string

--- a/src/client/opamCLIVersion.mli
+++ b/src/client/opamCLIVersion.mli
@@ -29,3 +29,7 @@ val ( >= ) : t -> int * int -> bool
 
 (** Comparison [<] with [(major, minor)] *)
 val ( < ) : t -> int * int -> bool
+
+(** Returns previous supported version.
+    @raise Not_found if there isn't one. *)
+val previous: t -> t

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2453,17 +2453,25 @@ let switch cli =
   in
   (* Deprecated options *)
   let d_alias_of =
-    mk_opt ~cli (cli_between cli2_0 cli2_0 ~replaced:"opam switch <switch-name> <compiler>")
-      ["A";"alias-of"] "COMP" "" Arg.(some string) None
+    mk_opt ~cli (cli_between cli2_0 cli2_1)
+      ["A";"alias-of"] "COMP" "Deprecated" Arg.(some string) None
   in
   let d_no_autoinstall =
-    mk_flag ~cli (cli_between cli2_0 cli2_0) ["no-autoinstall"] ""
+      mk_flag ~cli (cli_between cli2_0 cli2_1) ["no-autoinstall"] "Deprecated"
   in
   let switch
       global_options build_options command print_short
       no_switch packages formula empty descr full freeze no_install deps_only repos
       force no_action
-      _d_alias_of _d_no_autoinstall params =
+      d_alias_of d_no_autoinstall params =
+    if d_alias_of <> None then
+      OpamConsole.warning
+        "Option %s is deprecated, ignoring it. \
+         Use instead 'opam switch <switch-name> <compiler>'"
+        (OpamConsole.colorise `bold "--alias-of");
+    if d_no_autoinstall then
+      OpamConsole.warning "Option %s is deprecated, ignoring it."
+        (OpamConsole.colorise `bold "--no-autoinstall");
     apply_global_options global_options;
     apply_build_options build_options;
     let invariant_arg ?repos rt args =

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1351,9 +1351,6 @@ let config cli =
        | None ->
          bad_subcommand ~cli commands ("config", command, params)
        | Some opt_value ->
-         OpamConsole.errmsg
-           "Use opam var %s=%s instead.\n"
-           var (OpamStd.Option.to_string (fun v -> v) opt_value);
          OpamGlobalState.with_ `Lock_none @@ fun gt ->
          let value =
            OpamStd.Option.map_default (fun v -> `Overwrite v)
@@ -1372,9 +1369,6 @@ let config cli =
        | None ->
          bad_subcommand ~cli commands ("config", command, params)
        | Some opt_value ->
-         OpamConsole.errmsg
-           "Use opam var %s=%s --global instead.\n"
-           var (OpamStd.Option.to_string (fun v -> v) opt_value);
          OpamGlobalState.with_ `Lock_write @@ fun gt ->
          let value =
            OpamStd.Option.map_default (fun v -> `Overwrite v)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -74,7 +74,7 @@ let switch_to_updated_self debug opamroot =
 
 let global_options cli =
   let no_self_upgrade =
-    mk_flag ~section:global_option_section ["no-self-upgrade"]
+    mk_flag ~cli valid_cli_legacy ~section:global_option_section ["no-self-upgrade"]
       (Printf.sprintf
         "Opam will replace itself with a newer binary found \
          at $(b,OPAMROOT%sopam) if present. This disables this behaviour."
@@ -101,7 +101,7 @@ let global_options cli =
       OpamConsole.warning "Running as root is not recommended";
     {options with cli}, self_upgrade_status
   in
-  Term.(const self_upgrade $ no_self_upgrade $ global_options)
+  Term.(const self_upgrade $ no_self_upgrade $ global_options cli)
 
 let apply_global_options (options,self_upgrade) =
   apply_global_options options;
@@ -201,12 +201,12 @@ let init cli =
   ] @ OpamArg.man_build_option_section
   in
   let compiler =
-    mk_opt ["c";"compiler"] "PACKAGE"
+    mk_opt ~cli valid_cli_legacy ["c";"compiler"] "PACKAGE"
       "Set the compiler to install (when creating an initial switch)"
       Arg.(some string) None
   in
   let no_compiler =
-    mk_flag ["bare"]
+    mk_flag ~cli valid_cli_legacy ["bare"]
       "Initialise the opam state, but don't setup any compiler switch yet."
   in
   let repo_name =
@@ -226,47 +226,47 @@ let init cli =
     Arg.(value & pos ~rev:true 0 (some string) None & doc)
   in
   let interactive =
-    mk_vflag None [
-        Some false, ["a";"auto-setup"],
+    mk_vflag ~cli None [
+        valid_cli_legacy, Some false, ["a";"auto-setup"],
           "Automatically do a full setup, including adding a line to your \
            shell init files.";
-        Some true, ["i";"interactive"],
+        valid_cli_legacy, Some true, ["i";"interactive"],
           "Run the setup interactively (this is the default for an initial \
            run, or when no more specific options are specified)";
       ]
   in
   let update_config =
-    mk_vflag None [
-        Some true, ["shell-setup"],
+    mk_vflag ~cli None [
+        valid_cli_legacy, Some true, ["shell-setup"],
           "Automatically setup the user shell configuration for opam, e.g. \
            adding a line to the `~/.profile' file.";
-        Some false, ["n";"no-setup"],
+        valid_cli_legacy, Some false, ["n";"no-setup"],
           "Do not update the user shell configuration to setup opam. Also \
            implies $(b,--disable-shell-hook), unless $(b,--interactive) or \
            specified otherwise";
       ]
   in
   let setup_completion =
-    mk_vflag None [
-        Some true, ["enable-completion"],
+    mk_vflag ~cli None [
+        valid_cli_legacy, Some true, ["enable-completion"],
           "Setup shell completion in opam init scripts, for supported \
            shells.";
-        Some false, ["disable-completion"],
+        valid_cli_legacy, Some false, ["disable-completion"],
           "Disable shell completion in opam init scripts.";
       ]
   in
   let env_hook =
-    mk_vflag None [
-        Some true, ["enable-shell-hook"],
+    mk_vflag ~cli None [
+        valid_cli_legacy, Some true, ["enable-shell-hook"],
           "Setup opam init scripts to register a shell hook that will \
            automatically keep the shell environment up-to-date at every \
            prompt.";
-        Some false, ["disable-shell-hook"],
+        valid_cli_legacy, Some false, ["disable-shell-hook"],
           "Disable registration of a shell hook in opam init scripts.";
       ]
   in
   let config_file =
-    mk_opt_all ["config"] "FILE"
+    mk_opt_all ~cli valid_cli_legacy ["config"] "FILE"
       "Use the given init config file. If repeated, latest has the highest \
        priority ($(b,i.e.) each field gets its value from where it was defined \
        last). Specifying a URL pointing to a config file instead is \
@@ -274,27 +274,27 @@ let init cli =
       OpamArg.url
   in
   let no_config_file =
-    mk_flag ["no-opamrc"]
+    mk_flag ~cli valid_cli_legacy ["no-opamrc"]
       (Printf.sprintf
       "Don't read `/etc/opamrc' or `~%s.opamrc': use the default settings and \
        the files specified through $(b,--config) only" OpamArg.dir_sep)
   in
   let reinit =
-    mk_flag ["reinit"]
+    mk_flag ~cli valid_cli_legacy ["reinit"]
       "Re-run the initial checks and setup, according to opamrc, even if this \
        is not a new opam root"
   in
   let show_default_opamrc =
-    mk_flag ["show-default-opamrc"]
+    mk_flag ~cli valid_cli_legacy ["show-default-opamrc"]
       "Print the built-in default configuration to stdout and exit"
   in
   let bypass_checks =
-    mk_flag ["bypass-checks"]
+    mk_flag ~cli valid_cli_legacy ["bypass-checks"]
       "Skip checks on required or recommended tools, and assume everything is \
        fine"
   in
   let no_sandboxing =
-    mk_flag ["disable-sandboxing"]
+    mk_flag ~cli valid_cli_legacy ["disable-sandboxing"]
       "Use a default configuration with sandboxing disabled (note that this \
        may be overridden by `opamrc' if $(b,--no-opamrc) is not specified or \
        $(b,--config) is used). Use this at your own risk, without sandboxing \
@@ -421,10 +421,10 @@ let init cli =
     OpamSwitchState.drop st
   in
   Term.(const init
-        $global_options cli $build_options $repo_kind_flag $repo_name $repo_url
+        $global_options cli $build_options cli $repo_kind_flag cli $repo_name $repo_url
         $interactive $update_config $setup_completion $env_hook $no_sandboxing
-        $shell_opt $dot_profile_flag
-        $compiler $no_compiler
+        $shell_opt cli $dot_profile_flag cli
+        $compiler $ no_compiler
         $config_file $no_config_file $reinit $show_default_opamrc $bypass_checks),
   term_info "init" ~doc ~man
 
@@ -462,61 +462,61 @@ let list ?(force_search=false) cli =
       Arg.string
   in
   let state_selector =
-    mk_vflag_all ~section:selection_docs [
-        OpamListCommand.Any, ["A";"all"],
+    mk_vflag_all ~cli ~section:selection_docs [
+        valid_cli_legacy, OpamListCommand.Any, ["A";"all"],
           "Include all, even uninstalled or unavailable packages";
-        OpamListCommand.Installed, ["i";"installed"],
+        valid_cli_legacy, OpamListCommand.Installed, ["i";"installed"],
           "List installed packages only. This is the default when no \
                 further arguments are supplied";
-        OpamListCommand.Root, ["roots";"installed-roots"],
+        valid_cli_legacy, OpamListCommand.Root, ["roots";"installed-roots"],
           "List only packages that were explicitly installed, excluding \
                 the ones installed as dependencies";
-        OpamListCommand.Available, ["a";"available"],
+        valid_cli_legacy, OpamListCommand.Available, ["a";"available"],
           "List only packages that are available on the current system";
-        OpamListCommand.Installable, ["installable"],
+        valid_cli_legacy, OpamListCommand.Installable, ["installable"],
           "List only packages that can be installed on the current switch \
                 (this calls the solver and may be more costly; a package \
                 depending on an unavailable package may be available, but is \
                 never installable)";
-        OpamListCommand.Compiler, ["base"],
+        valid_cli_legacy, OpamListCommand.Compiler, ["base"],
           "List only the immutable base of the current switch (i.e. \
                 compiler packages)";
-        OpamListCommand.Pinned, ["pinned"],
+        valid_cli_legacy, OpamListCommand.Pinned, ["pinned"],
           "List only the pinned packages";
       ]
   in
   let section = selection_docs in
   let search =
     if force_search then Term.const true else
-      mk_flag ["search"] ~section
+      mk_flag ~cli valid_cli_legacy ["search"] ~section
         "Match $(i,PATTERNS) against the full descriptions of packages, and \
          require all of them to match, instead of requiring at least one to \
          match against package names (unless $(b,--or) is also specified)."
   in
   let repos =
-    mk_opt ["repos"] "REPOS" ~section
+    mk_opt ~cli valid_cli_legacy ["repos"] "REPOS" ~section
       "Include only packages that took their origin from one of the given \
        repositories (unless $(i,no-switch) is also specified, this excludes \
        pinned packages)."
       Arg.(some & list & repository_name) None
   in
   let owns_file =
-    mk_opt ["owns-file"] "FILE" ~section
+    mk_opt ~cli valid_cli_legacy ["owns-file"] "FILE" ~section
       "Finds installed packages responsible for installing the given file"
       Arg.(some OpamArg.filename) None
   in
   let no_switch =
-    mk_flag ["no-switch"] ~section:selection_docs
+    mk_flag ~cli valid_cli_legacy ["no-switch"] ~section:selection_docs
       "List what is available from the repositories, without consideration for \
        the current (or any other) switch (installed or pinned packages, etc.)"
   in
   let disjunction =
-    mk_flag ["or"] ~section:selection_docs
+    mk_flag ~cli valid_cli_legacy ["or"] ~section:selection_docs
       "Instead of selecting packages that match $(i,all) the criteria, select \
        packages that match $(i,any) of them"
   in
   let depexts =
-    mk_flag ["e";"external";"depexts"] ~section:display_docs
+    mk_flag ~cli valid_cli_legacy ["e";"external";"depexts"] ~section:display_docs
       "Instead of displaying the packages, display their external dependencies \
        that are associated with the current system. This excludes other \
        display options. Rather than using this directly, you should probably \
@@ -525,19 +525,19 @@ let list ?(force_search=false) cli =
        `opam depext'."
   in
   let vars =
-    mk_opt ["vars"] "[VAR=STR,...]" ~section:display_docs
+    mk_opt ~cli valid_cli_legacy ["vars"] "[VAR=STR,...]" ~section:display_docs
       "Define the given variable bindings. Typically useful with \
        $(b,--external) to override the values for $(i,arch), $(i,os), \
        $(i,os-distribution), $(i,os-version), $(i,os-family)."
       OpamArg.variable_bindings []
   in
   let silent =
-    mk_flag ["silent"]
+    mk_flag ~cli valid_cli_legacy ["silent"]
       "Don't write anything in the output, exit with return code 0 if the list \
        is not empty, 1 otherwise."
   in
   let no_depexts =
-    mk_flag ["no-depexts"]
+    mk_flag ~cli valid_cli_legacy ["no-depexts"]
       "Disable external dependencies handling for the query. This can be used \
        to include packages that are marked as unavailable because of an unavailable \
        system dependency."
@@ -668,9 +668,9 @@ let list ?(force_search=false) cli =
     else if OpamSysPkg.Set.is_empty results_depexts then
       OpamStd.Sys.exit_because `False
   in
-  Term.(const list $global_options cli $package_selection $state_selector
+  Term.(const list $global_options cli $package_selection cli $state_selector
         $no_switch $depexts $vars $repos $owns_file $disjunction $search
-        $silent $no_depexts $package_listing $pattern_list),
+        $silent $no_depexts $package_listing cli $pattern_list),
   term_info "list" ~doc ~man
 
 
@@ -693,7 +693,7 @@ let show cli =
         metadata will be shown."
   ] in
   let fields =
-    mk_opt ["f";"field"] "FIELDS"
+    mk_opt ~cli valid_cli_legacy ["f";"field"] "FIELDS"
       (Printf.sprintf
          "Only display the values of these fields. Fields can be selected \
           among %s. Multiple fields can be separated with commas, in which case \
@@ -704,36 +704,36 @@ let show cli =
       Arg.(list string) []
   in
   let show_empty =
-    mk_flag ["empty-fields"]
+    mk_flag ~cli valid_cli_legacy ["empty-fields"]
       "Show fields that are empty. This is implied when $(b,--field) is \
        given."
   in
   let raw =
-    mk_flag ["raw"] "Print the raw opam file for this package" in
+    mk_flag ~cli valid_cli_legacy ["raw"] "Print the raw opam file for this package" in
   let where =
-    mk_flag ["where"]
+    mk_flag ~cli valid_cli_legacy ["where"]
       "Print the location of the opam file used for this package" in
   let list_files =
-    mk_flag ["list-files"]
+    mk_flag ~cli valid_cli_legacy ["list-files"]
       "List the files installed by the package. Equivalent to \
        $(b,--field=installed-files), and only available for installed \
        packages"
   in
   let file =
-    mk_opt ["file"] "FILE" "DEPRECATED: see $(i,--just-file)"
+    mk_opt ~cli valid_cli_legacy ["file"] "FILE" "DEPRECATED: see $(i,--just-file)"
       Arg.(some existing_filename_or_dash) None
   in
   let normalise =
-    mk_flag ["normalise"]
+    mk_flag ~cli valid_cli_legacy ["normalise"]
       "Print the values of opam fields normalised (no newlines, no implicit \
        brackets)"
   in
   let no_lint =
-    mk_flag ["no-lint"]
+    mk_flag ~cli valid_cli_legacy ["no-lint"]
       "Don't output linting warnings or errors when reading from files"
   in
   let just_file =
-    mk_flag ["just-file"]
+    mk_flag ~cli valid_cli_legacy ["just-file"]
       "Load and display information from the given files (allowed \
        $(i,PACKAGES) are file or directory paths), without consideration for \
        the repositories or state of the package. This implies $(b,--raw) unless \
@@ -741,18 +741,18 @@ let show cli =
        PACKAGES argument is given, read opam file from stdin."
   in
   let all_versions =
-    mk_flag ["all-versions"]
+    mk_flag ~cli valid_cli_legacy ["all-versions"]
       "Display information of all packages matching $(i,PACKAGES), not \
        restrained to a single package matching $(i,PACKAGES) constraints."
   in
-  let sort = mk_flag ["sort"] "Sort opam fields" in
+  let sort = mk_flag ~cli valid_cli_legacy ["sort"] "Sort opam fields" in
   let opam_files_in_dir d =
     match OpamPinned.files_in_source d with
     | [] -> []
     | l -> List.map (fun (_,f,_) -> f) l
   in
   let pkg_info global_options fields show_empty raw where
-      list_files file normalise no_lint just_file all_versions sort atom_locs =
+      list_files _file normalise no_lint just_file all_versions sort atom_locs =
     let print_just_file opamf opam =
       if not no_lint then OpamFile.OPAM.print_errors opam;
       let opam =
@@ -786,7 +786,6 @@ let show cli =
         OpamStd.Format.align_table tbl |>
         OpamConsole.print_table stdout ~sep:" "
     in
-    OpamArg.deprecated_option file None "file" (Some "--just-file");
     apply_global_options global_options;
     match atom_locs, just_file with
     | [], false ->
@@ -878,7 +877,8 @@ let show cli =
 (* Shared between [option] and [var] *)
 module Var_Option_Common = struct
 
-  let global = mk_flag ["global"] "Act on global configuration"
+  let global cli =
+    mk_flag ~cli valid_cli_legacy ["global"] "Act on global configuration"
 
   let var_option global global_options cmd var =
     let switch_set = (fst global_options).opt_switch <> None in
@@ -1002,7 +1002,7 @@ let var cli =
     Arg.(value & pos 0 (some string) None & info ~docv ~doc [])
   in
   let package =
-    mk_opt ["package"] "PACKAGE"
+    mk_opt ~cli valid_cli_legacy ["package"] "PACKAGE"
       "List all variables defined for the given package"
       Arg.(some package_name) None
   in
@@ -1021,7 +1021,7 @@ let var cli =
                      'pkg:var' instead.")
   in
   Term.ret (
-    Term.(const print_var $global_options cli $package $varvalue $global)
+    Term.(const print_var $global_options cli $package $varvalue $global cli)
   ),
   term_info "var" ~doc ~man
 
@@ -1054,30 +1054,30 @@ let option cli =
     var_option global global_options `option fieldvalue
   in
   Term.ret (
-    Term.(const option $global_options cli $fieldvalue $global)
+    Term.(const option $global_options cli $fieldvalue $global cli)
   ),
   term_info "option" ~doc ~man
 
 module Common_config_flags = struct
-  let sexp =
-    mk_flag ["sexp"]
+  let sexp cli =
+    mk_flag ~cli valid_cli_legacy ["sexp"]
       "Print environment as an s-expression rather than in shell format"
 
-  let inplace_path =
-    mk_flag ["inplace-path"]
+  let inplace_path cli =
+    mk_flag ~cli valid_cli_legacy ["inplace-path"]
       "When updating the $(i,PATH) variable, replace any pre-existing opam \
        path in-place rather than putting the new path in front. This means \
        programs installed in opam that were shadowed will remain so after \
        $(b,opam env)"
 
-  let set_opamroot =
-    mk_flag ["set-root"]
+  let set_opamroot cli =
+    mk_flag ~cli valid_cli_legacy ["set-root"]
       "With the $(b,env) and $(b,exec) subcommands, also sets the \
        $(i,OPAMROOT) variable, making sure further calls to opam will use the \
        same root."
 
-  let set_opamswitch =
-    mk_flag ["set-switch"]
+  let set_opamswitch cli =
+    mk_flag ~cli valid_cli_legacy ["set-switch"]
       "With the $(b,env) and $(b,exec) subcommands, also sets the \
        $(i,OPAMSWITCH) variable, making sure further calls to opam will use \
        the same switch as this one."
@@ -1089,50 +1089,50 @@ let config_doc = "Display configuration options for packages."
 let config cli =
   let doc = config_doc in
   let commands = [
-    "env", `env, [],
+    valid_cli_legacy, "env", `env, [],
     "Returns the bindings for the environment variables set in the current \
      switch, e.g. PATH, in a format intended to be evaluated by a shell. With \
      $(i,-v), add comments documenting the reason or package of origin for \
      each binding. This is most usefully used as $(b,eval \\$(opam config \
      env\\)) to have further shell commands be evaluated in the proper opam \
      context. Can also be accessed through $(b,opam env).";
-    "revert-env", `revert_env, [],
+    valid_cli_legacy, "revert-env", `revert_env, [],
     "Reverts environment changes made by opam, e.g. $(b,eval \\$(opam config \
      revert-env)) undoes what $(b,eval \\$(opam config env\\)) did, as much as \
      possible.";
-    "exec", `exec, ["[--] COMMAND"; "[ARG]..."],
+    valid_cli_legacy, "exec", `exec, ["[--] COMMAND"; "[ARG]..."],
     "Execute $(i,COMMAND) with the correct environment variables. This command \
      can be used to cross-compile between switches using $(b,opam config exec \
      --switch=SWITCH -- COMMAND ARG1 ... ARGn). Opam expansion takes place in \
      command and args. If no switch is present on the command line or in the \
      $(i,OPAMSWITCH) environment variable, $(i,OPAMSWITCH) is not set in \
      $(i,COMMAND)'s environment. Can also be accessed through $(b,opam exec).";
-    "var", `var, ["VAR"],
+    valid_cli_legacy, "var", `var, ["VAR"],
     "Return the value associated with variable $(i,VAR), looking in switch \
      first, global if not found. Package variables can be accessed with the \
      syntax $(i,pkg:var). Can also be accessed through $(b,opam var VAR)";
-    "list", `list, ["[PACKAGE]..."],
+    valid_cli_legacy, "list", `list, ["[PACKAGE]..."],
     "Without argument, prints a documented list of all available variables. \
      With $(i,PACKAGE), lists all the variables available for these packages. \
      Use $(i,-) to include global configuration variables for this switch.";
-    "expand", `expand, ["STRING"],
+    valid_cli_legacy, "expand", `expand, ["STRING"],
     "Expand variable interpolations in the given string";
-    "subst", `subst, ["FILE..."],
+    valid_cli_legacy, "subst", `subst, ["FILE..."],
     "Substitute variables in the given files. The strings $(i,%{var}%) are \
      replaced by the value of variable $(i,var) (see $(b,var)).";
-    "report", `report, [],
+    valid_cli_legacy, "report", `report, [],
     "Prints a summary of your setup, useful for bug-reports.";
-    "cudf-universe",`cudf, ["[FILE]"],
+    valid_cli_legacy, "cudf-universe",`cudf, ["[FILE]"],
     "Outputs the current available package universe in CUDF format.";
-    "pef-universe", `pef, ["[FILE]"],
+    valid_cli_legacy, "pef-universe", `pef, ["[FILE]"],
     "Outputs the current package universe in PEF format.";
-    "set", `set, ["VAR";"VALUE"],
+    valid_cli_legacy, "set", `set, ["VAR";"VALUE"],
     "Deprecated, see $(b,set-var).";
-    "unset", `unset, ["VAR"],
+    valid_cli_legacy, "unset", `unset, ["VAR"],
     "Deprecated, see $(b,set-var).";
-    "set-global", `set_global, ["VAR";"VALUE"],
+    valid_cli_legacy, "set-global", `set_global, ["VAR";"VALUE"],
     "Deprecated, see $(b,set-var).";
-    "unset-global", `unset_global, ["VAR"],
+    valid_cli_legacy, "unset-global", `unset_global, ["VAR"],
     "Deprecated, see $(b,set-var).";
   ] in
   let man = [
@@ -1143,11 +1143,11 @@ let config cli =
     `P "Apart from $(b,opam config env), most of these commands are used \
         by opam internally, and are of limited interest for the casual \
         user.";
-  ] @ mk_subdoc commands
+  ] @ mk_subdoc ~cli commands
     @ [`S Manpage.s_options]
   in
 
-  let command, params = mk_subcommands commands in
+  let command, params = mk_subcommands ~cli commands in
   let open Common_config_flags in
 
   let config global_options
@@ -1210,7 +1210,7 @@ let config cli =
          OpamSwitchState.dump_pef_state st oc;
          close_out oc;
          `Ok ()
-       | _ -> bad_subcommand commands ("config", command, params))
+       | _ -> bad_subcommand ~cli commands ("config", command, params))
     | Some `cudf, params ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
       OpamSwitchState.with_ `Lock_none gt @@ fun opam_state ->
@@ -1223,7 +1223,7 @@ let config cli =
       (match params with
        | [] -> `Ok (dump stdout)
        | [file] -> let oc = open_out file in dump oc; close_out oc; `Ok ()
-       | _ -> bad_subcommand commands ("config", command, params))
+       | _ -> bad_subcommand ~cli commands ("config", command, params))
     | Some `report, [] -> (
         let print label fmt = OpamConsole.msg ("# %-20s "^^fmt^^"\n") label in
         OpamConsole.msg "# opam config report\n";
@@ -1336,7 +1336,7 @@ let config cli =
       in
       (match args with
        | None ->
-         bad_subcommand commands ("config", command, params)
+         bad_subcommand ~cli commands ("config", command, params)
        | Some opt_value ->
          OpamConsole.warning
            "Subcommand set is deprecated. Use opam var %s=%s instead."
@@ -1357,7 +1357,7 @@ let config cli =
       in
       (match args with
        | None ->
-         bad_subcommand commands ("config", command, params)
+         bad_subcommand ~cli commands ("config", command, params)
        | Some opt_value ->
          OpamConsole.warning
            "Subcommand set-global is deprecated. \
@@ -1370,14 +1370,14 @@ let config cli =
          in
          let _gt = OpamConfigCommand.set_var_global gt var value in
          `Ok ())
-    | command, params -> bad_subcommand commands ("config", command, params)
+    | command, params -> bad_subcommand ~cli commands ("config", command, params)
   in
 
   Term.ret (
     Term.(const config
-          $global_options cli $command $shell_opt $sexp
-          $inplace_path
-          $set_opamroot $set_opamswitch
+          $global_options cli $command $shell_opt cli $sexp cli
+          $inplace_path cli
+          $set_opamroot cli $set_opamswitch cli
           $params)
   ),
   term_info "config" ~doc ~man
@@ -1406,8 +1406,8 @@ let exec cli =
       ~set_opamroot ~set_opamswitch ~inplace_path cmd
   in
   let open Common_config_flags in
-  Term.(const exec $global_options cli $inplace_path
-        $set_opamroot $set_opamswitch
+  Term.(const exec $global_options cli $inplace_path cli
+        $set_opamroot cli $set_opamswitch cli
         $cmd),
   term_info "exec" ~doc ~man
 
@@ -1426,11 +1426,11 @@ let env cli =
     `P "This is a shortcut, and equivalent to $(b,opam config env).";
   ] in
   let revert =
-    mk_flag ["revert"]
+    mk_flag ~cli valid_cli_legacy ["revert"]
       "Output the environment with updates done by opam reverted instead."
   in
   let check =
-    mk_flag ["check"]
+    mk_flag ~cli valid_cli_legacy ["check"]
       "Exits with 0 if the environment is already up-to-date, 1 otherwise, after \
        printing the list of not up-to-date variables."
   in
@@ -1464,8 +1464,8 @@ let env cli =
   in
   let open Common_config_flags in
   Term.(const env
-        $global_options cli $shell_opt $sexp $inplace_path
-        $set_opamroot $set_opamswitch $revert $check),
+        $global_options cli $shell_opt cli $sexp cli $inplace_path cli
+        $set_opamroot cli $set_opamswitch cli $revert $check),
   term_info "env" ~doc ~man
 
 (* INSTALL *)
@@ -1496,29 +1496,29 @@ let install cli =
   ] @ OpamArg.man_build_option_section
    in
   let add_to_roots =
-    mk_vflag None [
-      Some true, ["set-root"],
+    mk_vflag ~cli None [
+      valid_cli_legacy, Some true, ["set-root"],
       "Mark given packages as installed roots. This is the default \
        for newly manually-installed packages.";
-      Some false, ["unset-root"],
+      valid_cli_legacy, Some false, ["unset-root"],
       "Mark given packages as \"installed automatically\".";
     ]
   in
   let deps_only =
-    mk_flag  ["deps-only"]
+    mk_flag ~cli valid_cli_legacy  ["deps-only"]
       "Install all its dependencies, but don't actually install the package."
   in
   let ignore_conflicts =
-    mk_flag ["ignore-conflicts"]
+    mk_flag ~cli valid_cli_legacy ["ignore-conflicts"]
       "Used with $(b,--deps-only), ignores conflicts of given package"
   in
   let restore =
-    mk_flag ["restore"]
+    mk_flag ~cli valid_cli_legacy ["restore"]
       "Attempt to restore packages that were marked for installation but have \
        been removed due to errors"
   in
   let destdir =
-    mk_opt ["destdir"] "DIR"
+    mk_opt ~cli valid_cli_legacy ["destdir"] "DIR"
       "Copy the files installed by the given package within the current opam \
        switch below the prefix $(i,DIR), respecting their hierarchy, after \
        installation. Caution, calling this can overwrite, but never remove \
@@ -1528,13 +1528,13 @@ let install cli =
       Arg.(some dirname) None
   in
   let check =
-    mk_flag ["check"]
+    mk_flag ~cli valid_cli_legacy ["check"]
       "Exit with 0 if all the dependencies of $(i,PACKAGES) are already \
        installed. If not, output the names of the missing dependencies to \
        stdout, and exits with 1."
   in
   let depext_only =
-    mk_flag ["depext-only"]
+    mk_flag ~cli valid_cli_legacy ["depext-only"]
       "Resolves the package installation normally, but only installs the required \
        system dependencies, without affecting the opam switch state or installing \
        opam packages."
@@ -1613,9 +1613,9 @@ let install cli =
       `Ok ()
   in
   Term.ret
-    Term.(const install $global_options cli $build_options
+    Term.(const install $global_options cli $build_options cli
           $add_to_roots $deps_only $ignore_conflicts $restore $destdir
-          $assume_built $check $recurse $subpath $depext_only
+          $assume_built cli $check $recurse cli $subpath cli $depext_only
           $atom_or_local_list),
   term_info "install" ~doc ~man
 
@@ -1637,18 +1637,18 @@ let remove cli =
   ] @ OpamArg.man_build_option_section
   in
   let autoremove =
-    mk_flag ["a";"auto-remove"]
+    mk_flag ~cli valid_cli_legacy ["a";"auto-remove"]
       "Remove all the packages which have not been explicitly installed and \
        which are not necessary anymore. It is possible to prevent the removal \
        of an already-installed package by running $(b,opam install <pkg> \
        --set-root). This flag can also be set using the $(b,\\$OPAMAUTOREMOVE) \
        configuration variable." in
   let force =
-    mk_flag ["force"]
+    mk_flag ~cli valid_cli_legacy ["force"]
       "Execute the remove commands of given packages directly, even if they are \
        not considered installed by opam." in
   let destdir =
-    mk_opt ["destdir"] "DIR"
+    mk_opt ~cli valid_cli_legacy ["destdir"] "DIR"
       "Instead of uninstalling the packages, reverts the action of $(b,opam \
        install --destdir): remove files corresponding to what the listed \
        packages installed to the current switch from the given $(i,DIR). Note \
@@ -1697,8 +1697,8 @@ let remove cli =
       let autoremove = autoremove || OpamClientConfig.(!r.autoremove) in
       OpamSwitchState.drop (OpamClient.remove st ~autoremove ~force atoms)
   in
-  Term.(const remove $global_options cli $build_options $autoremove $force $destdir
-        $recurse $subpath $atom_or_dir_list),
+  Term.(const remove $global_options cli $build_options cli $autoremove
+        $force $destdir $recurse cli $subpath cli $atom_or_dir_list),
   term_info "remove" ~doc ~man
 
 (* REINSTALL *)
@@ -1716,14 +1716,14 @@ let reinstall cli =
   ] @ OpamArg.man_build_option_section
   in
   let cmd =
-    mk_vflag `Default [
-        `Pending, ["pending"],
+    mk_vflag ~cli `Default [
+        valid_cli_legacy, `Pending, ["pending"],
           "Perform pending reinstallations, i.e. reinstallations of \
                 packages that have changed since installed";
-        `List_pending, ["list-pending"],
+        valid_cli_legacy, `List_pending, ["list-pending"],
           "List packages that have been changed since installed and are \
                 marked for reinstallation";
-        `Forget_pending, ["forget-pending"],
+        valid_cli_legacy, `Forget_pending, ["forget-pending"],
           "Forget about pending reinstallations of listed packages. This \
                 implies making opam assume that your packages were installed \
                 with a newer version of their metadata, so only use this if \
@@ -1785,8 +1785,9 @@ let reinstall cli =
     | _, _::_ ->
       `Error (true, "Package arguments not allowed with this option")
   in
-  Term.(ret (const reinstall $global_options cli $build_options $assume_built
-             $recurse $subpath $atom_or_dir_list $cmd)),
+  Term.(ret (const reinstall $global_options cli $build_options cli
+             $assume_built cli $recurse cli $subpath cli $atom_or_dir_list
+             $cmd)),
   term_info "reinstall" ~doc ~man
 
 (* UPDATE *)
@@ -1802,26 +1803,26 @@ let update cli =
         $(b,opam upgrade).";
   ] in
   let repos_only =
-    mk_flag ["R"; "repositories"]
+    mk_flag ~cli valid_cli_legacy ["R"; "repositories"]
       "Update repositories (skipping development packages unless \
        $(b,--development) is also specified)." in
   let dev_only =
-    mk_flag ["development"]
+    mk_flag ~cli valid_cli_legacy ["development"]
       "Update development packages (skipping repositories unless \
        $(b,--repositories) is also specified)." in
   let upgrade =
-    mk_flag ["u";"upgrade"]
+    mk_flag ~cli valid_cli_legacy ["u";"upgrade"]
       "Automatically run $(b,opam upgrade) after the update." in
   let name_list =
     arg_list "NAMES"
       "List of repository or development package names to update."
       Arg.string in
   let all =
-    mk_flag ["a"; "all"]
+    mk_flag ~cli valid_cli_legacy ["a"; "all"]
       "Update all configured repositories, not only what is set in the current \
        switch" in
   let check =
-    mk_flag ["check"]
+    mk_flag ~cli valid_cli_legacy ["check"]
       "Do the update, then return with code 0 if there were any upstream \
        changes, 1 if there were none. Repositories or development packages \
        that failed to update are considered without changes. With \
@@ -1854,7 +1855,7 @@ let update cli =
       OpamConsole.msg "Now run 'opam upgrade' to apply any package updates.\n";
     if not success then OpamStd.Sys.exit_because `Sync_error
   in
-  Term.(const update $global_options cli $jobs_flag $name_list
+  Term.(const update $global_options cli $jobs_flag cli $name_list
         $repos_only $dev_only $all $check $upgrade),
   term_info "update" ~doc ~man
 
@@ -1875,22 +1876,22 @@ let upgrade cli =
   ] @ OpamArg.man_build_option_section
   in
   let fixup =
-    mk_flag ["fixup"]
+    mk_flag ~cli valid_cli_legacy ["fixup"]
       "Recover from a broken state (eg. missing dependencies, two conflicting \
        packages installed together...)." in
   let check =
-    mk_flag ["check"]
+    mk_flag ~cli valid_cli_legacy ["check"]
       "Don't run the upgrade: just check if anything could be upgraded. \
        Returns 0 if that is the case, 1 if there is nothing that can be \
        upgraded." in
   let all =
-    mk_flag ["a";"all"]
+    mk_flag ~cli valid_cli_legacy ["a";"all"]
       "Run an upgrade of all installed packages. This is the default if \
        $(i,PACKAGES) was not specified, and can be useful with $(i,PACKAGES) \
        to upgrade while ensuring that some packages get or remain installed."
   in
   let installed =
-    mk_flag ["installed"]
+    mk_flag ~cli valid_cli_legacy ["installed"]
       "When a directory is provided as argument, do not install pinned package \
        that are not yet installed." in
   let upgrade global_options build_options fixup check only_installed all recurse
@@ -1912,8 +1913,8 @@ let upgrade cli =
       OpamSwitchState.drop @@ OpamClient.upgrade st ~check ~only_installed ~all atoms;
       `Ok ()
   in
-  Term.(ret (const upgrade $global_options cli $build_options $fixup $check
-             $installed $all $recurse $subpath $atom_or_dir_list)),
+  Term.(ret (const upgrade $global_options cli $build_options cli $fixup $check
+             $installed $all $recurse cli $subpath cli $atom_or_dir_list)),
   term_info "upgrade" ~doc ~man
 
 (* REPOSITORY *)
@@ -1922,7 +1923,7 @@ let repository cli =
   let doc = repository_doc in
   let scope_section = "SCOPE SPECIFICATION OPTIONS" in
   let commands = [
-    "add", `add, ["NAME"; "[ADDRESS]"; "[QUORUM]"; "[FINGERPRINTS]"],
+    valid_cli_legacy, "add", `add, ["NAME"; "[ADDRESS]"; "[QUORUM]"; "[FINGERPRINTS]"],
     "Adds under $(i,NAME) the repository at address $(i,ADDRESS) to the list \
      of configured repositories, if not already registered, and sets this \
      repository for use in the current switch (or the specified scope). \
@@ -1931,7 +1932,7 @@ let repository cli =
      address. The quorum is a positive integer that determines the validation \
      threshold for signed repositories, with fingerprints the trust anchors \
      for said validation.";
-    " ", `add, [],
+    valid_cli_legacy, " ", `add, [],
     (* using an unbreakable space here will indent the text paragraph at the level
        of the previous labelled paragraph, which is what we want for our note. *)
     "$(b,Note:) By default, the repository is only added to the current \
@@ -1939,23 +1940,24 @@ let repository cli =
      $(b,--all) or $(b,--set-default) options (see below). If you want to \
      enable a repository only to install its switches, you may be \
      looking for $(b,opam switch create --repositories=REPOS).";
-    "remove", `remove, ["NAME..."],
+    valid_cli_legacy, "remove", `remove, ["NAME..."],
     "Unselects the given repositories so that they will not be used to get \
      package definitions anymore. With $(b,--all), makes opam forget about \
      these repositories completely.";
-    "set-repos", `set_repos, ["NAME..."],
+    valid_cli_legacy, "set-repos", `set_repos, ["NAME..."],
     "Explicitly selects the list of repositories to look up package \
      definitions from, in the specified priority order (overriding previous \
      selection and ranks), according to the specified scope.";
-    "set-url", `set_url, ["NAME"; "ADDRESS"; "[QUORUM]"; "[FINGERPRINTS]"],
+    valid_cli_legacy, "set-url", `set_url,
+    ["NAME"; "ADDRESS"; "[QUORUM]"; "[FINGERPRINTS]"],
     "Updates the URL and trust anchors associated with a given repository \
      name. Note that if you don't specify $(i,[QUORUM]) and \
      $(i,[FINGERPRINTS]), any previous settings will be erased.";
-    "list", `list, [],
+    valid_cli_legacy, "list", `list, [],
     "Lists the currently selected repositories in priority order from rank 1. \
-     With $(b,--all), lists all configured repositories and the switches where \
-     they are active.";
-    "priority", `priority, ["NAME"; "RANK"],
+     With $(b,--all), lists all configured repositories and the switches \
+     where they are active.";
+    valid_cli_legacy, "priority", `priority, ["NAME"; "RANK"],
     "Synonym to $(b,add NAME --rank RANK)";
   ] in
   let man = [
@@ -1970,7 +1972,7 @@ let repository cli =
          explained in $(b,"^scope_section^").");
     `P "Without a subcommand, or with the subcommand $(b,list), lists selected \
         repositories, or all configured repositories with $(b,--all).";
-  ] @ mk_subdoc ~defaults:["","list"] commands @ [
+  ] @ mk_subdoc ~cli ~defaults:["","list"] commands @ [
       `S scope_section;
       `P "These flags allow one to choose which selections are changed by $(b,add), \
           $(b,remove), $(b,set-repos). If no flag in this section is specified \
@@ -1979,21 +1981,21 @@ let repository cli =
       `S Manpage.s_options;
     ]
   in
-  let command, params = mk_subcommands commands in
+  let command, params = mk_subcommands ~cli commands in
   let scope =
     let scope_info ?docv flags doc =
       Arg.info ~docs:scope_section ~doc ?docv flags
     in
     let flags =
-      mk_vflag_all ~section:scope_section [
-        `No_selection, ["dont-select"],
+      mk_vflag_all ~cli ~section:scope_section [
+        valid_cli_legacy, `No_selection, ["dont-select"],
           "Don't update any selections";
-        `Current_switch, ["this-switch"],
+        valid_cli_legacy, `Current_switch, ["this-switch"],
           "Act on the selections for the current switch (this is the default)";
-        `Default, ["set-default"],
+        valid_cli_legacy, `Default, ["set-default"],
           "Act on the default repository selection that is used for newly \
            created switches";
-        `All, ["all-switches";"a"],
+        valid_cli_legacy, `All, ["all-switches";"a"],
           "Act on the selections of all configured switches";
       ]
     in
@@ -2010,7 +2012,7 @@ let repository cli =
           $ flags $ switches)
   in
   let rank =
-    mk_opt ["rank"] "RANK"
+    mk_opt ~cli valid_cli_legacy ["rank"] "RANK"
       "Set the rank of the repository in the list of configured repositories. \
       Package definitions are looked in the repositories in increasing rank \
       order, therefore 1 is the highest priority.  Negative ints can be used to \
@@ -2203,11 +2205,11 @@ let repository cli =
            '--all' to see all configured repositories.";
       OpamRepositoryCommand.list rt ~global ~switches ~short;
       `Ok ()
-    | command, params -> bad_subcommand commands ("repository", command, params)
+    | command, params -> bad_subcommand ~cli commands ("repository", command, params)
   in
   Term.ret
-    Term.(const repository $global_options cli $command $repo_kind_flag
-          $print_short_flag $scope $rank $params),
+    Term.(const repository $global_options cli $command $repo_kind_flag cli
+          $print_short_flag cli $scope $rank $params),
   term_info "repository" ~doc ~man
 
 
@@ -2279,7 +2281,7 @@ let switch_doc = "Manage multiple installation prefixes."
 let switch cli =
   let doc = switch_doc in
   let commands = [
-    "create", `install, ["SWITCH"; "[COMPILER]"],
+    valid_cli_legacy, "create", `install, ["SWITCH"; "[COMPILER]"],
     "Create a new switch, and install the given compiler there. $(i,SWITCH) \
      can be a plain name, or a directory, absolute or relative, in which case \
      a local switch is created below the given directory. $(i,COMPILER), if \
@@ -2290,40 +2292,42 @@ let switch cli =
      opam-init(1)). If the chosen directory contains package definitions, a \
      compatible compiler is searched within the default selection, and the \
      packages will automatically get installed.";
-    "set", `set, ["SWITCH"],
+    valid_cli_legacy, "set", `set, ["SWITCH"],
     "Set the currently active switch, among the installed switches.";
-    "remove", `remove, ["SWITCH"], "Remove the given switch from disk.";
-    "export", `export, ["FILE"],
+    valid_cli_legacy, "remove", `remove, ["SWITCH"],
+    "Remove the given switch from disk.";
+    valid_cli_legacy, "export", `export, ["FILE"],
     "Save the current switch state to a file. If $(b,--full) is specified, it \
      includes the metadata of all installed packages, and if $(b,--freeze) is \
      specified, it freezes all vcs to their current commit.";
-    "import", `import, ["FILE"],
+    valid_cli_legacy, "import", `import, ["FILE"],
     "Import a saved switch state. If $(b,--switch) is specified and doesn't \
      point to an existing switch, the switch will be created for the import.";
-    "reinstall", `reinstall, ["[SWITCH]"],
+    valid_cli_legacy, "reinstall", `reinstall, ["[SWITCH]"],
     "Reinstall the given compiler switch and all its packages.";
-    "list", `list, [],
+    valid_cli_legacy, "list", `list, [],
     "Lists installed switches.";
-    "list-available", `list_available, ["[PATTERN]"],
+    valid_cli_legacy, "list-available", `list_available, ["[PATTERN]"],
     "Lists all the possible packages that are advised for installation when \
      creating a new switch, i.e. packages with the $(i,compiler) flag set. If \
      no pattern is supplied, all versions are shown.";
-    "show", `current, [], "Prints the name of the current switch.";
-    "invariant", `show_invariant, [],
+    valid_cli_legacy, "show", `current, [],
+    "Prints the name of the current switch.";
+    valid_cli_legacy, "invariant", `show_invariant, [],
     "Prints the active switch invariant.";
-    "set-invariant", `set_invariant, ["PACKAGES"],
+    valid_cli_legacy, "set-invariant", `set_invariant, ["PACKAGES"],
     "Updates the switch invariant, that is, the formula that the switch must \
      keep verifying throughout all operations. The previous setting is \
      overriden. See also options $(b,--force) and $(b,--no-action). Without \
      arguments, an invariant is chosen automatically.";
-    "set-description", `set_description, ["STRING"],
+    valid_cli_legacy, "set-description", `set_description, ["STRING"],
     "Sets the description for the selected switch.";
-    "link", `link, ["SWITCH";"[DIR]"],
+    valid_cli_legacy, "link", `link, ["SWITCH";"[DIR]"],
     "Sets a local alias for a given switch, so that the switch gets \
      automatically selected whenever in that directory or a descendant.";
-    "install", `install, ["SWITCH"],
+    valid_cli_legacy, "install", `install, ["SWITCH"],
     "Deprecated alias for 'create'.";
-    "set-base", `set_invariant, ["PACKAGES"],
+    valid_cli_legacy, "set-base", `set_invariant, ["PACKAGES"],
     "Deprecated alias for 'set-invariant'.";
   ] in
   let man = [
@@ -2351,7 +2355,7 @@ let switch cli =
         possible to select a switch in a given shell session, using the \
         environment. For that, use $(i,eval \\$(opam env \
         --switch=SWITCH --set-switch\\)).";
-  ] @ mk_subdoc ~defaults:["","list";"SWITCH","set"] commands
+  ] @ mk_subdoc ~cli ~defaults:["","list";"SWITCH","set"] commands
     @ [
       `S Manpage.s_examples;
       `Pre "    opam switch create 4.08.0";
@@ -2374,25 +2378,25 @@ let switch cli =
     @ OpamArg.man_build_option_section
   in
 
-  let command, params = mk_subcommands_with_default commands in
+  let command, params = mk_subcommands_with_default ~cli commands in
   let no_switch =
-    mk_flag ["no-switch"]
+    mk_flag ~cli valid_cli_legacy ["no-switch"]
       "Don't automatically select newly installed switches." in
   let packages =
-    mk_opt ["packages"] "PACKAGES"
+    mk_opt ~cli valid_cli_legacy ["packages"] "PACKAGES"
       "When installing a switch, explicitly define the set of packages to \
        enforce as the switch invariant."
       Arg.(some (list atom)) None in
   let formula =
-    mk_opt ["formula"] "FORMULA"
+    mk_opt ~cli valid_cli_legacy ["formula"] "FORMULA"
       "Allows specifying a complete \"dependency formula\", possibly including \
        disjunction cases, as the switch invariant."
       Arg.(some OpamArg.dep_formula) None in
   let empty =
-    mk_flag ["empty"]
+    mk_flag ~cli valid_cli_legacy ["empty"]
       "Allow creating an empty switch, with no invariant." in
   let repos =
-    mk_opt ["repositories"] "REPOS"
+    mk_opt ~cli valid_cli_legacy ["repositories"] "REPOS"
       "When creating a new switch, use the given selection of repositories \
        instead of the default. $(i,REPOS) should be a comma-separated list of \
        either already registered repository names (configured through e.g. \
@@ -2404,65 +2408,60 @@ let switch cli =
       Arg.(some (list string)) None
   in
   let descr =
-    mk_opt ["description"] "STRING"
+    mk_opt ~cli valid_cli_legacy ["description"] "STRING"
       "Attach the given description to a switch when creating it. Use the \
        $(i,set-description) subcommand to modify the description of an \
        existing switch."
       Arg.(some string) None
   in
   let full =
-    mk_flag ["full"]
+    mk_flag ~cli valid_cli_legacy ["full"]
       "When exporting, include the metadata of all installed packages, \
        allowing to re-import even if they don't exist in the repositories (the \
        default is to include only the metadata of pinned packages)."
   in
   let freeze =
-    mk_flag ["freeze"]
+    mk_flag ~cli valid_cli_legacy ["freeze"]
       "When exporting, locks all VCS urls to their current commit, failing if \
        it can not be retrieved. This ensures that an import will restore the \
        exact state. Implies $(b,--full)."
   in
   let no_install =
-    mk_flag ["no-install"]
+    mk_flag ~cli valid_cli_legacy ["no-install"]
       "When creating a local switch, don't look for any local package \
        definitions to install."
   in
   let deps_only =
-    mk_flag ["deps-only"]
+    mk_flag ~cli valid_cli_legacy ["deps-only"]
       "When creating a local switch in a project directory (i.e. a directory \
        containing opam package definitions), install the dependencies of the \
        project but not the project itself."
   in
   let force =
-    mk_flag ["force"]
+    mk_flag ~cli valid_cli_legacy ["force"]
       "Only for $(i,set-invariant): force setting the invariant, bypassing \
        consistency checks."
   in
   let no_action =
-    mk_flag ["n"; "no-action"]
+    mk_flag ~cli valid_cli_legacy ["n"; "no-action"]
       "Only for $(i,set-invariant): set the invariant, but don't enforce it \
        right away: wait for the next $(i,install), $(i,upgrade) or similar \
        command."
   in
   (* Deprecated options *)
   let d_alias_of =
-    mk_opt ["A";"alias-of"]
-      "COMP"
-      "This option is deprecated."
-      Arg.(some string) None
+    mk_opt ~cli (Deprecated (cli2_0, cli2_1,
+                             Some "opam switch <switch-name> <compiler>"))
+      ["A";"alias-of"] "COMP" "" Arg.(some string) None
   in
   let d_no_autoinstall =
-    mk_flag ["no-autoinstall"]
-      "This option is deprecated."
+    mk_flag ~cli (Deprecated (cli2_0, cli2_1, None)) ["no-autoinstall"] ""
   in
   let switch
       global_options build_options command print_short
       no_switch packages formula empty descr full freeze no_install deps_only repos
       force no_action
-      d_alias_of d_no_autoinstall params =
-   OpamArg.deprecated_option d_alias_of None
-   "alias-of" (Some "opam switch <switch-name> <compiler>");
-   OpamArg.deprecated_option d_no_autoinstall false "no-autoinstall" None;
+      _d_alias_of _d_no_autoinstall params =
     apply_global_options global_options;
     apply_build_options build_options;
     let invariant_arg ?repos rt args =
@@ -2743,11 +2742,11 @@ let switch cli =
       in
       OpamSwitchAction.install_switch_config gt.root st.switch config;
       `Ok ()
-    | command, params -> bad_subcommand commands ("switch", command, params)
+    | command, params -> bad_subcommand ~cli commands ("switch", command, params)
   in
   Term.(ret (const switch
-             $global_options cli $build_options $command
-             $print_short_flag
+             $global_options cli $build_options cli $command
+             $print_short_flag cli
              $no_switch
              $packages $formula $empty $descr $full $freeze $no_install
              $deps_only $repos $force $no_action $d_alias_of $d_no_autoinstall
@@ -2759,9 +2758,9 @@ let pin_doc = "Pin a given package to a specific version or source."
 let pin ?(unpin_only=false) cli =
   let doc = pin_doc in
   let commands = [
-    "list", `list, [], "Lists pinned packages.";
-    "scan", `scan, ["DIR"], "Lists available packages to pin in directory.";
-    "add", `add, ["PACKAGE"; "TARGET"],
+    valid_cli_legacy, "list", `list, [], "Lists pinned packages.";
+    valid_cli_legacy, "scan", `scan, ["DIR"], "Lists available packages to pin in directory.";
+    valid_cli_legacy, "add", `add, ["PACKAGE"; "TARGET"],
     "Pins package $(i,PACKAGE) to $(i,TARGET), which may be a version, a path, \
      or a URL.\n\
      $(i,PACKAGE) can be omitted if $(i,TARGET) contains one or more \
@@ -2778,11 +2777,11 @@ let pin ?(unpin_only=false) cli =
      For source pinnings, the package version may be specified by using the \
      format $(i,NAME).$(i,VERSION) for $(i,PACKAGE), in the source opam file, \
      or with $(b,edit).";
-    "remove", `remove, ["NAMES...|TARGET"],
+    valid_cli_legacy, "remove", `remove, ["NAMES...|TARGET"],
     "Unpins packages $(i,NAMES), restoring their definition from the \
      repository, if any. With a $(i,TARGET), unpins everything that is \
      currently pinned to that target.";
-    "edit", `edit, ["NAME"],
+    valid_cli_legacy, "edit", `edit, ["NAME"],
     "Opens an editor giving you the opportunity to change the package \
      definition that opam will locally use for package $(i,NAME), including \
      its version and source URL. Using the format $(i,NAME.VERSION) will \
@@ -2814,7 +2813,7 @@ let pin ?(unpin_only=false) cli =
         package. See also the $(b,--with-version) option.";
     `P "The default subcommand is $(i,list) if there are no further arguments, \
         and $(i,add) otherwise if unambiguous.";
-  ] @ mk_subdoc ~defaults:["","list"] commands @ [
+  ] @ mk_subdoc ~cli ~defaults:["","list"] commands @ [
       `S Manpage.s_options;
     ] @ OpamArg.man_build_option_section
   in
@@ -2823,9 +2822,9 @@ let pin ?(unpin_only=false) cli =
       Term.const (Some `remove),
       Arg.(value & pos_all string [] & Arg.info [])
     else
-      mk_subcommands_with_default commands in
+      mk_subcommands_with_default ~cli commands in
   let edit =
-    mk_flag ["e";"edit"]
+    mk_flag ~cli valid_cli_legacy ["e";"edit"]
       "With $(i,opam pin add), edit the opam file as with `opam pin edit' \
        after pinning." in
   let kind =
@@ -2856,16 +2855,16 @@ let pin ?(unpin_only=false) cli =
       ] in
     Arg.(value & opt (some & enum kinds) None & doc) in
   let no_act =
-    mk_flag ["n";"no-action"]
+    mk_flag ~cli valid_cli_legacy ["n";"no-action"]
       "Just record the new pinning status, and don't prompt for \
        (re)installation or removal of affected packages."
   in
   let dev_repo =
-    mk_flag ["dev-repo"] "Pin to the upstream package source for the latest \
-                          development version"
+    mk_flag ~cli valid_cli_legacy ["dev-repo"]
+      "Pin to the upstream package source for the latest development version"
   in
   let normalise =
-    mk_flag ["normalise"]
+    mk_flag ~cli valid_cli_legacy ["normalise"]
       (Printf.sprintf
          "Print list of available package to pin in format \
           `name.version%curl`, that is comprehensible by `opam pin \
@@ -2874,7 +2873,7 @@ let pin ?(unpin_only=false) cli =
          OpamPinCommand.scan_sep)
   in
   let with_version =
-    mk_opt ["with-version"] "VERSION"
+    mk_opt ~cli valid_cli_legacy ["with-version"] "VERSION"
       "Set the pinning version to $(i,VERSION) for named $(i,PACKAGES) or \
        packages retrieved from $(i,TARGET). It has priority over any other \
        version specification (opam file version field, $(b,name.vers) \
@@ -3109,7 +3108,7 @@ let pin ?(unpin_only=false) cli =
          `Ok ()
        | `Error e ->
          if command = Some `add then `Error (false, e)
-         else bad_subcommand commands ("pin", command, params))
+         else bad_subcommand ~cli commands ("pin", command, params))
     | `add_url arg ->
       (match pin_target kind arg with
        | `None | `Version _ ->
@@ -3141,12 +3140,13 @@ let pin ?(unpin_only=false) cli =
          OpamClient.PIN.pin st name ?version ~edit ~action ?subpath pin;
          `Ok ()
        | `Error e -> `Error (false, e))
-    | `incorrect -> bad_subcommand commands ("pin", command, params)
+    | `incorrect -> bad_subcommand ~cli commands ("pin", command, params)
   in
   Term.ret
     Term.(const pin
-          $global_options cli $build_options
-          $kind $edit $no_act $dev_repo $print_short_flag $recurse $subpath
+          $global_options cli $build_options cli
+          $kind $edit $no_act $dev_repo $print_short_flag cli
+          $recurse cli $subpath cli
           $normalise $with_version
           $command $params),
   term_info "pin" ~doc ~man
@@ -3165,14 +3165,14 @@ let source cli =
            ~doc:"A package name with an optional version constraint")
   in
   let dev_repo =
-    mk_flag ["dev-repo"]
+    mk_flag ~cli valid_cli_legacy ["dev-repo"]
       "Get the latest version-controlled source rather than the \
        release archive" in
   let pin =
-    mk_flag ["pin"]
+    mk_flag ~cli valid_cli_legacy ["pin"]
       "Pin the package to the downloaded source (see `opam pin')." in
   let dir =
-    mk_opt ["dir"] "DIR" "The directory where to put the source."
+    mk_opt ~cli valid_cli_legacy ["dir"] "DIR" "The directory where to put the source."
       Arg.(some dirname) None in
   let source global_options atom dev_repo pin dir =
     apply_global_options global_options;
@@ -3306,15 +3306,15 @@ let lint cli =
                  them. Current directory if unspecified")
   in
   let normalise =
-    mk_flag ["normalise"]
+    mk_flag ~cli valid_cli_legacy ["normalise"]
       "Output a normalised version of the opam file to stdout"
   in
   let short =
-    mk_flag ["short";"s"]
+    mk_flag ~cli valid_cli_legacy ["short";"s"]
       "Only print the warning/error numbers, space-separated, if any"
   in
   let warnings =
-    mk_opt ["warnings";"W"] "WARNS"
+    mk_opt ~cli valid_cli_legacy ["warnings";"W"] "WARNS"
       "Select the warnings to show or hide. $(i,WARNS) should be a \
        concatenation of $(b,+N), $(b,-N), $(b,+N..M), $(b,-N..M) to \
        respectively enable or disable warning or error number $(b,N) or \
@@ -3324,13 +3324,13 @@ let lint cli =
       warn_selector []
   in
   let package =
-    mk_opt ["package"] "PKG"
+    mk_opt ~cli valid_cli_legacy ["package"] "PKG"
       "Lint the current definition of the given package instead of specifying \
        an opam file directly."
       Arg.(some package) None
   in
   let check_upstream =
-    mk_flag ["check-upstream"]
+    mk_flag ~cli valid_cli_legacy ["check-upstream"]
       "Check upstream, archive availability and checksum(s)"
   in
   let lint global_options files package normalise short warnings_sel
@@ -3453,7 +3453,7 @@ let lint cli =
     if err then OpamStd.Sys.exit_because `False
   in
   Term.(const lint $global_options cli $files $package $normalise $short
-        $warnings $check_upstream $recurse $subpath),
+        $warnings $check_upstream $recurse cli $subpath cli),
   term_info "lint" ~doc ~man
 
 (* CLEAN *)
@@ -3467,37 +3467,37 @@ let clean cli =
         --switch-cleanup)."
   ] in
   let dry_run =
-    mk_flag ["dry-run"]
+    mk_flag ~cli valid_cli_legacy ["dry-run"]
       "Print the removal commands, but don't execute them"
   in
   let download_cache =
-    mk_flag ["c"; "download-cache"]
+    mk_flag ~cli valid_cli_legacy ["c"; "download-cache"]
       (Printf.sprintf
         "Clear the cache of downloaded files (\\$OPAMROOT%sdownload-cache), as \
          well as the obsolete \\$OPAMROOT%sarchives, if that exists."
         OpamArg.dir_sep OpamArg.dir_sep)
   in
   let repos =
-    mk_flag ["unused-repositories"]
+    mk_flag ~cli valid_cli_legacy ["unused-repositories"]
       "Clear any configured repository that is not used by any switch nor the \
        default."
   in
   let repo_cache =
-    mk_flag ["r"; "repo-cache"]
+    mk_flag ~cli valid_cli_legacy ["r"; "repo-cache"]
       "Clear the repository cache. It will be rebuilt by the next opam command \
        that needs it."
   in
   let logs =
-    mk_flag ["logs"] "Clear the logs directory."
+    mk_flag ~cli valid_cli_legacy ["logs"] "Clear the logs directory."
   in
   let switch =
-    mk_flag ["s";"switch-cleanup"]
+    mk_flag ~cli valid_cli_legacy ["s";"switch-cleanup"]
       "Run the switch-specific cleanup: clears backups, build dirs, \
        uncompressed package sources of non-dev packages, local metadata of \
        previously pinned packages, etc."
   in
   let all_switches =
-    mk_flag ["a"; "all-switches"]
+    mk_flag ~cli valid_cli_legacy ["a"; "all-switches"]
       "Run the switch cleanup commands in all switches. Implies $(b,--switch-cleanup)"
   in
   let clean global_options dry_run
@@ -3668,10 +3668,10 @@ let lock cli =
   ]
   in
   let only_direct_flag =
-    mk_flag ["d"; "direct-only"]
+    mk_flag ~cli valid_cli_legacy ["d"; "direct-only"]
       "Only lock direct dependencies, rather than the whole dependency tree."
   in
-  let lock_suffix = OpamArg.lock_suffix Manpage.s_options in
+  let lock_suffix = OpamArg.lock_suffix cli Manpage.s_options in
   let lock global_options only_direct lock_suffix atom_locs =
     apply_global_options global_options;
     OpamGlobalState.with_ `Lock_none @@ fun gt ->

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -226,44 +226,44 @@ let init cli =
     Arg.(value & pos ~rev:true 0 (some string) None & doc)
   in
   let interactive =
-    Arg.(value & vflag None [
-        Some false, info ["a";"auto-setup"] ~doc:
+    mk_vflag None [
+        Some false, ["a";"auto-setup"],
           "Automatically do a full setup, including adding a line to your \
            shell init files.";
-        Some true, info ["i";"interactive"] ~doc:
+        Some true, ["i";"interactive"],
           "Run the setup interactively (this is the default for an initial \
            run, or when no more specific options are specified)";
-      ])
+      ]
   in
   let update_config =
-    Arg.(value & vflag None [
-        Some true, info ["shell-setup"] ~doc:
+    mk_vflag None [
+        Some true, ["shell-setup"],
           "Automatically setup the user shell configuration for opam, e.g. \
            adding a line to the `~/.profile' file.";
-        Some false, info ["n";"no-setup"] ~doc:
+        Some false, ["n";"no-setup"],
           "Do not update the user shell configuration to setup opam. Also \
            implies $(b,--disable-shell-hook), unless $(b,--interactive) or \
            specified otherwise";
-      ])
+      ]
   in
   let setup_completion =
-    Arg.(value & vflag None [
-        Some true, info ["enable-completion"] ~doc:
+    mk_vflag None [
+        Some true, ["enable-completion"],
           "Setup shell completion in opam init scripts, for supported \
            shells.";
-        Some false, info ["disable-completion"] ~doc:
+        Some false, ["disable-completion"],
           "Disable shell completion in opam init scripts.";
-      ])
+      ]
   in
   let env_hook =
-    Arg.(value & vflag None [
-        Some true, info ["enable-shell-hook"] ~doc:
+    mk_vflag None [
+        Some true, ["enable-shell-hook"],
           "Setup opam init scripts to register a shell hook that will \
            automatically keep the shell environment up-to-date at every \
            prompt.";
-        Some false, info ["disable-shell-hook"] ~doc:
+        Some false, ["disable-shell-hook"],
           "Disable registration of a shell hook in opam init scripts.";
-      ])
+      ]
   in
   let config_file =
     mk_opt_all ["config"] "FILE"
@@ -462,29 +462,28 @@ let list ?(force_search=false) cli =
       Arg.string
   in
   let state_selector =
-    let docs = selection_docs in
-    Arg.(value & vflag_all [] [
-        OpamListCommand.Any, info ~docs ["A";"all"]
-          ~doc:"Include all, even uninstalled or unavailable packages";
-        OpamListCommand.Installed, info ~docs ["i";"installed"]
-          ~doc:"List installed packages only. This is the default when no \
+    mk_vflag_all ~section:selection_docs [
+        OpamListCommand.Any, ["A";"all"],
+          "Include all, even uninstalled or unavailable packages";
+        OpamListCommand.Installed, ["i";"installed"],
+          "List installed packages only. This is the default when no \
                 further arguments are supplied";
-        OpamListCommand.Root, info ~docs ["roots";"installed-roots"]
-          ~doc:"List only packages that were explicitly installed, excluding \
+        OpamListCommand.Root, ["roots";"installed-roots"],
+          "List only packages that were explicitly installed, excluding \
                 the ones installed as dependencies";
-        OpamListCommand.Available, info ~docs ["a";"available"]
-          ~doc:"List only packages that are available on the current system";
-        OpamListCommand.Installable, info ~docs ["installable"]
-          ~doc:"List only packages that can be installed on the current switch \
+        OpamListCommand.Available, ["a";"available"],
+          "List only packages that are available on the current system";
+        OpamListCommand.Installable, ["installable"],
+          "List only packages that can be installed on the current switch \
                 (this calls the solver and may be more costly; a package \
                 depending on an unavailable package may be available, but is \
                 never installable)";
-        OpamListCommand.Compiler, info ~docs ["base"]
-          ~doc:"List only the immutable base of the current switch (i.e. \
+        OpamListCommand.Compiler, ["base"],
+          "List only the immutable base of the current switch (i.e. \
                 compiler packages)";
-        OpamListCommand.Pinned, info ~docs ["pinned"]
-          ~doc:"List only the pinned packages";
-      ])
+        OpamListCommand.Pinned, ["pinned"],
+          "List only the pinned packages";
+      ]
   in
   let section = selection_docs in
   let search =
@@ -1497,14 +1496,13 @@ let install cli =
   ] @ OpamArg.man_build_option_section
    in
   let add_to_roots =
-    let root =
-      Some true, Arg.info ["set-root"]
-        ~doc:"Mark given packages as installed roots. This is the default \
-              for newly manually-installed packages." in
-    let unroot =
-      Some false, Arg.info ["unset-root"]
-        ~doc:"Mark given packages as \"installed automatically\"." in
-    Arg.(value & vflag None[root; unroot])
+    mk_vflag None [
+      Some true, ["set-root"],
+      "Mark given packages as installed roots. This is the default \
+       for newly manually-installed packages.";
+      Some false, ["unset-root"],
+      "Mark given packages as \"installed automatically\".";
+    ]
   in
   let deps_only =
     mk_flag  ["deps-only"]
@@ -1718,20 +1716,20 @@ let reinstall cli =
   ] @ OpamArg.man_build_option_section
   in
   let cmd =
-    Arg.(value & vflag `Default [
-        `Pending, info ["pending"]
-          ~doc:"Perform pending reinstallations, i.e. reinstallations of \
+    mk_vflag `Default [
+        `Pending, ["pending"],
+          "Perform pending reinstallations, i.e. reinstallations of \
                 packages that have changed since installed";
-        `List_pending, info ["list-pending"]
-          ~doc:"List packages that have been changed since installed and are \
+        `List_pending, ["list-pending"],
+          "List packages that have been changed since installed and are \
                 marked for reinstallation";
-        `Forget_pending, info ["forget-pending"]
-          ~doc:"Forget about pending reinstallations of listed packages. This \
+        `Forget_pending, ["forget-pending"],
+          "Forget about pending reinstallations of listed packages. This \
                 implies making opam assume that your packages were installed \
                 with a newer version of their metadata, so only use this if \
                 you know what you are doing, and the actual changes you are \
                 overriding."
-      ])
+      ]
   in
   let reinstall global_options build_options assume_built recurse subpath
       atoms_locs cmd =
@@ -1987,15 +1985,15 @@ let repository cli =
       Arg.info ~docs:scope_section ~doc ?docv flags
     in
     let flags =
-      Arg.vflag_all [] [
-        `No_selection, scope_info ["dont-select"]
+      mk_vflag_all ~section:scope_section [
+        `No_selection, ["dont-select"],
           "Don't update any selections";
-        `Current_switch, scope_info ["this-switch"]
+        `Current_switch, ["this-switch"],
           "Act on the selections for the current switch (this is the default)";
-        `Default, scope_info ["set-default"]
+        `Default, ["set-default"],
           "Act on the default repository selection that is used for newly \
            created switches";
-        `All, scope_info ["all-switches";"a"]
+        `All, ["all-switches";"a"],
           "Act on the selections of all configured switches";
       ]
     in
@@ -2009,7 +2007,7 @@ let repository cli =
             $ Arg.value switches)
     in
     Term.(const (fun l1 l2 -> match l1@l2 with [] -> [`Current_switch] | l -> l)
-          $ Arg.value flags $ switches)
+          $ flags $ switches)
   in
   let rank =
     mk_opt ["rank"] "RANK"

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -74,7 +74,7 @@ let switch_to_updated_self debug opamroot =
 
 let global_options cli =
   let no_self_upgrade =
-    mk_flag ~cli valid_cli_legacy ~section:global_option_section ["no-self-upgrade"]
+    mk_flag ~cli cli_original ~section:global_option_section ["no-self-upgrade"]
       (Printf.sprintf
         "Opam will replace itself with a newer binary found \
          at $(b,OPAMROOT%sopam) if present. This disables this behaviour."
@@ -201,12 +201,12 @@ let init cli =
   ] @ OpamArg.man_build_option_section
   in
   let compiler =
-    mk_opt ~cli valid_cli_legacy ["c";"compiler"] "PACKAGE"
+    mk_opt ~cli cli_original ["c";"compiler"] "PACKAGE"
       "Set the compiler to install (when creating an initial switch)"
       Arg.(some string) None
   in
   let no_compiler =
-    mk_flag ~cli valid_cli_legacy ["bare"]
+    mk_flag ~cli cli_original ["bare"]
       "Initialise the opam state, but don't setup any compiler switch yet."
   in
   let repo_name =
@@ -227,20 +227,20 @@ let init cli =
   in
   let interactive =
     mk_vflag ~cli None [
-        valid_cli_legacy, Some false, ["a";"auto-setup"],
+        cli_original, (Some false), ["a";"auto-setup"],
           "Automatically do a full setup, including adding a line to your \
            shell init files.";
-        valid_cli_legacy, Some true, ["i";"interactive"],
+        cli_original, (Some true), ["i";"interactive"],
           "Run the setup interactively (this is the default for an initial \
            run, or when no more specific options are specified)";
       ]
   in
   let update_config =
     mk_vflag ~cli None [
-        valid_cli_legacy, Some true, ["shell-setup"],
+        cli_original, (Some true), ["shell-setup"],
           "Automatically setup the user shell configuration for opam, e.g. \
            adding a line to the `~/.profile' file.";
-        valid_cli_legacy, Some false, ["n";"no-setup"],
+        cli_original, (Some false), ["n";"no-setup"],
           "Do not update the user shell configuration to setup opam. Also \
            implies $(b,--disable-shell-hook), unless $(b,--interactive) or \
            specified otherwise";
@@ -248,25 +248,25 @@ let init cli =
   in
   let setup_completion =
     mk_vflag ~cli None [
-        valid_cli_legacy, Some true, ["enable-completion"],
+        cli_original, (Some true), ["enable-completion"],
           "Setup shell completion in opam init scripts, for supported \
            shells.";
-        valid_cli_legacy, Some false, ["disable-completion"],
+        cli_original, (Some false), ["disable-completion"],
           "Disable shell completion in opam init scripts.";
       ]
   in
   let env_hook =
     mk_vflag ~cli None [
-        valid_cli_legacy, Some true, ["enable-shell-hook"],
+        cli_original, (Some true), ["enable-shell-hook"],
           "Setup opam init scripts to register a shell hook that will \
            automatically keep the shell environment up-to-date at every \
            prompt.";
-        valid_cli_legacy, Some false, ["disable-shell-hook"],
+        cli_original, (Some false), ["disable-shell-hook"],
           "Disable registration of a shell hook in opam init scripts.";
       ]
   in
   let config_file =
-    mk_opt_all ~cli valid_cli_legacy ["config"] "FILE"
+    mk_opt_all ~cli cli_original ["config"] "FILE"
       "Use the given init config file. If repeated, latest has the highest \
        priority ($(b,i.e.) each field gets its value from where it was defined \
        last). Specifying a URL pointing to a config file instead is \
@@ -274,27 +274,27 @@ let init cli =
       OpamArg.url
   in
   let no_config_file =
-    mk_flag ~cli valid_cli_legacy ["no-opamrc"]
+    mk_flag ~cli cli_original ["no-opamrc"]
       (Printf.sprintf
       "Don't read `/etc/opamrc' or `~%s.opamrc': use the default settings and \
        the files specified through $(b,--config) only" OpamArg.dir_sep)
   in
   let reinit =
-    mk_flag ~cli valid_cli_legacy ["reinit"]
+    mk_flag ~cli cli_original ["reinit"]
       "Re-run the initial checks and setup, according to opamrc, even if this \
        is not a new opam root"
   in
   let show_default_opamrc =
-    mk_flag ~cli valid_cli_legacy ["show-default-opamrc"]
+    mk_flag ~cli cli_original ["show-default-opamrc"]
       "Print the built-in default configuration to stdout and exit"
   in
   let bypass_checks =
-    mk_flag ~cli valid_cli_legacy ["bypass-checks"]
+    mk_flag ~cli cli_original ["bypass-checks"]
       "Skip checks on required or recommended tools, and assume everything is \
        fine"
   in
   let no_sandboxing =
-    mk_flag ~cli valid_cli_legacy ["disable-sandboxing"]
+    mk_flag ~cli cli_original ["disable-sandboxing"]
       "Use a default configuration with sandboxing disabled (note that this \
        may be overridden by `opamrc' if $(b,--no-opamrc) is not specified or \
        $(b,--config) is used). Use this at your own risk, without sandboxing \
@@ -421,11 +421,11 @@ let init cli =
     OpamSwitchState.drop st
   in
   Term.(const init
-        $global_options cli $build_options cli $repo_kind_flag cli $repo_name $repo_url
-        $interactive $update_config $setup_completion $env_hook $no_sandboxing
-        $shell_opt cli $dot_profile_flag cli
-        $compiler $ no_compiler
-        $config_file $no_config_file $reinit $show_default_opamrc $bypass_checks),
+        $global_options cli $build_options cli $repo_kind_flag cli cli_original
+        $repo_name $repo_url $interactive $update_config $setup_completion
+        $env_hook $no_sandboxing $shell_opt cli cli_original
+        $dot_profile_flag cli cli_original $compiler $ no_compiler $config_file
+        $no_config_file $reinit $show_default_opamrc $bypass_checks),
   term_info "init" ~doc ~man
 
 (* LIST *)
@@ -463,60 +463,60 @@ let list ?(force_search=false) cli =
   in
   let state_selector =
     mk_vflag_all ~cli ~section:selection_docs [
-        valid_cli_legacy, OpamListCommand.Any, ["A";"all"],
+        cli_original, OpamListCommand.Any, ["A";"all"],
           "Include all, even uninstalled or unavailable packages";
-        valid_cli_legacy, OpamListCommand.Installed, ["i";"installed"],
+        cli_original, OpamListCommand.Installed, ["i";"installed"],
           "List installed packages only. This is the default when no \
                 further arguments are supplied";
-        valid_cli_legacy, OpamListCommand.Root, ["roots";"installed-roots"],
+        cli_original, OpamListCommand.Root, ["roots";"installed-roots"],
           "List only packages that were explicitly installed, excluding \
                 the ones installed as dependencies";
-        valid_cli_legacy, OpamListCommand.Available, ["a";"available"],
+        cli_original, OpamListCommand.Available, ["a";"available"],
           "List only packages that are available on the current system";
-        valid_cli_legacy, OpamListCommand.Installable, ["installable"],
+        cli_original, OpamListCommand.Installable, ["installable"],
           "List only packages that can be installed on the current switch \
                 (this calls the solver and may be more costly; a package \
                 depending on an unavailable package may be available, but is \
                 never installable)";
-        valid_cli_legacy, OpamListCommand.Compiler, ["base"],
+        cli_original, OpamListCommand.Compiler, ["base"],
           "List only the immutable base of the current switch (i.e. \
                 compiler packages)";
-        valid_cli_legacy, OpamListCommand.Pinned, ["pinned"],
+        cli_original, OpamListCommand.Pinned, ["pinned"],
           "List only the pinned packages";
       ]
   in
   let section = selection_docs in
   let search =
     if force_search then Term.const true else
-      mk_flag ~cli valid_cli_legacy ["search"] ~section
+      mk_flag ~cli cli_original ["search"] ~section
         "Match $(i,PATTERNS) against the full descriptions of packages, and \
          require all of them to match, instead of requiring at least one to \
          match against package names (unless $(b,--or) is also specified)."
   in
   let repos =
-    mk_opt ~cli valid_cli_legacy ["repos"] "REPOS" ~section
+    mk_opt ~cli cli_original ["repos"] "REPOS" ~section
       "Include only packages that took their origin from one of the given \
        repositories (unless $(i,no-switch) is also specified, this excludes \
        pinned packages)."
       Arg.(some & list & repository_name) None
   in
   let owns_file =
-    mk_opt ~cli valid_cli_legacy ["owns-file"] "FILE" ~section
+    mk_opt ~cli cli_original ["owns-file"] "FILE" ~section
       "Finds installed packages responsible for installing the given file"
       Arg.(some OpamArg.filename) None
   in
   let no_switch =
-    mk_flag ~cli valid_cli_legacy ["no-switch"] ~section:selection_docs
+    mk_flag ~cli cli_original ["no-switch"] ~section:selection_docs
       "List what is available from the repositories, without consideration for \
        the current (or any other) switch (installed or pinned packages, etc.)"
   in
   let disjunction =
-    mk_flag ~cli valid_cli_legacy ["or"] ~section:selection_docs
+    mk_flag ~cli cli_original ["or"] ~section:selection_docs
       "Instead of selecting packages that match $(i,all) the criteria, select \
        packages that match $(i,any) of them"
   in
   let depexts =
-    mk_flag ~cli valid_cli_legacy ["e";"external";"depexts"] ~section:display_docs
+    mk_flag ~cli cli_original ["e";"external";"depexts"] ~section:display_docs
       "Instead of displaying the packages, display their external dependencies \
        that are associated with the current system. This excludes other \
        display options. Rather than using this directly, you should probably \
@@ -525,19 +525,19 @@ let list ?(force_search=false) cli =
        `opam depext'."
   in
   let vars =
-    mk_opt ~cli valid_cli_legacy ["vars"] "[VAR=STR,...]" ~section:display_docs
+    mk_opt ~cli cli_original ["vars"] "[VAR=STR,...]" ~section:display_docs
       "Define the given variable bindings. Typically useful with \
        $(b,--external) to override the values for $(i,arch), $(i,os), \
        $(i,os-distribution), $(i,os-version), $(i,os-family)."
       OpamArg.variable_bindings []
   in
   let silent =
-    mk_flag ~cli valid_cli_legacy ["silent"]
+    mk_flag ~cli cli_original ["silent"]
       "Don't write anything in the output, exit with return code 0 if the list \
        is not empty, 1 otherwise."
   in
   let no_depexts =
-    mk_flag ~cli valid_cli_legacy ["no-depexts"]
+    mk_flag ~cli cli_original ["no-depexts"]
       "Disable external dependencies handling for the query. This can be used \
        to include packages that are marked as unavailable because of an unavailable \
        system dependency."
@@ -693,7 +693,7 @@ let show cli =
         metadata will be shown."
   ] in
   let fields =
-    mk_opt ~cli valid_cli_legacy ["f";"field"] "FIELDS"
+    mk_opt ~cli cli_original ["f";"field"] "FIELDS"
       (Printf.sprintf
          "Only display the values of these fields. Fields can be selected \
           among %s. Multiple fields can be separated with commas, in which case \
@@ -704,37 +704,37 @@ let show cli =
       Arg.(list string) []
   in
   let show_empty =
-    mk_flag ~cli valid_cli_legacy ["empty-fields"]
+    mk_flag ~cli cli_original ["empty-fields"]
       "Show fields that are empty. This is implied when $(b,--field) is \
        given."
   in
   let raw =
-    mk_flag ~cli valid_cli_legacy ["raw"] "Print the raw opam file for this package" in
+    mk_flag ~cli cli_original ["raw"] "Print the raw opam file for this package" in
   let where =
-    mk_flag ~cli valid_cli_legacy ["where"]
+    mk_flag ~cli cli_original ["where"]
       "Print the location of the opam file used for this package" in
   let list_files =
-    mk_flag ~cli valid_cli_legacy ["list-files"]
+    mk_flag ~cli cli_original ["list-files"]
       "List the files installed by the package. Equivalent to \
        $(b,--field=installed-files), and only available for installed \
        packages"
   in
   let file =
-    mk_opt ~cli (Deprecated (cli2_0, cli2_1, Some "--just-file"))
+    mk_opt ~cli (cli_between cli2_0 cli2_1 ~replaced:"--just-file")
       ["file"] "FILE" ""
       Arg.(some existing_filename_or_dash) None
   in
   let normalise =
-    mk_flag ~cli valid_cli_legacy ["normalise"]
+    mk_flag ~cli cli_original ["normalise"]
       "Print the values of opam fields normalised (no newlines, no implicit \
        brackets)"
   in
   let no_lint =
-    mk_flag ~cli valid_cli_legacy ["no-lint"]
+    mk_flag ~cli cli_original ["no-lint"]
       "Don't output linting warnings or errors when reading from files"
   in
   let just_file =
-    mk_flag ~cli (Valid_since cli2_1) ["just-file"]
+    mk_flag ~cli (cli_from cli2_1) ["just-file"]
       "Load and display information from the given files (allowed \
        $(i,PACKAGES) are file or directory paths), without consideration for \
        the repositories or state of the package. This implies $(b,--raw) unless \
@@ -742,11 +742,11 @@ let show cli =
        PACKAGES argument is given, read opam file from stdin."
   in
   let all_versions =
-    mk_flag ~cli (Valid_since cli2_1) ["all-versions"]
+    mk_flag ~cli (cli_from cli2_1) ["all-versions"]
       "Display information of all packages matching $(i,PACKAGES), not \
        restrained to a single package matching $(i,PACKAGES) constraints."
   in
-  let sort = mk_flag ~cli (Valid_since cli2_1) ["sort"] "Sort opam fields" in
+  let sort = mk_flag ~cli (cli_from cli2_1) ["sort"] "Sort opam fields" in
   let opam_files_in_dir d =
     match OpamPinned.files_in_source d with
     | [] -> []
@@ -879,7 +879,7 @@ let show cli =
 module Var_Option_Common = struct
 
   let global cli =
-    mk_flag ~cli (Valid_since cli2_1) ["global"] "Act on global configuration"
+    mk_flag ~cli (cli_from cli2_1) ["global"] "Act on global configuration"
 
   let var_option global global_options cmd var =
     let switch_set = (fst global_options).opt_switch <> None in
@@ -1003,7 +1003,7 @@ let var cli =
     Arg.(value & pos 0 (some string) None & info ~docv ~doc [])
   in
   let package =
-    mk_opt ~cli valid_cli_legacy ["package"] "PACKAGE"
+    mk_opt ~cli cli_original ["package"] "PACKAGE"
       "List all variables defined for the given package"
       Arg.(some package_name) None
   in
@@ -1061,24 +1061,24 @@ let option cli =
 
 module Common_config_flags = struct
   let sexp cli =
-    mk_flag ~cli valid_cli_legacy ["sexp"]
+    mk_flag ~cli cli_original ["sexp"]
       "Print environment as an s-expression rather than in shell format"
 
   let inplace_path cli =
-    mk_flag ~cli valid_cli_legacy ["inplace-path"]
+    mk_flag ~cli cli_original ["inplace-path"]
       "When updating the $(i,PATH) variable, replace any pre-existing opam \
        path in-place rather than putting the new path in front. This means \
        programs installed in opam that were shadowed will remain so after \
        $(b,opam env)"
 
   let set_opamroot cli =
-    mk_flag ~cli valid_cli_legacy ["set-root"]
+    mk_flag ~cli cli_original ["set-root"]
       "With the $(b,env) and $(b,exec) subcommands, also sets the \
        $(i,OPAMROOT) variable, making sure further calls to opam will use the \
        same root."
 
   let set_opamswitch cli =
-    mk_flag ~cli valid_cli_legacy ["set-switch"]
+    mk_flag ~cli cli_original ["set-switch"]
       "With the $(b,env) and $(b,exec) subcommands, also sets the \
        $(i,OPAMSWITCH) variable, making sure further calls to opam will use \
        the same switch as this one."
@@ -1090,55 +1090,49 @@ let config_doc = "Display configuration options for packages."
 let config cli =
   let doc = config_doc in
   let commands = [
-    valid_cli_legacy, "env", `env, [],
+    cli_original, "env", `env, [],
     "Returns the bindings for the environment variables set in the current \
      switch, e.g. PATH, in a format intended to be evaluated by a shell. With \
      $(i,-v), add comments documenting the reason or package of origin for \
      each binding. This is most usefully used as $(b,eval \\$(opam config \
      env\\)) to have further shell commands be evaluated in the proper opam \
      context. Can also be accessed through $(b,opam env).";
-    valid_cli_legacy, "revert-env", `revert_env, [],
+    cli_original, "revert-env", `revert_env, [],
     "Reverts environment changes made by opam, e.g. $(b,eval \\$(opam config \
      revert-env)) undoes what $(b,eval \\$(opam config env\\)) did, as much as \
      possible.";
-    valid_cli_legacy, "list", `list, ["[PACKAGE]..."],
+    cli_original, "list", `list, ["[PACKAGE]..."],
     "Without argument, prints a documented list of all available variables. \
      With $(i,PACKAGE), lists all the variables available for these packages. \
      Use $(i,-) to include global configuration variables for this switch.";
-    valid_cli_legacy, "expand", `expand, ["STRING"],
+    cli_original, "expand", `expand, ["STRING"],
     "Expand variable interpolations in the given string";
-    valid_cli_legacy, "subst", `subst, ["FILE..."],
+    cli_original, "subst", `subst, ["FILE..."],
     "Substitute variables in the given files. The strings $(i,%{var}%) are \
      replaced by the value of variable $(i,var) (see $(b,var)).";
-    valid_cli_legacy, "report", `report, [],
+    cli_original, "report", `report, [],
     "Prints a summary of your setup, useful for bug-reports.";
-    valid_cli_legacy, "cudf-universe",`cudf, ["[FILE]"],
+    cli_original, "cudf-universe", `cudf, ["[FILE]"],
     "Outputs the current available package universe in CUDF format.";
-    valid_cli_legacy, "pef-universe", `pef, ["[FILE]"],
+    cli_original, "pef-universe", `pef, ["[FILE]"],
     "Outputs the current package universe in PEF format.";
     (* Deprecated options *)
-    Deprecated (cli2_1, cli3_0, Some "opam exec"),
-    "exec", `exec, ["[--] COMMAND"; "[ARG]..."],
+    cli_between cli2_0 cli2_1 ~replaced:"opam exec", "exec", `exec, ["[--] COMMAND"; "[ARG]..."],
     "Execute $(i,COMMAND) with the correct environment variables. This command \
      can be used to cross-compile between switches using $(b,opam config exec \
      --switch=SWITCH -- COMMAND ARG1 ... ARGn). Opam expansion takes place in \
      command and args. If no switch is present on the command line or in the \
      $(i,OPAMSWITCH) environment variable, $(i,OPAMSWITCH) is not set in \
      $(i,COMMAND)'s environment. Can also be accessed through $(b,opam exec).";
-    Deprecated (cli2_1, cli3_0, Some "opam var"),
-    "set", `set, ["VAR";"VALUE"],
+    cli_between cli2_0 cli2_1 ~replaced:"opam var", "set", `set, ["VAR";"VALUE"],
     "Set switch variable";
-    Deprecated (cli2_1, cli3_0, Some "opam var"),
-    "unset", `unset, ["VAR"],
+    cli_between cli2_0 cli2_1 ~replaced:"opam var", "unset", `unset, ["VAR"],
     "Unset switch variable";
-    Deprecated (cli2_1, cli3_0, Some "opam var"),
-    "set-global", `set_global, ["VAR";"VALUE"],
+    cli_between cli2_0 cli2_1 ~replaced:"opam var", "set-global", `set_global, ["VAR";"VALUE"],
     "Set global variable";
-    Deprecated (cli2_1, cli3_0, Some "opam var"),
-    "unset-global", `unset_global, ["VAR"],
+    cli_between cli2_0 cli2_1 ~replaced:"opam var", "unset-global", `unset_global, ["VAR"],
     "Unset global variable";
-    Deprecated (cli2_1, cli3_0, Some "opam var"),
-    "var", `var, ["VAR"],
+    cli_between cli2_0 cli2_1 ~replaced:"opam var", "var", `var, ["VAR"],
     "Return the value associated with variable $(i,VAR), looking in switch \
      first, global if not found. Package variables can be accessed with the \
      syntax $(i,pkg:var). Can also be accessed through $(b,opam var VAR)";
@@ -1382,7 +1376,7 @@ let config cli =
 
   Term.ret (
     Term.(const config
-          $global_options cli $command $shell_opt cli $sexp cli
+          $global_options cli $command $shell_opt cli cli_original $sexp cli
           $inplace_path cli
           $set_opamroot cli $set_opamswitch cli
           $params)
@@ -1433,11 +1427,11 @@ let env cli =
     `P "This is a shortcut, and equivalent to $(b,opam config env).";
   ] in
   let revert =
-    mk_flag ~cli valid_cli_legacy ["revert"]
+    mk_flag ~cli cli_original ["revert"]
       "Output the environment with updates done by opam reverted instead."
   in
   let check =
-    mk_flag ~cli (Valid_since cli2_1) ["check"]
+    mk_flag ~cli (cli_from cli2_1) ["check"]
       "Exits with 0 if the environment is already up-to-date, 1 otherwise, \
        after printing the list of not up-to-date variables."
   in
@@ -1471,8 +1465,9 @@ let env cli =
   in
   let open Common_config_flags in
   Term.(const env
-        $global_options cli $shell_opt cli $sexp cli $inplace_path cli
-        $set_opamroot cli $set_opamswitch cli $revert $check),
+        $global_options cli $shell_opt cli cli_original $sexp cli
+        $inplace_path cli $set_opamroot cli $set_opamswitch cli
+        $revert $check),
   term_info "env" ~doc ~man
 
 (* INSTALL *)
@@ -1504,28 +1499,28 @@ let install cli =
    in
   let add_to_roots =
     mk_vflag ~cli None [
-      valid_cli_legacy, Some true, ["set-root"],
+      cli_original, (Some true), ["set-root"],
       "Mark given packages as installed roots. This is the default \
        for newly manually-installed packages.";
-      valid_cli_legacy, Some false, ["unset-root"],
+      cli_original, (Some false), ["unset-root"],
       "Mark given packages as \"installed automatically\".";
     ]
   in
   let deps_only =
-    mk_flag ~cli valid_cli_legacy  ["deps-only"]
+    mk_flag ~cli cli_original  ["deps-only"]
       "Install all its dependencies, but don't actually install the package."
   in
   let ignore_conflicts =
-    mk_flag ~cli (Valid_since cli2_1) ["ignore-conflicts"]
+    mk_flag ~cli (cli_from cli2_1) ["ignore-conflicts"]
       "Used with $(b,--deps-only), ignores conflicts of given package"
   in
   let restore =
-    mk_flag ~cli valid_cli_legacy ["restore"]
+    mk_flag ~cli cli_original ["restore"]
       "Attempt to restore packages that were marked for installation but have \
        been removed due to errors"
   in
   let destdir =
-    mk_opt ~cli valid_cli_legacy ["destdir"] "DIR"
+    mk_opt ~cli cli_original ["destdir"] "DIR"
       "Copy the files installed by the given package within the current opam \
        switch below the prefix $(i,DIR), respecting their hierarchy, after \
        installation. Caution, calling this can overwrite, but never remove \
@@ -1535,13 +1530,13 @@ let install cli =
       Arg.(some dirname) None
   in
   let check =
-    mk_flag ~cli (Valid_since cli2_1) ["check"]
+    mk_flag ~cli (cli_from cli2_1) ["check"]
       "Exit with 0 if all the dependencies of $(i,PACKAGES) are already \
        installed. If not, output the names of the missing dependencies to \
        stdout, and exits with 1."
   in
   let depext_only =
-    mk_flag ~cli (Valid_since cli2_1) ["depext-only"]
+    mk_flag ~cli (cli_from cli2_1) ["depext-only"]
       "Resolves the package installation normally, but only installs \
        the required system dependencies, without affecting the opam switch \
        state or installing opam packages."
@@ -1644,18 +1639,18 @@ let remove cli =
   ] @ OpamArg.man_build_option_section
   in
   let autoremove =
-    mk_flag ~cli valid_cli_legacy ["a";"auto-remove"]
+    mk_flag ~cli cli_original ["a";"auto-remove"]
       "Remove all the packages which have not been explicitly installed and \
        which are not necessary anymore. It is possible to prevent the removal \
        of an already-installed package by running $(b,opam install <pkg> \
        --set-root). This flag can also be set using the $(b,\\$OPAMAUTOREMOVE) \
        configuration variable." in
   let force =
-    mk_flag ~cli valid_cli_legacy ["force"]
+    mk_flag ~cli cli_original ["force"]
       "Execute the remove commands of given packages directly, even if they are \
        not considered installed by opam." in
   let destdir =
-    mk_opt ~cli valid_cli_legacy ["destdir"] "DIR"
+    mk_opt ~cli cli_original ["destdir"] "DIR"
       "Instead of uninstalling the packages, reverts the action of $(b,opam \
        install --destdir): remove files corresponding to what the listed \
        packages installed to the current switch from the given $(i,DIR). Note \
@@ -1724,13 +1719,13 @@ let reinstall cli =
   in
   let cmd =
     mk_vflag ~cli `Default [
-        valid_cli_legacy, `Pending, ["pending"],
+        cli_original, `Pending, ["pending"],
           "Perform pending reinstallations, i.e. reinstallations of \
                 packages that have changed since installed";
-        valid_cli_legacy, `List_pending, ["list-pending"],
+        cli_original, `List_pending, ["list-pending"],
           "List packages that have been changed since installed and are \
                 marked for reinstallation";
-        valid_cli_legacy, `Forget_pending, ["forget-pending"],
+        cli_original, `Forget_pending, ["forget-pending"],
           "Forget about pending reinstallations of listed packages. This \
                 implies making opam assume that your packages were installed \
                 with a newer version of their metadata, so only use this if \
@@ -1810,26 +1805,26 @@ let update cli =
         $(b,opam upgrade).";
   ] in
   let repos_only =
-    mk_flag ~cli valid_cli_legacy ["R"; "repositories"]
+    mk_flag ~cli cli_original ["R"; "repositories"]
       "Update repositories (skipping development packages unless \
        $(b,--development) is also specified)." in
   let dev_only =
-    mk_flag ~cli valid_cli_legacy ["development"]
+    mk_flag ~cli cli_original ["development"]
       "Update development packages (skipping repositories unless \
        $(b,--repositories) is also specified)." in
   let upgrade =
-    mk_flag ~cli valid_cli_legacy ["u";"upgrade"]
+    mk_flag ~cli cli_original ["u";"upgrade"]
       "Automatically run $(b,opam upgrade) after the update." in
   let name_list =
     arg_list "NAMES"
       "List of repository or development package names to update."
       Arg.string in
   let all =
-    mk_flag ~cli valid_cli_legacy ["a"; "all"]
+    mk_flag ~cli cli_original ["a"; "all"]
       "Update all configured repositories, not only what is set in the current \
        switch" in
   let check =
-    mk_flag ~cli valid_cli_legacy ["check"]
+    mk_flag ~cli cli_original ["check"]
       "Do the update, then return with code 0 if there were any upstream \
        changes, 1 if there were none. Repositories or development packages \
        that failed to update are considered without changes. With \
@@ -1862,7 +1857,7 @@ let update cli =
       OpamConsole.msg "Now run 'opam upgrade' to apply any package updates.\n";
     if not success then OpamStd.Sys.exit_because `Sync_error
   in
-  Term.(const update $global_options cli $jobs_flag cli $name_list
+  Term.(const update $global_options cli $jobs_flag cli cli_original $name_list
         $repos_only $dev_only $all $check $upgrade),
   term_info "update" ~doc ~man
 
@@ -1883,22 +1878,22 @@ let upgrade cli =
   ] @ OpamArg.man_build_option_section
   in
   let fixup =
-    mk_flag ~cli valid_cli_legacy ["fixup"]
+    mk_flag ~cli cli_original ["fixup"]
       "Recover from a broken state (eg. missing dependencies, two conflicting \
        packages installed together...)." in
   let check =
-    mk_flag ~cli valid_cli_legacy ["check"]
+    mk_flag ~cli cli_original ["check"]
       "Don't run the upgrade: just check if anything could be upgraded. \
        Returns 0 if that is the case, 1 if there is nothing that can be \
        upgraded." in
   let all =
-    mk_flag ~cli valid_cli_legacy ["a";"all"]
+    mk_flag ~cli cli_original ["a";"all"]
       "Run an upgrade of all installed packages. This is the default if \
        $(i,PACKAGES) was not specified, and can be useful with $(i,PACKAGES) \
        to upgrade while ensuring that some packages get or remain installed."
   in
   let installed =
-    mk_flag ~cli (Valid_since cli2_1) ["installed"]
+    mk_flag ~cli (cli_from cli2_1) ["installed"]
       "When a directory is provided as argument, do not install pinned package \
        that are not yet installed." in
   let upgrade global_options build_options fixup check only_installed all
@@ -1930,7 +1925,7 @@ let repository cli =
   let doc = repository_doc in
   let scope_section = "SCOPE SPECIFICATION OPTIONS" in
   let commands = [
-    valid_cli_legacy, "add", `add, ["NAME"; "[ADDRESS]"; "[QUORUM]"; "[FINGERPRINTS]"],
+    cli_original, "add", `add, ["NAME"; "[ADDRESS]"; "[QUORUM]"; "[FINGERPRINTS]"],
     "Adds under $(i,NAME) the repository at address $(i,ADDRESS) to the list \
      of configured repositories, if not already registered, and sets this \
      repository for use in the current switch (or the specified scope). \
@@ -1939,7 +1934,7 @@ let repository cli =
      address. The quorum is a positive integer that determines the validation \
      threshold for signed repositories, with fingerprints the trust anchors \
      for said validation.";
-    valid_cli_legacy, " ", `add, [],
+    cli_original, " ", `add, [],
     (* using an unbreakable space here will indent the text paragraph at the level
        of the previous labelled paragraph, which is what we want for our note. *)
     "$(b,Note:) By default, the repository is only added to the current \
@@ -1947,24 +1942,24 @@ let repository cli =
      $(b,--all) or $(b,--set-default) options (see below). If you want to \
      enable a repository only to install its switches, you may be \
      looking for $(b,opam switch create --repositories=REPOS).";
-    valid_cli_legacy, "remove", `remove, ["NAME..."],
+    cli_original, "remove", `remove, ["NAME..."],
     "Unselects the given repositories so that they will not be used to get \
      package definitions anymore. With $(b,--all), makes opam forget about \
      these repositories completely.";
-    valid_cli_legacy, "set-repos", `set_repos, ["NAME..."],
+    cli_original, "set-repos", `set_repos, ["NAME..."],
     "Explicitly selects the list of repositories to look up package \
      definitions from, in the specified priority order (overriding previous \
      selection and ranks), according to the specified scope.";
-    valid_cli_legacy, "set-url", `set_url,
+    cli_original, "set-url",  `set_url,
     ["NAME"; "ADDRESS"; "[QUORUM]"; "[FINGERPRINTS]"],
     "Updates the URL and trust anchors associated with a given repository \
      name. Note that if you don't specify $(i,[QUORUM]) and \
      $(i,[FINGERPRINTS]), any previous settings will be erased.";
-    valid_cli_legacy, "list", `list, [],
+    cli_original, "list", `list, [],
     "Lists the currently selected repositories in priority order from rank 1. \
      With $(b,--all), lists all configured repositories and the switches \
      where they are active.";
-    valid_cli_legacy, "priority", `priority, ["NAME"; "RANK"],
+    cli_original, "priority", `priority, ["NAME"; "RANK"],
     "Synonym to $(b,add NAME --rank RANK)";
   ] in
   let man = [
@@ -1995,14 +1990,14 @@ let repository cli =
     in
     let flags =
       mk_vflag_all ~cli ~section:scope_section [
-        valid_cli_legacy, `No_selection, ["dont-select"],
+        cli_original, `No_selection, ["dont-select"],
           "Don't update any selections";
-        valid_cli_legacy, `Current_switch, ["this-switch"],
+        cli_original, `Current_switch, ["this-switch"],
           "Act on the selections for the current switch (this is the default)";
-        valid_cli_legacy, `Default, ["set-default"],
+        cli_original, `Default, ["set-default"],
           "Act on the default repository selection that is used for newly \
            created switches";
-        valid_cli_legacy, `All, ["all-switches";"a"],
+        cli_original, `All, ["all-switches";"a"],
           "Act on the selections of all configured switches";
       ]
     in
@@ -2019,7 +2014,7 @@ let repository cli =
           $ flags $ switches)
   in
   let rank =
-    mk_opt ~cli valid_cli_legacy ["rank"] "RANK"
+    mk_opt ~cli cli_original ["rank"] "RANK"
       "Set the rank of the repository in the list of configured repositories. \
       Package definitions are looked in the repositories in increasing rank \
       order, therefore 1 is the highest priority.  Negative ints can be used to \
@@ -2215,8 +2210,9 @@ let repository cli =
     | command, params -> bad_subcommand ~cli commands ("repository", command, params)
   in
   Term.ret
-    Term.(const repository $global_options cli $command $repo_kind_flag cli
-          $print_short_flag cli $scope $rank $params),
+    Term.(const repository $global_options cli $command
+          $repo_kind_flag cli cli_original $print_short_flag cli cli_original
+          $scope $rank $params),
   term_info "repository" ~doc ~man
 
 
@@ -2288,7 +2284,7 @@ let switch_doc = "Manage multiple installation prefixes."
 let switch cli =
   let doc = switch_doc in
   let commands = [
-    valid_cli_legacy, "create", `install, ["SWITCH"; "[COMPILER]"],
+    cli_original, "create", `install, ["SWITCH"; "[COMPILER]"],
     "Create a new switch, and install the given compiler there. $(i,SWITCH) \
      can be a plain name, or a directory, absolute or relative, in which case \
      a local switch is created below the given directory. $(i,COMPILER), if \
@@ -2299,44 +2295,42 @@ let switch cli =
      opam-init(1)). If the chosen directory contains package definitions, a \
      compatible compiler is searched within the default selection, and the \
      packages will automatically get installed.";
-    valid_cli_legacy, "set", `set, ["SWITCH"],
+    cli_original, "set", `set, ["SWITCH"],
     "Set the currently active switch, among the installed switches.";
-    valid_cli_legacy, "remove", `remove, ["SWITCH"],
+    cli_original, "remove", `remove, ["SWITCH"],
     "Remove the given switch from disk.";
-    valid_cli_legacy, "export", `export, ["FILE"],
+    cli_original, "export", `export, ["FILE"],
     "Save the current switch state to a file. If $(b,--full) is specified, it \
      includes the metadata of all installed packages, and if $(b,--freeze) is \
      specified, it freezes all vcs to their current commit.";
-    valid_cli_legacy, "import", `import, ["FILE"],
+    cli_original, "import", `import, ["FILE"],
     "Import a saved switch state. If $(b,--switch) is specified and doesn't \
      point to an existing switch, the switch will be created for the import.";
-    valid_cli_legacy, "reinstall", `reinstall, ["[SWITCH]"],
+    cli_original, "reinstall", `reinstall, ["[SWITCH]"],
     "Reinstall the given compiler switch and all its packages.";
-    valid_cli_legacy, "list", `list, [],
+    cli_original, "list", `list, [],
     "Lists installed switches.";
-    valid_cli_legacy, "list-available", `list_available, ["[PATTERN]"],
+    cli_original, "list-available", `list_available, ["[PATTERN]"],
     "Lists all the possible packages that are advised for installation when \
      creating a new switch, i.e. packages with the $(i,compiler) flag set. If \
      no pattern is supplied, all versions are shown.";
-    valid_cli_legacy, "show", `current, [],
+    cli_original, "show", `current, [],
     "Prints the name of the current switch.";
-    (Valid_since cli2_1), "invariant", `show_invariant, [],
+    cli_from cli2_1, "invariant", `show_invariant, [],
     "Prints the active switch invariant.";
-    (Valid_since cli2_1), "set-invariant", `set_invariant, ["PACKAGES"],
+    cli_from cli2_1, "set-invariant", `set_invariant, ["PACKAGES"],
     "Updates the switch invariant, that is, the formula that the switch must \
      keep verifying throughout all operations. The previous setting is \
      overriden. See also options $(b,--force) and $(b,--no-action). Without \
      arguments, an invariant is chosen automatically.";
-    valid_cli_legacy, "set-description", `set_description, ["STRING"],
+    cli_original, "set-description", `set_description, ["STRING"],
     "Sets the description for the selected switch.";
-    valid_cli_legacy, "link", `link, ["SWITCH";"[DIR]"],
+    cli_original, "link", `link, ["SWITCH";"[DIR]"],
     "Sets a local alias for a given switch, so that the switch gets \
      automatically selected whenever in that directory or a descendant.";
-    Deprecated (cli2_1, cli3_0, Some "create"),
-    "install", `install, ["SWITCH"],
+    cli_between cli2_0 cli2_1 ~replaced:"create", "install", `install, ["SWITCH"],
     "Install a new switch";
-    Deprecated (cli2_1, cli3_0, Some "set-invariant"),
-    "set-base", `set_invariant, ["PACKAGES"],
+    cli_between cli2_0 cli2_1 ~replaced:"set-invariant", "set-base", `set_invariant, ["PACKAGES"],
     "Define a set of switch base packages.";
   ] in
   let man = [
@@ -2389,23 +2383,23 @@ let switch cli =
 
   let command, params = mk_subcommands_with_default ~cli commands in
   let no_switch =
-    mk_flag ~cli valid_cli_legacy ["no-switch"]
+    mk_flag ~cli cli_original ["no-switch"]
       "Don't automatically select newly installed switches." in
   let packages =
-    mk_opt ~cli valid_cli_legacy ["packages"] "PACKAGES"
+    mk_opt ~cli cli_original ["packages"] "PACKAGES"
       "When installing a switch, explicitly define the set of packages to \
        enforce as the switch invariant."
       Arg.(some (list atom)) None in
   let formula =
-    mk_opt ~cli (Valid_since cli2_1) ["formula"] "FORMULA"
+    mk_opt ~cli (cli_from cli2_1) ["formula"] "FORMULA"
       "Allows specifying a complete \"dependency formula\", possibly including \
        disjunction cases, as the switch invariant."
       Arg.(some OpamArg.dep_formula) None in
   let empty =
-    mk_flag ~cli valid_cli_legacy ["empty"]
+    mk_flag ~cli cli_original ["empty"]
       "Allow creating an empty switch, with no invariant." in
   let repos =
-    mk_opt ~cli valid_cli_legacy ["repositories"] "REPOS"
+    mk_opt ~cli cli_original ["repositories"] "REPOS"
       "When creating a new switch, use the given selection of repositories \
        instead of the default. $(i,REPOS) should be a comma-separated list of \
        either already registered repository names (configured through e.g. \
@@ -2417,54 +2411,53 @@ let switch cli =
       Arg.(some (list string)) None
   in
   let descr =
-    mk_opt ~cli valid_cli_legacy ["description"] "STRING"
+    mk_opt ~cli cli_original ["description"] "STRING"
       "Attach the given description to a switch when creating it. Use the \
        $(i,set-description) subcommand to modify the description of an \
        existing switch."
       Arg.(some string) None
   in
   let full =
-    mk_flag ~cli valid_cli_legacy ["full"]
+    mk_flag ~cli cli_original ["full"]
       "When exporting, include the metadata of all installed packages, \
        allowing to re-import even if they don't exist in the repositories (the \
        default is to include only the metadata of pinned packages)."
   in
   let freeze =
-    mk_flag ~cli (Valid_since cli2_1) ["freeze"]
+    mk_flag ~cli (cli_from cli2_1) ["freeze"]
       "When exporting, locks all VCS urls to their current commit, failing if \
        it can not be retrieved. This ensures that an import will restore the \
        exact state. Implies $(b,--full)."
   in
   let no_install =
-    mk_flag ~cli valid_cli_legacy ["no-install"]
+    mk_flag ~cli cli_original ["no-install"]
       "When creating a local switch, don't look for any local package \
        definitions to install."
   in
   let deps_only =
-    mk_flag ~cli valid_cli_legacy ["deps-only"]
+    mk_flag ~cli cli_original ["deps-only"]
       "When creating a local switch in a project directory (i.e. a directory \
        containing opam package definitions), install the dependencies of the \
        project but not the project itself."
   in
   let force =
-    mk_flag ~cli (Valid_since cli2_1) ["force"]
+    mk_flag ~cli (cli_from cli2_1) ["force"]
       "Only for $(i,set-invariant): force setting the invariant, bypassing \
        consistency checks."
   in
   let no_action =
-    mk_flag ~cli (Valid_since cli2_1) ["n"; "no-action"]
+    mk_flag ~cli (cli_from cli2_1) ["n"; "no-action"]
       "Only for $(i,set-invariant): set the invariant, but don't enforce it \
        right away: wait for the next $(i,install), $(i,upgrade) or similar \
        command."
   in
   (* Deprecated options *)
   let d_alias_of =
-    mk_opt ~cli (Deprecated (cli2_0, cli2_1,
-                             Some "opam switch <switch-name> <compiler>"))
+    mk_opt ~cli (cli_between cli2_0 cli2_0 ~replaced:"opam switch <switch-name> <compiler>")
       ["A";"alias-of"] "COMP" "" Arg.(some string) None
   in
   let d_no_autoinstall =
-    mk_flag ~cli (Deprecated (cli2_0, cli2_1, None)) ["no-autoinstall"] ""
+    mk_flag ~cli (cli_between cli2_0 cli2_0) ["no-autoinstall"] ""
   in
   let switch
       global_options build_options command print_short
@@ -2755,7 +2748,7 @@ let switch cli =
   in
   Term.(ret (const switch
              $global_options cli $build_options cli $command
-             $print_short_flag cli
+             $print_short_flag cli cli_original
              $no_switch
              $packages $formula $empty $descr $full $freeze $no_install
              $deps_only $repos $force $no_action $d_alias_of $d_no_autoinstall
@@ -2767,10 +2760,10 @@ let pin_doc = "Pin a given package to a specific version or source."
 let pin ?(unpin_only=false) cli =
   let doc = pin_doc in
   let commands = [
-    valid_cli_legacy, "list", `list, [], "Lists pinned packages.";
-    (Valid_since cli2_1), "scan", `scan, ["DIR"],
+    cli_original, "list", `list, [], "Lists pinned packages.";
+    cli_from cli2_1, "scan", `scan, ["DIR"],
     "Lists available packages to pin in directory.";
-    valid_cli_legacy, "add", `add, ["PACKAGE"; "TARGET"],
+    cli_original, "add", `add, ["PACKAGE"; "TARGET"],
     "Pins package $(i,PACKAGE) to $(i,TARGET), which may be a version, a path, \
      or a URL.\n\
      $(i,PACKAGE) can be omitted if $(i,TARGET) contains one or more \
@@ -2787,11 +2780,11 @@ let pin ?(unpin_only=false) cli =
      For source pinnings, the package version may be specified by using the \
      format $(i,NAME).$(i,VERSION) for $(i,PACKAGE), in the source opam file, \
      or with $(b,edit).";
-    valid_cli_legacy, "remove", `remove, ["NAMES...|TARGET"],
+    cli_original, "remove", `remove, ["NAMES...|TARGET"],
     "Unpins packages $(i,NAMES), restoring their definition from the \
      repository, if any. With a $(i,TARGET), unpins everything that is \
      currently pinned to that target.";
-    valid_cli_legacy, "edit", `edit, ["NAME"],
+    cli_original, "edit", `edit, ["NAME"],
     "Opens an editor giving you the opportunity to change the package \
      definition that opam will locally use for package $(i,NAME), including \
      its version and source URL. Using the format $(i,NAME.VERSION) will \
@@ -2834,7 +2827,7 @@ let pin ?(unpin_only=false) cli =
     else
       mk_subcommands_with_default ~cli commands in
   let edit =
-    mk_flag ~cli valid_cli_legacy ["e";"edit"]
+    mk_flag ~cli cli_original ["e";"edit"]
       "With $(i,opam pin add), edit the opam file as with `opam pin edit' \
        after pinning." in
   let kind =
@@ -2865,16 +2858,16 @@ let pin ?(unpin_only=false) cli =
       ] in
     Arg.(value & opt (some & enum kinds) None & doc) in
   let no_act =
-    mk_flag ~cli valid_cli_legacy ["n";"no-action"]
+    mk_flag ~cli cli_original ["n";"no-action"]
       "Just record the new pinning status, and don't prompt for \
        (re)installation or removal of affected packages."
   in
   let dev_repo =
-    mk_flag ~cli valid_cli_legacy ["dev-repo"]
+    mk_flag ~cli cli_original ["dev-repo"]
       "Pin to the upstream package source for the latest development version"
   in
   let normalise =
-    mk_flag ~cli (Valid_since cli2_1) ["normalise"]
+    mk_flag ~cli (cli_from cli2_1) ["normalise"]
       (Printf.sprintf
          "Print list of available package to pin in format \
           `name.version%curl`, that is comprehensible by `opam pin \
@@ -2883,7 +2876,7 @@ let pin ?(unpin_only=false) cli =
          OpamPinCommand.scan_sep)
   in
   let with_version =
-    mk_opt ~cli (Valid_since cli2_1) ["with-version"] "VERSION"
+    mk_opt ~cli (cli_from cli2_1) ["with-version"] "VERSION"
       "Set the pinning version to $(i,VERSION) for named $(i,PACKAGES) or \
        packages retrieved from $(i,TARGET). It has priority over any other \
        version specification (opam file version field, $(b,name.vers) \
@@ -3155,7 +3148,7 @@ let pin ?(unpin_only=false) cli =
   Term.ret
     Term.(const pin
           $global_options cli $build_options cli
-          $kind $edit $no_act $dev_repo $print_short_flag cli
+          $kind $edit $no_act $dev_repo $print_short_flag cli cli_original
           $recurse cli $subpath cli
           $normalise $with_version
           $command $params),
@@ -3175,14 +3168,14 @@ let source cli =
            ~doc:"A package name with an optional version constraint")
   in
   let dev_repo =
-    mk_flag ~cli valid_cli_legacy ["dev-repo"]
+    mk_flag ~cli cli_original ["dev-repo"]
       "Get the latest version-controlled source rather than the \
        release archive" in
   let pin =
-    mk_flag ~cli valid_cli_legacy ["pin"]
+    mk_flag ~cli cli_original ["pin"]
       "Pin the package to the downloaded source (see `opam pin')." in
   let dir =
-    mk_opt ~cli valid_cli_legacy ["dir"] "DIR" "The directory where to put the source."
+    mk_opt ~cli cli_original ["dir"] "DIR" "The directory where to put the source."
       Arg.(some dirname) None in
   let source global_options atom dev_repo pin dir =
     apply_global_options global_options;
@@ -3316,15 +3309,15 @@ let lint cli =
                  them. Current directory if unspecified")
   in
   let normalise =
-    mk_flag ~cli valid_cli_legacy ["normalise"]
+    mk_flag ~cli cli_original ["normalise"]
       "Output a normalised version of the opam file to stdout"
   in
   let short =
-    mk_flag ~cli valid_cli_legacy ["short";"s"]
+    mk_flag ~cli cli_original ["short";"s"]
       "Only print the warning/error numbers, space-separated, if any"
   in
   let warnings =
-    mk_opt ~cli valid_cli_legacy ["warnings";"W"] "WARNS"
+    mk_opt ~cli cli_original ["warnings";"W"] "WARNS"
       "Select the warnings to show or hide. $(i,WARNS) should be a \
        concatenation of $(b,+N), $(b,-N), $(b,+N..M), $(b,-N..M) to \
        respectively enable or disable warning or error number $(b,N) or \
@@ -3334,13 +3327,13 @@ let lint cli =
       warn_selector []
   in
   let package =
-    mk_opt ~cli valid_cli_legacy ["package"] "PKG"
+    mk_opt ~cli cli_original ["package"] "PKG"
       "Lint the current definition of the given package instead of specifying \
        an opam file directly."
       Arg.(some package) None
   in
   let check_upstream =
-    mk_flag ~cli valid_cli_legacy ["check-upstream"]
+    mk_flag ~cli cli_original ["check-upstream"]
       "Check upstream, archive availability and checksum(s)"
   in
   let lint global_options files package normalise short warnings_sel
@@ -3477,37 +3470,37 @@ let clean cli =
         --switch-cleanup)."
   ] in
   let dry_run =
-    mk_flag ~cli valid_cli_legacy ["dry-run"]
+    mk_flag ~cli cli_original ["dry-run"]
       "Print the removal commands, but don't execute them"
   in
   let download_cache =
-    mk_flag ~cli valid_cli_legacy ["c"; "download-cache"]
+    mk_flag ~cli cli_original ["c"; "download-cache"]
       (Printf.sprintf
         "Clear the cache of downloaded files (\\$OPAMROOT%sdownload-cache), as \
          well as the obsolete \\$OPAMROOT%sarchives, if that exists."
         OpamArg.dir_sep OpamArg.dir_sep)
   in
   let repos =
-    mk_flag ~cli valid_cli_legacy ["unused-repositories"]
+    mk_flag ~cli cli_original ["unused-repositories"]
       "Clear any configured repository that is not used by any switch nor the \
        default."
   in
   let repo_cache =
-    mk_flag ~cli valid_cli_legacy ["r"; "repo-cache"]
+    mk_flag ~cli cli_original ["r"; "repo-cache"]
       "Clear the repository cache. It will be rebuilt by the next opam command \
        that needs it."
   in
   let logs =
-    mk_flag ~cli valid_cli_legacy ["logs"] "Clear the logs directory."
+    mk_flag ~cli cli_original ["logs"] "Clear the logs directory."
   in
   let switch =
-    mk_flag ~cli valid_cli_legacy ["s";"switch-cleanup"]
+    mk_flag ~cli cli_original ["s";"switch-cleanup"]
       "Run the switch-specific cleanup: clears backups, build dirs, \
        uncompressed package sources of non-dev packages, local metadata of \
        previously pinned packages, etc."
   in
   let all_switches =
-    mk_flag ~cli valid_cli_legacy ["a"; "all-switches"]
+    mk_flag ~cli cli_original ["a"; "all-switches"]
       "Run the switch cleanup commands in all switches. Implies $(b,--switch-cleanup)"
   in
   let clean global_options dry_run
@@ -3678,7 +3671,7 @@ let lock cli =
   ]
   in
   let only_direct_flag =
-    mk_flag ~cli valid_cli_legacy ["d"; "direct-only"]
+    mk_flag ~cli cli_original ["d"; "direct-only"]
       "Only lock direct dependencies, rather than the whole dependency tree."
   in
   let lock_suffix = OpamArg.lock_suffix cli Manpage.s_options in

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3795,7 +3795,7 @@ let admin =
   (* cmdliner never sees the admin subcommand, so this "can't happen" *)
   let doc = "Internal opam error - main admin command invoked" in
   Term.(ret (const (`Error (true, doc)))),
-  Term.info "admin"
+  Term.info "admin" ~doc:OpamAdminCommand.admin_command_doc
 
 (* Note: for cli versionning check, all commands must be constructed with
    [OpamArg.mk_command] or [OpamArg.mk_command_ret]. *)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -121,8 +121,6 @@ let apply_global_options (options,self_upgrade) =
 
 let self_upgrade_status global_options = snd global_options
 
-type command = unit Term.t * Term.info
-
 let get_init_config ~no_sandboxing ~no_default_config_file ~add_config_file =
   let builtin_config =
     OpamInitDefaults.init_config ~sandboxing:(not no_sandboxing) ()

--- a/src/client/opamCommands.mli
+++ b/src/client/opamCommands.mli
@@ -13,9 +13,6 @@
 
 (** {2 Commands} *)
 
-(** Type of commands *)
-type command = unit Cmdliner.Term.t * Cmdliner.Term.info
-
 (** [is_builtin_command arg] is [true] if [arg] is a prefix of any built-in
     command *)
 val is_builtin_command: string -> bool
@@ -24,4 +21,4 @@ val is_builtin_command: string -> bool
     sub-command. *)
 val is_admin_subcommand: string -> bool
 
-val get_cmdliner_parser: OpamCLIVersion.t -> command * command list
+val get_cmdliner_parser: OpamCLIVersion.t -> OpamArg.command * OpamArg.command list

--- a/tests/reftests/cli-versioning.test
+++ b/tests/reftests/cli-versioning.test
@@ -52,3 +52,17 @@ The following actions would be performed:
 ===== ∗ 6 =====
 ### opam install ocaml.4.10.0 --unlock-base --show
 opam: unlock-base was removed in version 2.1 of the opam CLI, but version 2.1 has been requested. Use --update-invariant instead or set OPAMCLI environment variable to 2.0.
+### #opam option use mk_command_ret
+### opam option foo
+[ERROR] No option named 'foo' found. Use 'opam option [--global]' to list them
+### OPAMCLI=2.0 opam option foo
+opam: option was added in version 2.1 of the opam CLI, but version 2.0 has been requested, which is older.
+### opam option foo --global
+[ERROR] Field or section foo not found
+### OPAMCLI=2.0 opam option foo --global
+opam: global was added in version 2.1 of the opam CLI, but version 2.0 has been requested, which is older.
+### # opam lock use mk_command
+### opam lock foo
+[ERROR] No package matching foo
+### OPAMCLI=2.0 opam lock foo
+opam: lock was added in version 2.1 of the opam CLI, but version 2.0 has been requested, which is older.

--- a/tests/reftests/cli-versioning.test
+++ b/tests/reftests/cli-versioning.test
@@ -1,0 +1,54 @@
+009e00fa
+### opam switch install cli-versioning --empty
+opam: install was removed in version 2.1 of the opam CLI, but version 2.1 has been requested. Use create instead or set OPAMCLI environment variable to 2.0.
+### OPAMCLI=2.0 opam switch install cli-versioning --empty
+### opam list --cli 31.4
+[ERROR] opam command-line version 31.4 is not supported.
+### opam install --show --assume-depexts base-unix --cli 2.1
+The following actions would be performed:
+  ∗ install base-unix base
+### OPAMCLI=2.0 opam install --show --assume-depexts base-unix
+opam: assume-depexts was added in version 2.1 of the opam CLI, but version 2.0 has been requested, which is older.
+### opam config set cli version
+opam: set was removed in version 2.1 of the opam CLI, but version 2.1 has been requested. Use opam var instead or set OPAMCLI environment variable to 2.0.
+### OPAMCLI=2.0 opam config set cli version
+Added 'cli: "version"' to field variables in switch cli-versioning
+### opam switch set-invariant ocaml.4.05.0
+### OPAMCLI=2.0 opam install ocaml.4.10.0
+[ERROR] Package conflict!
+  * No agreement on the version of ocaml:
+    - (invariant) → ocaml = 4.05.0
+    - ocaml = 4.10.0
+    You can temporarily relax the switch invariant with `--update-invariant'
+
+No solution found, exiting
+### opam install ocaml.4.10.0
+[ERROR] Package conflict!
+  * No agreement on the version of ocaml:
+    - (invariant) → ocaml = 4.05.0
+    - ocaml = 4.10.0
+    You can temporarily relax the switch invariant with `--update-invariant'
+
+No solution found, exiting
+### OPAMCLI=2.0 opam install ocaml.4.10.0 --update-invariant --show
+opam: update-invariant was added in version 2.1 of the opam CLI, but version 2.0 has been requested, which is older.
+### opam install ocaml.4.10.0 --update-invariant --show
+The following actions would be performed:
+  ∗ install base-bigarray       base
+  ∗ install ocaml-base-compiler 4.10.0 [required by ocaml]
+  ∗ install base-threads        base
+  ∗ install base-unix           base
+  ∗ install ocaml-config        1      [required by ocaml]
+  ∗ install ocaml               4.10.0
+===== ∗ 6 =====
+### OPAMCLI=2.0 opam install ocaml.4.10.0 --unlock-base --show
+The following actions would be performed:
+  ∗ install base-bigarray       base
+  ∗ install ocaml-base-compiler 4.10.0 [required by ocaml]
+  ∗ install base-threads        base
+  ∗ install base-unix           base
+  ∗ install ocaml-config        1      [required by ocaml]
+  ∗ install ocaml               4.10.0
+===== ∗ 6 =====
+### opam install ocaml.4.10.0 --unlock-base --show
+opam: unlock-base was removed in version 2.1 of the opam CLI, but version 2.1 has been requested. Use --update-invariant instead or set OPAMCLI environment variable to 2.0.


### PR DESCRIPTION
Implementing CLI versioning, handling of the different CLIs from [spec](https://github.com/ocaml/opam/wiki/Spec-for-opam-CLI-versioning).
It is only handled for subcommands and flags, not principal commands. A note is added in the manpage depending of flag  validity and requested cli. When a not valid flag is used, a message is also printed to the user with cli indication, etc.

_See discussion below for more precisions_

Summary of new `[N]` and deprecated `[D]` options in 2.1 (diff of manpages from 2.0.7 & master).

#### opam commands
  * [x] `lock` [N]
  * [x] `option` [N]

#### opam globals options
  * ~`--cli` [N]~

#### package build options
  * [x] `--assume-depexts` [N]
  * [ ] ~`--locked` (behaviour change)~
  * [x] `--lock-suffix` [N]
  * [x] `--no-depexts` [N]
  * [x] `--unlock-base` [D]
  * [x] `--update-invariant` [N]

#### opam admin add-hashes
  * [x] `--packages` [N]

#### opam config
  * [x] `set` [D]
  * [x] `unset` [D] 
  * [x] `set-global` [D]
  * [x] `unset-global` [D]
  * [x] `var` [D]
  * [x] `exec` [D]

#### opam env
  * [x] `--check` [N]

#### opam info/show
  * [x] `--all-versions` [N]
  * [x] `--just-file` [N]
  * [x] `--sort` [N]
  * [x] `--file` [D]

#### opam install
  * [x] `--check` [N]
  * [x] `--depext-only` [N]
  * [x] `--ignore-conflicts` [N]

#### opam pin
  * [x] `scan` [N]
  * [x] `--normalise` [N]
  * [x] `--with-version` [N]

#### opam switch
  * [x] `invariant` [N]
  * [x] `set-invariant` [N]
  * [x] `set-base` [D]
  * [x] `install` [D]
  * [x] `--force` [N]
  * [x] `--formula` [N]
  * [x] `--freeze` [N]
  * [x] `--no-action` [N]

#### opam unpin
  * [x] `--normalise` [N]
  * [x] `--with-version` [N]

#### opam upgrade
  * [x] `--installed` [N]

#### opam var
  * [x] `--global` [N]