### PR TITLE
Don't confirm pinning invariant packages

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -26,6 +26,8 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Pin
   * Don't look for lock files for pin depends [#4511 @rjbou - fix #4505]
+  * Don't ask for confirmation for pinning base packages (similarly makes no
+    sense with 2.1 switch invariants) [#4571 @dra27]
 
 ## List
   *

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -486,14 +486,6 @@ and source_pin
       (* else raise Exns.Aborted *);
       cur_version, cur_urlf
     with Not_found ->
-      if OpamPackage.has_name st.compiler_packages name then (
-        OpamConsole.warning
-          "Package %s is part of the base packages of this compiler."
-          (OpamPackage.Name.to_string name);
-        if not @@ OpamConsole.confirm
-            "Are you sure you want to override this and pin it anyway?"
-        then raise Aborted
-      );
       let version = default_version st name in
       version, None
   in


### PR DESCRIPTION
Related to #4569, but not itself a bug. Pinning an invariant package still displays this prompt:

```
$ opam pin add ocaml-base-compiler --dev-repo
[WARNING] Package ocaml-base-compiler is part of the base packages of this compiler.
Are you sure you want to override this and pin it anyway? [Y/n]
```

This prompt made sense in 2.0 where the base packages were locked, but it has no place any more with the glory of switch invariants!

**Combined with #4569 and forthcoming amendments PRs to ocaml/ocaml and ocaml/opam-repository, this makes pinning the compiler work naturally!** 🎉