### PR TITLE
Fix architecture detection when using 32bit mode on ARM64 and i486

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -43,8 +43,8 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Var
   * Add `opamfile-loc` as a package variable, containing the location of installed package opam file [#4402 @rjbou]
-  * Fix `arch` detection when using 32bit mode on ARM64
-  * Fix `arch` detection of i486
+  * Fix `arch` detection when using 32bit mode on ARM64 [#4462 @kit-ty-kate]
+  * Fix `arch` detection of i486 [#4462 @kit-ty-kate]
 
 ## Option
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -43,6 +43,8 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Var
   * Add `opamfile-loc` as a package variable, containing the location of installed package opam file [#4402 @rjbou]
+  * Fix `arch` detection when using 32bit mode on ARM64
+  * Fix `arch` detection of i486
 
 ## Option
 

--- a/shell/install.sh
+++ b/shell/install.sh
@@ -126,8 +126,8 @@ case "$ARCH" in
     x86|i?86) ARCH="i686";;
     x86_64|amd64) ARCH="x86_64";;
     ppc|powerpc|ppcle) ARCH="ppc";;
-    aarch64_be|aarch64|armv8b|armv8l) ARCH="arm64";;
-    armv5*|armv6*|earmv6*|armv7*|earmv7*) ARCH="armhf";;
+    aarch64_be|aarch64) ARCH="arm64";;
+    armv5*|armv6*|earmv6*|armv7*|earmv7*|armv8b|armv8l) ARCH="armhf";;
     *) ARCH=$(echo "$ARCH" | awk '{print tolower($0)}')
 esac
 

--- a/src/state/opamSysPoll.ml
+++ b/src/state/opamSysPoll.ml
@@ -25,7 +25,7 @@ let norm s = if s = "" then None else Some (String.lowercase_ascii s)
 
 let normalise_arch raw =
   match String.lowercase_ascii raw with
-  | "x86" | "i386" | "i586" | "i686" -> "x86_32"
+  | "x86" | "i386" | "i486" | "i586" | "i686" -> "x86_32"
   | "x86_64" | "amd64" -> "x86_64"
   | "powerpc" | "ppc" | "ppcle" -> "ppc32"
   | "ppc64" | "ppc64le" -> "ppc64"

--- a/src/state/opamSysPoll.ml
+++ b/src/state/opamSysPoll.ml
@@ -29,8 +29,8 @@ let normalise_arch raw =
   | "x86_64" | "amd64" -> "x86_64"
   | "powerpc" | "ppc" | "ppcle" -> "ppc32"
   | "ppc64" | "ppc64le" -> "ppc64"
-  | "aarch64_be" | "aarch64" | "armv8b" | "armv8l" -> "arm64"
-  | a when List.exists (fun prefix -> OpamStd.String.starts_with ~prefix a)
+  | "aarch64_be" | "aarch64" -> "arm64"
+  | a when a = "armv8b" || a = "armv8l" || List.exists (fun prefix -> OpamStd.String.starts_with ~prefix a)
         ["armv5"; "armv6"; "earmv6"; "armv7"; "earmv7"] -> "arm32"
   | s -> s
 


### PR DESCRIPTION
`armv8l` and `armv8b` actually mean "32bit emulation on an armv8 processor", see https://reviews.llvm.org/rG9b958356983afffaf56788f37bdab9213369fa45

This was causing issue in https://github.com/ocaml/opam-repository/pull/17747 where the package does not work on Arm32, restricted the availability there but 32bit environment is still wrongly detected as `arm64`:
```
#=== ERROR while compiling albatross.1.0.1 ====================================#
# context              2.0.7 | linux/arm64 | ocaml-base-compiler.4.11.1 | pinned(https://github.com/roburio/albatross/releases/download/v1.0.1/albatross-v1.0.1.tbz)
# path                 ~/.opam/4.11/.opam-switch/build/albatross.1.0.1
# command              ~/.opam/4.11/bin/dune build -p albatross -j 31
# exit-code            1
# env-file             ~/.opam/log/albatross-7-6a4d96.env
# output-file          ~/.opam/log/albatross-7-6a4d96.out
### output ###
#     discover stats/c_flags.sexp,stats/c_library_flags.sexp (exit 2)
# (cd _build/default/stats && config/discover.exe)
# Fatal error: exception Failure("Unsupported platform: linux_eabihf")
```
Test-case:
```
$ docker run --rm -it --entrypoint bash ocaml/opam:debian-10-ocaml-4.11@sha256:ca5b021f7b74707f3d5df69657bb5a34062e81f0cfb71fdf8101cb4b32a8980a
opam@3440e642156a:~$ uname -m
aarch64
opam@3440e642156a:~$ linux32 uname -m
armv8l
```