### PR TITLE
Fix the conflict with the environment variable name used by dune

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -51,7 +51,7 @@ New option/command/subcommand are prefixed with ◈.
 ## External dependencies
 
 ## Sandbox
-  *
+  * Fix the conflict with the environment variable name used by dune [#4535 @smorimoto]
 
 ## Repository management
   *

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -76,11 +76,11 @@ add_ccache_mount() {
 }
 
 add_dune_cache_mount() {
-  u_cache=${XDG_CACHE_HOME:-$HOME/.cache}
-  u_dune_cache=$u_cache/dune
-  cache=$(readlink -m "$u_cache")
-  dune_cache=$cache/dune
-  dune_cache=$(readlink -m "$u_dune_cache")
+  local u_cache=${XDG_CACHE_HOME:-$HOME/.cache}
+  local u_dune_cache=$u_cache/dune
+  local cache=$(readlink -m "$u_cache")
+  local dune_cache=$cache/dune
+  local dune_cache=$(readlink -m "$u_dune_cache")
   mkdir -p "${dune_cache}"
   add_mount rw "$u_dune_cache" "$dune_cache"
 }

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -49,9 +49,9 @@ add_ccache_mount() {
 }
 
 add_dune_cache_mount() {
-  DUNE_CACHE=${XDG_CACHE_HOME:-$HOME/.cache}/dune
-  mkdir -p "${DUNE_CACHE}"
-  add_mounts rw "$DUNE_CACHE"
+  dune_cache=${XDG_CACHE_HOME:-$HOME/.cache}/dune
+  mkdir -p "${dune_cache}"
+  add_mounts rw "$dune_cache"
  }
 
 # When using opam variable that must be defined at action time, add them also

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -49,10 +49,10 @@ add_ccache_mount() {
 }
 
 add_dune_cache_mount() {
-  dune_cache=${XDG_CACHE_HOME:-$HOME/.cache}/dune
+  local dune_cache=${XDG_CACHE_HOME:-$HOME/.cache}/dune
   mkdir -p "${dune_cache}"
   add_mounts rw "$dune_cache"
- }
+}
 
 # When using opam variable that must be defined at action time, add them also
 # at init check in OpamAuxCommands.check_and_revert_sandboxing (like


### PR DESCRIPTION
As the title says. This is a bug that was found while investigating https://github.com/ocaml/dune/issues/4166.

Related issue: https://github.com/ocaml/opam/issues/4068