### PR TITLE
Ensure we don't advertise upgrades to hidden versions

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -23,6 +23,7 @@ New option/command/subcommand are prefixed with ◈.
   * `post-install` hooks are allowed to modify or remove installed files, the but not add new ones. Those changes are integrated in changes file [#4388 @lefessan]
   * ◈ Add `--download-only` flag [#4071 @Armael @rjbou - fix #4036]
   * Run switch pre/post sessions hooks [#4476 @rjbou - fix #4472]
+  * Ensure we don't advertise upgrades to hidden versions [#4477 @AltGr - fix #4432]
 
 ## Remove
   * Fix `opam remove --autoremove <PKG>` to not autoremove unrelated packages [#4369 @AltGr - fix #4250 #4332]
@@ -65,6 +66,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Opamfile
   * Fix handling of filename-encoded pkgname in opam files [#4401 @AltGr - fix ocaml-opam/opam-publish#107]
+  * Make sure modifying the (currently existing) flags don't cause recompilation [#4477 @AltGr]
 
 ## External dependencies
   * Add support for NetBSD and DragonFlyBSD [#4396 @kit-ty-kate]

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -184,7 +184,11 @@ let compute_upgrade_t
              then (n, None)
              else
              let atom = (n, Some (`Gt, nv.version)) in
-             if OpamPackage.Set.exists (OpamFormula.check atom)
+             if OpamPackage.Set.exists
+                 (fun nv ->
+                    OpamFormula.check atom nv &&
+                    not (OpamFile.OPAM.has_flag Pkgflag_HiddenVersion
+                           (OpamSwitchState.opam t nv)))
                  (Lazy.force t.available_packages)
              then atom
              else (n, None)

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3071,7 +3071,17 @@ module OPAM = struct
       conflicts  = t.conflicts;
       conflict_class = t.conflict_class;
       available  = t.available;
-      flags      = t.flags;
+      flags      =
+        (List.filter (function
+             | Pkgflag_LightUninstall
+             | Pkgflag_Verbose
+             | Pkgflag_Plugin
+             | Pkgflag_Compiler
+             | Pkgflag_Conf
+             | Pkgflag_HiddenVersion
+             | Pkgflag_Unknown _
+               -> false)
+            t.flags);
       env        = t.env;
 
       build      = t.build;


### PR DESCRIPTION
Closes #4432 (together with defining unreleased versions of `ocaml` as
hidden).