### PR TITLE
Fix MacOS upgrade CI test using OS-specific opam 1.2 cache

### DIFF
--- a/.github/scripts/main.sh
+++ b/.github/scripts/main.sh
@@ -104,7 +104,12 @@ if [ $OPAM_UPGRADE -eq 1 ]; then
   OPAM12=$OPAM12CACHE/bin/opam
   if [[ ! -f $OPAM12 ]]; then
     mkdir -p $OPAM12CACHE/bin
-    wget https://github.com/ocaml/opam/releases/download/1.2.2/opam-1.2.2-x86_64-Linux -O $OPAM12
+
+    os="Linux"
+    if [ "$RUNNER_OS" = "macOS" ]; then
+      os="Darwin"
+    fi
+    wget "https://github.com/ocaml/opam/releases/download/1.2.2/opam-1.2.2-x86_64-$os" -O $OPAM12
     chmod +x $OPAM12
   fi
   export OPAMROOT=/tmp/opamroot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.OPAM12CACHE }}
-        key: opam1.2-root
+        key: ${{ runner.os }}-opam1.2-root
     - name: ocaml ${{ matrix.ocamlv }} cache
       id: ocaml-cache
       uses: actions/cache@v2

--- a/master_changes.md
+++ b/master_changes.md
@@ -128,6 +128,7 @@ New option/command/subcommand are prefixed with ◈.
   * patcher: fix local [#4467 @AltGr]
   * Add github actions [#4463 @rjbou]
   * Add reftests to github actions [#4467 @rjbou]
+  * Fix MacOS upgrade CI test using OS-specific opam 1.2 cache [#4475 @freevoid - fix #4474]
 
 ## Shell
   * Update completion scripts with `opam var` instead of `opam config list` [#4428 @rjbou]


### PR DESCRIPTION
This PR is aimed to fix #4474 by

 1) using `$RUNNER_OS` to build a OS-specific URL for opam 1.2 binary (albeit only Darwin and Linux releases are available so Windows is not supported)
 2) using `runner.os` when building a cache key for opam 1.2 root (so that MacOS will not try to re-use the linux binary and vice versa depending on which action ran first when the cache was empty)

Note that since the test still passes if the cache was built previously, we might be fine with just implementing 1, but this will lead to not-deterministic test behavior and can bring sorrow down the line.