### PR TITLE
Sandbox scripts fixes

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -54,6 +54,9 @@ New option/command/subcommand are prefixed with ◈.
 ## Sandbox
   * Fix the conflict with the environment variable name used by dune [#4535 @smorimoto - fix ocaml/dune#4166]
   * Kill builds on Ctrl-C with bubblewrap [#4530 @kit-ty-kate - fix #4400]
+  * Fix sandbox script shell mistake that made `PWD` read-write on remove actions [@4561 @AltGr]
+  * Change handling of TMPDIR: redefining `TMPDIR` broke sandbox scripts [@4561 @AltGr]
+  * Port `OPAM_USER_PATH_RO` improvements from bwrap to sandbox_exec [@4561 @AltGr]
 
 ## Repository management
   *

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -490,12 +490,11 @@ let check_and_revert_sandboxing root config =
   match OpamFilter.commands env sdbx_wrappers with
   | [] -> config
   | cmd::_ ->
-    OpamFilename.with_tmp_dir @@ fun tmp ->
-    let test_file = OpamFilename.(to_string Op.(tmp // "check")) in
+    let test_file = "$TMPDIR/opam-sandbox-check-out" in
     let test_cmd =
       [ "sh"; "-c";
-        Printf.sprintf "echo SUCCESS >%s && cat %s"
-          test_file test_file ]
+        Printf.sprintf "echo SUCCESS >%s && cat %s; rm -f %s"
+          test_file test_file test_file ]
     in
     let working_or_noop =
       let env =

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -15,8 +15,8 @@ fi
 # --die-with-parent requires bubblewrap 0.1.8
 ARGS=(--unshare-net --new-session --die-with-parent)
 ARGS=("${ARGS[@]}" --proc /proc --dev /dev)
-ARGS=("${ARGS[@]}" --bind "${TMPDIR:-/tmp}" /tmp)
-ARGS=("${ARGS[@]}" --setenv TMPDIR /tmp --setenv TMP /tmp --setenv TEMPDIR /tmp --setenv TEMP /tmp)
+ARGS=("${ARGS[@]}" --setenv TMPDIR /opam-tmp --setenv TMP /opam-tmp --setenv TEMPDIR /opam-tmp --setenv TEMP /opam-tmp)
+ARGS=("${ARGS[@]}" --tmpfs /opam-tmp)
 ARGS=("${ARGS[@]}" --tmpfs /run)
 
 add_mount() {
@@ -57,7 +57,7 @@ add_sys_mounts() {
 # use OPAM_USER_PATH_RO variable to add them
 # the OPAM_USER_PATH_RO format is the same as PATH
 # ie: export OPAM_USER_PATH_RO=/nix/store:/rw/usrlocal
-add_sys_mounts /usr /bin /lib /lib32 /lib64 /etc /opt /home /var
+add_sys_mounts /usr /bin /lib /lib32 /lib64 /etc /opt /home /var /tmp
 
 # C compilers using `ccache` will write to a shared cache directory
 # that remain writeable. ccache seems widespread in some Fedora systems.

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -119,7 +119,7 @@ case "$COMMAND" in
         fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"
-        if [ "X${PWD#$OPAM_SWITCH_PREFIX}/.opam-switch/" != "X${PWD}" ]; then
+        if [ "X${PWD#$OPAM_SWITCH_PREFIX/.opam-switch/}" != "X${PWD}" ]; then
           add_mounts rw "$PWD"
         fi
         ;;

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -129,4 +129,5 @@ case "$COMMAND" in
 esac
 
 # Note: we assume $1 can be trusted, see https://github.com/projectatomic/bubblewrap/issues/259
+# As of now we are compatible up to 0.1.8, '--' can be added here when we require >= 0.3.0
 exec bwrap "${ARGS[@]}" "$@"

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -87,6 +87,11 @@ add_dune_cache_mount() {
   add_mount rw "$u_dune_cache" "$dune_cache"
 }
 
+# mount unusual path in ro
+if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
+   add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
+fi
+
 # When using opam variable that must be defined at action time, add them also
 # at init check in OpamAuxCommands.check_and_revert_sandboxing (like
 # OPAM_SWITCH_PREFIX).
@@ -94,29 +99,17 @@ add_dune_cache_mount() {
 COMMAND="$1"; shift
 case "$COMMAND" in
     build)
-        # mount unusual path in ro
-        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-           add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
-        fi
         add_mounts ro "$OPAM_SWITCH_PREFIX"
         add_mounts rw "$PWD"
         add_ccache_mount
         add_dune_cache_mount
         ;;
     install)
-        # mount unusual path in ro
-        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-           add_mounts ro  $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
-        fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"
         add_mounts rw "$PWD"
         ;;
     remove)
-        # mount unusual path in ro
-        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-           add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
-        fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"
         if [ "X${PWD#$OPAM_SWITCH_PREFIX/.opam-switch/}" != "X${PWD}" ]; then

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -61,20 +61,32 @@ add_dune_cache_mount() {
 COMMAND="$1"; shift
 case "$COMMAND" in
     build)
+        # mount unusual path in ro
+        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
+           add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
+        fi
         add_mounts ro "$OPAM_SWITCH_PREFIX"
         add_mounts rw "$PWD"
         add_ccache_mount
         add_dune_cache_mount
         ;;
     install)
+        # mount unusual path in ro
+        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
+           add_mounts ro  $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
+        fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"
         add_mounts rw "$PWD"
         ;;
     remove)
+        # mount unusual path in ro
+        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
+           add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
+        fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"
-        if [ "X${PWD#$OPAM_SWITCH_PREFIX/.opam-switch}" != "X${PWD}" ]; then
+        if [ "X${PWD#$OPAM_SWITCH_PREFIX/.opam-switch/}" != "X${PWD}" ]; then
           add_mounts rw "$PWD"
         fi
         ;;

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -54,6 +54,11 @@ add_dune_cache_mount() {
   add_mounts rw "$dune_cache"
 }
 
+# mount unusual path in ro
+if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
+   add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
+fi
+
 # When using opam variable that must be defined at action time, add them also
 # at init check in OpamAuxCommands.check_and_revert_sandboxing (like
 # OPAM_SWITCH_PREFIX).
@@ -61,29 +66,17 @@ add_dune_cache_mount() {
 COMMAND="$1"; shift
 case "$COMMAND" in
     build)
-        # mount unusual path in ro
-        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-           add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
-        fi
         add_mounts ro "$OPAM_SWITCH_PREFIX"
         add_mounts rw "$PWD"
         add_ccache_mount
         add_dune_cache_mount
         ;;
     install)
-        # mount unusual path in ro
-        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-           add_mounts ro  $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
-        fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"
         add_mounts rw "$PWD"
         ;;
     remove)
-        # mount unusual path in ro
-        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-           add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
-        fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"
         if [ "X${PWD#$OPAM_SWITCH_PREFIX/.opam-switch/}" != "X${PWD}" ]; then


### PR DESCRIPTION
* Linux sandbox (bwrap): change how TMPDIR is handled, because dune
  2.8 re-setting it was breaking the previous behaviour ; packages
  writing to /tmp instead of $TMPDIR will be broken though. See
  37ee01db1 for details.

* Macos sandbox (sandbox_exec): port improvements made to bwrap in the
  past years while it was, it seems, forgotten.