### PR TITLE
opam-solver: Require opam-0install-cudf >= 0.4

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -112,6 +112,7 @@ New option/command/subcommand are prefixed with ◈.
 ## Solver
   * Fix missing conflict message when trying to remove required packages [#4362 @AltGr]
   * Fix the Z3 backend for upgrades [#4393 @AltGr]
+  * Increase the minimal requirement for the 0install backend to opam-0install-cudf >= 0.4 [#4398 @kit-ty-kate]
 
 ## Client
   *

--- a/opam-solver.opam
+++ b/opam-solver.opam
@@ -38,5 +38,5 @@ depopts: [
 ]
 conflicts: [
   "z3" {< "4.8.4"}
-  "opam-0install-cudf" {< "0.3"}
+  "opam-0install-cudf" {< "0.4"}
 ]


### PR DESCRIPTION
[opam-0install-cudf.0.4](https://github.com/ocaml-opam/opam-0install-solver/releases/tag/v0.4) fixed a rather big issue with the way the solver treated conflicts and the previous version (0.3) should be avoided by end users.