### PR TITLE
Rebuild "base" packages on changes

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -22,7 +22,8 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Switch
-  *
+  * Don't exclude base packages from rebuilds (made some sense in opam 2.0
+    with base packages but doesn't make sense with 2.1 switch invariants) [#4569 @dra27]
 
 ## Pin
   * Don't look for lock files for pin depends [#4511 @rjbou - fix #4505]

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -357,12 +357,6 @@ let load lock_kind gt rt switch =
         opams installed_opams
       |> OpamPackage.keys
     in
-    let changed =
-      changed --
-      OpamPackage.Set.filter
-        (fun nv -> not (OpamPackage.has_name pinned nv.name))
-        compiler_packages
-    in
     log "Detected changed packages (marked for reinstall): %a"
       (slog OpamPackage.Set.to_string) changed;
     changed


### PR DESCRIPTION
opam 2.0 excludes base packages from consideration with rebuilds. This wasn't particularly correct in opam 2.0, but it limited the chances of being told that you had to use `--unlock-base`.

It makes no sense at all to keep it with switch invariants - if a package has upstream changes, it should be rebuilt regardless of whether it happens to be the compiler or not!