### PR TITLE
Fix handling of filename-encoded pkgname in opam files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,12 @@ uninstalllib-%: opam-installer opam-%.install
 libinstall: $(DUNE_DEP) opam-admin.top $(OPAMLIBS:%=installlib-%)
 	@
 
+custom-libinstall: $(DUNE_DEP) opam-lib opam
+	for p in $(OPAMLIBS); do \
+	  ./opam$(EXE) custom-install --no-recompilations opam-$$p.$(version) -- \
+	    $(DUNE) install opam-$$p; \
+	done
+
 processed-%.install: %.install
 	sed -f process.sed $^ > $@
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -45,6 +45,9 @@ New option/command/subcommand are prefixed with ◈.
 ## Lock
   *
 
+## Opamfile
+  * Fix handling of filename-encoded pkgname in opam files [#4401 @AltGr - fix ocaml-opam/opam-publish#107]
+
 ## External dependencies
   *
 
@@ -62,6 +65,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Build
   * Update opam file to 2.0 [#4371 @AltGr]
+  * Makefile: Add rule `custom-libinstall` for `opam-custom-install` use [#4401 @AltGr]
 
 ## Infrastructure
   *

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -602,7 +602,7 @@ let lint_command cli =
     let ret =
       OpamPackage.Map.fold (fun nv prefix ret ->
           let opam_file = OpamRepositoryPath.opam repo_root prefix nv in
-          let w, _ = OpamFileTools.lint_file opam_file in
+          let w, _ = OpamFileTools.lint_file ~handle_dirname:true opam_file in
           if List.exists (fun (n,_,_) -> List.mem n ign) w then ret else
           let w =
             List.filter (fun (n,_,_) ->

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -151,3 +151,25 @@ module PIN: sig
   val post_pin_action: rw switch_state -> package_set -> name list -> rw switch_state
 
 end
+
+
+(** {2 Auxiliary functions}
+    These functions are exposed for advanced uses by external libraries
+*)
+
+(** Orphan packages are installed but no longer available packages; we add
+    special treatment so that opam doesn't force their removal for consistency
+    reasons on any action. Returns the "fixed" state, fully orphan packages (no
+    available version of the package remaining), and orphan package versions.
+
+    Find more technical explanations in the source. *)
+val orphans:
+  ?changes:package_set -> ?transitive:bool ->
+  'a switch_state ->
+  'a switch_state * package_set * package_set
+
+(** An extended version of [orphans] that checks for conflicts between a given
+    request and the orphan packages *)
+val check_conflicts:
+  'a switch_state -> atom list ->
+  'a switch_state * package_set * package_set

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3391,9 +3391,10 @@ let lint cli =
           try
             let warnings,opam =
               match opam_f with
-              | Some f -> OpamFileTools.lint_file ~check_upstream f
+              | Some f ->
+                OpamFileTools.lint_file ~check_upstream ~handle_dirname:true f
               | None ->
-                OpamFileTools.lint_channel ~check_upstream
+                OpamFileTools.lint_channel ~check_upstream ~handle_dirname:false
                   (OpamFile.make (OpamFilename.of_string "-")) stdin
             in
             let enabled =

--- a/src/state/opamFileTools.mli
+++ b/src/state/opamFileTools.mli
@@ -19,20 +19,22 @@ val template: package -> OpamFile.OPAM.t
 (** Runs several sanity checks on the opam file; returns a list of warnings.
    [`Error] level should be considered unfit for publication, while [`Warning]
    are advisory but may be accepted. The int is an identifier for this specific
-   warning/error. If [check_extra_files] is unspecified, warning 53 won't be
-   checked. *)
+   warning/error. If [check_extra_files] is unspecified or false, warning 53
+   won't be checked. *)
 val lint:
   ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
-  ?check_upstream: bool ->
+  ?check_upstream:bool ->
   OpamFile.OPAM.t -> (int * [`Warning|`Error] * string) list
 
 (** Same as [lint], but operates on a file, which allows catching parse errors
-   too. You can specify an expected name and version. [check_extra_files]
-   defaults to a function that will look for a [files/] directory besides
-   [filename] *)
+   too. [check_extra_files] defaults to a function that will look for a [files/]
+   directory besides [filename]. [handle_dirname] is used for warning 4, and
+   should be set when reading packages from a repository, so that package name
+   and version are inferred from the filename. *)
 val lint_file:
   ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
-  ?check_upstream: bool ->
+  ?check_upstream:bool ->
+  ?handle_dirname:bool ->
   OpamFile.OPAM.t OpamFile.typed_file ->
   (int * [`Warning|`Error] * string) list * OpamFile.OPAM.t option
 
@@ -42,6 +44,7 @@ val lint_file:
 val lint_channel:
   ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
   ?check_upstream: bool ->
+  ?handle_dirname:bool ->
   OpamFile.OPAM.t OpamFile.typed_file -> in_channel ->
   (int * [`Warning|`Error] * string) list * OpamFile.OPAM.t option
 
@@ -51,6 +54,7 @@ val lint_channel:
 val lint_string:
   ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
   ?check_upstream: bool ->
+  ?handle_dirname:bool ->
   OpamFile.OPAM.t OpamFile.typed_file -> string ->
   (int * [`Warning|`Error] * string) list * OpamFile.OPAM.t option
 


### PR DESCRIPTION
It was hardcoded at too low level, and not properly disabled when not
reading files from repositories.

This also exports a few more helpful functions for plugins.