### PR TITLE
depext: macport variants handling

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -49,6 +49,7 @@ New option/command/subcommand are prefixed with ◈.
   * Fix `features` parser [#4507 @rjbou]
 
 ## External dependencies
+  * Handle macport variants [#4509 @rjbou - fix #4297]
 
 ## Sandbox
   * Fix the conflict with the environment variable name used by dune [#4535 @smorimoto - fix ocaml/dune#4166]


### PR DESCRIPTION
Fixes #4297, see discussion there.
~Variants availability is not part of the PR as it is time consuming: one call per system package to check available variants~ One call is done now
