### PR TITLE
Detect available packages from homebrew

### DIFF
--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -618,6 +618,11 @@ let packages_status ?(env=OpamVariable.Map.empty) config packages =
     in
     compute_sets sys_installed
   | Homebrew ->
+    let sys_available =
+      run_query_command "brew" ["formulae"]
+      |> List.map OpamSysPkg.of_string
+      |> OpamSysPkg.Set.of_list
+    in
     (* accept 'pkgname' and 'pkgname@version'
        exampe output
        >openssl@1.1
@@ -641,7 +646,7 @@ let packages_status ?(env=OpamVariable.Map.empty) config packages =
       |> List.map OpamSysPkg.of_string
       |> OpamSysPkg.Set.of_list
     in
-    compute_sets sys_installed
+    compute_sets ~sys_available sys_installed
   | Macports ->
     let variants_map, packages =
       OpamSysPkg.(Set.fold (fun spkg (map, set) ->


### PR DESCRIPTION
Even if it makes less sense than on Debian or other distributions, having opam detect which packages are available in homebrew might be still useful:
- users might have local brew remotes
- this helps the solver decide to avoid certain packages (e.g. camlp4 which isn't available in homebrew anymore)
- this leaves the door open to easily tell opam that some packages have been installed manually (using `opam option depext-bypass` / `--assume-depexts` / `--no-depexts`)

cc @patricoferris who got the issue with `camlp4` on the upcoming macOS CI