### PR TITLE
config report: fix not found and compilers variables display

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -12,8 +12,9 @@ New option/command/subcommand are prefixed with ◈.
 ## Init
   *
 
-## Config Upgrade
-  *
+## Config report
+  * Fix `Not_found` (config file) error [#4570 @rjbou]
+  * Print variables of installed compilers and their (installed) dependencies [#4570 @rjbou]
 
 ## Install
   * Don't patch twice [#4529 @rjbou]

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1319,19 +1319,21 @@ let config cli =
           print "current-switch" "%s"
             (OpamSwitch.to_string state.switch);
           let process nv =
-            let conf = OpamSwitchState.package_config state nv.name in
-            let bindings =
-              let f (name, value) =
-                (OpamVariable.Full.create nv.name name,
-                 OpamVariable.string_of_variable_contents value)
+            try
+              let conf = OpamSwitchState.package_config state nv.name in
+              let bindings =
+                let f (name, value) =
+                  (OpamVariable.Full.create nv.name name,
+                   OpamVariable.string_of_variable_contents value)
+                in
+                List.map f (OpamFile.Dot_config.bindings conf)
               in
-              List.map f (OpamFile.Dot_config.bindings conf)
-            in
-            let print (name, value) =
-              let name = OpamVariable.Full.to_string name in
-              print name "%s" value
-            in
-            List.iter print bindings
+              let print (name, value) =
+                let name = OpamVariable.Full.to_string name in
+                print name "%s" value
+              in
+              List.iter print bindings
+            with Not_found -> ()
           in
           List.iter process (OpamPackage.Set.elements state.compiler_packages);
           if List.mem "." (OpamStd.Sys.split_path_variable (Sys.getenv "PATH"))


### PR DESCRIPTION
Instead of  `compiler_packages` or invariant (which is not necessarily a compiler), ~it looks for installed packages with compiler flag and display their variables.~ it displays variables of installed compilers (packages with compiler flag) and their installed dependencies.

cc/ @dra27 
