### PR TITLE
Fix opam-devel's tests on platforms without openssl, GNU-diff and a system-wide ocaml

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -60,7 +60,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Build
-  *
+  * Fix opam-devel's tests on platforms without openssl, GNU-diff and a system-wide ocaml [#4500 @kit-ty-kate]
 
 ## Infrastructure
   *

--- a/opam-devel.opam
+++ b/opam-devel.opam
@@ -30,6 +30,8 @@ depends: [
   "opam-client" {= version}
   "cmdliner" {>= "0.9.8"}
   "dune" {>= "1.5.0"}
+  "conf-openssl" {with-test}
+  "conf-diffutils" {with-test}
 ]
 post-messages: [
 "The development version of opam has been successfully compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,5 @@
 OCAMLC = ocamlc
+PATH = $(PWD)/bin:$(shell echo $$PATH)
 OS_TYPE := $(shell $(OCAMLC) -config | sed -ne "s/os_type: //p" | tr -d '\r')
 EXT_LIB := $(shell $(OCAMLC) -config | sed -ne "s/ext_lib: .//p" | tr -d '\r')
 

--- a/tests/bin/dune
+++ b/tests/bin/dune
@@ -1,0 +1,7 @@
+(rule
+  (targets ocamlc)
+  (action (copy %{ocamlc} %{targets})))
+
+(rule
+  (targets ocamlopt)
+  (action (copy %{ocamlopt} %{targets})))

--- a/tests/dune
+++ b/tests/dune
@@ -1,6 +1,6 @@
 (alias
   (name runtest)
-  (deps (source_tree .) ../src/client/opamMain.exe ../src/tools/opam_check.exe)
+  (deps (source_tree .) ../src/client/opamMain.exe ../src/tools/opam_check.exe ./bin/ocamlc ./bin/ocamlopt)
   (action (run make all)))
 
 (ignored_subdirs (packages))


### PR DESCRIPTION
On some systems, opam's tests might be called by opam itself.
However, opam seems to hide parts of the `PATH` that looks like an opam `bin` directory.

To counteract that the tests need to copy `ocamlc` and `ocamlopt` directly before calling the local opam binary.

`openssl` and GNU-`diff` was also missing from the list of test dependencies. For instance those are not installed by default on Alpine.