### PR TITLE
`lock` options fixes

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -43,7 +43,8 @@ New option/command/subcommand are prefixed with ◈.
   * fix W59 & E60 with conf flag handling (no url required) [#4550 @rjbou - fix #4549]
 
 ## Lock
-  *
+  * Don't write lock file with `--read-only', `--safe`, and `--dryrun` [#4562 @rjbou - fix #4320]
+  * Make consistent with `opam install`, on local pin always take last opam file even if uncomitted [#4562 @rjbou - fix #4320]
 
 ## Opamfile
   * Fix `features` parser [#4507 @rjbou]

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3730,12 +3730,16 @@ let lock cli =
               (OpamFilename.of_string (OpamPackage.name_to_string nv))
               ("opam." ^ lock_suffix)
           in
-          OpamFile.OPAM.write_with_preserved_format
-            (OpamFile.make locked_fname) locked;
-          (nv, locked_fname)::msgs
-        ) packages []
+          if not (OpamCoreConfig.(!r).OpamCoreConfig.safe_mode
+                  || OpamStateConfig.(!r.dryrun)) then
+            OpamFile.OPAM.write_with_preserved_format
+              (OpamFile.make locked_fname) locked;
+          (nv, locked_fname)::msgs)
+        packages []
     in
-    OpamConsole.msg "Generated lock files for:\n%s"
+    OpamConsole.msg "Generated %slock files for:\n%s"
+      (if OpamCoreConfig.(!r).safe_mode || OpamStateConfig.(!r.dryrun) then
+         "(not saved) " else "")
       (OpamStd.Format.itemize (fun (nv, file) ->
            Printf.sprintf "%s: %s"
              (OpamPackage.to_string nv)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3689,7 +3689,9 @@ let lock cli =
     `P "By using these locked opam files, it is then possible to recover the \
         precise build environment that was setup when they were generated.";
     `P "If paths (filename or directory) are given, those opam files are locked. \
-        If package is given, installed one is locked, otherwise its latest version.";
+        If package is given, installed one is locked, otherwise its latest \
+        version. If a locally pinned package is given, its current local opam \
+        file is locked, even if not versioned or uncommitted changes";
     `P "Fails if all mandatory dependencies are not installed in the switch.";
     `S "LOCK FILE CHANGED FIELDS";
     `P "- $(i,depends) are fixed to their specific versions, with all filters \


### PR DESCRIPTION
* fix `--safe` & `--read-only` 
* fix inconsistency with `opam install` : on local pin, always take the last up to date opam file
fix #4320