### PR TITLE
New operator '~' for semantic versioning

### DIFF
--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -617,7 +617,8 @@ let atom_or_dir =
 let dep_formula =
   let module OpamParser = OpamParser.FullPos in
   let module OpamPrinter = OpamPrinter.FullPos in
-  let pp = OpamFormat.V.(package_formula `Conj (constraints version)) in
+  let pp = OpamFormat.V.(package_formula `Conj
+                           (constraints version OpamPackage.Version.next)) in
   let parse str =
     try
       let v = OpamParser.value_from_string str "<command-line>" in

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1352,7 +1352,8 @@ module ConfigSyntax = struct
         (Pp.V.map_list ~depth:1 Pp.V.arg);
       "default-compiler", Pp.ppacc
         with_default_compiler default_compiler
-        (Pp.V.package_formula `Disj Pp.V.(constraints Pp.V.version));
+        (Pp.V.package_formula `Disj
+           Pp.V.(constraints Pp.V.version OpamPackage.Version.next));
       "depext", Pp.ppacc
         with_depext depext
         Pp.V.bool;
@@ -1511,7 +1512,8 @@ module InitConfigSyntax = struct
            (fun (name, (url, ta)) -> (name, Some url, ta)));
       "default-compiler", Pp.ppacc
         with_default_compiler default_compiler
-        (Pp.V.package_formula `Disj Pp.V.(constraints Pp.V.version));
+        (Pp.V.package_formula `Disj
+           Pp.V.(constraints Pp.V.version OpamPackage.Version.next));
       "jobs", Pp.ppacc_opt
         (with_jobs @* OpamStd.Option.some) jobs
         Pp.V.pos_int;
@@ -1729,7 +1731,8 @@ module Switch_configSyntax = struct
       (Pp.V.map_list ~depth:2 Pp.V.env_binding);
     "invariant", Pp.ppacc
       (fun invariant t -> {t with invariant}) (fun t -> t.invariant)
-      (Pp.V.package_formula `Conj Pp.V.(constraints version));
+      (Pp.V.package_formula `Conj
+         Pp.V.(constraints version OpamPackage.Version.next));
     "depext-bypass", Pp.ppacc
       (fun depext_bypass t -> { t with depext_bypass})
       (fun t -> t.depext_bypass)
@@ -2684,12 +2687,15 @@ module OPAMSyntax = struct
         (Pp.V.map_list ~depth:1 Pp.V.string);
 
       "depends", no_cleanup Pp.ppacc with_depends depends
-        (Pp.V.package_formula `Conj Pp.V.(filtered_constraints ext_version));
+        (Pp.V.package_formula `Conj
+           Pp.V.(filtered_constraints ext_version (fun f -> FNext f)));
       "depopts", with_cleanup cleanup_depopts Pp.ppacc with_depopts depopts
-        (Pp.V.package_formula `Disj Pp.V.(filtered_constraints ext_version));
+        (Pp.V.package_formula `Disj
+           Pp.V.(filtered_constraints ext_version (fun f -> FNext f)));
       "conflicts", with_cleanup cleanup_conflicts
         Pp.ppacc with_conflicts conflicts
-        (Pp.V.package_formula `Disj Pp.V.(filtered_constraints ext_version));
+        (Pp.V.package_formula `Disj
+           Pp.V.(filtered_constraints ext_version (fun f -> FNext f)));
       "conflict-class", no_cleanup Pp.ppacc with_conflict_class conflict_class
         (Pp.V.map_list ~depth:1 Pp.V.pkgname);
       "available", no_cleanup Pp.ppacc with_available available
@@ -2721,7 +2727,8 @@ module OPAMSyntax = struct
         (Pp.V.map_list ~depth:1 @@
          Pp.V.map_options_2
            (Pp.V.ident -| Pp.of_module "variable" (module OpamVariable))
-           (Pp.V.package_formula_items `Conj Pp.V.(filtered_constraints ext_version))
+           (Pp.V.package_formula_items `Conj
+              Pp.V.(filtered_constraints ext_version (fun f -> FNext f)))
            (Pp.singleton -| Pp.V.string));
 
       "messages", no_cleanup Pp.ppacc with_messages messages
@@ -2782,7 +2789,8 @@ module OPAMSyntax = struct
       "ocaml-version", no_cleanup
         Pp.ppacc_opt with_ocaml_version OpamStd.Option.none
         (Pp.V.list_depth 1 -| Pp.V.list -|
-         Pp.V.constraints Pp.V.compiler_version);
+           Pp.V.constraints Pp.V.compiler_version
+             (fun _ -> raise (Failure "unexpected '~' in compiler constraints")));
       "os", no_cleanup Pp.ppacc_opt with_os OpamStd.Option.none
         Pp.V.os_constraint;
       "descr", no_cleanup Pp.ppacc_opt with_descr OpamStd.Option.none
@@ -3613,7 +3621,8 @@ module CompSyntax = struct
         (Pp.V.map_list ~depth:1 Pp.V.command);
 
       "packages", Pp.ppacc with_packages packages
-        (Pp.V.package_formula `Conj (Pp.V.constraints Pp.V.version));
+        (Pp.V.package_formula `Conj
+           (Pp.V.constraints Pp.V.version OpamPackage.Version.next));
       "env", Pp.ppacc with_env env
         (Pp.V.map_list ~depth:2 Pp.V.env_binding);
       "preinstalled", Pp.ppacc_opt with_preinstalled

--- a/src/format/opamFormat.mli
+++ b/src/format/opamFormat.mli
@@ -134,12 +134,14 @@ module V : sig
 
   (** Simple dependency constraints *)
   val constraints :
-    (value, 'a) t ->
-    (value list, (OpamFormula.relop * 'a) OpamFormula.formula) t
+    (value, 'version) t ->
+    ('version -> 'version) ->
+    (value list, (OpamFormula.relop * 'version) OpamFormula.formula) t
 
   (** Dependency constraints mixed with filters *)
   val filtered_constraints :
     (value, 'version) t ->
+    ('version -> 'version) ->
     (value list, 'version filter_or_constraint OpamFormula.formula) t
 
   (** Package versions *)

--- a/src/format/opamFormula.ml
+++ b/src/format/opamFormula.ml
@@ -63,7 +63,10 @@ let atom_of_string str =
     let sversion = Re.Group.get sub 3 in
     let name = OpamPackage.Name.of_string sname in
     let sop = if sop = "." then "=" else sop in
-    let op = OpamLexer.FullPos.relop sop in
+    let op = match OpamLexer.FullPos.relop sop with
+      | `Eq | `Neq | `Gt | `Geq | `Lt | `Leq as sop -> sop
+      | `Sem -> raise (Failure "unexpected '~' in atomic constraint")
+    in
     let version = OpamPackage.Version.of_string sversion in
     name, Some (op, version)
   with Not_found | Failure _ | OpamLexer.Error _ ->

--- a/src/format/opamFormula.mli
+++ b/src/format/opamFormula.mli
@@ -13,7 +13,7 @@
     functions *)
 
 (** binary operations (compatible with the Dose type for Cudf operators!) *)
-type relop = OpamParserTypes.FullPos.relop_kind (* = [ `Eq | `Neq | `Geq | `Gt | `Leq | `Lt ] *)
+type relop = [ `Eq | `Neq | `Geq | `Gt | `Leq | `Lt ]
 
 (** Version constraints for OPAM *)
 type version_constraint = relop * OpamPackage.Version.t

--- a/src/format/opamPackage.mli
+++ b/src/format/opamPackage.mli
@@ -24,6 +24,10 @@ module Version: sig
 
   (** Are two package versions equal? *)
   val equal: t -> t -> bool
+
+  (** Next version from semantic versioning perspective (#2976) *)
+  val next: t -> t
+
 end
 
 (** Names *)

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -174,7 +174,7 @@ type repository = {
 
 (** {2 Variable-based filters} *)
 
-type relop = OpamParserTypes.FullPos.relop_kind
+type relop = OpamFormula.relop
 
 type filter =
   | FBool of bool
@@ -182,6 +182,7 @@ type filter =
   | FIdent of (name option list * variable * (string * string) option)
   (** packages (or None for self-ref through "_"), variable name,
       string converter (val_if_true, val_if_false_or_undef) *)
+  | FNext of filter
   | FOp of filter * relop * filter
   | FAnd of filter * filter
   | FOr of filter * filter

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -786,7 +786,7 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
          | FOp (fl,_,fr) -> (aux acc true fl) @ aux acc true fr
          | FAnd (fl, fr) | FOr (fl, fr)  ->
            (aux acc false fl) @ aux acc false fr
-         | FNot f | FDefined f | FUndef f -> aux acc false f
+         | FNot f | FNext f | FDefined f | FUndef f -> aux acc false f
        in
        aux [] false
      in
@@ -1137,7 +1137,7 @@ let read_repo_opam ~repo_name ~repo_root dir =
 
 let dep_formula_to_string f =
   let pp =
-    OpamFormat.V.(package_formula `Conj (constraints version))
+    OpamFormat.V.(package_formula `Conj (constraints version OpamPackage.Version.next))
   in
   OpamPrinter.FullPos.value (OpamPp.print pp f)
 


### PR DESCRIPTION
This follows #2976 as an attempt to implement the '~' operator. It requires another patch of opam-file-format, coming along.

Given the difference between this operator and the others, I tried to avoid it to go too deep in the opam internals. Thus, most of the changes are contained in [opamFormat.ml](https://github.com/ocaml/opam/blob/master/src/format/opamFormat.ml) where occurrences of the new operator are caught and rewrote from `~ v` to ` >= v & < next(v)` with the behavior of `next` defined [in the issue](https://github.com/ocaml/opam/issues/2976#issuecomment-311049761).


I open the PR as a draft, as I feel the changes might need some more work to be satisfactory. Comments and reviews are most welcome.