### PR TITLE
Treat os-family=ubuntu as os-family=debian

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -57,7 +57,8 @@ New option/command/subcommand are prefixed with ◈.
 ## External dependencies
   * Add support for NetBSD and DragonFlyBSD [#4396 @kit-ty-kate]
   * Fix OpenBSD, FreeBSD and Gentoo: Allow short names and full name paths for ports-based systems [#4396 @kit-ty-kate]
-
+  * Handle the case where `os-family=ubuntu` as `os-family=debian` [#4441 @alan-j-hu]
+  
 ## Sandbox
   *
 
@@ -86,7 +87,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## State
-  * Handle the case where `os-family=ubuntu` as `os-family=debian`
+  * 
 
 ## Solver
   * Fix missing conflict message when trying to remove required packages [#4362 @AltGr]

--- a/master_changes.md
+++ b/master_changes.md
@@ -85,6 +85,9 @@ New option/command/subcommand are prefixed with ◈.
 ## Opam installer
   *
 
+## State
+  * Handle the case where `os-family=ubuntu` as `os-family=debian`
+
 ## Solver
   * Fix missing conflict message when trying to remove required packages [#4362 @AltGr]
   * Fix the Z3 backend for upgrades [#4393 @AltGr]

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -118,7 +118,7 @@ let family =
             Printf.ksprintf failwith
               "External dependency handling not supported for OS family 'bsd'."
         end
-      | "debian" -> Debian
+      | "debian" | "ubuntu" -> Debian
       | "gentoo" -> Gentoo
       | "homebrew" -> Homebrew
       | "macports" -> Macports


### PR DESCRIPTION
At least on Linux Mint 20, the value of `os-family` is `ubuntu`. This caused `opam depext` to fail for me, as `ubuntu` is not one of the handled cases. This PR treats `os-family=ubuntu` as `os-family=debian`.
