### PR TITLE
Use --depth=1 for Git repos

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -73,7 +73,7 @@ users)
   *
 
 ## Repository management
-  *
+  * Pass --depth=1 to git-fetch in the Git repo backend [#4442 @dra27]
 
 ## VCS
   *

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -93,7 +93,7 @@ module VCS : OpamVCS.VCS = struct
           OpamFilename.write alternates
             (OpamFilename.Dir.to_string (cache / "objects")))
       global_cache;
-    git repo_root [ "fetch" ; "-q"; origin; "--update-shallow"; refspec ]
+    git repo_root [ "fetch" ; "-q"; origin; "--update-shallow"; "--depth=1"; refspec ]
     @@> fun r ->
     if OpamProcess.check_success_and_cleanup r then
       let refspec =


### PR DESCRIPTION
Triggered from [this Discuss comment](https://discuss.ocaml.org/t/removing-fat-compiler-images-on-hub-docker-com-r-ocaml-opam2/6658/6). This PR acts as a tracking "issue" for further discussion. I don't think in the repo backends we _need_ the Git history for the repository being checked out - we just need it to be possible to update it?

So this adds `--depth=1` to the git-fetch call. This reduces opam-repository as a Git clone, for example, from ~95MiB storage to ~15MiB.

But there may be other consequences...