### PR TITLE
Print shell-appropriate eval command on `opam init`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -14,6 +14,7 @@ New option/command/subcommand are prefixed with ◈.
 ## Init
   * Fix sandbox check with not yet set opam environment variables [#4370 @rjbou - fix #4368]
   * Sandboxing check: use configured temp dir and cleanup afterwards [#4467 @AltGr]
+  * Print shell-appropriate eval command on `opam init` [#4427 @freevoid]
 
 ## Config Upgrade
   *

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -335,6 +335,24 @@ let is_up_to_date ?skip st =
   is_up_to_date_raw ?skip
     (updates ~set_opamroot:false ~set_opamswitch:false ~force_path:false st)
 
+(** Returns shell-appropriate statement to evaluate [cmd]. *)
+let shell_eval_invocation shell cmd =
+  match shell with
+  | SH_fish ->
+    Printf.sprintf "eval (%s)" cmd
+  | SH_csh ->
+    Printf.sprintf "eval `%s`" cmd
+  | _ ->
+    Printf.sprintf "eval $(%s)" cmd
+
+(** Returns "opam env" invocation string together with optional root and switch
+    overrides *)
+let opam_env_invocation ?root ?switch ?(set_opamswitch=false) () =
+  let root = OpamStd.Option.map_default (Printf.sprintf " --root=%s") "" root in
+  let switch = OpamStd.Option.map_default (Printf.sprintf " --switch=%s") "" switch in
+  let setswitch = if set_opamswitch then " --set-switch" else "" in
+  Printf.sprintf "opam env%s%s%s" root switch setswitch
+
 let eval_string gt ?(set_opamswitch=false) switch =
   let root =
     let opamroot_cur = OpamFilename.Dir.to_string gt.root in
@@ -344,34 +362,29 @@ let eval_string gt ?(set_opamswitch=false) switch =
         OpamFilename.Dir.to_string OpamStateConfig.(default.root_dir)
       ) in
     if opamroot_cur <> opamroot_env then
-      Printf.sprintf " --root=%s" opamroot_cur
+      Some opamroot_cur
     else
-      "" in
+      None
+  in
   let switch =
-    match switch with
-    | None -> ""
-    | Some sw ->
+    (* Returns the switch only if it is different from the one determined by the
+      environment *)
+    let f sw =
       let sw_cur = OpamSwitch.to_string sw in
       let sw_env =
         OpamStd.Option.Op.(
           OpamStd.Env.getopt "OPAMSWITCH" ++
           (OpamStateConfig.get_current_switch_from_cwd gt.root >>|
-           OpamSwitch.to_string) ++
+            OpamSwitch.to_string) ++
           (OpamFile.Config.switch gt.config >>| OpamSwitch.to_string)
         )
       in
-      if Some sw_cur <> sw_env then Printf.sprintf " --switch=%s" sw_cur
-      else ""
+      if Some sw_cur <> sw_env then Some sw_cur else None
+    in
+    OpamStd.Option.replace f switch
   in
-  let setswitch = if set_opamswitch then " --set-switch" else "" in
-  match OpamStd.Sys.guess_shell_compat () with
-  | SH_fish ->
-    Printf.sprintf "eval (opam env%s%s%s)" root switch setswitch
-  | SH_csh ->
-    Printf.sprintf "eval `opam env%s%s%s`" root switch setswitch
-  | _ ->
-    Printf.sprintf "eval $(opam env%s%s%s)" root switch setswitch
-
+  let shell = OpamStd.Sys.guess_shell_compat () in
+  shell_eval_invocation shell (opam_env_invocation ?root ?switch ~set_opamswitch ())
 
 
 (* -- Shell and init scripts handling -- *)
@@ -700,7 +713,7 @@ let setup
         (OpamConsole.colorise `bold @@ string_of_shell shell)
         (OpamConsole.colorise `cyan @@ OpamFilename.prettify dot_profile)
         (OpamConsole.colorise `bold @@ source root shell (init_file shell))
-        (OpamConsole.colorise `bold @@ "eval $(opam env)");
+        (OpamConsole.colorise `bold @@ shell_eval_invocation shell (opam_env_invocation ()));
       if OpamCoreConfig.(!r.answer = Some true) then begin
         OpamConsole.warning "Shell not updated in non-interactive mode: use --shell-setup";
         None

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -70,6 +70,15 @@ val is_up_to_date_switch: dirname -> switch -> bool
     its set of installed packages *)
 val compute_updates: ?force_path:bool -> 'a switch_state -> env_update list
 
+(** Returns shell-appropriate statement to evaluate [cmd]. *)
+val shell_eval_invocation:
+  OpamTypes.shell -> string -> string
+
+(** Returns "opam env" invocation string together with optional root and switch
+    overrides *)
+val opam_env_invocation:
+  ?root:string -> ?switch:string -> ?set_opamswitch:bool -> unit -> string
+
 (** The shell command to run by the user to set his OPAM environment, adapted to
     the current shell (as returned by [eval `opam config env`]) *)
 val eval_string:


### PR DESCRIPTION
This change is similar in spirit to https://github.com/ocaml/opam/pull/3274/commits/46eab70fd9318057c785a2bcfb31e8184f9fa492 (an open pull request marked as obsolete) with a slightly different implementation.

I'm new to OCaml and been following the instructions to install `opam`, during `opam init` it prints a shell-dependent line that will be added, but incorrectly prints `eval $(opam env)` (I use `fish` so that should be `eval (opam env)`):

```
In normal operation, opam only alters files within ~/.opam.

  However, to best integrate with your system, some environment variables
  should be set. If you allow it to, this initialisation step will update
  your fish configuration by adding the following line to ~/.config/fish/config.fish:

    source /Users/name/.opam/opam-init/init.fish > /dev/null 2> /dev/null; or true

  Otherwise, every time you want to access your opam installation, you will
  need to run:

    eval $(opam env)

  You can always re-run this setup with 'opam init' later.
```

Let me know if the change is not idiomatic, since I just installed `opam` and `ocaml` and have no previous experience with either.