### PR TITLE
Github actions: linux & macos

### DIFF
--- a/.github/scripts/hygiene.sh
+++ b/.github/scripts/hygiene.sh
@@ -1,0 +1,146 @@
+#!/bin/bash -xue
+
+PR_COMMIT_RANGE=
+if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+  PR_COMMIT_RANGE="$GITHUB_REF_SHA...$GITHUB_SHA"
+fi
+CI_BRANCH=${GITHUB_REF##*/}
+
+
+echo "PR_COMMIT_RANGE=$PR_COMMIT_RANGE"
+echo "GITHUB_SHA=$GITHUB_SHA"
+if [[ $GITHUB_EVENT_NAME = 'pull_request' ]] ; then
+  FETCH_HEAD=$(git rev-parse FETCH_HEAD)
+  echo "FETCH_HEAD=$FETCH_HEAD"
+else
+  FETCH_HEAD=$GITHUB_SHA
+fi
+
+if [[ $GITHUB_EVENT_NAME = 'push' ]] ; then
+  if ! git cat-file -e "$GITHUB_SHA" 2> /dev/null ; then
+    echo 'GITHUB_SHA does not exist - CI failure'
+    exit 1
+  fi
+else
+  if [[ $GITHUB_SHA != $(git rev-parse FETCH_HEAD) ]] ; then
+    echo 'WARNING! Travis GITHUB_SHA and FETCH_HEAD do not agree!'
+    if git cat-file -e "$GITHUB_SHA" 2> /dev/null ; then
+      echo 'GITHUB_SHA exists, so going with it'
+    else
+      echo 'GITHUB_SHA does not exist; setting to FETCH_HEAD'
+      GITHUB_SHA=$FETCH_HEAD
+    fi
+  fi
+fi
+
+CheckConfigure () {
+  GIT_INDEX_FILE=tmp-index git read-tree --reset -i "$1"
+  git diff-tree --diff-filter=d --no-commit-id --name-only -r "$1" \
+    | (while IFS= read -r path
+  do
+    case "$path" in
+      configure|configure.ac|m4/*)
+        touch CHECK_CONFIGURE;;
+    esac
+  done)
+  rm -f tmp-index
+  if [[ -e CHECK_CONFIGURE ]] ; then
+    echo "configure generation altered in $1"
+    echo 'Verifying that configure.ac generates configure'
+    git clean -dfx
+    git checkout -f "$1"
+    mv configure configure.ref
+    make configure
+    if ! diff -q configure configure.ref >/dev/null ; then
+      echo -e "[\e[31mERROR\e[0m] configure.ac in $1 doesn't generate configure, \
+please run make configure and fixup the commit"
+      ERROR=1
+    fi
+  fi
+}
+
+set +x
+
+ERROR=0
+
+###
+# Check install.sh
+###
+
+if [ "$GITHUB_EVENT_NAME" = "pull_request" ] ; then
+  CUR_HEAD=$GITHUB_REF_SHA
+  PR_HEAD=$GITHUB_SHA
+  DEEPEN=50
+  while ! git merge-base "$CUR_HEAD" "$PR_HEAD" >& /dev/null
+  do
+    echo "Deepening $CI_BRANCH by $DEEPEN commits"
+    git fetch origin --deepen=$DEEPEN "$CI_BRANCH"
+    ((DEEPEN*=2))
+  done
+  MERGE_BASE=$(git merge-base "$CUR_HEAD" "$PR_HEAD")
+  if ! git diff "$MERGE_BASE..$PR_HEAD" --name-only --exit-code -- shell/install.sh > /dev/null ; then
+    echo "shell/install.sh updated - checking it"
+    eval $(grep '^\(OPAM_BIN_URL_BASE\|DEV_VERSION\|VERSION\)=' shell/install.sh)
+    echo "OPAM_BIN_URL_BASE=$OPAM_BIN_URL_BASE"
+    echo "VERSION = $VERSION"
+    echo "DEV_VERSION = $DEV_VERSION"
+    for VERSION in $DEV_VERSION $VERSION; do
+      eval $(grep '^TAG=' shell/install.sh)
+      echo "TAG = $TAG"
+      ARCHES=0
+
+      while read -r key sha
+      do
+        ARCHES=1
+        URL="$OPAM_BIN_URL_BASE$TAG/opam-$TAG-$key"
+        echo "Checking $URL"
+        check=$(curl -Ls "$URL" | sha512sum | cut -d' ' -f1)
+        if [ "$check" = "$sha" ] ; then
+          echo "Checksum as expected ($sha)"
+        else
+          echo -e "[\e[31mERROR\e[0m] Checksum downloaded: $check"
+          echo -e "[\e[31mERROR\e[0m] Checksum install.sh: $sha"
+          ERROR=1
+        fi
+      done < <(sed -ne "s/.*opam-$TAG-\([^)]*\).*\"\([^\"]*\)\".*/\1 \2/p" shell/install.sh)
+    done
+    if [ $ARCHES -eq 0 ] ; then
+      echo "[\e[31mERROR\e[0m] No sha512 checksums were detected in shell/install.sh"
+      echo "That can't be right..."
+      ERROR=1
+    fi
+  fi
+fi
+
+###
+# Check configure
+###
+
+if [[ -z $PR_COMMIT_RANGE ]]
+then CheckConfigure "$GITHUB_SHA"
+else
+  if [[ $GITHUB_EVENT_NAME = 'pull_request' ]]
+  then PR_COMMIT_RANGE=$MERGE_BASE..$GITHUB_SHA
+  fi
+  for commit in $(git rev-list "$PR_COMMIT_RANGE" --reverse)
+  do
+    CheckConfigure "$commit"
+  done
+fi
+
+###
+# Check src_ext patches
+###
+# Check that the lib-ext/lib-pkg patches are "simple"
+make -C src_ext PATCH="busybox patch" clone
+make -C src_ext PATCH="busybox patch" clone-pkg
+# Check that the lib-ext/lib-pkg patches have been re-packaged
+cd src_ext
+../shell/re-patch.sh
+if [[ $(find patches -name \*.old | wc -l) -ne 0 ]] ; then
+  echo -e "[\e[31mERROR\e[0m] ../shell/re-patch.sh should be run from src_ext before CI check"
+  git diff
+  ERROR=1
+fi
+cd ..
+exit $ERROR

--- a/.github/scripts/main.sh
+++ b/.github/scripts/main.sh
@@ -1,0 +1,155 @@
+#!/bin/bash -xue
+
+. .github/scripts/preamble.sh
+
+unset-dev-version () {
+  # disable git versioning to allow OPAMYES use for upgrade
+  touch src/client/no-git-version
+}
+
+export OPAMYES=1
+export OCAMLRUNPARAM=b
+
+( # Run subshell in bootstrap root env to build
+  (set +x ; echo -en "::group::build opam\r") 2>/dev/null
+  if [[ $OPAM_TEST -eq 1 ]] ; then
+    export OPAMROOT=$OPAMBSROOT
+    # If the cached root is newer, regenerate a binary compatible root
+    opam env || { rm -rf $OPAMBSROOT; init-bootstrap; }
+    eval $(opam env)
+  fi
+
+  ./configure --prefix ~/local --with-mccs
+
+  if [[ $OPAM_TEST$OPAM_COLD -eq 0 ]] ; then
+    make lib-ext
+  fi
+  if [ $OPAM_UPGRADE -eq 1 ]; then
+    unset-dev-version
+  fi
+  make all admin
+
+  rm -f ~/local/bin/opam
+  make install
+  (set +x ; echo -en "::endgroup::build opam\r") 2>/dev/null
+
+  export PATH=~/local/bin:$PATH
+  opam config report
+
+  if [ "$OPAM_TEST" = "1" ]; then
+    # test if an upgrade is needed
+    set +e
+    opam list 2> /dev/null
+    rcode=$?
+    if [ $rcode -eq 10 ]; then
+      echo "Recompiling for an opam root upgrade"
+      (set +x ; echo -en "::group::rebuild opam\r") 2>/dev/null
+      unset-dev-version
+      make all admin
+      rm -f ~/local/bin/opam
+      make install
+      opam list 2> /dev/null
+      rcode=$?
+      set -e
+      if [ $rcode -ne 10 ]; then
+        echo -e "\e[31mBad return code $rcode, should be 10\e[0m";
+        exit $rcode
+      fi
+      (set +x ; echo -en "::endgroup::rebuild opam\r") 2>/dev/null
+    fi
+    set -e
+    make distclean
+
+    # Compile and run opam-rt
+    (set +x ; echo -en "::group::opam-rt\r") 2>/dev/null
+    opamrt_url="https://github.com/ocaml/opam-rt"
+    if [ ! -d $CACHE/opam-rt ]; then
+      git clone $opamrt_url  $CACHE/opam-rt
+    fi
+    cd $CACHE/opam-rt
+    git fetch origin
+    if git ls-remote --exit-code --heads $opamrt_url $BRANCH ; then 
+      if git branch | grep -q $BRANCH; then
+        git checkout $BRANCH
+        git reset --hard origin/$BRANCH
+      else
+        git checkout -b $BRANCH origin/$BRANCH
+      fi
+    else
+      git checkout master
+      git reset --hard origin/master
+    fi
+    test -d _opam || opam switch create . --empty 
+    eval $(opam env)
+    opam pin --kind=path $GITHUB_WORKSPACE --yes --no-action
+    opam pin . -yn
+    opam install opam-rt --deps-only
+    make
+    (set +x ; echo -en "::endgroup::opam-rt\r") 2>/dev/null
+
+  elif [ $OPAM_UPGRADE -ne 1 ]; then
+    # Note: these tests require a "system" compiler and will use the one in $OPAMBSROOT
+     make tests ||
+      (tail -n 2000 _build/default/tests/fulltest-*.log; echo "-- TESTS FAILED --"; exit 1)
+  fi
+)
+
+export PATH=~/local/bin:$PATH
+
+if [ $OPAM_UPGRADE -eq 1 ]; then
+  OPAM12CACHE=`eval echo $OPAM12CACHE`
+  OPAM12=$OPAM12CACHE/bin/opam
+  if [[ ! -f $OPAM12 ]]; then
+    mkdir -p $OPAM12CACHE/bin
+    wget https://github.com/ocaml/opam/releases/download/1.2.2/opam-1.2.2-x86_64-Linux -O $OPAM12
+    chmod +x $OPAM12
+  fi
+  export OPAMROOT=/tmp/opamroot
+  rm -rf $OPAMROOT
+  if [[ ! -d $OPAM12CACHE/root ]]; then
+    $OPAM12 init
+    cp -r /tmp/opamroot/ $OPAM12CACHE/root
+  else
+    cp -r $OPAM12CACHE/root /tmp/opamroot
+  fi
+  set +e
+  $OPAM12 --version
+  opam --version
+  opam update
+  rcode=$?
+  if [ $rcode -ne 10 ]; then
+    echo "[31mBad return code $rcode, should be 10[0m";
+    exit $rcode
+  fi
+  opam_version=$(sed -ne 's/opam-version: *//p' $OPAMROOT/config)
+  if [ "$opam_version" = '"1.2"' ]; then
+    echo -e "\e[31mUpgrade failed, opam-root is still 1.2\e[0m";
+    cat $OPAMROOT/config
+    exit 2
+  fi
+  exit 0
+fi
+
+( # Finally run the tests, in a clean environment
+  export OPAMKEEPLOGS=1
+
+  if [[ $OPAM_TEST -eq 1 ]] ; then
+    cd $CACHE/opam-rt
+    make KINDS="local git" run
+  else
+    if [[ $OPAM_COLD -eq 1 ]] ; then
+      export PATH=$PWD/bootstrap/ocaml/bin:$PATH
+    fi
+
+    # Test basic actions
+    # The SHA is fixed so that upstream changes shouldn't affect CI. The SHA needs
+    # to be moved forwards when a new version of OCaml is added to ensure that the
+    # ocaml-system package is available at the correct version.
+    opam init --bare default git+https://github.com/ocaml/opam-repository#$OPAM_TEST_REPO_SHA
+    opam switch create default ocaml-system
+    eval $(opam env)
+    opam install lwt
+    opam list
+    opam config report
+  fi
+)

--- a/.github/scripts/ocaml-cache.sh
+++ b/.github/scripts/ocaml-cache.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -xue
+
+. .github/scripts/preamble.sh
+
+wget "http://caml.inria.fr/pub/distrib/ocaml-${OCAML_VERSION%.*}/ocaml-$OCAML_VERSION.tar.gz"
+tar -xzf "ocaml-$OCAML_VERSION.tar.gz"
+
+cd "ocaml-$OCAML_VERSION"
+if [[ $OPAM_TEST -ne 1 ]] ; then
+  if [[ -e configure.ac ]]; then
+    CONFIGURE_SWITCHES="--disable-debugger --disable-debug-runtime --disable-ocamldoc"
+    if [[ ${OCAML_VERSION%.*} = '4.08' ]]; then
+      CONFIGURE_SWITCHES="$CONFIGURE_SWITCHES --disable-graph-lib"
+    fi
+  else
+    CONFIGURE_SWITCHES="-no-graph -no-debugger -no-ocamldoc"
+    if [[ "$OCAML_VERSION" != "4.02.3" ]] ; then
+      CONFIGURE_SWITCHES="$CONFIGURE_SWITCHES -no-ocamlbuild"
+    fi
+
+  fi
+fi
+
+./configure --prefix $OCAML_LOCAL ${CONFIGURE_SWITCHES:-}
+
+if [[ $OPAM_TEST -eq 1 ]] ; then
+  make -j 4 world.opt
+else
+  make world.opt
+fi
+
+make install
+
+cd ..
+rm -rf "ocaml-$OCAML_VERSION"

--- a/.github/scripts/opam-bs-cache.sh
+++ b/.github/scripts/opam-bs-cache.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -xue
+
+. .github/scripts/preamble.sh
+
+rm -f $OPAM_LOCAL/bin/opam-bootstrap
+mkdir -p $OPAM_LOCAL/bin/
+
+os=$( (uname -s || echo unknown) | awk '{print tolower($0)}')
+if [ "$os" = "darwin" ] ; then
+  os=macos
+fi
+
+wget -q -O $OPAM_LOCAL/bin/opam-bootstrap \
+  "https://github.com/ocaml/opam/releases/download/$OPAMBSVERSION/opam-$OPAMBSVERSION-$(uname -m)-$os"
+cp -f $OPAM_LOCAL/bin/opam-bootstrap $OPAM_LOCAL/bin/opam
+chmod a+x $OPAM_LOCAL/bin/opam
+
+opam --version
+
+if [[ -d $OPAMBSROOT ]] ; then
+  init-bootstrap || { rm -rf $OPAMBSROOT; init-bootstrap; }
+else
+  init-bootstrap
+fi

--- a/.github/scripts/preamble.sh
+++ b/.github/scripts/preamble.sh
@@ -1,0 +1,46 @@
+
+CWD=$PWD
+CACHE=~/.cache
+CACHE=`eval echo $CACHE`
+echo "Cache -> $CACHE"
+OCAML_LOCAL=$CACHE/ocaml-local
+OPAM_LOCAL=$CACHE/opam-local
+PATH=$OPAM_LOCAL/bin:$OCAML_LOCAL/bin:$PATH; export PATH
+
+OPAM_COLD=${OPAM_COLD:-0}
+OPAM_TEST=${OPAM_TEST:-0}
+OPAM_UPGRADE=${OPAM_UPGRADE:-0}
+
+OPAMBSSWITCH=opam-build
+
+BRANCH=${GITHUB_REF##*/}
+
+git config --global user.email "travis@example.com"
+git config --global user.name "Travis CI"
+git config --global gc.autoDetach false
+
+# used only for TEST jobs
+init-bootstrap () {
+  if [ "$OPAM_TEST" = "1" ]; then
+    set -e
+    export OPAMROOT=$OPAMBSROOT
+    # The system compiler will be picked up
+    opam init --yes --no-setup git+https://github.com/ocaml/opam-repository#$OPAM_REPO_SHA
+    eval $(opam env)
+#    opam update
+    CURRENT_SWITCH=$(opam config var switch)
+    if [[ $CURRENT_SWITCH != "default" ]] ; then
+      opam switch default
+      eval $(opam env)
+      opam switch remove $CURRENT_SWITCH --yes
+    fi
+
+    opam switch create $OPAMBSSWITCH ocaml-system
+    eval $(opam env)
+    # extlib is installed, since UChar.cmi causes problems with the search
+    # order. See also the removal of uChar and uTF8 in src_ext/jbuild-extlib-src
+    opam install . --deps-only --yes
+
+    rm -f "$OPAMBSROOT"/log/*
+  fi
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,196 @@
+name: Builds, tests & co 
+
+on: [ push, pull_request ]
+
+env:
+  OPAMBSVERSION: 2.1.0-alpha2
+  OPAMBSROOT: ~/.cache/.opam.cached
+  OPAM12CACHE: ~/.cache/opam1.2/cache
+  # This should be identical to the value in appveyor.yml
+  OPAM_TEST_REPO_SHA: 6877131f0
+  OPAM_REPO_SHA: 88c17a663
+  # Default ocaml version for some jobs
+  OCAML_VERSION: 4.11.1
+  ## variables for cache paths
+  GH_OCAML_CACHE: ~/.cache/ocaml-local/**
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+####
+# Caches
+####
+  ocaml-cache:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        ocamlv: [ 4.02.3, 4.03.0, 4.04.2, 4.05.0, 4.06.1, 4.07.1, 4.08.1, 4.09.1, 4.10.1, 4.11.1 ]
+        include:
+          - os: macos-latest
+            ocamlv: 4.11.1
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: ocaml ${{ matrix.ocamlv }} cache
+      id: ocaml-cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.GH_OCAML_CACHE }}
+        key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ hashFiles ('.github/scripts/ocaml-cache.sh', '.github/scripts/preamble.sh') }}
+    - name: Building ocaml ${{ matrix.ocamlv }} cache
+      if: steps.ocaml-cache.outputs.cache-hit != 'true'
+      env:
+        OCAML_VERSION: ${{ matrix.ocamlv }}
+      run: bash -exu .github/scripts/ocaml-cache.sh ocaml
+
+  archives-cache:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: src ext archives cache
+      id: archives
+      uses: actions/cache@v2
+      with:
+        path: src_ext/archives
+        key: archives-${{ hashFiles('src_ext/Makefile.sources', 'src_ext/Makefile') }}
+    - name: Retrieve archives
+      if: steps.archives.outputs.cache-hit != 'true'
+      run: |#bash -exu .github/scripts/caches.sh archives
+        rm -rf src_ext/archives
+        export PATH=~/.cache/ocaml-local/bin:$PATH
+        which ocaml && export OCAML=`which ocaml` || true
+        make -C src_ext cache-archives
+        ls src_ext/archives -al
+
+####
+# Build
+####
+  build:
+    needs: [ ocaml-cache ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # If a target is added in the matrix, ensure that it's corresponding ocaml-cache is generated
+      matrix:
+        os: [ ubuntu-latest ]
+        ocamlv: [ 4.02.3, 4.03.0, 4.04.2, 4.05.0, 4.06.1, 4.07.1, 4.08.1, 4.09.1, 4.10.1, 4.11.1 ]
+        include:
+          - os: macos-latest
+            ocamlv: 4.11.1
+      # Intentionnaly fail fast, no need to run all build if there is a
+      # problem in a given version; usually it is functions not defined in lower
+      # versions of caml
+      # fail-fast: false
+    steps:
+    - name: install deps
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: sudo apt install bubblewrap
+    - uses: actions/checkout@v2
+    - name: ocaml ${{ matrix.ocamlv }} cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.GH_OCAML_CACHE }}
+        key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ hashFiles ('.github/scripts/ocaml-cache.sh', '.github/scripts/preamble.sh') }}
+    - name: Build
+      env:
+        OCAML_VERSION: ${{ matrix.ocamlv }}
+      run: bash -exu .github/scripts/main.sh
+
+####
+# Opam tests
+####
+  test:
+    needs: [ build, archives-cache ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        #os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
+        ocamlv: [ 4.11.1 ]
+      fail-fast: false
+    env:
+      OPAM_TEST: 1
+    steps:
+    - uses: actions/checkout@v2
+    - name: install deps
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: sudo apt install bubblewrap
+    - name: ocaml ${{ matrix.ocamlv }} cache
+      id: ocaml-cache-test
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.GH_OCAML_CACHE }}
+        key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ hashFiles ('.github/scripts/ocaml-cache.sh', '.github/scripts/preamble.sh') }}-test
+    - name: Building ocaml ${{ env.OCAML_VERSION }} cache
+      if: steps.ocaml-cache-test.outputs.cache-hit != 'true'
+      env:
+        OCAML_VERSION: ${{ matrix.ocamlv }}
+      run: bash -exu .github/scripts/ocaml-cache.sh ocaml
+    - name: opam bootstrap cache
+      id: opam-bootstrap
+      uses: actions/cache@v2
+      with:
+        path: |
+          ${{ env.OPAMBSROOT }}/**
+          ~/.cache/opam-local/bin/**
+        key: opam-${{ env.OPAMBSVERSION }}-${{ env.OPAM_REPO_SHA }}-${{ hashFiles ('.github/scripts/opam-bs-cache.sh', '.github/scripts/preamble.sh') }}
+    - name: opam root cache
+      if: steps.opam-bootstrap.outputs.cache-hit != 'true'
+      run: bash -exu .github/scripts/opam-bs-cache.sh
+    - name: opam-rt cache
+      id: opam-rt
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/opam-rt/**
+        key: ${{ runner.os }}-opam-rt
+    - name: Test
+      env:
+        OCAML_VERSION: ${{ matrix.ocamlv }}
+      run: bash -exu .github/scripts/main.sh
+
+  cold:
+    needs: [ build, archives-cache ]
+    runs-on: ubuntu-latest
+    steps:
+    - name: install deps
+      run: sudo apt install bubblewrap
+    - uses: actions/checkout@v2
+    - name: src ext archives cache
+      uses: actions/cache@v2
+      with:
+        path: src_ext/archives
+        key: archives-${{ hashFiles('src_ext/Makefile.sources', 'src_ext/Makefile') }}
+    - name: Cold
+      env:
+        OCAML_VERSION: ${{ env.OCAML_VERSION }}
+        OPAM_COLD: 1
+      run: |
+        make compiler
+        make lib-pkg
+        bash -exu .github/scripts/main.sh
+
+  upgrade:
+    needs: [ build, ocaml-cache ]
+    runs-on: ubuntu-latest
+    steps:
+    - name: install deps
+      run: sudo apt install bubblewrap
+    - uses: actions/checkout@v2
+    - name: opam 1.2 root cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.OPAM12CACHE }}
+        key: opam1.2-root
+    - name: ocaml ${{ env.OCAML_VERSION }} cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.GH_OCAML_CACHE }}
+        key: ${{ runner.os }}-ocaml-${{ env.OCAML_VERSION }}-${{ hashFiles ('.github/scripts/ocaml-cache.sh', '.github/scripts/preamble.sh') }}
+    - name: Upgrade
+      env:
+        OCAML_VERSION: ${{ env.OCAML_VERSION }}
+        OPAM_UPGRADE: 1
+      run: bash -exu .github/scripts/main.sh


### PR DESCRIPTION
Divided in several jobs:
 * cache for ocaml system compilation
 * cache for src_ext archives retrieving
 * build on linux 4.0.2.3 -> 4.11.1 & macos 4.11.1
 * test (opam-rt) on linux/macos 4.11.1 with an embedded compiler build cache & an opam-rt cache
 * upgrade 1.2 -> 2.0 test on linux 4.11.1, with an embedded cache for opam 1.2 root
 * make cold test

Travis is not yet disabled, those scripts need to be stress tested.

Jobs are imitating travis ones, ie:
* all linux build to check compiler compliance
* on macos build to check macos compliance
* one test job per platform (we need to introduce here further reftests and disable make tests from main build jobs)
* one make cold job on linux, to test make cold (need on macos also ?)

And:
* builds with fail fast, no need to build them all if there is a compilation issue
* test/cold/upgrade jobs depends on build jobs success, as there is no fail fast between jobs (and no need to run jobs if in the main there is a compilation issue)