### PR TITLE
Clickable links in opam show

### DIFF
--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -760,7 +760,18 @@ let info st ~fields ~raw ~where ?normalise ?(show_empty=false)
       List.fold_left (fun acc item ->
           let contents = detail_printer ?normalise ~sort st nv item in
           if show_empty || contents <> "" then
-            [ OpamConsole.colorise `blue (string_of_field ~raw item); contents ]
+            let name = string_of_field ~raw item in
+            let name_url =
+              try
+                let basic_contents = detail_printer ~prettify:true ?normalise ~sort st nv item in
+                let contents_url = OpamUrl.parse basic_contents in
+                if OpamUrl.(contents_url.transport = "http" || contents_url.transport = "https") then
+                  OpamConsole.url ~ref:(OpamUrl.(to_string ({contents_url with backend = `http}))) ~label:name
+                else
+                  name
+              with OpamUrl.Parse_error _ -> name
+            in
+            [ OpamConsole.colorise `blue name_url; contents ]
             :: acc
           else acc)
         [] (List.rev fields)

--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -442,6 +442,12 @@ let carriage_delete =
   else
     carriage_delete_unix
 
+let url ~ref ~label =
+  if not (color ()) || Sys.win32 && get_win32_console_shim `stdout Mode = Shim then
+    label
+  else
+    Printf.sprintf "\027]8;;%s\027\\%s\027]8;;\027\\" ref label
+
 let displaying_status = ref false
 
 let clear_status_unix () =

--- a/src/core/opamConsole.mli
+++ b/src/core/opamConsole.mli
@@ -44,6 +44,7 @@ val colorise : text_style -> string -> string
 val colorise' : text_style list -> string -> string
 val acolor : text_style -> unit -> string -> string
 val acolor_w : int -> text_style -> Format.formatter -> string -> unit
+val url : ref:string -> label:string -> string
 
 module Symbols : sig
   val rightwards_arrow : OpamCompat.Uchar.t

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1175,13 +1175,25 @@ module OpamFormat = struct
         | '\xc2'..'\xdf' -> aux (acc - min 1 (len - i)) (i + 2)
         | '\xe0'..'\xef' -> aux (acc - min 2 (len - i)) (i + 3)
         | '\xf0'..'\xf4' -> aux (acc - min 3 (len - i)) (i + 4)
-        | '\027' ->
-          (try
-             let j = String.index_from s (ofs+i+1) 'm' - ofs in
-             if j > len then acc - (len - i) else
-               aux (acc - (j - i + 1)) (j + 1)
-           with Not_found | Invalid_argument _ ->
-             acc - (len - i))
+        | '\027' when i < len - 1 ->
+          begin match s.[ofs + i + 1] with
+            | '[' ->
+              (try
+                 let j = String.index_from s (ofs+i+1) 'm' - ofs in
+                 if j > len then acc - (len - i) else
+                   aux (acc - (j - i + 1)) (j + 1)
+               with Not_found | Invalid_argument _ ->
+                 acc - (len - i))
+            | ']' ->
+              (try
+                 let esc_middle = String.index_from s (ofs+i+1) '\027' in
+                 let esc_end = String.index_from s (esc_middle+1) '\027' in
+                 if esc_middle > len || esc_end > len then acc - (len - i) else
+                   aux (acc - (esc_middle - i + 2) - 7) (esc_end + 7)
+               with Not_found | Invalid_argument _ ->
+                 acc - (len - i))
+            | _ -> acc - (len - i)
+          end
         | _ -> aux acc (i + 1)
     in
     aux len 0


### PR DESCRIPTION
A piece of sleeplessness-induced silliness looking at #4565 - if a field in opam show parses as a URL, turn the field marker into a clickable hyperlink.

Not for 2.1 (if at all, but the function might be useful, even if not used in opam show)