### PR TITLE
Var option: fix, test, update

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -425,7 +425,8 @@ overridden from configuration. You can get the list of currently defined
 variables by running:
 
 ```
-opam config list
+opam config list # opam 2.0
+opam var         # opam 2.1.0
 ```
 
 #### Global variables

--- a/doc/pages/Packaging.md
+++ b/doc/pages/Packaging.md
@@ -148,9 +148,9 @@ remove the others rather than leave them empty.
   containing arguments either as a string (`"./configure"`) or a variable name
   (`make`, defined by default to point at the chosen "make" command -- think
   `$(MAKE)` in Makefiles). `%{prefix}%` is another syntax to replace variables
-  within strings. `opam config list` will give you a list of available
-  variables. `build` instructions shouldn't need to write outside of the
-  package's source directory.
+  within strings. `opam config list` (or `opam var` with opam 2.1.0) will give
+  you a list of available variables. `build` instructions shouldn't need to
+  write outside of the package's source directory.
 * `install` is similar to `build`, but tells opam how to install. The example
   above should indeed be `install: [ [make "install"] ]`, but the extra square
   brackets are optional when there is a single element. This field can be
@@ -210,7 +210,8 @@ This is just a very short introduction, don't be afraid to consult
   package formula like `depends`. simple list of package names. If you require
   specific versions, add a `conflicts` field with the ones that won't work.
 * [**Variables**](Manual.html#Variables): you can get a list of predefined
-  variables that you can use in your opam rules with `opam config list`.
+  variables that you can use in your opam rules with `opam config list` (or
+  `opam var` with opam 2.1.0).
 * [**Filters**](Manual.html#Filters): dependencies, commands and single command
   arguments may need to be omitted depending on the environment. This uses the
   same optional argument syntax as above, postfix curly braces, with boolean

--- a/master_changes.md
+++ b/master_changes.md
@@ -46,8 +46,11 @@ New option/command/subcommand are prefixed with ◈.
   * Add `opamfile-loc` as a package variable, containing the location of installed package opam file [#4402 @rjbou]
   * Fix `arch` detection when using 32bit mode on ARM64 [#4462 @kit-ty-kate]
   * Fix `arch` detection of i486 [#4462 @kit-ty-kate]
+  * Don't load switch for some variable looking [#4428 @rjbou]
+  * Fix package variables display when no config file is found [#4428 @rjbou]
 
 ## Option
+  * Fix `depext-bypass` removal (`-=`) [#4428 @rjbou]
 
 ## Lint
   * W66: check strings in filtered package formula are booleans or variables [#443 @rjbou - fix #4439]
@@ -64,9 +67,6 @@ New option/command/subcommand are prefixed with ◈.
   * Handle the case where `os-family=ubuntu` as `os-family=debian` [#4441 @alan-j-hu]
   
 ## Sandbox
-  *
-
-## Test
   *
 
 ## Repository management
@@ -114,7 +114,12 @@ New option/command/subcommand are prefixed with ◈.
 ## Test
   * Ensure that a cold `dune runtest` works [#4375 @emillon]
   * Use dune "expected" convention for patcher test [#4395 @emillon]
+  * Add var/option test [#4428 @rjbou]
+
+## Shell
+  * Update completion scripts with `opam var` instead of `opam config list` [#4428 @rjbou]
 
 ## Doc
+  * Change `opam config list` into `opam var [--package]` [#4428 @rjbou]
   * Update ùaintainer name [#4456 @nbraud]
   * Specify url syntaxe in usage/opam pin [#4460 @rjbou - fix #4459]

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -736,7 +736,7 @@ let set_var_global gt var value =
           OpamPrinter.Normalise.value (nullify_pos @@ List (nullify_pos @@ [
               nullify_pos @@ Ident (OpamVariable.to_string var);
               nullify_pos @@ String v;
-              nullify_pos @@ String "Set through 'opam config set-var global'"
+              nullify_pos @@ String "Set through 'opam var'"
             ])));
       stv_set_opt = (fun config value ->
           let gt =

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -527,7 +527,7 @@ let switch_allowed_fields, switch_allowed_sections =
               (fun nc c ->
                  { c with depext_bypass = nc.depext_bypass ++ c.depext_bypass }),
               (fun nc c ->
-                 { c with depext_bypass = nc.depext_bypass -- c.depext_bypass })
+                 { c with depext_bypass = c.depext_bypass -- nc.depext_bypass })
             )),
           (fun t -> { t with depext_bypass = empty.depext_bypass });
         ] @ allwd_wrappers empty.wrappers wrappers

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -979,7 +979,7 @@ let is_switch_defined_var switch_config v =
       with Failure _ -> false)
   || OpamStd.String.contains_char v ':'
 
-let var_switch_raw ?(only_switch=true) gt v =
+let var_switch_raw gt v =
   match OpamStateConfig.get_switch_opt () with
   | Some switch ->
     let switch_config =
@@ -987,7 +987,7 @@ let var_switch_raw ?(only_switch=true) gt v =
         (OpamPath.Switch.switch_config gt.root switch)
     in
     let rsc =
-      if only_switch && is_switch_defined_var switch_config v then
+      if is_switch_defined_var switch_config v then
         OpamPackageVar.resolve_switch_raw gt switch switch_config
           (OpamVariable.Full.of_string v)
       else None
@@ -1016,7 +1016,7 @@ let var_show_switch gt ?st v =
 let var_show_global gt f = var_show_t (OpamPackageVar.resolve_global gt) f
 
 let var_show gt v =
-  if var_switch_raw ~only_switch:false gt v = None then
+  if var_switch_raw gt v = None then
     OpamSwitchState.with_ `Lock_none gt @@ fun st ->
     let switch =
       if is_switch_defined_var st.switch_config v then Some st.switch else None

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -921,7 +921,7 @@ let vars_list ?st gt =
   vars_list_global gt;
   OpamConsole.header_msg "Configuration variables from the current switch";
   vars_list_switch ?st gt;
-  OpamConsole.header_msg "Package variables ('opam config list PKG' to show)";
+  OpamConsole.header_msg "Package variables ('opam var --package PKG' to show)";
   List.map (fun (var, doc) -> [
         ("PKG:"^var) % `bold;
         "";

--- a/src/state/shellscripts/complete.sh
+++ b/src/state/shellscripts/complete.sh
@@ -33,7 +33,7 @@ _opam_commands()
 
 _opam_vars()
 {
-  opam config list --safe 2>/dev/null | \
+  opam var --safe 2>/dev/null | \
       sed -n \
       -e '/^PKG:/d' \
       -e 's%^\([^#= ][^ ]*\).*%\1%p'

--- a/src/state/shellscripts/complete.zsh
+++ b/src/state/shellscripts/complete.zsh
@@ -35,7 +35,7 @@ _opam_commands()
 
 _opam_vars()
 {
-  opam config list --safe 2>/dev/null | \
+  opam var -safe 2>/dev/null | \
       sed -n \
       -e '/^PKG:/d' \
       -e 's%^\([^#= ][^ ]*\).*%\1%p'

--- a/tests/reftests/var-option.test
+++ b/tests/reftests/var-option.test
@@ -1,0 +1,473 @@
+009e00fa
+### opam switch create var-option --empty
+### opam var user=reftest --switch var-option
+Added 'user: "reftest"' to field variables in switch var-option
+### opam var group=reftest --switch var-option
+Added 'group: "reftest"' to field variables in switch var-option
+### opam var arch=x86_64 --global
+Added '[arch "x86_64" "Set through 'opam var'"]' to field global-variables in global configuration
+### opam var jobs=7 --global
+Added '[jobs "7" "Set through 'opam var'"]' to field global-variables in global configuration
+### opam var make=make --global
+Added '[make "make" "Set through 'opam var'"]' to field global-variables in global configuration
+### opam var opam-version=68.79 --global
+Added '[opam-version "68.79" "Set through 'opam var'"]' to field global-variables in global configuration
+### opam var os=linux --global
+Added '[os "linux" "Set through 'opam var'"]' to field global-variables in global configuration
+### opam var os-distribution=lorem --global
+Added '[os-distribution "lorem" "Set through 'opam var'"]' to field global-variables in global configuration
+### opam var os-family=ipsum --global
+Added '[os-family "ipsum" "Set through 'opam var'"]' to field global-variables in global configuration
+### opam var os-version=dolor --global
+Added '[os-version "dolor" "Set through 'opam var'"]' to field global-variables in global configuration
+### opam var sys-ocaml-arch=x86_64 --global
+Added '[sys-ocaml-arch "x86_64" "Set through 'opam var'"]' to field global-variables in global configuration
+### opam var sys-ocaml-cc=cc --global
+Added '[sys-ocaml-cc "cc" "Set through 'opam var'"]' to field global-variables in global configuration
+### opam var sys-ocaml-libc=libc --global
+Added '[sys-ocaml-libc "libc" "Set through 'opam var'"]' to field global-variables in global configuration
+### opam option wrap-build-commands=[] --global
+Set to '[]' the field wrap-build-commands in global configuration
+### opam option wrap-install-commands=[] --global
+Set to '[]' the field wrap-install-commands in global configuration
+### opam option wrap-remove-commands=[] --global
+Set to '[]' the field wrap-remove-commands in global configuration
+### opam install ocaml-base-compiler.4.09.0 --fake --yes
+The following actions will be faked:
+  ∗ install base-bigarray       base
+  ∗ install ocaml-base-compiler 4.09.0
+  ∗ install base-threads        base
+  ∗ install base-unix           base
+  ∗ install ocaml-config        1
+  ∗ install ocaml               4.09.0
+===== ∗ 6 =====
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-base-compiler.4.09.0
+Faking installation of ocaml-config.1
+Faking installation of ocaml.4.09.0
+Done.
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+
+<><> Global opam variables ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+arch              x86_64                         # Set through 'opam var'
+exe                                              # Suffix needed for executable filenames (Windows)
+jobs              7                              # Set through 'opam var'
+make              make                           # Set through 'opam var'
+opam-version      68.79                          # Set through 'opam var'
+os                linux                          # Set through 'opam var'
+os-distribution   lorem                          # Set through 'opam var'
+os-family         ipsum                          # Set through 'opam var'
+os-version        dolor                          # Set through 'opam var'
+root              ${BASEDIR}/.opam # The current opam root directory
+switch                                           # The identifier of the current switch
+sys-ocaml-arch    x86_64                         # Set through 'opam var'
+sys-ocaml-cc      cc                             # Set through 'opam var'
+sys-ocaml-libc    libc                           # Set through 'opam var'
+sys-ocaml-version 4.08.0                         # Set through 'opam var'
+
+<><> Configuration variables from the current switch ><><><><><><><><><><><><><>
+prefix   ${BASEDIR}/.opam/var-option
+lib      ${BASEDIR}/.opam/var-option/lib
+bin      ${BASEDIR}/.opam/var-option/bin
+sbin     ${BASEDIR}/.opam/var-option/sbin
+share    ${BASEDIR}/.opam/var-option/share
+doc      ${BASEDIR}/.opam/var-option/doc
+etc      ${BASEDIR}/.opam/var-option/etc
+man      ${BASEDIR}/.opam/var-option/man
+toplevel ${BASEDIR}/.opam/var-option/lib/toplevel
+stublibs ${BASEDIR}/.opam/var-option/lib/stublibs
+user     reftest
+group    reftest
+
+<><> Package variables ('opam config list PKG' to show) <><><><><><><><><><><><>
+PKG:name       # Name of the package
+PKG:version    # Version of the package
+PKG:depends    # Resolved direct dependencies of the package
+PKG:installed  # Whether the package is installed
+PKG:enable     # Takes the value "enable" or "disable" depending on whether the package is installed
+PKG:pinned     # Whether the package is pinned
+PKG:bin        # Binary directory for this package
+PKG:sbin       # System binary directory for this package
+PKG:lib        # Library directory for this package
+PKG:man        # Man directory for this package
+PKG:doc        # Doc directory for this package
+PKG:share      # Share directory for this package
+PKG:etc        # Etc directory for this package
+PKG:build      # Directory where the package was built
+PKG:hash       # Hash of the package archive
+PKG:dev        # True if this is a development package
+PKG:build-id   # A hash identifying the precise package version with all its dependencies
+PKG:opamfile   # Path of the curent opam file
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+prefix   ${BASEDIR}/.opam/var-option
+lib      ${BASEDIR}/.opam/var-option/lib
+bin      ${BASEDIR}/.opam/var-option/bin
+sbin     ${BASEDIR}/.opam/var-option/sbin
+share    ${BASEDIR}/.opam/var-option/share
+doc      ${BASEDIR}/.opam/var-option/doc
+etc      ${BASEDIR}/.opam/var-option/etc
+man      ${BASEDIR}/.opam/var-option/man
+toplevel ${BASEDIR}/.opam/var-option/lib/toplevel
+stublibs ${BASEDIR}/.opam/var-option/lib/stublibs
+user     reftest
+group    reftest
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+arch              x86_64                         # Set through 'opam var'
+exe                                              # Suffix needed for executable filenames (Windows)
+jobs              7                              # Set through 'opam var'
+make              make                           # Set through 'opam var'
+opam-version      68.79                          # Set through 'opam var'
+os                linux                          # Set through 'opam var'
+os-distribution   lorem                          # Set through 'opam var'
+os-family         ipsum                          # Set through 'opam var'
+os-version        dolor                          # Set through 'opam var'
+root              ${BASEDIR}/.opam # The current opam root directory
+switch                                           # The identifier of the current switch
+sys-ocaml-arch    x86_64                         # Set through 'opam var'
+sys-ocaml-cc      cc                             # Set through 'opam var'
+sys-ocaml-libc    libc                           # Set through 'opam var'
+sys-ocaml-version 4.08.0                         # Set through 'opam var'
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var bin
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+STATE                           LOAD-SWITCH-STATE @ var-option
+STATE                           Switch state loaded in 0.000s
+${BASEDIR}/.opam/var-option/bin
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var bin --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+${BASEDIR}/.opam/var-option/bin
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var bin --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[ERROR] Variable bin not found in global config
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var bin=global-bin --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Added '[bin "global-bin" "Set through 'opam var'"]' to field global-variables in global configuration
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var bin=switch-bin --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Added 'bin: "switch-bin"' to field variables in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var bin
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+STATE                           LOAD-SWITCH-STATE @ var-option
+STATE                           Switch state loaded in 0.000s
+${BASEDIR}/.opam/var-option/bin
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var bin --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+${BASEDIR}/.opam/var-option/bin
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var bin --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+global-bin
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var foo=global-foo --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Added '[foo "global-foo" "Set through 'opam var'"]' to field global-variables in global configuration
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var foo=switch-foo --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Added 'foo: "switch-foo"' to field variables in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var foo
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+STATE                           LOAD-SWITCH-STATE @ var-option
+STATE                           Switch state loaded in 0.000s
+switch-foo
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var foo --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+switch-foo
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var foo --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+global-foo
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var ocaml-base-compiler:version
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+STATE                           LOAD-SWITCH-STATE @ var-option
+STATE                           Switch state loaded in 0.000s
+4.09.0
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var ocaml-base-compiler:version --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+STATE                           LOAD-SWITCH-STATE @ var-option
+STATE                           Switch state loaded in 0.000s
+4.09.0
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+
+<><> Global configuration <><><><><><><><><><><><><><><><><><><><><><><><><><><>
+best-effort-prefix-criteria    {}
+depext                         true
+depext-bypass                  {}
+depext-cannot-install          false
+depext-run-installs            true
+download-command               {}
+download-jobs                  3
+jobs                           {}
+post-build-commands            {}
+post-install-commands          {}
+post-remove-commands           {}
+post-session-commands          {}
+pre-build-commands             {}
+pre-install-commands           {}
+pre-remove-commands            {}
+pre-session-commands           {}
+repository-validation-command  {}
+solver                         {}
+solver-criteria                {}
+solver-fixup-criteria          {}
+solver-upgrade-criteria        {}
+wrap-build-commands            {}
+wrap-install-commands          {}
+wrap-remove-commands           {}
+
+<><> Switch configuration (var-option) ><><><><><><><><><><><><><><><><><><><><>
+depext-bypass          {}
+post-build-commands    {}
+post-install-commands  {}
+post-remove-commands   {}
+post-session-commands  {}
+pre-build-commands     {}
+pre-install-commands   {}
+pre-remove-commands    {}
+pre-session-commands   {}
+setenv                 {}
+synopsis               "var-option"
+wrap-build-commands    {}
+wrap-install-commands  {}
+wrap-remove-commands   {}
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+3
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+3
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[ERROR] Field or section download-jobs not found
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option jobs
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option jobs --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option jobs --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[ERROR] Field or section jobs not found
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option synopsis
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+"var-option"
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'synopsis="sit amet"'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Set to '"sit amet"' the field synopsis in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option synopsis
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+"sit amet"
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option synopsis --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+"sit amet"
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option synopsis --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[ERROR] Field or section synopsis not found
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option synopsis=
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Reverted field synopsis in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option synopsis
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+""
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'synopsis="consectetur adipiscing"' --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Set to '"consectetur adipiscing"' the field synopsis in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option synopsis
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+"consectetur adipiscing"
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option synopsis= --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Reverted field synopsis in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option synopsis
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+""
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+3
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs=10
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Set to '10' the field download-jobs in global configuration
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+10
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[ERROR] Field or section download-jobs not found
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+10
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs=
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Reverted field download-jobs in global configuration
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+1
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs=12 --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Set to '12' the field download-jobs in global configuration
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+12
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs= --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Reverted field download-jobs in global configuration
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+1
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'pre-session-commands=["elit"]'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Set to '["elit"]' the field pre-session-commands in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+"elit"
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+"elit"
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands=
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Reverted field pre-session-commands in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'pre-session-commands=["sed"]' --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Set to '["sed"]' the field pre-session-commands in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+"sed"
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+"sed"
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands= --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Reverted field pre-session-commands in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'pre-session-commands=["do"]' --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Set to '["do"]' the field pre-session-commands in global configuration
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+"do"
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands= --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Reverted field pre-session-commands in global configuration
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'depext-bypass+=["tempor"]'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Added '["tempor"]' to field depext-bypass in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'depext-bypass+=["incididunt"]'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Added '["incididunt"]' to field depext-bypass in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+["incididunt" "tempor"]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'depext-bypass-=["incididunt"]'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Removed '["incididunt"]' from field depext-bypass in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'depext-bypass=["incididunt tempor"]'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Set to '["incididunt tempor"]' the field depext-bypass in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'depext-bypass-=["tempor"]'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Removed '["tempor"]' from field depext-bypass in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+["tempor"]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'depext-bypass-=["ut"]'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Removed '["ut"]' from field depext-bypass in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+["ut"]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'depext-bypass-=[]'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Removed '[]' from field depext-bypass in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass=
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+No modification in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'depext-bypass-=["tempor"]'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Removed '["tempor"]' from field depext-bypass in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+["tempor"]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'jobs+=3'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[ERROR] Field jobs can't be appended
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'jobs-=3'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[ERROR] Field jobs can't be substracted
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option bar
+[ERROR] No option named 'bar' found. Use 'opam option [--global]' to list them
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option bar --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[ERROR] Field or section bar not found
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option bar --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[ERROR] Field or section bar not found
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option bar=sit
+[ERROR] No option named 'bar' found. Use 'opam option [--global]' to list them
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option bar=sit --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[ERROR] There is no option named 'bar'. The allowed options are:
+jobs download-command download-jobs solver-criteria solver-upgrade-criteria solver-fixup-criteria best-effort-prefix-criteria solver global-variables eval-variables repository-validation-command depext depext-run-installs depext-cannot-install depext-bypass pre-build-commands pre-install-commands pre-remove-commands pre-session-commands wrap-build-commands wrap-install-commands wrap-remove-commands post-build-commands post-install-commands post-remove-commands post-session-commands
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option bar=sit --switch var-option
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[ERROR] There is no option named 'bar'. The allowed options are:
+synopsis setenv depext-bypass pre-build-commands pre-install-commands pre-remove-commands pre-session-commands wrap-build-commands wrap-install-commands wrap-remove-commands post-build-commands post-install-commands post-remove-commands post-session-commands variables

--- a/tests/reftests/var-option.test
+++ b/tests/reftests/var-option.test
@@ -1,9 +1,9 @@
 009e00fa
 ### opam switch create var-option --empty
-### opam var user=reftest --switch var-option
-Added 'user: "reftest"' to field variables in switch var-option
-### opam var group=reftest --switch var-option
-Added 'group: "reftest"' to field variables in switch var-option
+### opam var user= --switch var-option
+Removed variable user in switch var-option
+### opam var group= --switch var-option
+Removed variable group in switch var-option
 ### opam var arch=x86_64 --global
 Added '[arch "x86_64" "Set through 'opam var'"]' to field global-variables in global configuration
 ### opam var jobs=7 --global
@@ -20,35 +20,35 @@ Added '[os-distribution "lorem" "Set through 'opam var'"]' to field global-varia
 Added '[os-family "ipsum" "Set through 'opam var'"]' to field global-variables in global configuration
 ### opam var os-version=dolor --global
 Added '[os-version "dolor" "Set through 'opam var'"]' to field global-variables in global configuration
-### opam var sys-ocaml-arch=x86_64 --global
-Added '[sys-ocaml-arch "x86_64" "Set through 'opam var'"]' to field global-variables in global configuration
-### opam var sys-ocaml-cc=cc --global
-Added '[sys-ocaml-cc "cc" "Set through 'opam var'"]' to field global-variables in global configuration
-### opam var sys-ocaml-libc=libc --global
-Added '[sys-ocaml-libc "libc" "Set through 'opam var'"]' to field global-variables in global configuration
+### opam var sys-ocaml-arch= --global
+Removed variable sys-ocaml-arch in global configuration
+### opam var sys-ocaml-cc= --global
+Removed variable sys-ocaml-cc in global configuration
+### opam var sys-ocaml-libc= --global
+Removed variable sys-ocaml-libc in global configuration
 ### opam option wrap-build-commands=[] --global
 Set to '[]' the field wrap-build-commands in global configuration
 ### opam option wrap-install-commands=[] --global
 Set to '[]' the field wrap-install-commands in global configuration
 ### opam option wrap-remove-commands=[] --global
 Set to '[]' the field wrap-remove-commands in global configuration
-### opam install ocaml-base-compiler.4.09.0 --fake --yes
+### opam install ocaml-base-compiler.4.08.0 --fake --yes
 The following actions will be faked:
   ∗ install base-bigarray       base
-  ∗ install ocaml-base-compiler 4.09.0
+  ∗ install ocaml-base-compiler 4.08.0
   ∗ install base-threads        base
   ∗ install base-unix           base
   ∗ install ocaml-config        1
-  ∗ install ocaml               4.09.0
+  ∗ install ocaml               4.08.0
 ===== ∗ 6 =====
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Faking installation of base-bigarray.base
 Faking installation of base-threads.base
 Faking installation of base-unix.base
-Faking installation of ocaml-base-compiler.4.09.0
+Faking installation of ocaml-base-compiler.4.08.0
 Faking installation of ocaml-config.1
-Faking installation of ocaml.4.09.0
+Faking installation of ocaml.4.08.0
 Done.
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
@@ -65,9 +65,6 @@ os-family         ipsum                          # Set through 'opam var'
 os-version        dolor                          # Set through 'opam var'
 root              ${BASEDIR}/.opam # The current opam root directory
 switch                                           # The identifier of the current switch
-sys-ocaml-arch    x86_64                         # Set through 'opam var'
-sys-ocaml-cc      cc                             # Set through 'opam var'
-sys-ocaml-libc    libc                           # Set through 'opam var'
 sys-ocaml-version 4.08.0                         # Set through 'opam var'
 
 <><> Configuration variables from the current switch ><><><><><><><><><><><><><>
@@ -81,10 +78,8 @@ etc      ${BASEDIR}/.opam/var-option/etc
 man      ${BASEDIR}/.opam/var-option/man
 toplevel ${BASEDIR}/.opam/var-option/lib/toplevel
 stublibs ${BASEDIR}/.opam/var-option/lib/stublibs
-user     reftest
-group    reftest
 
-<><> Package variables ('opam config list PKG' to show) <><><><><><><><><><><><>
+<><> Package variables ('opam var --package PKG' to show) <><><><><><><><><><><>
 PKG:name       # Name of the package
 PKG:version    # Version of the package
 PKG:depends    # Resolved direct dependencies of the package
@@ -115,8 +110,6 @@ etc      ${BASEDIR}/.opam/var-option/etc
 man      ${BASEDIR}/.opam/var-option/man
 toplevel ${BASEDIR}/.opam/var-option/lib/toplevel
 stublibs ${BASEDIR}/.opam/var-option/lib/stublibs
-user     reftest
-group    reftest
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var --global
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 arch              x86_64                         # Set through 'opam var'
@@ -130,14 +123,9 @@ os-family         ipsum                          # Set through 'opam var'
 os-version        dolor                          # Set through 'opam var'
 root              ${BASEDIR}/.opam # The current opam root directory
 switch                                           # The identifier of the current switch
-sys-ocaml-arch    x86_64                         # Set through 'opam var'
-sys-ocaml-cc      cc                             # Set through 'opam var'
-sys-ocaml-libc    libc                           # Set through 'opam var'
 sys-ocaml-version 4.08.0                         # Set through 'opam var'
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var bin
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
-STATE                           LOAD-SWITCH-STATE @ var-option
-STATE                           Switch state loaded in 0.000s
 ${BASEDIR}/.opam/var-option/bin
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var bin --switch var-option
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
@@ -153,8 +141,6 @@ GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 Added 'bin: "switch-bin"' to field variables in switch var-option
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var bin
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
-STATE                           LOAD-SWITCH-STATE @ var-option
-STATE                           Switch state loaded in 0.000s
 ${BASEDIR}/.opam/var-option/bin
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var bin --switch var-option
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
@@ -170,8 +156,6 @@ GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 Added 'foo: "switch-foo"' to field variables in switch var-option
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var foo
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
-STATE                           LOAD-SWITCH-STATE @ var-option
-STATE                           Switch state loaded in 0.000s
 switch-foo
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var foo --switch var-option
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
@@ -183,12 +167,29 @@ global-foo
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 STATE                           LOAD-SWITCH-STATE @ var-option
 STATE                           Switch state loaded in 0.000s
-4.09.0
+4.08.0
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var ocaml-base-compiler:version --switch var-option
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 STATE                           LOAD-SWITCH-STATE @ var-option
 STATE                           Switch state loaded in 0.000s
-4.09.0
+4.08.0
+### opam var --package ocaml | grep -v build-id | grep -v opamfile
+ocaml:name      ocaml                                                                     # Name of the package
+ocaml:version   4.08.0                                                                    # Version of the package
+ocaml:depends   ocaml-base-compiler.4.08.0 ocaml-config.1                                 # Resolved direct dependencies of the package
+ocaml:installed true                                                                      # Whether the package is installed
+ocaml:enable    enable                                                                    # Takes the value "enable" or "disable" depending on whether the package is installed
+ocaml:pinned    false                                                                     # Whether the package is pinned
+ocaml:bin       ${BASEDIR}/.opam/var-option/bin                             # Binary directory for this package
+ocaml:sbin      ${BASEDIR}/.opam/var-option/sbin                            # System binary directory for this package
+ocaml:lib       ${BASEDIR}/.opam/var-option/lib/ocaml                       # Library directory for this package
+ocaml:man       ${BASEDIR}/.opam/var-option/man                             # Man directory for this package
+ocaml:doc       ${BASEDIR}/.opam/var-option/doc/ocaml                       # Doc directory for this package
+ocaml:share     ${BASEDIR}/.opam/var-option/share/ocaml                     # Share directory for this package
+ocaml:etc       ${BASEDIR}/.opam/var-option/etc/ocaml                       # Etc directory for this package
+ocaml:build     ${BASEDIR}/.opam/var-option/.opam-switch/build/ocaml.4.08.0 # Directory where the package was built
+ocaml:hash                                                                                # Hash of the package archive
+ocaml:dev       false                                                                     # True if this is a development package
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 
@@ -233,6 +234,7 @@ synopsis               "var-option"
 wrap-build-commands    {}
 wrap-install-commands  {}
 wrap-remove-commands   {}
+### # Check global & switch option setting
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 3
@@ -324,6 +326,7 @@ Reverted field download-jobs in global configuration
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option download-jobs
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 1
+### # Check same option name setting through global & switch
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 []
@@ -399,6 +402,7 @@ GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option pre-session-commands --global
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 []
+### # Check addition & removal on set
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 []
@@ -416,37 +420,106 @@ GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 Removed '["incididunt"]' from field depext-bypass in switch var-option
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
-[]
-### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'depext-bypass=["incididunt tempor"]'
+["tempor"]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'depext-bypass=["incididunt" "tempor"]'
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
-Set to '["incididunt tempor"]' the field depext-bypass in switch var-option
+Set to '["incididunt" "tempor"]' the field depext-bypass in switch var-option
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'depext-bypass-=["tempor"]'
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 Removed '["tempor"]' from field depext-bypass in switch var-option
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
-["tempor"]
+["incididunt"]
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'depext-bypass-=["ut"]'
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
-Removed '["ut"]' from field depext-bypass in switch var-option
+No modification in switch var-option
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
-["ut"]
+["incididunt"]
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'depext-bypass-=[]'
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
-Removed '[]' from field depext-bypass in switch var-option
+No modification in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+["incididunt"]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass=
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Reverted field depext-bypass in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'depext-bypass-=["tempor"]'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+No modification in switch var-option
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 []
-### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass=
+### # Check addition & removal on list
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'setenv+=lorem="labore"'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Added 'lorem="labore"' to field setenv in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'setenv+=ipsum="dolore"'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Added 'ipsum="dolore"' to field setenv in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option setenv
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[[ipsum = "dolore"] [lorem = "labore"]]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'setenv-=lorem="labore"'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Removed 'lorem="labore"' from field setenv in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option setenv
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+ipsum = "dolore"
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'setenv=[[lorem="labore"] [ipsum="dolore"]]'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Set to '[[lorem="labore"] [ipsum="dolore"]]' the field setenv in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'setenv-=lorem="labore"'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Removed 'lorem="labore"' from field setenv in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option setenv
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+ipsum = "dolore"
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'setenv-=lorem="et"'
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 No modification in switch var-option
-### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'depext-bypass-=["tempor"]'
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option setenv
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
-Removed '["tempor"]' from field depext-bypass in switch var-option
-### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option depext-bypass
+ipsum = "dolore"
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option setenv=
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
-["tempor"]
+Reverted field setenv in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'setenv-=lorem="labore"'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+No modification in switch var-option
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option setenv
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### # Check that eval-variable is removed when a global variable is removed
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option global-variables
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[[foo "global-foo" "Set through 'opam var'"] [bin "global-bin" "Set through 'opam var'"] [os-version "dolor" "Set through 'opam var'"] [os-family "ipsum" "Set through 'opam var'"] [os-distribution "lorem" "Set through 'opam var'"] [os "linux" "Set through 'opam var'"] [opam-version "68.79" "Set through 'opam var'"] [make "make" "Set through 'opam var'"] [jobs "7" "Set through 'opam var'"] [arch "x86_64" "Set through 'opam var'"] [sys-ocaml-version "4.08.0" "Set through 'opam var'"]]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'eval-variables=[dolore ["mania"] "alica"]'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Set to '[dolore ["mania"] "alica"]' the field eval-variables in global configuration
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option eval-variables
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[dolore ["mania"] "alica"]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var dolore="mania" --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Added '[dolore "mania" "Set through 'opam var'"]' to field global-variables in global configuration
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam var dolore= --global
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+Removed variable dolore in global configuration
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option eval-variables
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[]
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option global-variables
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[[foo "global-foo" "Set through 'opam var'"] [bin "global-bin" "Set through 'opam var'"] [os-version "dolor" "Set through 'opam var'"] [os-family "ipsum" "Set through 'opam var'"] [os-distribution "lorem" "Set through 'opam var'"] [os "linux" "Set through 'opam var'"] [opam-version "68.79" "Set through 'opam var'"] [make "make" "Set through 'opam var'"] [jobs "7" "Set through 'opam var'"] [arch "x86_64" "Set through 'opam var'"] [sys-ocaml-version "4.08.0" "Set through 'opam var'"]]
+### # Check uniable operations
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'variables+={esse: "cillum"}'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[ERROR] Field variables can't be directly appended to, use `opam var` instead
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'invariant="inv"'
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
+[ERROR] Field invariant is not modifiable
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS="GSTATE STATE" opam option 'jobs+=3'
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/.opam
 [ERROR] Field jobs can't be appended


### PR DESCRIPTION
  * Don't load switch for some variable looking
  * Fix package variables display when no config file is found
  * Fix `depext-bypass` removal (`-=`)
  * Add var/option test
  * Change `opam config list` to `opam var [--package]`. This option need to be deprecated