### PR TITLE
init: fix non-existing file check in csh

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -15,6 +15,7 @@ New option/command/subcommand are prefixed with ◈.
   * Fix sandbox check with not yet set opam environment variables [#4370 @rjbou - fix #4368]
   * Sandboxing check: use configured temp dir and cleanup afterwards [#4467 @AltGr]
   * Print shell-appropriate eval command on `opam init` [#4427 @freevoid]
+  * Fix non-existing file check in csh [#4482 @gahr]
 
 ## Config Upgrade
   *

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -472,18 +472,18 @@ let env_hook_script shell =
     (env_hook_script_base shell)
 
 let source root shell f =
-  let file f = OpamFilename.to_string (OpamPath.init root // f) in
+  let fname = OpamFilename.to_string (OpamPath.init root // f) in
   match shell with
   | SH_csh ->
-    Printf.sprintf "if ( -f %s ) source %s >& /dev/null\n" (file f) (file f)
+    Printf.sprintf "if ( -f %s ) source %s >& /dev/null\n" fname fname
   | SH_fish ->
-    Printf.sprintf "source %s > /dev/null 2> /dev/null; or true\n" (file f)
+    Printf.sprintf "source %s > /dev/null 2> /dev/null; or true\n" fname
   | SH_sh | SH_bash ->
     Printf.sprintf "test -r %s && . %s > /dev/null 2> /dev/null || true\n"
-      (file f) (file f)
+      fname fname
   | SH_zsh ->
     Printf.sprintf "[[ ! -r %s ]] || source %s  > /dev/null 2> /dev/null\n"
-      (file f) (file f)
+      fname fname
 
 let if_interactive_script shell t e =
   let ielse else_opt = match else_opt with

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -475,7 +475,7 @@ let source root shell f =
   let file f = OpamFilename.to_string (OpamPath.init root // f) in
   match shell with
   | SH_csh ->
-    Printf.sprintf "source %s >& /dev/null || true\n" (file f)
+    Printf.sprintf "if ( -f %s ) source %s >& /dev/null\n" (file f) (file f)
   | SH_fish ->
     Printf.sprintf "source %s > /dev/null 2> /dev/null; or true\n" (file f)
   | SH_sh | SH_bash ->


### PR DESCRIPTION
This fixes an issue whereas disabling the hook script by answering "no"
to the 2nd question of "opam init" you end with an init script that
tries to source the non-existing env hook script.

