### PR TITLE
Fix Cudf preprocessing

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -80,7 +80,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Solver
-  *
+  * Fix Cudf preprocessing [#4534 @AltGr]
 
 ## Client
   *


### PR DESCRIPTION
This bug didn't impact correctness, but it did make it less efficient
(in particular, it could make higher versions of OPAMDIGDEPTH perform less 
trimming !)