### PR TITLE
archlinux: Always upgrade all the installed packages when installing a new package

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -50,6 +50,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## External dependencies
   * Handle macport variants [#4509 @rjbou - fix #4297]
+  * Always upgrade all the installed packages when installing a new package on Archlinux [#4556 @kit-ty-kate]
 
 ## Sandbox
   * Fix the conflict with the environment variable name used by dune [#4535 @smorimoto - fix ocaml/dune#4166]

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -527,7 +527,7 @@ let install_packages_commands_t sys_packages =
   in
   match family () with
   | Alpine -> ["apk", "add"::yes ~no:["-i"] [] packages], None
-  | Arch -> ["pacman", "-S"::yes ["--noconfirm"] packages], None
+  | Arch -> ["pacman", "-Su"::yes ["--noconfirm"] packages], None
   | Centos ->
     (* TODO: check if they all declare "rhel" as primary family *)
     (* When opam-packages specify the epel-release package, usually it


### PR DESCRIPTION
e.g. when libc is upgraded and `opam update --depexts && opam install conf-gtksourceview3` is called, pacman will not upgrade the underlying libc and will result in a link failure similar to `undefined reference to 'stat64@GLIBC_2.33'`

Backported to `opam-depext` in https://github.com/ocaml-opam/opam-depext/pull/138