### PR TITLE
Restore mingw CI testing

### DIFF
--- a/appveyor.patch
+++ b/appveyor.patch
@@ -1,0 +1,16 @@
+diff --git a/shell/bootstrap-ocaml.sh b/shell/bootstrap-ocaml.sh
+index e36e07b5..65d05ac1 100755
+--- a/shell/bootstrap-ocaml.sh
++++ b/shell/bootstrap-ocaml.sh
+@@ -34,6 +34,11 @@ fi
+ 
+ if [ ${GEN_CONFIG_ONLY} -eq 0 ] ; then
+   tar -zxf ${V}.tar.gz
++  cd ${V}
++  ${CURL} https://github.com/ocaml/ocaml/commit/26ebd64227e99a125bb0530bdfdfdb2782792d56.patch
++  # OCaml PR#9939 for mingw-w64 8.0.0 support
++  patch -p1 -i 26ebd64227e99a125bb0530bdfdfdb2782792d56.patch
++  cd ..
+ else
+   mkdir -p ${V}
+ fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ environment:
       DEP_MODE: lib-pkg
       GIT_FOR_WINDOWS: 1
     - OCAML_PORT: msvc64
-#    - OCAML_PORT: mingw
+    - OCAML_PORT: mingw
     - OCAML_PORT: mingw64
       DEP_MODE: lib-pkg
       GIT_FOR_WINDOWS: 1

--- a/appveyor_build.cmd
+++ b/appveyor_build.cmd
@@ -124,6 +124,7 @@ if "%INSTALLED_URL%" neq "%OCAML_URL% %FLEXDLL_URL% %DEP_MODE%" if exist bootstr
   echo Re-building bootstrap compiler
   rd /s/q bootstrap
   if exist src_ext\archives\nul rd /s/q src_ext\archives
+  "%CYG_ROOT%\bin\bash.exe" -lc "cd $APPVEYOR_BUILD_FOLDER && patch -p1 -i appveyor.patch"
 )
 
 if "%DEP_MODE%" equ "lib-pkg" "%CYG_ROOT%\bin\bash.exe" -lc "cd $APPVEYOR_BUILD_FOLDER && make --no-print-directory -C src_ext lib-pkg-urls | head -n -1 | sort | uniq" > current-lib-pkg-list

--- a/master_changes.md
+++ b/master_changes.md
@@ -134,6 +134,7 @@ New option/command/subcommand are prefixed with ◈.
   * Add github actions [#4463 @rjbou]
   * Add reftests to github actions [#4467 @rjbou]
   * Fix MacOS upgrade CI test using OS-specific opam 1.2 cache [#4475 @freevoid - fix #4474]
+  * Fix mingw32/mingw64 AppVeyor testing [#4483 @dra27]
 
 ## Shell
   * Update completion scripts with `opam var` instead of `opam config list` [#4428 @rjbou]

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -14,8 +14,8 @@ PATCH ?= patch
 URL_ocaml = https://caml.inria.fr/pub/distrib/ocaml-4.11/ocaml-4.11.1.tar.gz
 MD5_ocaml = 3bee0ea50ed28b9cf0e8a35233f61480
 
-URL_flexdll = https://github.com/alainfrisch/flexdll/archive/0.38.tar.gz
-MD5_flexdll = dca52bce081c8f19e9cd78219458a816
+URL_flexdll = https://github.com/alainfrisch/flexdll/archive/0.39.tar.gz
+MD5_flexdll = c8493c7b6e95c4763b89213a9a710af5
 
 ifndef FETCH
   ifneq ($(shell command -v curl 2>/dev/null),)


### PR DESCRIPTION
mingw-w64 8.0.0 requires some changes in OCaml. These will be in 4.11.2 and 4.12.0, but in the meantime this PR sorts out the AppVeyor workers to eliminate the failures on PRs.

The bump of FlexDLL 0.39 is not necessary to restore the support, but it has the benefit of clearing the AppVeyor caches and rebuilding the compilers!