### PR TITLE
Provide opam during build

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -17,6 +17,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Install
   * The stdout of `pre-` and `post-session` hooks is now propagated to the user [#4382 @AltGr - fix #4359]
+  * A PACKAGE.opam file is provided during build in the build/ directory [@lefessan]
 
 ## Remove
   *

--- a/master_changes.md
+++ b/master_changes.md
@@ -17,7 +17,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Install
   * The stdout of `pre-` and `post-session` hooks is now propagated to the user [#4382 @AltGr - fix #4359]
-  * A PACKAGE.opam file is provided during build in the build/ directory [@lefessan]
+  * A `PACKAGE.opam` file is provided during build in the `build/` directory [#4387 @lefessan]
 
 ## Remove
   *

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -398,6 +398,9 @@ let prepare_package_source st nv dir =
                  (OpamStd.Format.itemize OpamFilename.to_string bad_hash)));
   in
   OpamFilename.mkdir dir;
+  OpamFile.OPAM.write
+    (OpamFile.make (OpamPath.Switch.build_opam ~build_dir:dir))
+    opam;
   get_extra_sources_job @@+ function Some _ as err -> Done err | None ->
     check_extra_files |> function Some _ as err -> Done err | None ->
       let opam = OpamSwitchState.opam st nv in

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -399,7 +399,7 @@ let prepare_package_source st nv dir =
   in
   OpamFilename.mkdir dir;
   OpamFile.OPAM.write
-    (OpamFile.make (OpamPath.Switch.build_opam ~build_dir:dir))
+    (OpamPath.Switch.build_opam st.switch_global.root st.switch nv)
     opam;
   get_extra_sources_job @@+ function Some _ as err -> Done err | None ->
     check_extra_files |> function Some _ as err -> Done err | None ->

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -718,8 +718,10 @@ let parallel_apply t ~requested ?add_roots ~assume_built ?(force_remove=false)
           when not (OpamPackage.has_name t.pinned nv.name) ->
           let build_dir =
             OpamPath.Switch.build t.switch_global.root t.switch nv in
-          if not OpamClientConfig.(!r.keep_build_dir) then
-            OpamFilename.rmdir build_dir
+          if not OpamClientConfig.(!r.keep_build_dir) then begin
+            OpamFilename.rmdir build_dir;
+            OpamFilename.remove ( OpamPath.Switch.build_opam ~build_dir )
+          end
         | `Remove _ | `Install _ | `Build _ | `Fetch _ -> ()
         | _ -> assert false)
       graph

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -720,7 +720,7 @@ let parallel_apply t ~requested ?add_roots ~assume_built ?(force_remove=false)
             OpamPath.Switch.build t.switch_global.root t.switch nv in
           if not OpamClientConfig.(!r.keep_build_dir) then begin
             OpamFilename.rmdir build_dir;
-            OpamFilename.remove ( OpamPath.Switch.build_opam ~build_dir )
+            OpamFilename.remove (OpamFile.filename (OpamPath.Switch.build_opam t.switch_global.root t.switch nv))
           end
         | `Remove _ | `Install _ | `Build _ | `Fetch _ -> ()
         | _ -> assert false)

--- a/src/format/opamPath.ml
+++ b/src/format/opamPath.ml
@@ -102,6 +102,9 @@ module Switch = struct
 
   let build t a nv = build_dir t a / OpamPackage.to_string nv
 
+  let build_opam ~build_dir =
+    OpamFilename.of_string ( OpamFilename.Dir.to_string build_dir ^ ".opam" )
+
   let remove_dir t a = meta t a / "remove"
 
   let remove t a nv = remove_dir t a / OpamPackage.to_string nv

--- a/src/format/opamPath.ml
+++ b/src/format/opamPath.ml
@@ -102,8 +102,7 @@ module Switch = struct
 
   let build t a nv = build_dir t a / OpamPackage.to_string nv
 
-  let build_opam ~build_dir =
-    OpamFilename.of_string ( OpamFilename.Dir.to_string build_dir ^ ".opam" )
+  let build_opam t a nv = build_dir t a /- (OpamPackage.to_string nv ^ ".opam")
 
   let remove_dir t a = meta t a / "remove"
 

--- a/src/format/opamPath.mli
+++ b/src/format/opamPath.mli
@@ -119,7 +119,7 @@ module Switch: sig
 
   (** Temporary copy of the opam description of the package during
       the build/install process *)
-  val build_opam: build_dir:dirname -> filename
+  val build_opam: t -> switch -> package -> OpamFile.OPAM.t OpamFile.t
 
   (** Temporary folders used to decompress the corresponding archives, used only
       for package removal {i $meta/remove/$packages} *)

--- a/src/format/opamPath.mli
+++ b/src/format/opamPath.mli
@@ -117,6 +117,10 @@ module Switch: sig
       {i $meta/build/$packages} *)
   val build: t -> switch -> package -> dirname
 
+  (** Temporary copy of the opam description of the package during
+      the build/install process *)
+  val build_opam: build_dir:dirname -> filename
+
   (** Temporary folders used to decompress the corresponding archives, used only
       for package removal {i $meta/remove/$packages} *)
   val remove: t -> switch -> package -> dirname
@@ -251,32 +255,32 @@ module Switch: sig
       a switch's layout in non-switch contexts *)
   module DefaultF : functor (L:LAYOUT) -> sig
     val lib: t -> L.ctx -> name -> dirname
-  
+
     val lib_dir: t -> L.ctx -> dirname
-  
+
     val stublibs: t -> L.ctx -> dirname
-  
+
     val toplevel: t -> L.ctx -> dirname
-  
+
     val doc: t -> L.ctx -> name -> dirname
-  
+
     val doc_dir: t -> L.ctx -> dirname
-  
+
     val share_dir: t -> L.ctx -> dirname
-  
+
     val share: t -> L.ctx -> name -> dirname
-  
+
     val etc_dir: t -> L.ctx -> dirname
-  
+
     val etc: t -> L.ctx -> name -> dirname
-  
+
     val man_dir: ?num:string -> t -> L.ctx -> dirname
-  
+
     val bin: t -> L.ctx -> dirname
-  
+
     val sbin: t -> L.ctx -> dirname
   end
-  
+
 
   (** Actual config handling the global-config.config indirections *)
 


### PR DESCRIPTION
With the latest version of `opam`, `opam-bin` fails because an internal call (to `opam show` to get the `opam` file corresponding to the built package) fails because of the global lock (it happens only when creating a switch).

This PR makes `opam` create an `opam` description file in the build directory called `$OPAMROOT/$SWITCH/.opam-switch/build/$PACKAGE.opam` that can be used by hooks, and `opam-bin` in particular, avoiding the recursive call to `opam`.