### PR TITLE
Allow `post-install-commands` hooks to modify/remove installed files

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -1378,7 +1378,8 @@ them modified with [`opam option --global`](man/opam-option.html).
     modified during the installation of the package.
     Note that this hook is run after the scan for installed files is
     done, so any additional installed files won't be recorded and must be taken
-    care of by a `pre-remove-commands` hook.
+    care of by a `pre-remove-commands` hook. However, modified or deleted installed
+    files during the `post-install-commands` will be handled correctly by `opam`.
 - <a id="configfield-pre-session-commands">`pre-session-commands: [ [ <term> { <filter> } ... ] { <filter> } ... ]`</a>,
   <a id="configfield-post-session-commands">`post-session-commands: [ [ <term> { <filter> } ... ] { <filter> } ... ]`</a>:
   These commands will be run once respectively before and after the sequence of

--- a/master_changes.md
+++ b/master_changes.md
@@ -17,6 +17,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Install
   * The stdout of `pre-` and `post-session` hooks is now propagated to the user [#4382 @AltGr - fix #4359]
+  * `post-install` hooks are allowed to modify or remove installed files, but not add new ones (@lefessan)
 
 ## Remove
   *

--- a/master_changes.md
+++ b/master_changes.md
@@ -17,7 +17,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Install
   * The stdout of `pre-` and `post-session` hooks is now propagated to the user [#4382 @AltGr - fix #4359]
-  * `post-install` hooks are allowed to modify or remove installed files, but not add new ones (@lefessan)
+  * `post-install` hooks are allowed to modify or remove installed files, the but not add new ones. Those changes are integrated in changes file [#4388 @lefessan]
 
 ## Remove
   *

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -900,7 +900,7 @@ let install_package t ?(test=false) ?(doc=false) ?build_dir nv =
     | None, None ->
       let changes =
         if has_hooks then
-          OpamDirTrack.update (OpamFilename.Dir.to_string switch_prefix) changes
+          OpamDirTrack.update switch_prefix changes
         else
           changes
       in

--- a/src/core/opamDirTrack.ml
+++ b/src/core/opamDirTrack.ml
@@ -268,3 +268,32 @@ let revert ?title ?(verbose=OpamConsole.verbose()) ?(force=false)
                     (OpamStd.Option.to_string (fun pr ->
                          if pr then "[hash] " else "[tms] ") pre) ^ x) lf))
           cannot))
+
+let update prefix t =
+  let removed = ref [] in
+  let update_digest file digest =
+    match
+      let filename = Filename.concat prefix file in
+      let precise = is_precise_digest digest in
+      item_digest ( item_of_filename ~precise filename )
+    with
+    | exception Unix.Unix_error ( ENOENT, _, _) ->
+      removed := file :: !removed;
+      digest
+    | exception _exn -> digest
+    | digest -> digest
+  in
+  let t =
+    SM.mapi (fun file change ->
+        match change with
+        | Added digest -> Added (update_digest file digest)
+        | Removed -> Removed
+        | Contents_changed digest ->
+          Contents_changed (update_digest file digest)
+        | Perm_changed digest -> Perm_changed (update_digest file digest)
+        | Kind_changed digest -> Kind_changed (update_digest file digest)
+      ) t
+  in
+  List.fold_left (fun t file ->
+      SM.remove file t
+    ) t !removed

--- a/src/core/opamDirTrack.ml
+++ b/src/core/opamDirTrack.ml
@@ -271,6 +271,7 @@ let revert ?title ?(verbose=OpamConsole.verbose()) ?(force=false)
 
 let update prefix t =
   let removed = ref [] in
+  let prefix = OpamFilename.Dir.to_string prefix in
   let update_digest file digest =
     match
       let filename = Filename.concat prefix file in

--- a/src/core/opamDirTrack.mli
+++ b/src/core/opamDirTrack.mli
@@ -57,4 +57,4 @@ val check:
 
 (** Reload all the digests from the directory [prefix]. Remove a file
     from the map if it has been removed from the file-system. *)
-val update : string -> t -> t
+val update : OpamFilename.Dir.t -> t -> t

--- a/src/core/opamDirTrack.mli
+++ b/src/core/opamDirTrack.mli
@@ -54,3 +54,7 @@ val revert:
 val check:
   OpamFilename.Dir.t -> t ->
   (OpamFilename.t * [`Unchanged | `Removed | `Changed]) list
+
+(** Reload all the digests from the directory [prefix]. Remove a file
+    from the map if it has been removed from the file-system. *)
+val update : string -> t -> t


### PR DESCRIPTION
This modification is necessary because `opam-bin` uses the `post-install-commands` to share files between switches using hard links. Unfortunately, without this PR, such actions modify the digests of the files just after their recording, so that `opam remove` will complain that the installed files have been modified.


Please update `master_changes.md` file with your changes.

