### PR TITLE
Mention pre-built opam for Arm Macs in INSTALL.md

### DIFF
--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -37,7 +37,7 @@ and run `sh install.sh`)
 
 We provide pre-compiled binaries for:
 - Linux i686, amd64, arm7, arm64
-- OSX (intel 64 bits)
+- OSX (intel 64 bits, arm64)
 - We do not at present provide an official Windows distribution of opam, but please see [this separately maintained distribution](https://fdopen.github.io/opam-repository-mingw/)
 (other platforms are available using the other methods below)
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -93,4 +93,5 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Doc
+  * Install page: add OSX arm64 [#4506 @eth-arm]
   * Document the default build environment variables [#4496 @kit-ty-kate]


### PR DESCRIPTION
Opam 2.0.7 binaries for `arm64-macos` was added to `install.sh` in commit 037c31036a0f94d43fdc91856830fb248e63e8b3.