### PR TITLE
Rollback to fetch failure

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -116,6 +116,7 @@ New option/command/subcommand are prefixed with ◈.
   * Fix CLI debug log printed without taking into account debug sections [#4391 @rjbou]
   * Internal caches: use size checks from Marshal [#4430 @AltGr]
   * openssl invocation: Fix permission denied fallback [#4449 @Blaisorblade - fix #4448]
+  * If all action error are fetching failure, return code 31 (`Sync_error`) instead of code 40 (`Package_operation_error`) [#4416 @rjbou - fix #4214]
   * Add debug & verbose log for patch & subst application [#4464 @rjbou - fix #4453]
   * Be more robust w.r.t. new caches updates when `--read-only` is not used [#4467 @AltGr - fix #4354]
 


### PR DESCRIPTION
* If all action error are fetching failure, return code 31 (`Sync_error`) instead of code 40 (`Package_operation_error`).
* if there is mixed failures, exit with code 40
* if there is some sucess, and some fetching failures, exit with code 31

Fix #4214
