### PR TITLE
Allow to upgrade to a hidden-version package if a hidden-version package is already installed

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -104,6 +104,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Solver
   * Fix Cudf preprocessing [#4534 @AltGr]
+  * Allow to upgrade to a hidden-version package if a hidden-version package is already installed [#4525 @kit-ty-kate]
 
 ## Client
   *

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -187,8 +187,8 @@ let compute_upgrade_t
              if OpamPackage.Set.exists
                  (fun nv ->
                     OpamFormula.check atom nv &&
-                    not (OpamFile.OPAM.has_flag Pkgflag_AvoidVersion
-                           (OpamSwitchState.opam t nv)))
+                    (not (OpamFile.OPAM.has_flag Pkgflag_AvoidVersion (OpamSwitchState.opam t nv)) ||
+                     OpamSwitchState.can_upgrade_to_avoid_version (OpamPackage.name nv) t))
                  (Lazy.force t.available_packages)
              then atom
              else (n, None)

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -239,6 +239,9 @@ val unavailable_reason:
   'a switch_state -> ?default:string -> name * OpamFormula.version_formula ->
   string
 
+(** Returns whether or not the package can be upgraded to a version tagged with avoid-version *)
+val can_upgrade_to_avoid_version : OpamPackage.Name.t -> 'a switch_state -> bool
+
 (** Handle a cache of the opam files of installed packages *)
 module Installed_cache: sig
   type t = OpamFile.OPAM.t OpamPackage.Map.t


### PR DESCRIPTION
Currently if for instance `ocaml-base-compiler.4.12.0~beta1` (flagged with `hidden-version) is installed, calling `opam upgrade` results in:
```
$ opam upgrade
Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).

The following packages are not being upgraded because the new versions conflict with other installed packages:
  - ocaml.4.13.0
However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
Nothing to do.
$ opam switch invariant
["ocaml-base-compiler"]
```
With this patch it should be upgraded to `ocaml-base-compiler.4.12.0~beta2` in this case.

cc @dra27 @AltGr 