### PR TITLE
Kill builds on Ctrl-C with bubblewrap

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -51,7 +51,8 @@ New option/command/subcommand are prefixed with ◈.
 ## External dependencies
 
 ## Sandbox
-  * Fix the conflict with the environment variable name used by dune [#4535 @smorimoto]
+  * Fix the conflict with the environment variable name used by dune [#4535 @smorimoto - fix ocaml/dune#4166]
+  * Kill builds on Ctrl-C with bubblewrap [#4530 @kit-ty-kate - fix #4400]
 
 ## Repository management
   *

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -11,7 +11,9 @@ if ! command -v bwrap >/dev/null; then
     exit 10
 fi
 
-ARGS=(--unshare-net --new-session)
+# --new-session requires bubblewrap 0.1.7
+# --die-with-parent requires bubblewrap 0.1.8
+ARGS=(--unshare-net --new-session --die-with-parent)
 ARGS=("${ARGS[@]}" --proc /proc --dev /dev)
 ARGS=("${ARGS[@]}" --bind "${TMPDIR:-/tmp}" /tmp)
 ARGS=("${ARGS[@]}" --setenv TMPDIR /tmp --setenv TMP /tmp --setenv TEMPDIR /tmp --setenv TEMP /tmp)


### PR DESCRIPTION
Per comment in https://github.com/ocaml/opam/issues/4400#issuecomment-774725510, I don't think we need to worry about supporting older version of bubblewrap.

- Only users on Debian 9 (EOL since July 2020) will have to upgrade bubblewrap
- Also, turns out opam already required bubblewrap >= 0.1.7

Fixes https://github.com/ocaml/opam/issues/4400