### PR TITLE
Fix hooks

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -7,7 +7,7 @@ New option/command/subcommand are prefixed with ◈.
   * Bump version to '2.1.0~beta3' [#4351 @AltGr]
 
 ## Global CLI
-  *
+  * Fix hooks broken by 371963a6b [#4386 @lefessan]
 
 ## Init
   * Fix sandbox check with not yet set opam environment variables [#4370 @rjbou - fix #4368]

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -449,7 +449,7 @@ let get_wrapper t opam wrappers ?local getter =
   let local_env =
     let hook_env = OpamEnv.hook_env t.switch_global.root in
     match local with
-    | Some e -> OpamVariable.Map.merge (fun _ _ v -> v) e hook_env
+    | Some e -> OpamVariable.Map.union (fun _ v -> v) e hook_env
     | None -> hook_env
   in
   OpamFilter.commands (OpamPackageVar.resolve ~local:local_env ~opam t)


### PR DESCRIPTION
When merging variables to be used in hooks, `OpamVariable.Map.merge`
keeps only values from OpamEnv.hook_env, because the function used for
the merge to not check for missing values. `OpamVariable.Map.union`
should be used instead.

Please update `master_changes.md` file with your changes.
