### PR TITLE
Make install faster by not scanning the whole switch when no install field is present

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -26,6 +26,7 @@ New option/command/subcommand are prefixed with ◈.
   * Don't patch twice [#4529 @rjbou]
   * With `--deps-only`, set dependencies as root packages [#4964 @rjbou - fix #4502]
   * Keep global lock only if root format upgrade is performed [#4612 @rjbou - fix #4597]
+  * Improve installation times by only tracking files listed in `.install` instead of the whole switch prefix when there are no `install:` instructions (and no preinstall commands) [#4494 @kit-ty-kate @rjbou - fix #4422]
 
 ## Remove
   *

--- a/src/core/opamDirTrack.mli
+++ b/src/core/opamDirTrack.mli
@@ -41,6 +41,13 @@ val track:
   OpamFilename.Dir.t -> ?except:OpamFilename.Base.Set.t ->
   (unit -> 'a OpamProcess.job) -> ('a * t) OpamProcess.job
 
+(** [track_files prefix paths ?except job] as [track] wraps a job to track
+    changes for a predefined list of [paths] (files and directories).
+    [paths] are relative to [prefix]. *)
+val track_files:
+  prefix:OpamFilename.Dir.t -> string list -> ?except:OpamFilename.Base.Set.t ->
+  (unit -> 'a OpamProcess.job) -> ('a * t) OpamProcess.job
+
 (** Removes the added and kind-changed items unless their contents changed and
     [force] isn't set, and prints warnings for other changes unless [verbose] is
     set to [false]. Ignores non-existing files.

--- a/tests/reftests/dot-install.test
+++ b/tests/reftests/dot-install.test
@@ -1,0 +1,123 @@
+632bc2e
+### <cat.ml>
+#load "str.cma"
+
+let read file =
+  let ic = open_in file in
+  let rec aux lines =
+    try aux (input_line ic :: lines)
+    with End_of_file -> lines
+  in
+  let r = Str.regexp "/\\|\\\\\\\\" in
+  try
+    List.rev_map
+      (Str.global_replace r "-")
+      (aux [])
+  with Sys_error _ -> ["Not found: "^file]
+
+let cat header path =
+  Printf.printf "==> %s\n" header;
+  let contents = read path in
+  Printf.printf "%s\n" (String.concat "\n" contents)
+
+let pkg = (Sys.argv).(1)
+let root = Sys.getenv "OPAMROOT"
+let (/) = Filename.concat
+let share = root / "inst" / "share"
+let inst_file = share / pkg / "file"
+let changes = root / "inst" / ".opam-switch" / "install" / pkg ^ ".changes"
+let _ =
+  cat (pkg ^" installed file") inst_file;
+  cat (pkg^" changes") changes
+### <dotty/dot.opam>
+opam-version: "2.0"
+synopsis: "One-line description"
+description: """
+Longer description
+"""
+maintainer: "Name <email>"
+authors: "Name <email>"
+license: "MIT"
+homepage: " "
+bug-reports: " "
+dev-repo: "git://do.t"
+depends: "nodot"
+### <dotty/dot.install>
+share: [ "file" ]
+### <dotty/file>
+hellow
+### <dotty/nodot.opam>
+opam-version: "2.0"
+synopsis: "One-line description"
+description: """
+Longer description
+"""
+maintainer: "Name <email>"
+authors: "Name <email>"
+license: "MIT"
+homepage: " "
+bug-reports: " "
+dev-repo: "git://nodo.t"
+install: [ "echo" "hellow" ]
+### <dotty/nodot.install>
+share: [ "file" ]
+### opam switch create inst --empty
+### opam pin ./dotty -yn
+This will pin the following packages: dot, nodot. Continue? [Y/n] y
+Package dot does not exist, create as a NEW package? [Y/n] y
+dot is now pinned to file://${BASEDIR}/dotty (version ~dev)
+Package nodot does not exist, create as a NEW package? [Y/n] y
+nodot is now pinned to file://${BASEDIR}/dotty (version ~dev)
+### OPAMPRECISETRACKING=1 OPAMDEBUGSECTIONS="TRACK ACTION" OPAMDEBUG=-1
+### opam install nodot -y
+
+<><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
+[nodot.~dev] synchronised (no changes)
+
+The following actions will be performed:
+  - install nodot ~dev*
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+ACTION                          download_package: nodot.~dev
+-> retrieved nodot.~dev  (file://${BASEDIR}/dotty)
+ACTION                          prepare_package_source: nodot.~dev at ${BASEDIR}/OPAM/inst/.opam-switch/build/nodot.~dev
+ACTION                          Installing nodot.~dev.
+
+ACTION                          creating ${BASEDIR}/OPAM/inst/share/nodot
+TRACK                           after install: 19 elements, 3 added, scanned in 0.000s
+-> installed nodot.~dev
+Done.
+### ocaml cat.ml nodot
+==> nodot installed file
+hellow
+==> nodot changes
+added: [
+  "share" {"D"}
+  "share-nodot" {"D"}
+  "share-nodot-file" {"F:12fc204edeae5b57713c5ad7dcb97d39"}
+]
+### opam install dot -y
+
+<><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
+[dot.~dev] synchronised (no changes)
+
+The following actions will be performed:
+  - install dot ~dev*
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+ACTION                          download_package: dot.~dev
+-> retrieved dot.~dev  (file://${BASEDIR}/dotty)
+ACTION                          prepare_package_source: dot.~dev at ${BASEDIR}/OPAM/inst/.opam-switch/build/dot.~dev
+ACTION                          Installing dot.~dev.
+
+ACTION                          creating ${BASEDIR}/OPAM/inst/share/dot
+-> installed dot.~dev
+Done.
+### ocaml cat.ml dot
+==> dot installed file
+hellow
+==> dot changes
+added: [
+  "share-dot" {"D"}
+  "share-dot-file" {"F:12fc204edeae5b57713c5ad7dcb97d39"}
+]

--- a/tests/reftests/dot-install.test
+++ b/tests/reftests/dot-install.test
@@ -111,6 +111,7 @@ ACTION                          prepare_package_source: dot.~dev at ${BASEDIR}/O
 ACTION                          Installing dot.~dev.
 
 ACTION                          creating ${BASEDIR}/OPAM/inst/share/dot
+TRACK                           after install: 2 elements, 2 added, scanned in 0.000s
 -> installed dot.~dev
 Done.
 ### ocaml cat.ml dot

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -112,6 +112,22 @@
    (run ./run.exe %{bin:opam} %{dep:cudf-preprocess.test} %{read-lines:testing-env}))))
 
 (alias
+ (name reftest-dot-install)
+ (action
+  (diff dot-install.test dot-install.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-dot-install)))
+
+(rule
+ (deps root-632bc2e)
+ (action
+  (with-stdout-to
+   dot-install.out
+   (run ./run.exe %{bin:opam} %{dep:dot-install.test} %{read-lines:testing-env}))))
+
+(alias
  (name reftest-init)
  (action
   (diff init.test init.out)))


### PR DESCRIPTION
Implements https://github.com/ocaml/opam/issues/4422

Currently opam scans the whole switch directory recursively twice when installing a package (per package). This introduces a huge strain on the IO of the machine. This is especially visible under high load (e.g. in CI)

This PR makes so that opam only scan the files that are going to be installed (if they exist already, this is rare) if the package does not have any `install` field. If the package does have an `install` field the old behaviour is used.