### PR TITLE
Parallel pin source fetching

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -26,7 +26,9 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Pin
   * Url pin: fix opamfile format upgrade [#4366 @rjbou - fix #4365]
-  * don't save the pin with `--show` [#4367 @rjbou - fix #4348]
+  * Don't save the pin with `--show` [#4367 @rjbou - fix #4348]
+  * When several pins are needed, do their fetching in parallel [#4399 @rjbou - fix #4315]
+  * Don't cleanup vcs pin source directory [#4399 @rjbou]
 
 ## List
   *

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1520,6 +1520,15 @@ module PIN = struct
       then
         OpamStd.Sys.exit_because `Aborted
     | _ -> ());
+    let pins =
+      let urls_ok =
+        OpamPinCommand.fetch_all_pins st (List.map (fun (name, _, _, url, subpath) ->
+            OpamPackage.Name.to_string name, url, subpath) pins)
+      in
+      List.filter (fun (_,_,_, url, subpath) ->
+          List.mem (url, subpath) urls_ok)
+        pins
+    in
     let pinned = st.pinned in
     let st =
       List.fold_left (fun st (name, version, opam, url, subpath as pin) ->

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -366,6 +366,43 @@ let default_version st name =
   try OpamPackage.version (OpamSwitchState.get_package st name)
   with Not_found -> OpamPackage.Version.of_string "~dev"
 
+let fetch_all_pins st pins =
+  let root = st.switch_global.root in
+  let fetched =
+    let cache_dir =
+      OpamRepositoryPath.download_cache OpamStateConfig.(!r.root_dir)
+    in
+    let command (name, url, subpath) =
+      let srcdir =
+        OpamPath.Switch.pinned_package root st.switch
+          (OpamPackage.Name.of_string name)
+      in
+      OpamProcess.Job.Op.(
+        OpamRepository.pull_tree ~cache_dir ?subpath name srcdir [] [url]
+        @@| fun r -> (name, url, subpath, r))
+    in
+    OpamParallel.map ~jobs:OpamStateConfig.(!r.dl_jobs) ~command pins
+  in
+  let errored, to_pin =
+    List.fold_left (fun (err,ok) result ->
+        let name, url, subpath, result = result in
+        match result with
+        | Not_available _ -> (* clean dir ? *)
+          (name, url, subpath)::err, ok
+        | _ -> err, (url, subpath)::ok)
+      ([],[]) fetched
+  in
+  if errored = []
+  || OpamConsole.confirm "Could not retrieve%s\nContinue?"
+       (OpamStd.Format.itemize (fun (name, url, subpath) ->
+            name ^ ": " ^ OpamUrl.to_string url ^
+            (OpamStd.Option.to_string (fun s -> "("^s^")") subpath))
+           errored)
+  then
+    to_pin
+  else
+    OpamStd.Sys.exit_because `Aborted
+
 let rec handle_pin_depends st nv opam =
   let extra_pins = OpamFile.OPAM.pin_depends opam in
   let extra_pins =
@@ -384,12 +421,18 @@ let rec handle_pin_depends st nv opam =
               (OpamConsole.colorise `underline (OpamUrl.to_string url)))
           extra_pins);
      if OpamConsole.confirm "Pin and install them?" then
-       List.fold_left (fun st (nv, url) ->
-           source_pin st nv.name ~version:nv.version (Some url)
-             ~ignore_extra_pins:true)
-         st extra_pins
-     else
-     if OpamConsole.confirm
+       (let extra_pins =
+          let urls_ok =
+            fetch_all_pins st (List.map (fun (nv, u) ->
+                OpamPackage.name_to_string nv, u, None) extra_pins)
+          in
+          List.filter (fun (_, url) -> List.mem (url, None) urls_ok) extra_pins
+        in
+        List.fold_left (fun st (nv, url) ->
+            source_pin st nv.name ~version:nv.version (Some url)
+              ~ignore_extra_pins:true)
+          st extra_pins)
+     else if OpamConsole.confirm
          "Try to install anyway, assuming `--ignore-pin-depends'?"
      then st else
        OpamStd.Sys.exit_because `Aborted)

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -393,7 +393,9 @@ let fetch_all_pins st pins =
       ([],[]) fetched
   in
   if errored = []
-  || OpamConsole.confirm "Could not retrieve%s\nContinue?"
+  || OpamConsole.confirm
+       "Could not retrieve some package source, they will not be pinned nor
+        installed:%s\nContinue anyway?"
        (OpamStd.Format.itemize (fun (name, url, subpath) ->
             name ^ ": " ^ OpamUrl.to_string url ^
             (OpamStd.Option.to_string (fun s -> "("^s^")") subpath))

--- a/src/client/opamPinCommand.mli
+++ b/src/client/opamPinCommand.mli
@@ -43,6 +43,14 @@ val source_pin:
 val handle_pin_depends:
   rw switch_state -> package -> OpamFile.OPAM.t -> rw switch_state
 
+(** Fetch in parallel jobs a list of pins [name, url, subpath], and return the
+    successful ones.
+    Ask for confirmation to continue if a fetching fails.
+*)
+val fetch_all_pins:
+  'a switch_state -> (string * url * string option) list ->
+  (url * string option) list
+
 (** Let the user edit a pinned package's opam file. If given, the version is put
     into the template in advance. Writes and returns the updated switch
     state. *)

--- a/src/solver/opamActionGraph.ml
+++ b/src/solver/opamActionGraph.ml
@@ -157,6 +157,7 @@ module MakeAction (P: GenericPackage) : ACTION with type package = P.t
       Some (`Change(d, o, p))
     | `O ["recompile", p] -> P.of_json p >>= (fun p -> Some (`Reinstall p))
     | `O ["build", p] -> P.of_json p >>= (fun p -> Some (`Build p))
+    | `O ["fetch", p] -> P.of_json p >>= (fun p -> Some (`Fetch p))
     | _ -> None
 
   module O = struct

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -507,7 +507,16 @@ let cleanup_source st old_opam_opt new_opam =
     { u with OpamUrl.hash = None }
   in
   let url_remote opam = OpamFile.OPAM.url opam >>| base_url in
-  if url_remote new_opam <> (old_opam_opt >>= url_remote) then
+  let new_opam_o = url_remote new_opam in
+  let old_opam_o = old_opam_opt >>= url_remote in
+  let backend u = u.OpamUrl.backend in
+  let clean =
+    match new_opam_o >>| backend, old_opam_o >>| backend with
+    | Some #OpamUrl.version_control, (Some #OpamUrl.version_control | None) ->
+      false
+    | _ -> new_opam_o <> old_opam_o
+  in
+  if clean then
     OpamFilename.rmdir
       (OpamSwitchState.source_dir st (OpamFile.OPAM.package new_opam))
 


### PR DESCRIPTION
Fix #4315
Using the same example, it took 4m32 (with download-only option), and now with parallel and reuse of source dir, it takes only 1m32.
It also applies to `pin scan` arguments, and url pin.
cc/ @NathanReb