### PR TITLE
Don't patch twice the same file

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -16,7 +16,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Install
-  *
+  * Don't patch twice [#4529 @rjbou]
 
 ## Remove
   *


### PR DESCRIPTION
Patch was launched twice on the same file, and the same piece of code lead to an error with dev profile errors enabled : 
```
File "src/client/opamAction.ml", line 305, characters 6-34:
305 |       OpamFilename.patch patch dir)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: This expression has type exn option job
       but an expression was expected of type unit
```
+ ~Add a test  for patching and substitution~ moved to #4546