### PR TITLE
2.0: 4.12 and Dune 2 compatibility

### DIFF
--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -117,7 +117,7 @@ ext-ignore:
 	@echo "(ignored_subdirs (dune-local $(filter-out dune-local $(SRC_EXTS),$(PKG_EXTS))))" >> dune
 
 clone: $(DUNE_CLONE) $(SRC_EXTS:=.stamp) | ext-ignore
-	@rm -f cppo/ocamlbuild_plugin/jbuild
+	@rm -f cppo/ocamlbuild_plugin/dune
 
 .PHONY: pkg-ignore
 pkg-ignore:

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -3,8 +3,8 @@ MD5_cppo = 1cd25741d31417995b0973fe0b6f6c82
 
 $(call PKG_SAME,cppo)
 
-URL_extlib = http://ygrek.org/p/release/ocaml-extlib/extlib-1.7.5.tar.gz
-MD5_extlib = d989951536077563bf4c5e3479c3866f
+URL_extlib = https://ygrek.org/p/release/ocaml-extlib/extlib-1.7.7.tar.gz
+MD5_extlib = 2c620993aecd4b31b3a362b21b55dd94
 
 $(call PKG_SAME,extlib)
 

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -1,5 +1,5 @@
-URL_cppo = https://github.com/mjambon/cppo/archive/v1.6.5.tar.gz
-MD5_cppo = 1cd25741d31417995b0973fe0b6f6c82
+URL_cppo = https://github.com/ocaml-community/cppo/releases/download/v1.6.6/cppo-v1.6.6.tbz
+MD5_cppo = b13afeea6631d7c9b61f95bfd984a542
 
 $(call PKG_SAME,cppo)
 

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -8,8 +8,8 @@ MD5_extlib = 2c620993aecd4b31b3a362b21b55dd94
 
 $(call PKG_SAME,extlib)
 
-URL_re = https://github.com/ocaml/ocaml-re/releases/download/1.8.0/re-1.8.0.tbz
-MD5_re = 765f6f8d3e6ab200866e719ed7e5178d
+URL_re = https://github.com/ocaml/ocaml-re/releases/download/1.9.0/re-1.9.0.tbz
+MD5_re = bddaed4f386a22cace7850c9c7dac296
 
 $(call PKG_SAME,re)
 
@@ -43,8 +43,8 @@ MD5_opam-file-format = d7852cb63df0f442bed14ba2c5740135
 
 $(call PKG_SAME,opam-file-format)
 
-URL_result = https://github.com/janestreet/result/releases/download/1.3/result-1.3.tbz
-MD5_result = 4beebefd41f7f899b6eeba7414e7ae01
+URL_result = https://github.com/janestreet/result/archive/1.4.tar.gz
+MD5_result = d3162dbc501a2af65c8c71e0866541da
 
 $(call PKG_SAME,result)
 

--- a/src_ext/patches/cppo.common/0001-Restore-4.02-compatibility.patch
+++ b/src_ext/patches/cppo.common/0001-Restore-4.02-compatibility.patch
@@ -1,0 +1,24 @@
+diff -Naur a/src/compat.ml b/src/compat.ml
+--- a/src/compat.ml	1970-01-01 00:00:00.000000000 +0000
++++ b/src/compat.ml	2020-11-24 09:04:43.959367163 +0000
+@@ -0,0 +1,7 @@
++if Filename.check_suffix Sys.argv.(1) ".ml" &&
++   Scanf.sscanf Sys.ocaml_version "%d.%d" (fun a b -> (a, b)) < (4, 03) then
++  print_endline "\
++module String = struct
++  include String
++  let capitalize_ascii = capitalize
++end"
+diff -Naur a/src/dune b/src/dune
+--- a/src/dune	2019-05-26 23:49:42.000000000 +0000
++++ b/src/dune	2020-11-24 09:04:43.959367163 +0000
+@@ -13,4 +13,9 @@
+  (name cppo_main)
+  (package cppo)
+  (public_name cppo)
++ (modules :standard \ compat)
++ (preprocess (per_module
++  ((action (progn
++    (run ocaml %{dep:compat.ml} %{input-file})
++    (cat %{input-file}))) cppo_eval)))
+  (libraries unix str))

--- a/src_ext/patches/cppo.common/0001-Treat-tilde-and-hyphen-equivalently-in-semver.patch
+++ b/src_ext/patches/cppo.common/0001-Treat-tilde-and-hyphen-equivalently-in-semver.patch
@@ -1,0 +1,34 @@
+diff -Naur a/Changes b/Changes
+--- a/Changes	2019-05-26 23:49:42.000000000 +0000
++++ b/Changes	2020-11-18 16:48:22.436525214 +0000
+@@ -1,3 +1,7 @@
++## v1.6.7 (2020-??-??)
++- [compat] Treat ~ and - the same in semver in order to parse
++           OCaml 4.12.0 pre-release versions.
++
+ ## v1.6.6 (2019-05-27)
+ - [pkg] port build system to dune from jbuilder.
+ - [pkg] upgrade opam metadata to 2.0 format.
+diff -Naur a/src/cppo_main.ml b/src/cppo_main.ml
+--- a/src/cppo_main.ml	2019-05-26 23:49:42.000000000 +0000
++++ b/src/cppo_main.ml	2020-11-18 16:48:22.436525214 +0000
+@@ -18,7 +18,7 @@
+ \\([0-9]+\\)\
+ \\.\\([0-9]+\\)\
+ \\.\\([0-9]+\\)\
+-\\(-\\([^+]*\\)\\)?\
++\\([~-]\\([^+]*\\)\\)?\
+ \\(\\+\\(.*\\)\\)?\
+ \r?$"
+ 
+@@ -108,6 +108,10 @@
+             VAR_VERSION_FULL    is the original string
+ 
+           Example: cppo -V OCAML:4.02.1
++
++          Note that cppo recognises both '-' and '~' preceding the pre-release
++          meaning -V OCAML:4.11.0+alpha1 sets OCAML_BUILD to alpha1 but
++          -V OCAML:4.12.0~alpha1 sets OCAML_PRERELEASE to alpha1.
+ ";
+ 
+     "-o", Arg.String (fun s -> out_file := Some s),

--- a/src_ext/patches/cudf.pkg/0002-Fix-compilation-using-Microsoft-C-Compiler.patch
+++ b/src_ext/patches/cudf.pkg/0002-Fix-compilation-using-Microsoft-C-Compiler.patch
@@ -1,17 +1,7 @@
-From 441cd1403081099ded532119cd195b3c27e36392 Mon Sep 17 00:00:00 2001
-From: David Allsopp <david.allsopp@metastack.com>
-Date: Thu, 23 Jul 2015 17:53:05 +0100
-Subject: [PATCH] Fix compilation using Microsoft C Compiler
-
----
- Makefile | 6 ++++--
- 1 file changed, 4 insertions(+), 2 deletions(-)
-
-diff --git a/Makefile b/Makefile
-index edf24c4..9e1f7b0 100644
---- a/Makefile
-+++ b/Makefile
-@@ -2,6 +2,8 @@ include Makefile.config
+diff -Naur a/Makefile b/Makefile
+--- a/Makefile	2017-03-21 14:39:23.000000000 +0000
++++ b/Makefile	2020-11-18 15:01:28.859442630 +0000
+@@ -2,6 +2,8 @@
  
  NAME = cudf
  
@@ -20,7 +10,7 @@ index edf24c4..9e1f7b0 100644
  ifeq ("$(shell (ocamlc -config 2>/dev/null || ocamlopt -config) | fgrep os_type)","os_type: Win32")
  EXE=.exe
  OCAMLLIBDIR := $(shell cygpath $(OCAMLLIBDIR))
-@@ -81,9 +83,9 @@ TAGS: $(SOURCES)
+@@ -81,9 +83,9 @@
  	otags $^
  
  INSTALL_STUFF = META
@@ -32,6 +22,3 @@ index edf24c4..9e1f7b0 100644
  INSTALL_STUFF += $(wildcard _build/cudf.o _build/cudf.cmx _build/cudf.cmi)
  
  install:
--- 
-2.4.4.windows.2
-

--- a/src_ext/patches/dose3.common/0001-fixes-for-4.06-safe-string.patch
+++ b/src_ext/patches/dose3.common/0001-fixes-for-4.06-safe-string.patch
@@ -1,17 +1,6 @@
-From bb10c2537b740fe5ab4eacc5323132df89e58b62 Mon Sep 17 00:00:00 2001
-From: Damien Doligez <damien.doligez@inria.fr>
-Date: Wed, 22 Nov 2017 15:40:35 +0100
-Subject: [PATCH] fixes for 4.06 safe-string
-
----
- common/criteria_lexer.mll | 4 ++--
- common/input.ml           | 2 +-
- 2 files changed, 3 insertions(+), 3 deletions(-)
-
-diff --git a/common/criteria_lexer.mll b/common/criteria_lexer.mll
-index 71f9178..5518fa0 100644
---- a/common/criteria_lexer.mll
-+++ b/common/criteria_lexer.mll
+diff -Naur a/common/criteria_lexer.mll b/common/criteria_lexer.mll
+--- a/common/criteria_lexer.mll	2016-07-20 11:45:05.000000000 +0000
++++ b/common/criteria_lexer.mll	2020-11-18 15:01:29.007442859 +0000
 @@ -18,7 +18,7 @@
      let c = Lexing.lexeme_char lexbuf 2 in (* the delimiter can be any character *)
      (* find the terminating delimiter *)
@@ -30,11 +19,10 @@ index 71f9178..5518fa0 100644
      lexbuf.Lexing.lex_curr_pos <- lexbuf.Lexing.lex_start_pos + ((String.length s)+4);
      s
  
-diff --git a/common/input.ml b/common/input.ml
-index ea189de..e25ca99 100644
---- a/common/input.ml
-+++ b/common/input.ml
-@@ -42,7 +42,7 @@ let bzip_open_file file =
+diff -Naur a/common/input.ml b/common/input.ml
+--- a/common/input.ml	2016-07-20 11:45:05.000000000 +0000
++++ b/common/input.ml	2020-11-18 15:01:29.007442859 +0000
+@@ -42,7 +42,7 @@
      with End_of_file -> raise IO.No_more_input
    in
    let read ch s pos len =
@@ -43,6 +31,3 @@ index ea189de..e25ca99 100644
      with End_of_file -> raise IO.No_more_input
    in
    IO.create_in
--- 
-2.7.2
-

--- a/src_ext/patches/dose3.pkg/0001-Fix-build-process-under-Windows.patch
+++ b/src_ext/patches/dose3.pkg/0001-Fix-build-process-under-Windows.patch
@@ -1,18 +1,7 @@
-From b7f7507882975e58851e3d25ea8511c2af3d6c73 Mon Sep 17 00:00:00 2001
-From: David Allsopp <david.allsopp@metastack.com>
-Date: Wed, 22 Jul 2015 16:59:37 +0100
-Subject: [PATCH 1/2] Fix build process under Windows
-
-Convert LIBDIR using cygpath
----
- Makefile.config.in | 12 ++++++------
- 1 file changed, 6 insertions(+), 6 deletions(-)
-
-diff --git a/Makefile.config.in b/Makefile.config.in
-index 155a77a..f9f1e6f 100644
---- a/Makefile.config.in
-+++ b/Makefile.config.in
-@@ -12,14 +12,14 @@ DOSELIBS = _build/doselibs
+diff -Naur a/Makefile.config.in b/Makefile.config.in
+--- a/Makefile.config.in	2016-07-20 11:45:05.000000000 +0000
++++ b/Makefile.config.in	2020-11-18 15:01:29.227443199 +0000
+@@ -12,14 +12,14 @@
  BINDIR = @prefix@@bindir@
  # if prefix is /usr/local (default), then we use ocamlfind, 
  # otherwise use build the destdir using the given prefix
@@ -33,6 +22,3 @@ index 155a77a..f9f1e6f 100644
  endif
  
  # if DESTDIR is specified, we ignore the prefix and we use the 
--- 
-2.12.0.windows.1
-

--- a/src_ext/patches/dose3.pkg/0002-Fix-compilation-using-Microsoft-C-Compiler.patch
+++ b/src_ext/patches/dose3.pkg/0002-Fix-compilation-using-Microsoft-C-Compiler.patch
@@ -1,22 +1,7 @@
-From 0cb15311dee5101729918bc93dbb586577fb0e7d Mon Sep 17 00:00:00 2001
-From: David Allsopp <david.allsopp@metastack.com>
-Date: Thu, 23 Jul 2015 16:45:59 +0100
-Subject: [PATCH 2/2] Fix compilation using Microsoft C Compiler
-
-Assumption that libraries have a .a extension replaced with a test for
-ext_lib from the compiler.
----
- Makefile           | 2 +-
- Makefile.config.in | 6 ++++--
- configure          | 3 +++
- configure.ac       | 2 ++
- 4 files changed, 10 insertions(+), 3 deletions(-)
-
-diff --git a/Makefile b/Makefile
-index 09464ff..226590a 100644
---- a/Makefile
-+++ b/Makefile
-@@ -222,7 +222,7 @@ DIST_EXCLUDE = cudf tests $(wildcard */tests) experimental doc/webpages
+diff -Naur a/Makefile b/Makefile
+--- a/Makefile	2016-07-20 11:45:05.000000000 +0000
++++ b/Makefile	2020-11-18 15:01:29.275443274 +0000
+@@ -222,7 +222,7 @@
  INSTALL_STUFF_ = META
  INSTALL_STUFF_ += $(wildcard _build/doselibs/*.cma _build/doselibs/*.cmi)
  INSTALL_STUFF_ += $(wildcard _build/doselibs/*.cmxa _build/doselibs/*.cmxs)
@@ -25,11 +10,10 @@ index 09464ff..226590a 100644
  #INSTALL_STUFF_ += $(wildcard _build/*/*.mli)
  INSTALL_STUFF_ += $(wildcard _build/rpm/*.so)
  
-diff --git a/Makefile.config.in b/Makefile.config.in
-index f9f1e6f..c401df4 100644
---- a/Makefile.config.in
-+++ b/Makefile.config.in
-@@ -134,12 +134,14 @@ uninstallcudf:
+diff -Naur a/Makefile.config.in b/Makefile.config.in
+--- a/Makefile.config.in	2020-11-18 15:01:29.227443199 +0000
++++ b/Makefile.config.in	2020-11-18 15:01:29.275443274 +0000
+@@ -134,12 +134,14 @@
  endif
  
  ifeq ("@OCAMLEXT@","native")
@@ -46,11 +30,10 @@ index f9f1e6f..c401df4 100644
  ifeq ("@HAS_XML@","yes")
  ifeq ("@HAS_CURL@","yes")
    EXPERIMENTAL += experimental/dudftocudf/deb-dudftocudf.@OCAMLEXT@
-diff --git a/configure b/configure
-index 49c02df..26bdfa8 100755
---- a/configure
-+++ b/configure
-@@ -648,6 +648,7 @@ PKG_ZIP
+diff -Naur a/configure b/configure
+--- a/configure	2016-07-20 11:45:05.000000000 +0000
++++ b/configure	2020-11-18 15:01:29.275443274 +0000
+@@ -648,6 +648,7 @@
  CONFIG_ZIP
  CPPOFLAGS
  LN
@@ -58,7 +41,7 @@ index 49c02df..26bdfa8 100755
  OCAML_SYSTEM
  EGREP
  GREP
-@@ -5317,6 +5318,8 @@ fi
+@@ -5317,6 +5318,8 @@
  
  OCAML_SYSTEM="$($OCAMLBESTCC -config | fgrep system | sed -e "s/system: \(.*\)/\1/")"
  
@@ -67,11 +50,10 @@ index 49c02df..26bdfa8 100755
  
  if test "${OCAML_OS_TYPE}" = "Win32"; then :
  
-diff --git a/configure.ac b/configure.ac
-index d73d724..6935fa6 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -256,6 +256,8 @@ fi
+diff -Naur a/configure.ac b/configure.ac
+--- a/configure.ac	2016-07-20 11:45:05.000000000 +0000
++++ b/configure.ac	2020-11-18 15:01:29.275443274 +0000
+@@ -256,6 +256,8 @@
  
  OCAML_SYSTEM="$($OCAMLBESTCC -config | fgrep system | sed -e "s/system: \(.*\)/\1/")"
  AC_SUBST(OCAML_SYSTEM)
@@ -80,6 +62,3 @@ index d73d724..6935fa6 100644
  
  AS_IF([test "${OCAML_OS_TYPE}" = "Win32"],[
    AC_MSG_CHECKING([for a workable solution for ln -s])
--- 
-2.12.0.windows.1
-

--- a/src_ext/patches/dose3.pkg/0003-Install-.cmx-files-for-packs.patch
+++ b/src_ext/patches/dose3.pkg/0003-Install-.cmx-files-for-packs.patch
@@ -1,18 +1,7 @@
-From 22643ffd33afc8bbf69ab9c9cdbdda98d674f773 Mon Sep 17 00:00:00 2001
-From: David Allsopp <david.allsopp@metastack.com>
-Date: Sat, 20 May 2017 16:45:08 +0100
-Subject: [PATCH] Install .cmx files for packs
-
-Enables cross-module inlining and eliminates Warning 58 on OCaml 4.04.0+
----
- Makefile | 25 +++++++++++++------------
- 1 file changed, 13 insertions(+), 12 deletions(-)
-
-diff --git a/Makefile b/Makefile
-index 09464ff..751fe26 100644
---- a/Makefile
-+++ b/Makefile
-@@ -56,7 +56,7 @@ $(DOSELIBS)/cudf.%:
+diff -Naur a/Makefile b/Makefile
+--- a/Makefile	2020-11-18 15:01:29.275443274 +0000
++++ b/Makefile	2020-11-18 15:01:29.331443360 +0000
+@@ -56,7 +56,7 @@
  	@for i in _build/cudf/cudf.*; do \
  	  if [ -e $$i ]; then \
  	  cp $$i $(DOSELIBS) ; \
@@ -21,7 +10,7 @@ index 09464ff..751fe26 100644
  	  fi ; \
  	done
  
-@@ -67,7 +67,7 @@ $(DOSELIBS)/common.%: common/*.ml common/*.mli
+@@ -67,7 +67,7 @@
  	  if [ -e $$i ]; then \
  	  cp $$i $(DOSELIBS) ; \
  		rm $$i ;\
@@ -30,7 +19,7 @@ index 09464ff..751fe26 100644
  	  fi ; \
  	done
  
-@@ -78,7 +78,7 @@ $(DOSELIBS)/versioning.%: versioning/*.ml versioning/*.mli
+@@ -78,7 +78,7 @@
  	  if [ -e $$i ]; then \
  	  cp $$i $(DOSELIBS) ; \
  		rm $$i ;\
@@ -39,7 +28,7 @@ index 09464ff..751fe26 100644
  	  fi ; \
  	done
  
-@@ -88,7 +88,7 @@ $(DOSELIBS)/algo.%: algo/*.ml algo/*.mli $(DOSELIBS)/common.%
+@@ -88,7 +88,7 @@
  	  if [ -e $$i ]; then \
  	  cp $$i $(DOSELIBS) ; \
  		rm $$i ;\
@@ -48,7 +37,7 @@ index 09464ff..751fe26 100644
  	  fi ; \
  	done
  
-@@ -98,7 +98,7 @@ $(DOSELIBS)/debian.%: deb/*.ml deb/*.mli $(DOSELIBS)/pef.%
+@@ -98,7 +98,7 @@
  	  if [ -e $$i ]; then \
  	  cp $$i $(DOSELIBS) ; \
  		rm $$i ;\
@@ -57,7 +46,7 @@ index 09464ff..751fe26 100644
  	  fi ; \
  	done
  
-@@ -108,7 +108,7 @@ $(DOSELIBS)/opam.%: opam/*.ml opam/*.mli $(DOSELIBS)/pef.%
+@@ -108,7 +108,7 @@
  	  if [ -e $$i ]; then \
  	  cp $$i $(DOSELIBS) ; \
  		rm $$i ;\
@@ -66,7 +55,7 @@ index 09464ff..751fe26 100644
  	  fi ; \
  	done
  
-@@ -118,7 +118,7 @@ $(DOSELIBS)/npm.%: npm/*.ml npm/*.mli $(DOSELIBS)/versioning.% $(DOSELIBS)/pef.%
+@@ -118,7 +118,7 @@
  	  if [ -e $$i ]; then \
  	  cp $$i $(DOSELIBS) ; \
  		rm $$i ;\
@@ -75,7 +64,7 @@ index 09464ff..751fe26 100644
  	  fi ; \
  	done
  
-@@ -128,7 +128,7 @@ $(DOSELIBS)/rpm.%: rpm/*.ml $(DOSELIBS)/algo.%
+@@ -128,7 +128,7 @@
  	  if [ -e $$i ]; then \
  	  cp $$i $(DOSELIBS) ; \
  		rm $$i ;\
@@ -84,7 +73,7 @@ index 09464ff..751fe26 100644
  	  fi ; \
  	done
  
-@@ -138,7 +138,7 @@ $(DOSELIBS)/pef.%: pef/*.ml pef/*.mli
+@@ -138,7 +138,7 @@
  	  if [ -e $$i ]; then \
  	  cp $$i $(DOSELIBS) ; \
  		rm $$i ;\
@@ -93,7 +82,7 @@ index 09464ff..751fe26 100644
  	  fi ; \
  	done
  
-@@ -148,7 +148,7 @@ $(DOSELIBS)/csw.%: opencsw/*.ml $(DOSELIBS)/versioning.%
+@@ -148,7 +148,7 @@
  	  if [ -e $$i ]; then \
  	  cp $$i $(DOSELIBS) ; \
  		rm $$i ;\
@@ -102,7 +91,7 @@ index 09464ff..751fe26 100644
  	  fi ; \
  	done
  
-@@ -158,7 +158,7 @@ $(DOSELIBS)/doseparse.%: $(DOSELIBS)/pef.% $(DOSELIBS)/debian.%
+@@ -158,7 +158,7 @@
  	  if [ -e $$i ]; then \
  	  cp $$i $(DOSELIBS) ; \
  		rm $$i ;\
@@ -111,7 +100,7 @@ index 09464ff..751fe26 100644
  	  fi ; \
  	done
  
-@@ -168,7 +168,7 @@ $(DOSELIBS)/doseparseNoRpm.%: $(DOSELIBS)/pef.% $(DOSELIBS)/debian.%
+@@ -168,7 +168,7 @@
  	  if [ -e $$i ]; then \
  			cp $$i $(DOSELIBS) ;\
  			rm $$i ;\
@@ -120,7 +109,7 @@ index 09464ff..751fe26 100644
  	  fi ; \
  	done
  
-@@ -222,6 +222,7 @@ DIST_EXCLUDE = cudf tests $(wildcard */tests) experimental doc/webpages
+@@ -222,6 +222,7 @@
  INSTALL_STUFF_ = META
  INSTALL_STUFF_ += $(wildcard _build/doselibs/*.cma _build/doselibs/*.cmi)
  INSTALL_STUFF_ += $(wildcard _build/doselibs/*.cmxa _build/doselibs/*.cmxs)
@@ -128,6 +117,3 @@ index 09464ff..751fe26 100644
  INSTALL_STUFF_ += $(wildcard _build/doselibs/*.$(EXT_LIB))
  #INSTALL_STUFF_ += $(wildcard _build/*/*.mli)
  INSTALL_STUFF_ += $(wildcard _build/rpm/*.so)
--- 
-2.12.0.windows.1
-

--- a/src_ext/patches/dose3.pkg/dose3-5.0~rc1.patch
+++ b/src_ext/patches/dose3.pkg/dose3-5.0~rc1.patch
@@ -1,45 +1,6 @@
---- ./configure.ac
-+++ ./configure.ac
-@@ -104,7 +104,7 @@
-  AC_MSG_ERROR([Please install OCaml findlib module 'ocamlgraph'.])
- fi
- TMPVERSION=`$OCAMLFIND query -format %v ocamlgraph | sed 's/\.//g'`
--CONFIG_OCAMLGRAPH="-D 'OCAMLGRAPHVERSION $TMPVERSION'"
-+CONFIG_OCAMLGRAPH="-D \"OCAMLGRAPHVERSION $TMPVERSION\""
- 
- AC_ARG_WITH(parmap,
-         [ --with-parmap ],
-@@ -260,7 +260,7 @@
- AS_IF([test "${OCAML_OS_TYPE}" = "Win32"],[
-   AC_MSG_CHECKING([for a workable solution for ln -s])
-   ln -s configure conftestLink
--  AS_IF([test "`cmd /c dir conftestLink 2>/dev/null | fgrep SYMLINK`" = ""],[LN=cp],[LN="ln -s"])
-+  AS_IF([test "`cmd /c dir conftestLink 2>/dev/null | fgrep SYMLINK`" = ""],[LN="cp -a"],[LN="ln -s"])
-   AC_MSG_RESULT([$LN])
- ],[
-   LN="ln -s"
---- ./configure
-+++ ./configure
-@@ -3907,7 +3907,7 @@
-  as_fn_error $? "Please install OCaml findlib module 'ocamlgraph'." "$LINENO" 5
- fi
- TMPVERSION=`$OCAMLFIND query -format %v ocamlgraph | sed 's/\.//g'`
--CONFIG_OCAMLGRAPH="-D 'OCAMLGRAPHVERSION $TMPVERSION'"
-+CONFIG_OCAMLGRAPH="-D \"OCAMLGRAPHVERSION $TMPVERSION\""
- 
- 
- # Check whether --with-parmap was given.
-@@ -5324,7 +5324,7 @@
- $as_echo_n "checking for a workable solution for ln -s... " >&6; }
-   ln -s configure conftestLink
-   if test "`cmd /c dir conftestLink 2>/dev/null | fgrep SYMLINK`" = ""; then :
--  LN=cp
-+  LN="cp -a"
- else
-   LN="ln -s"
- fi
---- ./Makefile
-+++ ./Makefile
+diff -Naur a/Makefile b/Makefile
+--- a/Makefile	2020-11-18 15:01:29.331443360 +0000
++++ b/Makefile	2020-11-18 15:01:29.387443447 +0000
 @@ -1,5 +1,6 @@
  #this is a forward reference to the target all below
 -all: all
@@ -48,7 +9,7 @@
  
  #SHELL=/bin/bash
  include Makefile.config
-@@ -14,8 +15,8 @@
+@@ -15,8 +16,8 @@
  #OBFLAGS := $(OBFLAGS) -classic-display
  
  addnotrpm:
@@ -59,3 +20,45 @@
  		if [ ! -s doseparseNoRpm.mlpack ]; then \
  			$(LN) doseparse.mlpack doseparseNoRpm.mlpack ; \
  		fi ; \
+diff -Naur a/configure b/configure
+--- a/configure	2020-11-18 15:01:29.275443274 +0000
++++ b/configure	2020-11-18 15:01:29.387443447 +0000
+@@ -3908,7 +3908,7 @@
+  as_fn_error $? "Please install OCaml findlib module 'ocamlgraph'." "$LINENO" 5
+ fi
+ TMPVERSION=`$OCAMLFIND query -format %v ocamlgraph | sed 's/\.//g'`
+-CONFIG_OCAMLGRAPH="-D 'OCAMLGRAPHVERSION $TMPVERSION'"
++CONFIG_OCAMLGRAPH="-D \"OCAMLGRAPHVERSION $TMPVERSION\""
+ 
+ 
+ # Check whether --with-parmap was given.
+@@ -5327,7 +5327,7 @@
+ $as_echo_n "checking for a workable solution for ln -s... " >&6; }
+   ln -s configure conftestLink
+   if test "`cmd /c dir conftestLink 2>/dev/null | fgrep SYMLINK`" = ""; then :
+-  LN=cp
++  LN="cp -a"
+ else
+   LN="ln -s"
+ fi
+diff -Naur a/configure.ac b/configure.ac
+--- a/configure.ac	2020-11-18 15:01:29.275443274 +0000
++++ b/configure.ac	2020-11-18 15:01:29.387443447 +0000
+@@ -104,7 +104,7 @@
+  AC_MSG_ERROR([Please install OCaml findlib module 'ocamlgraph'.])
+ fi
+ TMPVERSION=`$OCAMLFIND query -format %v ocamlgraph | sed 's/\.//g'`
+-CONFIG_OCAMLGRAPH="-D 'OCAMLGRAPHVERSION $TMPVERSION'"
++CONFIG_OCAMLGRAPH="-D \"OCAMLGRAPHVERSION $TMPVERSION\""
+ 
+ AC_ARG_WITH(parmap,
+         [ --with-parmap ],
+@@ -262,7 +262,7 @@
+ AS_IF([test "${OCAML_OS_TYPE}" = "Win32"],[
+   AC_MSG_CHECKING([for a workable solution for ln -s])
+   ln -s configure conftestLink
+-  AS_IF([test "`cmd /c dir conftestLink 2>/dev/null | fgrep SYMLINK`" = ""],[LN=cp],[LN="ln -s"])
++  AS_IF([test "`cmd /c dir conftestLink 2>/dev/null | fgrep SYMLINK`" = ""],[LN="cp -a"],[LN="ln -s"])
+   AC_MSG_RESULT([$LN])
+ ],[
+   LN="ln -s"

--- a/src_ext/patches/extlib.common/0001-Add-support-for-OCaml-4.12.patch
+++ b/src_ext/patches/extlib.common/0001-Add-support-for-OCaml-4.12.patch
@@ -1,0 +1,12 @@
+diff -Naur a/src/extList.ml b/src/extList.ml
+--- a/src/extList.ml	2020-04-24 21:55:13.000000000 +0000
++++ b/src/extList.ml	2020-11-18 15:01:29.659443867 +0000
+@@ -380,7 +380,7 @@
+   loop dummy l1 l2;
+   dummy.tl
+ 
+-let sort ?(cmp=compare) = List.sort cmp
++let sort ?(cmp=Pervasives.compare) = List.sort cmp
+ 
+ #if OCAML < 406
+ let rec init size f =

--- a/src_ext/patches/extlib.common/0002-caml_hash_univ_param-was-removed-for-OCaml-pre-4.00-.patch
+++ b/src_ext/patches/extlib.common/0002-caml_hash_univ_param-was-removed-for-OCaml-pre-4.00-.patch
@@ -1,0 +1,24 @@
+diff -Naur a/src/extHashtbl.ml b/src/extHashtbl.ml
+--- a/src/extHashtbl.ml	2020-04-24 21:55:13.000000000 +0000
++++ b/src/extHashtbl.ml	2020-11-18 15:01:29.691443917 +0000
+@@ -22,7 +22,7 @@
+ module Hashtbl =
+   struct
+ 
+-#if OCAML >= 400
++#if OCAML >= 400 && OCAML < 412
+   external old_hash_param :
+     int -> int -> 'a -> int = "caml_hash_univ_param" "noalloc"
+ #endif
+@@ -114,7 +114,11 @@
+     (* compatibility with old hash tables *)
+     if Obj.size (Obj.repr h) >= 3
+     then (seeded_hash_param 10 100 (h_conv h).seed key) land (Array.length (h_conv h).data - 1)
++  #if OCAML >= 412
++    else failwith "Old hash function not supported anymore"
++  #else
+     else (old_hash_param 10 100 key) mod (Array.length (h_conv h).data)
++  #endif
+ #else
+   let key_index h key = (hash key) mod (Array.length (h_conv h).data)
+ #endif

--- a/src_ext/patches/extlib/extlib-1.7.5.patch
+++ b/src_ext/patches/extlib/extlib-1.7.5.patch
@@ -1,6 +1,6 @@
-diff -Naur extlib-1.7.5/src/configure.ml extlib/src/configure.ml
---- extlib-1.7.5/src/configure.ml	2018-07-09 01:54:13.000000000 +0100
-+++ extlib/src/configure.ml	2018-07-16 21:09:16.147453999 +0100
+diff -Naur a/src/configure.ml b/src/configure.ml
+--- a/src/configure.ml	2020-04-24 21:55:13.000000000 +0000
++++ b/src/configure.ml	2020-11-18 15:01:29.511443638 +0000
 @@ -1,15 +1,21 @@
  open Printf
  

--- a/src_ext/patches/ocamlgraph/ocamlgraph-jbuilder.patch
+++ b/src_ext/patches/ocamlgraph/ocamlgraph-jbuilder.patch
@@ -1,6 +1,6 @@
-diff -Naur ocamlgraph-1.8.7/src/imperative.ml ocamlgraph/src/imperative.ml
---- ocamlgraph-1.8.7/src/imperative.ml	2016-04-12 08:47:31.000000000 +0200
-+++ ocamlgraph/src/imperative.ml	2017-06-26 12:29:20.195718700 +0200
+diff -Naur a/src/imperative.ml b/src/imperative.ml
+--- a/src/imperative.ml	2017-10-17 09:25:15.000000000 +0000
++++ b/src/imperative.ml	2020-11-18 15:01:29.831444133 +0000
 @@ -233,7 +233,7 @@
    module Concrete(V: COMPARABLE) = struct
  
@@ -37,9 +37,9 @@ diff -Naur ocamlgraph-1.8.7/src/imperative.ml ocamlgraph/src/imperative.ml
  
      (* Export some definitions of [G] *)
      module Mark = G.Mark
-diff -Naur ocamlgraph-1.8.7/src/persistent.ml ocamlgraph/src/persistent.ml
---- ocamlgraph-1.8.7/src/persistent.ml	2016-04-12 08:47:31.000000000 +0200
-+++ ocamlgraph/src/persistent.ml	2017-06-26 12:29:20.204618600 +0200
+diff -Naur a/src/persistent.ml b/src/persistent.ml
+--- a/src/persistent.ml	2017-10-17 09:25:15.000000000 +0000
++++ b/src/persistent.ml	2020-11-18 15:01:29.831444133 +0000
 @@ -209,7 +209,7 @@
    module Concrete(V: COMPARABLE) = struct
  

--- a/src_ext/patches/seq.pkg/0001-switch-between-definition-alias-module-depending-on-.patch
+++ b/src_ext/patches/seq.pkg/0001-switch-between-definition-alias-module-depending-on-.patch
@@ -1,41 +1,13 @@
-From 2d608bd49647a4a6d0ec51c61cf63678212ea185 Mon Sep 17 00:00:00 2001
-From: Simon Cruanes <simon.cruanes.2007@m4x.org>
-Date: Thu, 19 Apr 2018 00:08:23 -0500
-Subject: [PATCH] switch between definition/alias module depending on ocaml's
- version
-
----
- .gitignore        |  2 ++
- Makefile          | 11 ++++++-
- select_version.ml | 14 +++++++++
- seq.opam          |  3 --
- src/seq.ml        | 73 --------------------------------------------
- src/seq.mli       | 77 -----------------------------------------------
- src/seq_alias.ml  |  1 +
- src/seq_alias.mli |  2 ++
- src/seq_redef.ml  | 73 ++++++++++++++++++++++++++++++++++++++++++++
- src/seq_redef.mli | 75 +++++++++++++++++++++++++++++++++++++++++++++
- 10 files changed, 177 insertions(+), 154 deletions(-)
- create mode 100644 select_version.ml
- delete mode 100644 src/seq.ml
- delete mode 100644 src/seq.mli
- create mode 100644 src/seq_alias.ml
- create mode 100644 src/seq_alias.mli
- create mode 100644 src/seq_redef.ml
- create mode 100644 src/seq_redef.mli
-
-diff --git a/.gitignore b/.gitignore
-index e35d885..487f91e 100644
---- a/.gitignore
-+++ b/.gitignore
+diff -Naur a/.gitignore b/.gitignore
+--- a/.gitignore	2018-04-19 02:18:40.000000000 +0000
++++ b/.gitignore	2020-11-18 15:01:30.207444715 +0000
 @@ -1 +1,3 @@
  _build
 +src/seq.ml
 +src/seq.mli
-diff --git a/Makefile b/Makefile
-index fbf5dc9..c3048a5 100644
---- a/Makefile
-+++ b/Makefile
+diff -Naur a/Makefile b/Makefile
+--- a/Makefile	2018-04-19 02:18:40.000000000 +0000
++++ b/Makefile	2020-11-18 15:01:30.207444715 +0000
 @@ -1,9 +1,18 @@
  
 +all: build
@@ -56,11 +28,9 @@ index fbf5dc9..c3048a5 100644
  	ocamlbuild -clean
  
  TOINSTALL=$(wildcard _build/src/*)
-diff --git a/select_version.ml b/select_version.ml
-new file mode 100644
-index 0000000..f92c665
---- /dev/null
-+++ b/select_version.ml
+diff -Naur a/select_version.ml b/select_version.ml
+--- a/select_version.ml	1970-01-01 00:00:00.000000000 +0000
++++ b/select_version.ml	2020-11-18 15:01:30.207444715 +0000
 @@ -0,0 +1,14 @@
 +
 +let () =
@@ -76,11 +46,10 @@ index 0000000..f92c665
 +  print_string file;
 +  flush stdout
 +
-diff --git a/seq.opam b/seq.opam
-index 8d3569c..b75ca84 100644
---- a/seq.opam
-+++ b/seq.opam
-@@ -21,8 +21,5 @@ tags: [ "iterator" "seq" "pure" "list" "compatibility" "cascade" ]
+diff -Naur a/seq.opam b/seq.opam
+--- a/seq.opam	2018-04-19 02:18:40.000000000 +0000
++++ b/seq.opam	2020-11-18 15:01:30.207444715 +0000
+@@ -21,8 +21,5 @@
  homepage: "https://github.com/c-cube/seq/"
  bug-reports: "https://github.com/c-cube/seq/issues"
  dev-repo: "https://github.com/c-cube/seq.git"
@@ -89,11 +58,9 @@ index 8d3569c..b75ca84 100644
 -]
  
  
-diff --git a/src/seq.ml b/src/seq.ml
-deleted file mode 100644
-index ccdbfde..0000000
---- a/src/seq.ml
-+++ /dev/null
+diff -Naur a/src/seq.ml b/src/seq.ml
+--- a/src/seq.ml	2018-04-19 02:18:40.000000000 +0000
++++ b/src/seq.ml	1970-01-01 00:00:00.000000000 +0000
 @@ -1,73 +0,0 @@
 -(**************************************************************************)
 -(*                                                                        *)
@@ -168,11 +135,9 @@ index ccdbfde..0000000
 -        aux next
 -  in
 -  aux seq
-diff --git a/src/seq.mli b/src/seq.mli
-deleted file mode 100644
-index f33c19a..0000000
---- a/src/seq.mli
-+++ /dev/null
+diff -Naur a/src/seq.mli b/src/seq.mli
+--- a/src/seq.mli	2018-04-19 02:18:40.000000000 +0000
++++ b/src/seq.mli	1970-01-01 00:00:00.000000000 +0000
 @@ -1,77 +0,0 @@
 -(**************************************************************************)
 -(*                                                                        *)
@@ -251,26 +216,20 @@ index f33c19a..0000000
 -val iter : ('a -> unit) -> 'a t -> unit
 -(** Iterate on the sequence, calling the (imperative) function on every element.
 -    The traversal happens immediately and will not terminate on infinite sequences. *)
-diff --git a/src/seq_alias.ml b/src/seq_alias.ml
-new file mode 100644
-index 0000000..49d3313
---- /dev/null
-+++ b/src/seq_alias.ml
+diff -Naur a/src/seq_alias.ml b/src/seq_alias.ml
+--- a/src/seq_alias.ml	1970-01-01 00:00:00.000000000 +0000
++++ b/src/seq_alias.ml	2020-11-18 15:01:30.207444715 +0000
 @@ -0,0 +1 @@
 +include Stdlib.Seq
-diff --git a/src/seq_alias.mli b/src/seq_alias.mli
-new file mode 100644
-index 0000000..8872dd5
---- /dev/null
-+++ b/src/seq_alias.mli
+diff -Naur a/src/seq_alias.mli b/src/seq_alias.mli
+--- a/src/seq_alias.mli	1970-01-01 00:00:00.000000000 +0000
++++ b/src/seq_alias.mli	2020-11-18 15:01:30.207444715 +0000
 @@ -0,0 +1,2 @@
 +
 +include module type of Stdlib.Seq
-diff --git a/src/seq_redef.ml b/src/seq_redef.ml
-new file mode 100644
-index 0000000..ccdbfde
---- /dev/null
-+++ b/src/seq_redef.ml
+diff -Naur a/src/seq_redef.ml b/src/seq_redef.ml
+--- a/src/seq_redef.ml	1970-01-01 00:00:00.000000000 +0000
++++ b/src/seq_redef.ml	2020-11-18 15:01:30.211444721 +0000
 @@ -0,0 +1,73 @@
 +(**************************************************************************)
 +(*                                                                        *)
@@ -345,11 +304,9 @@ index 0000000..ccdbfde
 +        aux next
 +  in
 +  aux seq
-diff --git a/src/seq_redef.mli b/src/seq_redef.mli
-new file mode 100644
-index 0000000..c22dff9
---- /dev/null
-+++ b/src/seq_redef.mli
+diff -Naur a/src/seq_redef.mli b/src/seq_redef.mli
+--- a/src/seq_redef.mli	1970-01-01 00:00:00.000000000 +0000
++++ b/src/seq_redef.mli	2020-11-18 15:01:30.211444721 +0000
 @@ -0,0 +1,75 @@
 +(**************************************************************************)
 +(*                                                                        *)
@@ -426,6 +383,3 @@ index 0000000..c22dff9
 +val iter : ('a -> unit) -> 'a t -> unit
 +(** Iterate on the sequence, calling the (imperative) function on every element.
 +    The traversal happens immediately and will not terminate on infinite sequences. *)
--- 
-2.17.1
-

--- a/src_ext/patches/seq/0001-seq-0.2-for-jbuilder.patch
+++ b/src_ext/patches/seq/0001-seq-0.2-for-jbuilder.patch
@@ -1,40 +1,13 @@
-From 048e95da1f0899ce77b1f28c324b1a96fc1d5da5 Mon Sep 17 00:00:00 2001
-From: Simon Cruanes <simon.cruanes.2007@m4x.org>
-Date: Thu, 19 Apr 2018 00:08:23 -0500
-Subject: [PATCH] seq 0.2 for jbuilder
-
----
- .gitignore        |  2 ++
- Makefile          | 11 ++++++-
- select_version.ml | 14 +++++++++
- seq.opam          |  8 ++---
- src/seq.ml        | 73 --------------------------------------------
- src/seq.mli       | 77 -----------------------------------------------
- src/seq_alias.ml  |  1 +
- src/seq_alias.mli |  2 ++
- src/seq_redef.ml  | 73 ++++++++++++++++++++++++++++++++++++++++++++
- src/seq_redef.mli | 75 +++++++++++++++++++++++++++++++++++++++++++++
- 10 files changed, 181 insertions(+), 155 deletions(-)
- create mode 100644 select_version.ml
- delete mode 100644 src/seq.ml
- delete mode 100644 src/seq.mli
- create mode 100644 src/seq_alias.ml
- create mode 100644 src/seq_alias.mli
- create mode 100644 src/seq_redef.ml
- create mode 100644 src/seq_redef.mli
-
-diff --git a/.gitignore b/.gitignore
-index e35d885..487f91e 100644
---- a/.gitignore
-+++ b/.gitignore
+diff -Naur a/.gitignore b/.gitignore
+--- a/.gitignore	2018-04-19 02:18:40.000000000 +0000
++++ b/.gitignore	2020-11-18 15:01:30.083444523 +0000
 @@ -1 +1,3 @@
  _build
 +src/seq.ml
 +src/seq.mli
-diff --git a/Makefile b/Makefile
-index fbf5dc9..c3048a5 100644
---- a/Makefile
-+++ b/Makefile
+diff -Naur a/Makefile b/Makefile
+--- a/Makefile	2018-04-19 02:18:40.000000000 +0000
++++ b/Makefile	2020-11-18 15:01:30.083444523 +0000
 @@ -1,9 +1,18 @@
  
 +all: build
@@ -55,11 +28,9 @@ index fbf5dc9..c3048a5 100644
  	ocamlbuild -clean
  
  TOINSTALL=$(wildcard _build/src/*)
-diff --git a/select_version.ml b/select_version.ml
-new file mode 100644
-index 0000000..a5c25ac
---- /dev/null
-+++ b/select_version.ml
+diff -Naur a/select_version.ml b/select_version.ml
+--- a/select_version.ml	1970-01-01 00:00:00.000000000 +0000
++++ b/select_version.ml	2020-11-18 15:01:30.083444523 +0000
 @@ -0,0 +1,14 @@
 +
 +let () =
@@ -75,11 +46,10 @@ index 0000000..a5c25ac
 +  print_string file;
 +  flush stdout
 +
-diff --git a/seq.opam b/seq.opam
-index 8d3569c..d8f19cf 100644
---- a/seq.opam
-+++ b/seq.opam
-@@ -3,7 +3,7 @@ name: "seq"
+diff -Naur a/seq.opam b/seq.opam
+--- a/seq.opam	2018-04-19 02:18:40.000000000 +0000
++++ b/seq.opam	2020-11-18 15:01:30.083444523 +0000
+@@ -3,7 +3,7 @@
  version: "0.1"
  author: "Simon Cruanes"
  maintainer: "simon.cruanes.2007@m4x.org"
@@ -88,7 +58,7 @@ index 8d3569c..d8f19cf 100644
  build: [
    [make "build"]
  ]
-@@ -21,8 +21,8 @@ tags: [ "iterator" "seq" "pure" "list" "compatibility" "cascade" ]
+@@ -21,8 +21,8 @@
  homepage: "https://github.com/c-cube/seq/"
  bug-reports: "https://github.com/c-cube/seq/issues"
  dev-repo: "https://github.com/c-cube/seq.git"
@@ -100,11 +70,9 @@ index 8d3569c..d8f19cf 100644
 +# because OCaml starts having a `Seq` module in the stdlib
 +available: [ocaml-version < "4.07.0"]
  
-diff --git a/src/seq.ml b/src/seq.ml
-deleted file mode 100644
-index ccdbfde..0000000
---- a/src/seq.ml
-+++ /dev/null
+diff -Naur a/src/seq.ml b/src/seq.ml
+--- a/src/seq.ml	2018-04-19 02:18:40.000000000 +0000
++++ b/src/seq.ml	1970-01-01 00:00:00.000000000 +0000
 @@ -1,73 +0,0 @@
 -(**************************************************************************)
 -(*                                                                        *)
@@ -179,11 +147,9 @@ index ccdbfde..0000000
 -        aux next
 -  in
 -  aux seq
-diff --git a/src/seq.mli b/src/seq.mli
-deleted file mode 100644
-index f33c19a..0000000
---- a/src/seq.mli
-+++ /dev/null
+diff -Naur a/src/seq.mli b/src/seq.mli
+--- a/src/seq.mli	2018-04-19 02:18:40.000000000 +0000
++++ b/src/seq.mli	1970-01-01 00:00:00.000000000 +0000
 @@ -1,77 +0,0 @@
 -(**************************************************************************)
 -(*                                                                        *)
@@ -262,26 +228,20 @@ index f33c19a..0000000
 -val iter : ('a -> unit) -> 'a t -> unit
 -(** Iterate on the sequence, calling the (imperative) function on every element.
 -    The traversal happens immediately and will not terminate on infinite sequences. *)
-diff --git a/src/seq_alias.ml b/src/seq_alias.ml
-new file mode 100644
-index 0000000..49d3313
---- /dev/null
-+++ b/src/seq_alias.ml
+diff -Naur a/src/seq_alias.ml b/src/seq_alias.ml
+--- a/src/seq_alias.ml	1970-01-01 00:00:00.000000000 +0000
++++ b/src/seq_alias.ml	2020-11-18 15:01:30.087444529 +0000
 @@ -0,0 +1 @@
 +include Stdlib.Seq
-diff --git a/src/seq_alias.mli b/src/seq_alias.mli
-new file mode 100644
-index 0000000..8872dd5
---- /dev/null
-+++ b/src/seq_alias.mli
+diff -Naur a/src/seq_alias.mli b/src/seq_alias.mli
+--- a/src/seq_alias.mli	1970-01-01 00:00:00.000000000 +0000
++++ b/src/seq_alias.mli	2020-11-18 15:01:30.087444529 +0000
 @@ -0,0 +1,2 @@
 +
 +include module type of Stdlib.Seq
-diff --git a/src/seq_redef.ml b/src/seq_redef.ml
-new file mode 100644
-index 0000000..ccdbfde
---- /dev/null
-+++ b/src/seq_redef.ml
+diff -Naur a/src/seq_redef.ml b/src/seq_redef.ml
+--- a/src/seq_redef.ml	1970-01-01 00:00:00.000000000 +0000
++++ b/src/seq_redef.ml	2020-11-18 15:01:30.087444529 +0000
 @@ -0,0 +1,73 @@
 +(**************************************************************************)
 +(*                                                                        *)
@@ -356,11 +316,9 @@ index 0000000..ccdbfde
 +        aux next
 +  in
 +  aux seq
-diff --git a/src/seq_redef.mli b/src/seq_redef.mli
-new file mode 100644
-index 0000000..c22dff9
---- /dev/null
-+++ b/src/seq_redef.mli
+diff -Naur a/src/seq_redef.mli b/src/seq_redef.mli
+--- a/src/seq_redef.mli	1970-01-01 00:00:00.000000000 +0000
++++ b/src/seq_redef.mli	2020-11-18 15:01:30.087444529 +0000
 @@ -0,0 +1,75 @@
 +(**************************************************************************)
 +(*                                                                        *)
@@ -437,6 +395,3 @@ index 0000000..c22dff9
 +val iter : ('a -> unit) -> 'a t -> unit
 +(** Iterate on the sequence, calling the (imperative) function on every element.
 +    The traversal happens immediately and will not terminate on infinite sequences. *)
--- 
-2.17.1
-


### PR DESCRIPTION
~~Wants double-checking with 4.12.0~alpha1 - I've seen some failures with cppo, but hopefully they were one-offs.~~

Fixes:
- https://github.com/ocaml/opam/pull/4425#issuecomment-729676670 - we wind extlib forwards to 1.7.7 and apply the patch for 4.12
- Update cppo to 1.6.6 in order to have `dune` instead of `jbuild` files for Dune 2 compatibility.
- cppo patches for 4.12 and 4.02.3
- Update re to 1.9.0 and result to 1.4 in order to have `dune` files instead of `jbuild` files for Dune 2 compatibility