### PR TITLE
Be more robust w.r.t. new caches updates

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -91,6 +91,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Internal
+  * Be more robust w.r.t. new caches updates [#4429 @AltGr - fix #4354]
   * ActionGraph: removal postponing, protect against addition of cycles [#4358 @AltGr - fix #4357]
   * Initialise random [#4391 @rjbou]
   * Fix CLI debug log printed without taking into account debug sections [#4391 @rjbou]

--- a/src/core/opamCached.ml
+++ b/src/core/opamCached.ml
@@ -92,15 +92,19 @@ end = struct
     if OpamCoreConfig.(!r.safe_mode) then
       log "Running in safe mode, not upgrading the %s cache" X.name
     else
-    let chrono = OpamConsole.timer () in
-    OpamFilename.with_flock `Lock_write cache_file @@ fun fd ->
-    log "Writing the %s cache to %s ...\n"
-      X.name (OpamFilename.prettify cache_file);
-    let oc = Unix.out_channel_of_descr fd in
-    output_string oc (OpamVersion.magic ());
-    Marshal.to_channel oc t [];
-    flush oc;
-    log "%a written in %.3fs" (slog OpamFilename.prettify) cache_file (chrono ())
+    try
+      let chrono = OpamConsole.timer () in
+      OpamFilename.with_flock `Lock_write cache_file @@ fun fd ->
+      log "Writing the %s cache to %s ..."
+        X.name (OpamFilename.prettify cache_file);
+      let oc = Unix.out_channel_of_descr fd in
+      output_string oc (OpamVersion.magic ());
+      Marshal.to_channel oc t [];
+      flush oc;
+      log "%a written in %.3fs" (slog OpamFilename.prettify) cache_file (chrono ())
+    with Unix.Unix_error _ ->
+      log "Could not acquire lock for writing %s, skipping %s cache update"
+        (OpamFilename.prettify cache_file) X.name
 
   let remove cache_file =
     OpamFilename.remove cache_file


### PR DESCRIPTION
Technically speaking, users should use `--readonly`, but it's nicer of us just
to skip the cache update and go on anyway since no functionnality will be
impacted.