### PR TITLE
Include doc field in opam show

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -38,7 +38,7 @@ New option/command/subcommand are prefixed with ◈.
   * --silent renamed to --check [#4595 @dra27 - fix #4323]
 
 ## Show
-  *
+  * Include doc field in opam-show [#4567 @dra27 - partially fix #4565]
 
 ## Var
   *

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -741,6 +741,7 @@ let info st ~fields ~raw ~where ?normalise ?(show_empty=false)
     Field "url.src";
     Field "url.checksum";
     Field "homepage";
+    Field "doc";
     Field "bug-reports";
     Field "dev-repo";
     Field "authors";


### PR DESCRIPTION
#4565 mentions that it would be good to have the `doc` field in the output of `opam show`.

Rather than a separate issue, here's the one-line PR (for discussion).