### PR TITLE
Fix `opam install <dir> -w` when package already pinned with another url

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -28,6 +28,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Pin
   * Don't look for lock files for pin depends [#4511 @rjbou - fix #4505]
+  * Fetch sources when pinning an already pinned package with a different url when using working directory [#4542 @rjbou - fix #4484]
   * Don't ask for confirmation for pinning base packages (similarly makes no
     sense with 2.1 switch invariants) [#4571 @dra27]
 

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1515,8 +1515,9 @@ module PIN = struct
     | _ -> ());
     let pins =
       let urls_ok =
-        OpamPinCommand.fetch_all_pins st (List.map (fun (name, _, _, url, subpath) ->
-            OpamPackage.Name.to_string name, url, subpath) pins)
+        OpamPinCommand.fetch_all_pins st
+          (List.map (fun (name, _, _, url, subpath) ->
+               name, url, subpath) pins)
       in
       List.filter (fun (_,_,_, url, subpath) ->
           List.mem (url, subpath) urls_ok)

--- a/src/client/opamPinCommand.mli
+++ b/src/client/opamPinCommand.mli
@@ -65,13 +65,13 @@ val unpin_one: 'a switch_state -> package -> 'a switch_state
 (** List the pinned packages to the user. *)
 val list: 'a switch_state -> short:bool -> unit
 
-(** Scan pinning separator, used for printing and parsing by [scna] and
+(** Scan pinning separator, used for printing and parsing by [scan] and
     [parse_pins]. *)
 val scan_sep: char
 
 (** Scan for available packages to pin, and display it on stdout. If
     [normalise] is true, displays it's normalised format
-    `name.version[scan_sep]curl[scan_sep]subpath`. *)
+    `name.version[scan_sep]url[scan_sep]subpath`. *)
 val scan: normalise:bool -> recurse:bool -> ?subpath: string -> url -> unit
 
 (** Detect if a string is a normalised format of [scan]. *)

--- a/src/client/opamPinCommand.mli
+++ b/src/client/opamPinCommand.mli
@@ -48,7 +48,7 @@ val handle_pin_depends:
     Ask for confirmation to continue if a fetching fails.
 *)
 val fetch_all_pins:
-  'a switch_state -> (string * url * string option) list ->
+  'a switch_state -> ?working_dir:bool -> (name * url * string option) list ->
   (url * string option) list
 
 (** Let the user edit a pinned package's opam file. If given, the version is put


### PR DESCRIPTION
It was a blind spot of source fetching
fix #4484