### PR TITLE
Depexts: Add support for NetBSD, DragonFlyBSD (+ fix OpenBSD, FreeBSD and Gentoo)

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -46,7 +46,8 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## External dependencies
-  *
+  * Add support for NetBSD and DragonFlyBSD [#4396 @kit-ty-kate]
+  * Fix OpenBSD, FreeBSD and Gentoo: Allow short names and full name paths for ports-based systems [#4396 @kit-ty-kate]
 
 ## Sandbox
   *

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -106,10 +106,14 @@ let family =
       | "amzn" | "centos" | "fedora" | "mageia" | "oraclelinux" | "ol"
       | "rhel" -> Centos
       | "archlinux" | "arch" -> Arch
-      | "bsd" when OpamSysPoll.os_distribution () = Some "freebsd" ->
-        Freebsd
-      | "bsd" when OpamSysPoll.os_distribution () = Some "openbsd" ->
-        Openbsd
+      | "bsd" ->
+        begin match OpamSysPoll.os_distribution () with
+        | Some ("freebsd" | "dragonfly") -> Freebsd
+        | Some "openbsd" -> Openbsd
+        | _ ->
+          Printf.ksprintf failwith
+            "External dependency handling not supported for OS family 'bsd'."
+        end
       | "debian" -> Debian
       | "gentoo" -> Gentoo
       | "homebrew" -> Homebrew

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -90,8 +90,8 @@ type families =
   | Gentoo
   | Homebrew
   | Macports
-  | Openbsd
   | Netbsd
+  | Openbsd
   | Suse
 
 (* System status *)

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -180,9 +180,9 @@ let packages_status packages =
   let package_set_of_pkgpath l =
     List.fold_left (fun set pkg ->
         let short_name =
-          match String.rindex_opt pkg '/' with
-          | None -> pkg
-          | Some idx -> String.sub pkg idx (String.length pkg - idx)
+          match String.rindex pkg '/' with
+          | exception Not_found -> pkg
+          | idx -> String.sub pkg idx (String.length pkg - idx)
         in
         set
         |> OpamSysPkg.Set.add (OpamSysPkg.of_string pkg)

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -318,7 +318,7 @@ let packages_status packages =
     compute_sets sys_installed ~sys_available
   | Freebsd ->
     let sys_installed =
-      run_query_command "pkg" ["query"; "%n"]
+      run_query_command "pkg" ["query"; "%n\n%o"]
       |> List.map OpamSysPkg.of_string
       |> OpamSysPkg.Set.of_list
     in


### PR DESCRIPTION
This PR:
* Adds support for DragonFlyBSD, which use virtually the same package manager as FreeBSD (`pkg`). For our purpose they behave exactly the same way and have the same required commands so I just merged the two together like it's done for centos/fedora/...
* Adds support for NetBSD, it seems like `pkgin` is the default package manager now, the old `pkg_add` is not even configured by default. It is to be noted that OpenBSD's and NetBSD's `pkg_info`/`pkg_add` are two very different software, even if they have the same name.
* Fixes OpenBSD, FreeBSD and Gentoo with regards to package paths. Packages on those systems come from their "ports collection" system and categorize their packages to prevent name conflicts.
  - On OpenBSD and Gentoo, packages can be installed using the fullpath name or the short one, and fail or ask the user if the short one is requested but another package with the same name exists
  - On FreeBSD it's the same thing, however a prefix or suffix is added to the package name in case of a conflict. For instance, both `lang/elm` and `mail/elm` exists but `lang/elm` becomes `hs-elm` when "packetized".

Many packages in opam-repository right now have either one of the form (long names or short ones) and as it stands with opam 2.1 the long ones would not be detected on gentoo on freebsd and the short ones would not be detected on openbsd.

*Side note: I only tested individual commands on those systems, not opam directly. More testing is needed if we want to ensure this works correctly.*