### PR TITLE
~Reorder options,~ fix brew instructions, spelling

### DIFF
--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -4,7 +4,6 @@ This page describes how to install and configure opam. For further help on how
 to use opam, either read [`opam --help`](man/opam.html) or move on to the
 [Usage](Usage.html) guide.
 
-
 ## Upgrading from a previous version
 
 Generally, you should just reproduce the same installation steps as for the
@@ -53,7 +52,7 @@ sudo install <downloaded file> /usr/local/bin/opam
 
 > Note that this script is intended for end-users, not CI. For that purpose,
 > you can use pre-built [Docker images for various
-> configurations](https://hub.docker.com/r/ocaml/opam2/).
+> configurations](https://hub.docker.com/r/ocaml/opam).
 
 ## Using your distribution's package system
 
@@ -159,11 +158,9 @@ make install
 [![badge](https://repology.org/badge/version-for-repo/homebrew/opam.svg)](https://repology.org/project/opam/versions) [![badge](https://repology.org/badge/version-for-repo/macports/opam.svg)](https://repology.org/project/opam/versions)
 
 Opam packages for [homebrew](http://mxcl.github.com/homebrew/) and [MacPorts](http://www.macports.org/) are available.
-homebrew need a prior installation of `gpatch`, as opam uses gnu-specific options.
 
 ```
 # Homebrew
-brew install gpatch
 brew install opam
 
 # MacPort

--- a/master_changes.md
+++ b/master_changes.md
@@ -228,6 +228,7 @@ users)
   * Add `avoid-version` doc [#4896 @AltGR - fix #4864]
   * Document custom licenses [#4863 @kit-ty-kate - fix #4862]
   * Add OpenBSD & FreeBSD in the precompiled binaries list [#5001 @mndrix]
+  * install.md: fix brew instructions, spelling [#4421 @johnwhitington]
 
 ## Security fixes
   *


### PR DESCRIPTION
This PR reflects three lessons learned when writing the new ocaml.org "Up and Running" guide https://github.com/ocaml/ocaml.org/pull/1165 :

1) Having the binary distribution at the top of this page, when it is not the recommended installation mechanism for most users, is confusing.
2) Brew will shortly be updated https://github.com/Homebrew/homebrew-core/pull/64301 to make opam depend on gpatch, thus removing this instruction from the OS X instructions.
3) OSX is now spelled macOS

EDIT @rjbou: split the PR, reordering question that was blocking the PR is meant to go to another PR