### PR TITLE
Internal caches: use size checks from Marshal

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -94,6 +94,7 @@ New option/command/subcommand are prefixed with ◈.
   * ActionGraph: removal postponing, protect against addition of cycles [#4358 @AltGr - fix #4357]
   * Initialise random [#4391 @rjbou]
   * Fix CLI debug log printed without taking into account debug sections [#4391 @rjbou]
+  * Internal caches: use size checks from Marshal [#4430 @AltGr]
 
 ## Test
   * Ensure that a cold `dune runtest` works [#4375 @emillon]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1118,7 +1118,7 @@ let global_options =
       "Whenever updating packages that are bound to a local, \
        version-controlled directory, update to the current working state of \
        their source instead of the last committed state, or the ref they are \
-       pointing to. As source directory is copied as it is, it it isn't clean \
+       pointing to. As source directory is copied as it is, if it isn't clean \
        it may result on a opam build failure.\
        This only affects packages explicitly listed on the command-line.\
        It can also be set with $(b,\\$OPAMWORKINGDIR). "


### PR DESCRIPTION
it seems in some cases (large files) there can be a bit of padding, and the
`Marshal` module should already detect size issues, no need do duplicate the 
work.