### PR TITLE
Rename hidden-version to avoid-version

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -47,6 +47,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Opamfile
   * Fix `features` parser [#4507 @rjbou]
+  * Rename `hidden-version` to `avoid-version` [#4527 @dra27]
 
 ## External dependencies
 

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -187,7 +187,7 @@ let compute_upgrade_t
              if OpamPackage.Set.exists
                  (fun nv ->
                     OpamFormula.check atom nv &&
-                    not (OpamFile.OPAM.has_flag Pkgflag_HiddenVersion
+                    not (OpamFile.OPAM.has_flag Pkgflag_AvoidVersion
                            (OpamSwitchState.opam t nv)))
                  (Lazy.force t.available_packages)
              then atom

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3078,7 +3078,7 @@ module OPAM = struct
              | Pkgflag_Plugin
              | Pkgflag_Compiler
              | Pkgflag_Conf
-             | Pkgflag_HiddenVersion
+             | Pkgflag_AvoidVersion
              | Pkgflag_Unknown _
                -> false)
             t.flags);

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -111,8 +111,8 @@ type package_flag =
   | Pkgflag_Compiler (** Package may be used for 'opam switch' *)
   | Pkgflag_Conf (** Virtual package: no source, no install or remove instructions,
                      .install, but likely has depexts *)
-  | Pkgflag_HiddenVersion (** This version of the package will only be installed if
-                              strictly required *)
+  | Pkgflag_AvoidVersion (** This version of the package will only be installed if
+                             strictly required *)
   | Pkgflag_Unknown of string (** Used for error reporting, otherwise ignored *)
 
 (** At some point we want to abstract so that the same functions can be used

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -157,7 +157,7 @@ let string_of_pkg_flag = function
   | Pkgflag_Plugin -> "plugin"
   | Pkgflag_Compiler -> "compiler"
   | Pkgflag_Conf -> "conf"
-  | Pkgflag_HiddenVersion -> "hidden-version"
+  | Pkgflag_AvoidVersion -> "avoid-version"
   | Pkgflag_Unknown s -> s
 
 let pkg_flag_of_string = function
@@ -166,7 +166,7 @@ let pkg_flag_of_string = function
   | "plugin" -> Pkgflag_Plugin
   | "compiler" -> Pkgflag_Compiler
   | "conf" -> Pkgflag_Conf
-  | "hidden-version" -> Pkgflag_HiddenVersion
+  | "avoid-version" -> Pkgflag_AvoidVersion
   | s -> Pkgflag_Unknown s
 
 let action_contents = function

--- a/src/solver/opamBuiltinMccs.ml.real
+++ b/src/solver/opamBuiltinMccs.ml.real
@@ -14,18 +14,18 @@ let name solver_backend = "builtin-"^Mccs.get_solver_id ~solver:solver_backend (
 
 let default_criteria = {
   crit_default = "-removed,\
-                  -count[hidden-version,changed],\
+                  -count[avoid-version,changed],\
                   -count[version-lag,request],\
                   -count[version-lag,changed],\
                   -count[missing-depexts,changed],\
                   -changed";
   crit_upgrade = "-removed,\
-                  -count[hidden-version,changed],\
+                  -count[avoid-version,changed],\
                   -count[version-lag,solution],\
                   -count[missing-depexts,changed],\
                   -new";
   crit_fixup = "-changed,\
-                -count[hidden-version:,true],\
+                -count[avoid-version:,true],\
                 -count[version-lag:,false],\
                 -count[missing-depexts:,true]";
   crit_best_effort_prefix = Some "+count[opam-query:,false],";

--- a/src/solver/opamBuiltinZ3.ml.real
+++ b/src/solver/opamBuiltinZ3.ml.real
@@ -22,18 +22,18 @@ let command_name = None
 
 let default_criteria = {
   crit_default = "-removed,\
-                  -count[hidden-version,changed],\
+                  -count[avoid-version,changed],\
                   -count[version-lag,request],\
                   -count[version-lag,changed],\
                   -count[missing-depexts,changed],\
                   -changed";
   crit_upgrade = "-removed,\
-                  -count[hidden-version,changed],\
+                  -count[avoid-version,changed],\
                   -count[version-lag,solution],\
                   -count[missing-depexts,changed],\
                   -new";
   crit_fixup = "-changed,\
-                -count[hidden-version,changed],\
+                -count[avoid-version,changed],\
                 -count[version-lag,solution],\
                 -count[missing-depexts,changed]";
   crit_best_effort_prefix = Some "+count[opam-query,solution],";

--- a/src/solver/opamCudfSolver.ml
+++ b/src/solver/opamCudfSolver.ml
@@ -125,7 +125,7 @@ module Aspcud_def = struct
   let default_criteria =
     {
       crit_default = "-count(removed),\
-                      -sum(solution,hidden-version),\
+                      -sum(solution,avoid-version),\
                       -sum(request,version-lag),\
                       -count(down),\
                       -sum(solution,version-lag),\
@@ -133,12 +133,12 @@ module Aspcud_def = struct
                       -sum(solution,missing-depexts)";
       crit_upgrade = "-count(down),\
                       -count(removed),\
-                      -sum(solution,hidden-version),\
+                      -sum(solution,avoid-version),\
                       -sum(solution,version-lag),\
                       -sum(solution,missing-depexts),\
                       -count(new)";
       crit_fixup = "-count(changed),\
-                    -count[hidden-version:,true],\
+                    -count[avoid-version:,true],\
                     -notuptodate(solution),\
                     -sum(solution,version-lag),\
                     -count[missing-depexts:,true]";
@@ -177,19 +177,19 @@ module Mccs_def = struct
 
   let default_criteria =  {
     crit_default = "-removed,\
-                    -count[hidden-version:,true],\
+                    -count[avoid-version:,true],\
                     -count[version-lag:,true],\
                     -changed,\
                     -count[version-lag:,false],\
                     -count[missing-depexts:,true],\
                     -new";
     crit_upgrade = "-removed,\
-                    -count[hidden-version:,true],\
+                    -count[avoid-version:,true],\
                     -count[version-lag:,false],\
                     -count[missing-depexts:,true],\
                     -new";
     crit_fixup = "-changed,\
-                  -count[hidden-version:,true],\
+                  -count[avoid-version:,true],\
                   -count[version-lag:,false],\
                   -count[missing-depexts:,true]";
     crit_best_effort_prefix = Some "+count[opam-query:,false],";

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -189,25 +189,25 @@ let opam2cudf universe version_map packages =
   let reinstall_map = set_to_bool_map universe.u_reinstall in
   let installed_root_map = set_to_bool_map universe.u_installed_roots in
   let pinned_to_current_version_map = set_to_bool_map universe.u_pinned in
-  let hidden_versions =
+  let avoid_versions =
     OpamStd.Option.default OpamPackage.Set.empty @@
-    OpamStd.List.assoc_opt "hidden-version" universe.u_attrs
+    OpamStd.List.assoc_opt "avoid-version" universe.u_attrs
   in
   let version_lag_map =
     OpamPackage.Name.Map.fold (fun name version_set acc ->
         let nvers, vs =
           OpamPackage.Version.Set.fold (fun v (i,acc) ->
-              if OpamPackage.Set.mem (OpamPackage.create name v) hidden_versions
+              if OpamPackage.Set.mem (OpamPackage.create name v) avoid_versions
               then i, acc
               else i+1, OpamPackage.Version.Map.add v i acc)
             version_set (0, OpamPackage.Version.Map.empty)
         in
         let nvers, vs =
-          (* Place all hidden-versions after normal versions *)
+          (* Place all avoid-versions after normal versions *)
           (* Not strictly necessary, but gives a better fallback in case the
-             specific criteria for hidden versions are not set *)
+             specific criteria for avoided versions are not set *)
           OpamPackage.Version.Set.fold (fun v (i,acc) ->
-              if OpamPackage.Set.mem (OpamPackage.create name v) hidden_versions
+              if OpamPackage.Set.mem (OpamPackage.create name v) avoid_versions
               then i+1, OpamPackage.Version.Map.add v i acc
               else i, acc)
             version_set (nvers, vs)

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -917,9 +917,9 @@ let universe st
       (Lazy.force st.sys_packages)
       OpamPackage.Set.empty
   in
-  let hidden_versions =
+  let avoid_versions =
     OpamPackage.Map.fold (fun nv opam acc ->
-        if OpamFile.OPAM.has_flag Pkgflag_HiddenVersion opam
+        if OpamFile.OPAM.has_flag Pkgflag_AvoidVersion opam
         then OpamPackage.Set.add nv acc else acc)
       st.opams
       OpamPackage.Set.empty
@@ -940,7 +940,7 @@ let universe st
   u_reinstall;
   u_attrs     = ["opam-query", requested_allpkgs;
                  "missing-depexts", missing_depexts;
-                 "hidden-version", hidden_versions];
+                 "avoid-version", avoid_versions];
 }
   in
   u


### PR DESCRIPTION
As per https://github.com/ocaml/opam/wiki/Dev-Meeting-2020.11.27#hidden-version, but apparently I forgot to open the issue to track it!

There were two other points:

- Post-process solutions to see if packages have changed to be hidden and warn (with a default of not installing)
- ocaml.4.12.0 needs to be tagged hidden-version

The second point I think has already been addressed addressed by https://github.com/ocaml/opam/pull/4477. I'll open an issue to track the other.