### PR TITLE
Introducing default cli

### DIFF
--- a/.github/scripts/hygiene.sh
+++ b/.github/scripts/hygiene.sh
@@ -143,4 +143,21 @@ fi
 cd ..
 (set +x ; echo -en "::endgroup::check src_ext patches\r") 2>/dev/null
 
+###
+# Default cli version check
+###
+
+if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "${GITHUB_REF##*/}" = "master" ]; then
+  (set +x ; echo -en "::group::check default cli\r") 2>/dev/null
+  CURRENT_MAJOR="`sed -n "s/^AC_INIT(opam,\([0-9]\+\)[^0-9]*.*)$/\1/p" configure.ac`"
+  DEFAULT_CLI_MAJOR="`sed -n "/let *default *=/s/.*(\([0-9]*\)[^0-9]*.*/\1/p" src/client/opamCLIVersion.ml`"
+  if [ $CURRENT_MAJOR -eq $DEFAULT_CLI_MAJOR ]; then
+    echo "Major viersion is default cli one: $CURRENT_MAJOR"
+  else
+    echo -e "[\e[31mERROR\e[0m] Major version $CURRENT_MAJOR and default cli version $DEFAULT_CLI_MAJOR mismatches"
+  (set +x ; echo -en "::endgroup::check default cli\r") 2>/dev/null
+    ERROR=1
+  fi
+fi
+
 exit $ERROR

--- a/master_changes.md
+++ b/master_changes.md
@@ -7,7 +7,8 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Global CLI
-  * Fix `opam exec` on native Windows when calling cygwin executables [#4588 @AltGr]
+  * Add default cli mechanism: deprecated options are acceptedi (in the major version) if no cli is specified [#4575 @rjbou]
+  * Add `opam config` deprecated subcommands in the default cli  [#4575 @rjbou - fix #4503]
 
 ## Init
   *
@@ -86,6 +87,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Infrastructure
   * Release scripts: switch to OCaml 4.10.2 by default, add macos/arm64 builds by default [#4559 @AltGr]
+  * Release script: add default cli version check on full archive build [#4575 @rjbou]
 
 ## Admin
   *
@@ -106,10 +108,13 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Internal
+  * Generalise `mk_tristate_opt' to mk_state_opt [#4575 @rjbou]
+  * Fix `opam exec` on native Windows when calling cygwin executables [#4588 @AltGr]
   * Fix temporary file with a too long name causing errors on Windows [#4590 @AltGr]
 
 ## Test
   * Fix configure check in github actions [#4593 @rjbou]
+  * GHA: Add default cli check in hygien job [#4575 @rjbou]
 
 ## Shell
   *

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -121,7 +121,7 @@ let index_command cli =
     OpamHTTP.make_index_tar_gz repo_root;
     OpamConsole.msg "Done.\n";
   in
-  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
+  OpamArg.mk_command  ~cli OpamArg.cli_original command ~doc ~man
     Term.(const cmd $ global_options cli $ urls_txt_arg cli)
 
 let cache_urls repo_root repo_def =
@@ -272,7 +272,7 @@ let cache_command cli =
 
     OpamConsole.msg "Done.\n";
   in
-  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
+  OpamArg.mk_command  ~cli OpamArg.cli_original command ~doc ~man
     Term.(const cmd $ global_options cli $
           cache_dir_arg $ no_repo_update_arg $ link_arg $ jobs_arg)
 
@@ -491,7 +491,7 @@ let add_hashes_command cli =
     if has_error then OpamStd.Sys.exit_because `Sync_error
     else OpamStd.Sys.exit_because `Success
   in
-  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
+  OpamArg.mk_command  ~cli OpamArg.cli_original command ~doc ~man
     Term.(const cmd $ global_options cli $
           hash_types_arg $ replace_arg $ packages)
 
@@ -541,7 +541,7 @@ let upgrade_command cli =
             \  opam admin index"
       | Some m -> OpamAdminRepoUpgrade.do_upgrade_mirror (OpamFilename.cwd ()) m
   in
-  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
+  OpamArg.mk_command  ~cli OpamArg.cli_original command ~doc ~man
     Term.(const cmd $ global_options cli $
           clear_cache_arg $ create_mirror_arg)
 
@@ -624,7 +624,7 @@ let lint_command cli =
     in
     OpamStd.Sys.exit_because (if ret then `Success else `False)
   in
-  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
+  OpamArg.mk_command  ~cli OpamArg.cli_original command ~doc ~man
     Term.(const cmd $ global_options cli $
           short_arg $ list_arg $ include_arg $ exclude_arg $ ignore_arg $
           warn_error_arg)
@@ -708,7 +708,7 @@ let check_command cli =
        (pr obsolete "obsolete packages"));
     OpamStd.Sys.exit_because (if all_ok then `Success else `False)
   in
-  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
+  OpamArg.mk_command  ~cli OpamArg.cli_original command ~doc ~man
   Term.(const cmd $ global_options cli $ ignore_test_arg $ print_short_arg
         $ installability_arg $ cycles_arg $ obsolete_arg)
 
@@ -859,7 +859,7 @@ let list_command cli =
     in
     OpamListCommand.display st format results
   in
-  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
+  OpamArg.mk_command  ~cli OpamArg.cli_original command ~doc ~man
   Term.(const cmd $ global_options cli $ OpamArg.package_selection cli $
         or_arg cli $ state_selection_arg cli $ OpamArg.package_listing cli $
         env_arg cli $ pattern_list_arg)
@@ -946,7 +946,7 @@ let filter_command cli =
              OpamFilename.rmdir_cleanup d))
       pkg_prefixes
   in
-  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
+  OpamArg.mk_command  ~cli OpamArg.cli_original command ~doc ~man
   Term.(const cmd $ global_options cli $ OpamArg.package_selection cli $
         or_arg cli $ state_selection_arg cli $ env_arg cli $ remove_arg $
         dryrun_arg $
@@ -1055,7 +1055,7 @@ let add_constraint_command cli =
              |> OpamFile.OPAM.with_conflicts conflicts))
       pkg_prefixes
   in
-  OpamArg.mk_command cli OpamArg.cli_original command ~doc ~man
+  OpamArg.mk_command  ~cli OpamArg.cli_original command ~doc ~man
   Term.(pure cmd $ global_options cli $ force_arg $ atom_arg)
 
 (* HELP *)

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -26,7 +26,7 @@ let checked_repo_root () =
   repo_root
 
 let global_options cli =
-  let apply_cli options = {options with OpamArg.cli} in
+  let apply_cli options = { options with OpamArg.cli = options.OpamArg.cli} in
   Term.(const apply_cli $ OpamArg.global_options cli)
 
 let admin_command_doc =

--- a/src/client/opamAdminCommand.mli
+++ b/src/client/opamAdminCommand.mli
@@ -13,4 +13,4 @@ val admin_command_doc: string
 
 type command = unit Cmdliner.Term.t * Cmdliner.Term.info
 
-val get_cmdliner_parser: OpamCLIVersion.t -> command * command list
+val get_cmdliner_parser: OpamCLIVersion.Sourced.t -> command * command list

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -847,11 +847,11 @@ module Mk : sig
   type command = unit Term.t * Term.info
 
   val mk_command:
-    OpamCLIVersion.t -> validity -> string -> doc:string ->
+    cli:OpamCLIVersion.t -> validity -> string -> doc:string ->
     man:Manpage.block list -> (unit -> unit) Term.t -> command
 
   val mk_command_ret:
-    OpamCLIVersion.t -> validity -> string -> doc:string ->
+    cli:OpamCLIVersion.t -> validity -> string -> doc:string ->
     man:Manpage.block list -> (unit -> unit Term.ret) Term.t -> command
 
 end = struct
@@ -1217,7 +1217,7 @@ end = struct
 
   type command = unit Term.t * Term.info
 
-  let mk_command cli validity name ~doc ~man cmd =
+  let mk_command ~cli validity name ~doc ~man cmd =
     let doc = update_doc_w_cli doc ~cli validity in
     let info = term_info name ~doc ~man in
     let check =
@@ -1227,7 +1227,7 @@ end = struct
     in
     Term.(cmd $ check), info
 
-  let mk_command_ret cli validity name ~doc ~man cmd =
+  let mk_command_ret ~cli validity name ~doc ~man cmd =
     let doc = update_doc_w_cli doc ~cli validity in
     let info = term_info name ~doc ~man in
     let check =

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -822,9 +822,9 @@ module Mk : sig
     cli:OpamCLIVersion.Sourced.t -> ?section:string -> ?default:'a list ->
     (validity * 'a * string list * string) list -> 'a list Term.t
 
-  val mk_tristate_opt:
+  val mk_state_opt:
     cli:OpamCLIVersion.Sourced.t -> validity -> ?section:string -> string list ->
-    string -> string -> [> `Always | `Auto | `Never ] option Term.t
+    string -> (string * 'a) list -> string -> 'a option Term.t
 
   type 'a subcommand = validity * string * 'a * string list * string
   type 'a subcommands = 'a subcommand list
@@ -1130,11 +1130,11 @@ end = struct
     let default = List.map (fun x -> `Valid x) default in
     term_cli_check ~check Arg.(vflag_all default info_flags)
 
-  let mk_tristate_opt ~cli validity ?section flags value doc =
+  let mk_state_opt ~cli validity ?section flags value state doc =
     let doc = update_doc_w_cli doc ~cli validity in
     let doc = Arg.info ?docs:section ~docv:value ~doc flags in
     let check elem = check_cli_validity cli validity elem flags in
-    term_cli_check ~check Arg.(opt (some (enum when_enum)) None & doc)
+    term_cli_check ~check Arg.(opt (some (enum state)) None & doc)
 
   (* Subcommands *)
   type 'a subcommand = validity * string * 'a * string list * string
@@ -1404,7 +1404,7 @@ let global_options cli =
   let quiet =
     mk_flag ~cli cli_original ~section ["q";"quiet"] "Disables $(b,--verbose)." in
   let color =
-    mk_tristate_opt ~cli cli_original ~section ["color"] "WHEN"
+    mk_state_opt ~cli cli_original ~section ["color"] "WHEN" when_enum
       (Printf.sprintf "Colorize the output. $(docv) must be %s."
          (Arg.doc_alts_enum when_enum)) in
   (* The --cli option is pre-processed, because it has to be able to appear

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -311,7 +311,7 @@ val make_command_alias:
 type command = unit Term.t * Term.info
 
 val mk_command:
-  OpamCLIVersion.t -> validity -> string -> doc:string ->
+  cli:OpamCLIVersion.t -> validity -> string -> doc:string ->
   man:Manpage.block list -> (unit -> unit) Term.t -> command
   (* [mk_command cli validity name doc man term] is the command [name] with its
      [doc] and [man], and using [term]. Its [validity] is checked at runtime
@@ -319,7 +319,7 @@ val mk_command:
      valid. *)
 
 val mk_command_ret:
-  OpamCLIVersion.t -> validity -> string -> doc:string ->
+  cli:OpamCLIVersion.t -> validity -> string -> doc:string ->
   man:Manpage.block list -> (unit -> unit Term.ret) Term.t -> command
   (* Same as {!mk_command} but [term] returns a [Cmdliner.Term.ret] *)
 

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -31,7 +31,8 @@ val cli_from: OpamCLIVersion.t -> validity
    [since], removed in [until], [replaced] is the replacement helper
    message *)
 val cli_between:
-  OpamCLIVersion.t -> ?replaced:string -> OpamCLIVersion.t -> validity
+  OpamCLIVersion.t -> ?default:bool -> ?replaced:string -> OpamCLIVersion.t ->
+  validity
 
 (* Original cli options : [validity] from 2.0 and no removal.
    No new options should use this. *)

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -46,29 +46,29 @@ val cli_original: validity
    validation. *)
 
 val mk_flag:
-  cli:OpamCLIVersion.t -> validity ->
+  cli:OpamCLIVersion.Sourced.t -> validity ->
   ?section:string -> string list -> string ->
   bool Term.t
 
 val mk_opt:
-  cli:OpamCLIVersion.t -> validity ->
+  cli:OpamCLIVersion.Sourced.t -> validity ->
   ?section:string -> ?vopt:'a -> string list -> string -> string ->
   'a Arg.converter -> 'a ->
   'a Term.t
 
 val mk_opt_all:
-  cli:OpamCLIVersion.t -> validity ->
+  cli:OpamCLIVersion.Sourced.t -> validity ->
   ?section:string -> ?vopt:'a -> ?default:'a list ->
   string list -> string -> string ->
   'a Arg.converter -> 'a list Term.t
 
 val mk_vflag:
-  cli:OpamCLIVersion.t ->
+  cli:OpamCLIVersion.Sourced.t ->
   ?section:string -> 'a -> (validity * 'a * string list * string) list ->
   'a Term.t
 
 val mk_vflag_all:
-  cli:OpamCLIVersion.t ->
+  cli:OpamCLIVersion.Sourced.t ->
   ?section:string -> ?default:'a list ->
   (validity * 'a * string list * string) list ->
   'a list Term.t
@@ -84,23 +84,23 @@ val escape_path: string -> string
 
 (** --short *)
 val print_short_flag:
-  OpamCLIVersion.t -> validity -> bool Term.t
+  OpamCLIVersion.Sourced.t -> validity -> bool Term.t
 
 (** --shell *)
 val shell_opt:
-  OpamCLIVersion.t -> validity -> shell option Term.t
+  OpamCLIVersion.Sourced.t -> validity -> shell option Term.t
 
 (** --dot-profile *)
 val dot_profile_flag:
-  OpamCLIVersion.t -> validity -> filename option Term.t
+  OpamCLIVersion.Sourced.t -> validity -> filename option Term.t
 
 (** --http/ --git/ --local *)
 val repo_kind_flag:
-  OpamCLIVersion.t -> validity -> OpamUrl.backend option Term.t
+  OpamCLIVersion.Sourced.t -> validity -> OpamUrl.backend option Term.t
 
 (** --jobs *)
 val jobs_flag:
-  OpamCLIVersion.t -> validity -> int option Term.t
+  OpamCLIVersion.Sourced.t -> validity -> int option Term.t
 
 (** package names *)
 val name_list: name list Term.t
@@ -154,7 +154,7 @@ type global_options = {
 }
 
 (** Global options *)
-val global_options: OpamCLIVersion.t -> global_options Term.t
+val global_options: OpamCLIVersion.Sourced.t -> global_options Term.t
 
 (** Apply global options *)
 val apply_global_options: global_options -> unit
@@ -168,23 +168,23 @@ type build_options
 val man_build_option_section: Manpage.block list
 
 (** Build options *)
-val build_options: OpamCLIVersion.t -> build_options Term.t
+val build_options: OpamCLIVersion.Sourced.t -> build_options Term.t
 
 (** Install and reinstall options *)
-val assume_built: OpamCLIVersion.t -> bool Term.t
+val assume_built: OpamCLIVersion.Sourced.t -> bool Term.t
 
 (* Options common to all path based/related commands, e.g. (un)pin, upgrade,
    remove, (re)install
    Disabled *)
-val recurse: OpamCLIVersion.t -> bool Term.t
-val subpath: OpamCLIVersion.t -> string option Term.t
+val recurse: OpamCLIVersion.Sourced.t -> bool Term.t
+val subpath: OpamCLIVersion.Sourced.t -> string option Term.t
 
 (** Applly build options *)
 val apply_build_options: build_options -> unit
 
 (** Lock options *)
-val locked: ?section:string -> OpamCLIVersion.t -> bool Term.t
-val lock_suffix: ?section:string -> OpamCLIVersion.t -> string Term.t
+val locked: ?section:string -> OpamCLIVersion.Sourced.t -> bool Term.t
+val lock_suffix: ?section:string -> OpamCLIVersion.Sourced.t -> string Term.t
 
 (** {3 Package listing and filtering options} *)
 
@@ -192,7 +192,7 @@ val lock_suffix: ?section:string -> OpamCLIVersion.t -> string Term.t
 val package_selection_section: string
 
 (** Build a package selection filter *)
-val package_selection: OpamCLIVersion.t -> OpamListCommand.selector list Term.t
+val package_selection: OpamCLIVersion.Sourced.t -> OpamListCommand.selector list Term.t
 
 (** Man section name *)
 val package_listing_section: string
@@ -200,7 +200,7 @@ val package_listing_section: string
 (** Package selection filter based on the current state of packages (installed,
     available, etc.) *)
 val package_listing:
-  OpamCLIVersion.t ->
+  OpamCLIVersion.Sourced.t ->
   (force_all_versions:bool -> OpamListCommand.package_listing_format) Term.t
 
 (** {3 Converters} *)
@@ -273,26 +273,26 @@ type 'a subcommand = validity * string * 'a * string list * string
 type 'a subcommands = 'a subcommand list
 
 val mk_subcommands:
-  cli:OpamCLIVersion.t ->
+  cli:OpamCLIVersion.Sourced.t ->
   'a subcommands -> 'a option Term.t * string list Term.t
 (** [subcommands cmds] are the terms [cmd] and [params]. [cmd] parses
     which sub-commands in [cmds] is selected and [params] parses the
     remaining of the command-line parameters as a list of strings. *)
 
 val mk_subcommands_with_default:
-  cli:OpamCLIVersion.t ->
+  cli:OpamCLIVersion.Sourced.t ->
   'a default subcommands -> 'a option Term.t * string list Term.t
 (** Same as {!mk_subcommand} but use the default value if no
     sub-command is selected. *)
 
 val bad_subcommand:
-  cli:OpamCLIVersion.t ->
+  cli:OpamCLIVersion.Sourced.t ->
   'a default subcommands -> (string * 'a option * string list) -> 'b Term.ret
 (** [bad_subcommand cmds cmd] is a command return value
     denoting a parsing error of sub-commands. *)
 
 val mk_subdoc :
-  cli:OpamCLIVersion.t ->
+  cli:OpamCLIVersion.Sourced.t ->
   ?defaults:(string * string) list -> 'a subcommands -> Manpage.block list
 (** [mk_subdoc cmds] is the documentation block for [cmds]. *)
 
@@ -311,7 +311,7 @@ val make_command_alias:
 type command = unit Term.t * Term.info
 
 val mk_command:
-  cli:OpamCLIVersion.t -> validity -> string -> doc:string ->
+  cli:OpamCLIVersion.Sourced.t -> validity -> string -> doc:string ->
   man:Manpage.block list -> (unit -> unit) Term.t -> command
   (* [mk_command cli validity name doc man term] is the command [name] with its
      [doc] and [man], and using [term]. Its [validity] is checked at runtime
@@ -319,7 +319,7 @@ val mk_command:
      valid. *)
 
 val mk_command_ret:
-  cli:OpamCLIVersion.t -> validity -> string -> doc:string ->
+  cli:OpamCLIVersion.Sourced.t -> validity -> string -> doc:string ->
   man:Manpage.block list -> (unit -> unit Term.ret) Term.t -> command
   (* Same as {!mk_command} but [term] returns a [Cmdliner.Term.ret] *)
 

--- a/src/client/opamCLIVersion.ml
+++ b/src/client/opamCLIVersion.ml
@@ -34,10 +34,8 @@ let to_string (major, minor) = Printf.sprintf "%d.%d" major minor
 
 let to_json v = `String (to_string v)
 let of_json = function
-| `String x -> of_string_opt x
-| _ -> None
-
-let env = OpamStd.Config.env of_string
+  | `String x -> of_string_opt x
+  | _ -> None
 
 let ( >= ) = Stdlib.( >= )
 let ( < ) = Stdlib.( < )
@@ -50,6 +48,24 @@ let previous cli =
   let previous = List.fold_left f zero supported_versions in
   if previous = zero then raise Not_found
   else previous
+
+(* CLI version extended with provenance *)
+module Sourced = struct
+  type nonrec t = t * OpamStateTypes.provenance
+
+  let current = current, `Default
+
+  let env () =
+    OpamStd.Option.map (fun c -> c, `Env)
+      (OpamStd.Config.env of_string "CLI")
+
+end
+
+module Op = struct
+  let ( @>= ) (c,_) = Stdlib.( >= ) c
+  let ( @< ) (c,_) = Stdlib.( < ) c
+  let ( @= ) (c,_) = Stdlib.( = ) c
+end
 
 module O = struct
   type nonrec t = t

--- a/src/client/opamCLIVersion.ml
+++ b/src/client/opamCLIVersion.ml
@@ -27,6 +27,7 @@ let of_string s =
   | _ -> failwith "OpamVersion.CLI.of_string"
 
 let current = of_string @@ OpamVersion.(to_string current_nopatch)
+let default = (2,0)
 
 let of_string_opt s = try Some (of_string s) with Failure _ -> None
 

--- a/src/client/opamCLIVersion.ml
+++ b/src/client/opamCLIVersion.ml
@@ -27,6 +27,9 @@ let of_string s =
   | _ -> failwith "OpamVersion.CLI.of_string"
 
 let current = of_string @@ OpamVersion.(to_string current_nopatch)
+
+(* This line is checked on CI to ensure that default cli version
+   matches release opam version *)
 let default = (2,0)
 
 let of_string_opt s = try Some (of_string s) with Failure _ -> None

--- a/src/client/opamCLIVersion.mli
+++ b/src/client/opamCLIVersion.mli
@@ -18,11 +18,9 @@ val current : t
 (** Tests whether a valid CLI version is supported by the client library *)
 val is_supported : t -> bool
 
-(** Parse the given environment variable as MAJOR.MINOR *)
-val env: OpamStd.Config.env_var -> t option
-
 (** ['a option] version of {!to_string} *)
 val of_string_opt : string -> t option
+val of_string : string -> t
 
 (** Comparison [>]] with [(major, minor)] *)
 val ( >= ) : t -> int * int -> bool
@@ -33,3 +31,22 @@ val ( < ) : t -> int * int -> bool
 (** Returns previous supported version.
     @raise Not_found if there isn't one. *)
 val previous: t -> t
+
+(* CLI version extended with provenance *)
+module Sourced : sig
+
+  type nonrec t = t * OpamStateTypes.provenance
+
+  (** The current version of the CLI (major and minor of OpamVersion.current *)
+  val current : t
+
+  (** Parse the given environment variable as MAJOR.MINOR *)
+  val env: unit -> t option
+
+end
+
+module Op : sig
+  val (@<)  : Sourced.t -> t -> bool
+  val (@=)  : Sourced.t -> t -> bool
+  val (@>=) : Sourced.t -> t -> bool
+end

--- a/src/client/opamCLIVersion.mli
+++ b/src/client/opamCLIVersion.mli
@@ -15,7 +15,8 @@ include OpamStd.ABSTRACT
 (** The current version of the CLI (major and minor of OpamVersion.current *)
 val current : t
 
-(* Default CLI version, currently 2.0 *)
+(* Default CLI version, currently 2.0.
+   This value is checked in CI. *)
 val default : t
 
 (** Tests whether a valid CLI version is supported by the client library *)

--- a/src/client/opamCLIVersion.mli
+++ b/src/client/opamCLIVersion.mli
@@ -15,6 +15,9 @@ include OpamStd.ABSTRACT
 (** The current version of the CLI (major and minor of OpamVersion.current *)
 val current : t
 
+(* Default CLI version, currently 2.0 *)
+val default : t
+
 (** Tests whether a valid CLI version is supported by the client library *)
 val is_supported : t -> bool
 

--- a/src/client/opamCliMain.mli
+++ b/src/client/opamCliMain.mli
@@ -16,7 +16,7 @@
     leading [--yes] argument.
     @raise InvalidCLI *)
 val check_and_run_external_commands:
-  unit -> (OpamCLIVersion.t * OpamStateTypes.provenance) * string list
+  unit -> OpamCLIVersion.Sourced.t * string list
 
 (** Handles flushing buffers and catching exceptions from the main call,
     including special cases like [OpamStd.Sys.Exec] that is expected to do a

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -419,7 +419,7 @@ let init cli =
     in
     OpamSwitchState.drop st
   in
-  mk_command cli cli_original "init" ~doc ~man
+  mk_command  ~cli cli_original "init" ~doc ~man
     Term.(const init
           $global_options cli $build_options cli $repo_kind_flag cli
           cli_original $repo_name $repo_url $interactive $update_config
@@ -668,7 +668,7 @@ let list ?(force_search=false) cli =
     else if OpamSysPkg.Set.is_empty results_depexts then
       OpamStd.Sys.exit_because `False
   in
-  mk_command cli cli_original "list" ~doc ~man
+  mk_command  ~cli cli_original "list" ~doc ~man
     Term.(const list $global_options cli $package_selection cli $state_selector
           $no_switch $depexts $vars $repos $owns_file $disjunction $search
           $silent $no_depexts $package_listing cli $pattern_list)
@@ -881,7 +881,7 @@ let show cli =
            `Ok ()
       )
   in
-  mk_command_ret cli cli_original "show" ~doc ~man
+  mk_command_ret  ~cli cli_original "show" ~doc ~man
     Term.(const show $global_options cli $fields $show_empty $raw $where
           $list_files $file $normalise $no_lint $just_file $all_versions
           $sort $atom_or_local_list)
@@ -1032,7 +1032,7 @@ let var cli =
       `Error (true, "--package can't be specified with a var argument, use \
                      'pkg:var' instead.")
   in
-  mk_command_ret cli cli_original "var" ~doc ~man
+  mk_command_ret  ~cli cli_original "var" ~doc ~man
     Term.(const print_var
           $global_options cli $package $varvalue $global cli)
 
@@ -1064,7 +1064,7 @@ let option cli =
     apply_global_options global_options;
     var_option global global_options `option fieldvalue
   in
-  mk_command_ret cli (cli_from cli2_1) "option" ~doc ~man
+  mk_command_ret  ~cli (cli_from cli2_1) "option" ~doc ~man
     Term.(const option
           $global_options cli $fieldvalue $global cli)
 
@@ -1394,7 +1394,7 @@ let config cli =
     | command, params -> bad_subcommand ~cli commands ("config", command, params)
   in
 
-  mk_command_ret cli cli_original "config" ~doc ~man
+  mk_command_ret  ~cli cli_original "config" ~doc ~man
     Term.(const config
           $global_options cli $command $shell_opt cli cli_original $sexp cli
           $inplace_path cli
@@ -1425,7 +1425,7 @@ let exec cli =
       ~set_opamroot ~set_opamswitch ~inplace_path cmd
   in
   let open Common_config_flags in
-  mk_command cli cli_original "exec" ~doc ~man
+  mk_command  ~cli cli_original "exec" ~doc ~man
     Term.(const exec $global_options cli $inplace_path cli
           $set_opamroot cli $set_opamswitch cli
           $cmd)
@@ -1487,7 +1487,7 @@ let env cli =
         (OpamEnv.add [] [])
   in
   let open Common_config_flags in
-  mk_command cli cli_original "env" ~doc ~man
+  mk_command  ~cli cli_original "env" ~doc ~man
   Term.(const env
         $global_options cli $shell_opt cli cli_original $sexp cli
         $inplace_path cli $set_opamroot cli $set_opamswitch cli
@@ -1641,7 +1641,7 @@ let install cli =
       OpamAuxCommands.copy_files_to_destdir st dest packages;
       `Ok ()
   in
-  mk_command_ret cli cli_original "install" ~doc ~man
+  mk_command_ret  ~cli cli_original "install" ~doc ~man
     Term.(const install $global_options cli $build_options cli
           $add_to_roots $deps_only $ignore_conflicts $restore $destdir
           $assume_built cli $check $recurse cli $subpath cli $depext_only
@@ -1725,7 +1725,7 @@ let remove cli =
       let autoremove = autoremove || OpamClientConfig.(!r.autoremove) in
       OpamSwitchState.drop (OpamClient.remove st ~autoremove ~force atoms)
   in
-  mk_command cli cli_original "remove" ~doc ~man
+  mk_command  ~cli cli_original "remove" ~doc ~man
     Term.(const remove $global_options cli $build_options cli $autoremove
           $force $destdir $recurse cli $subpath cli $atom_or_dir_list)
 
@@ -1813,7 +1813,7 @@ let reinstall cli =
     | _, _::_ ->
       `Error (true, "Package arguments not allowed with this option")
   in
-  mk_command_ret cli cli_original "reinstall" ~doc ~man
+  mk_command_ret  ~cli cli_original "reinstall" ~doc ~man
     Term.(const reinstall $global_options cli $build_options cli
           $assume_built cli $recurse cli $subpath cli $atom_or_dir_list
           $cmd)
@@ -1891,7 +1891,7 @@ let update cli =
       OpamConsole.msg "Now run 'opam upgrade' to apply any package updates.\n";
     if not success then OpamStd.Sys.exit_because `Sync_error
   in
-  mk_command cli cli_original "update" ~doc ~man
+  mk_command  ~cli cli_original "update" ~doc ~man
   Term.(const update $global_options cli $jobs_flag cli cli_original $name_list
         $repos_only $dev_only $depexts_only $all $check $upgrade)
 
@@ -1949,7 +1949,7 @@ let upgrade cli =
       OpamSwitchState.drop @@ OpamClient.upgrade st ~check ~only_installed ~all atoms;
       `Ok ()
   in
-  mk_command_ret cli cli_original "upgrade" ~doc ~man
+  mk_command_ret  ~cli cli_original "upgrade" ~doc ~man
     Term.(const upgrade $global_options cli $build_options cli $fixup $check
           $installed $all $recurse cli $subpath cli $atom_or_dir_list)
 
@@ -2243,7 +2243,7 @@ let repository cli =
       `Ok ()
     | command, params -> bad_subcommand ~cli commands ("repository", command, params)
   in
-  mk_command_ret cli cli_original "repository" ~doc ~man
+  mk_command_ret  ~cli cli_original "repository" ~doc ~man
     Term.(const repository $global_options cli $command
           $repo_kind_flag cli cli_original $print_short_flag cli cli_original
           $scope $rank $params)
@@ -2793,7 +2793,7 @@ let switch cli =
       `Ok ()
     | command, params -> bad_subcommand ~cli commands ("switch", command, params)
   in
-  mk_command_ret cli cli_original "switch" ~doc ~man
+  mk_command_ret  ~cli cli_original "switch" ~doc ~man
     Term.(const switch
           $global_options cli $build_options cli $command
           $print_short_flag cli cli_original
@@ -3195,7 +3195,7 @@ let pin ?(unpin_only=false) cli =
        | `Error e -> `Error (false, e))
     | `incorrect -> bad_subcommand ~cli commands ("pin", command, params)
   in
-  mk_command_ret cli cli_original "pin" ~doc ~man
+  mk_command_ret  ~cli cli_original "pin" ~doc ~man
     Term.(const pin
           $global_options cli $build_options cli
           $kind $edit $no_act $dev_repo $print_short_flag cli cli_original
@@ -3329,7 +3329,7 @@ let source cli =
       OpamSwitchState.drop
         (OpamClient.PIN.pin t nv.name ~version:nv.version target)
   in
-  mk_command cli cli_original "source" ~doc ~man
+  mk_command  ~cli cli_original "source" ~doc ~man
     Term.(const source
           $global_options cli $atom $dev_repo $pin $dir)
 
@@ -3504,7 +3504,7 @@ let lint cli =
     OpamStd.Option.iter (fun json -> OpamJson.append "lint" (`A json)) json;
     if err then OpamStd.Sys.exit_because `False
   in
-  mk_command cli cli_original "lint" ~doc ~man
+  mk_command  ~cli cli_original "lint" ~doc ~man
     Term.(const lint $global_options cli $files $package $normalise $short
           $warnings $check_upstream $recurse cli $subpath cli)
 
@@ -3682,7 +3682,7 @@ let clean cli =
       (OpamConsole.msg "Clearing logs\n";
        cleandir (OpamPath.log root))
   in
-  mk_command cli cli_original "clean" ~doc ~man
+  mk_command  ~cli cli_original "clean" ~doc ~man
     Term.(const clean $global_options cli $dry_run $download_cache $repos
           $repo_cache $logs $switch $all_switches)
 
@@ -3758,7 +3758,7 @@ let lock cli =
              (OpamPackage.to_string nv)
              (OpamFilename.to_string file)) pkg_done)
   in
-  mk_command cli (cli_from cli2_1) "lock" ~doc ~man
+  mk_command  ~cli (cli_from cli2_1) "lock" ~doc ~man
     Term.(const lock $global_options cli $only_direct_flag $lock_suffix
           $atom_or_local_list)
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1132,22 +1132,24 @@ let config cli =
     cli_original, "pef-universe", `pef, ["[FILE]"],
     "Outputs the current package universe in PEF format.";
     (* Deprecated options *)
-    cli_between cli2_0 cli2_1 ~replaced:"opam exec", "exec", `exec, ["[--] COMMAND"; "[ARG]..."],
+    cli_between ~default:true cli2_0 cli2_1 ~replaced:"opam exec", "exec",
+    `exec, ["[--] COMMAND"; "[ARG]..."],
     "Execute $(i,COMMAND) with the correct environment variables. This command \
      can be used to cross-compile between switches using $(b,opam config exec \
      --switch=SWITCH -- COMMAND ARG1 ... ARGn). Opam expansion takes place in \
      command and args. If no switch is present on the command line or in the \
      $(i,OPAMSWITCH) environment variable, $(i,OPAMSWITCH) is not set in \
      $(i,COMMAND)'s environment. Can also be accessed through $(b,opam exec).";
-    cli_between cli2_0 cli2_1 ~replaced:"opam var", "set", `set, ["VAR";"VALUE"],
-    "Set switch variable";
-    cli_between cli2_0 cli2_1 ~replaced:"opam var", "unset", `unset, ["VAR"],
-    "Unset switch variable";
-    cli_between cli2_0 cli2_1 ~replaced:"opam var", "set-global", `set_global, ["VAR";"VALUE"],
-    "Set global variable";
-    cli_between cli2_0 cli2_1 ~replaced:"opam var", "unset-global", `unset_global, ["VAR"],
-    "Unset global variable";
-    cli_between cli2_0 cli2_1 ~replaced:"opam var", "var", `var, ["VAR"],
+    cli_between ~default:true cli2_0 cli2_1 ~replaced:"opam var", "set", `set,
+    ["VAR";"VALUE"], "Set switch variable";
+    cli_between ~default:true cli2_0 cli2_1 ~replaced:"opam var", "unset",
+    `unset, ["VAR"], "Unset switch variable";
+    cli_between ~default:true cli2_0 cli2_1 ~replaced:"opam var", "set-global",
+    `set_global, ["VAR";"VALUE"], "Set global variable";
+    cli_between ~default:true cli2_0 cli2_1 ~replaced:"opam var",
+    "unset-global", `unset_global, ["VAR"], "Unset global variable";
+    cli_between ~default:true cli2_0 cli2_1 ~replaced:"opam var", "var", `var,
+    ["VAR"],
     "Return the value associated with variable $(i,VAR), looking in switch \
      first, global if not found. Package variables can be accessed with the \
      syntax $(i,pkg:var). Can also be accessed through $(b,opam var VAR)";

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -99,7 +99,7 @@ let global_options cli =
     if not (options.safe_mode || root_is_ok) &&
        Unix.getuid () = 0 then
       OpamConsole.warning "Running as root is not recommended";
-    {options with cli}, self_upgrade_status
+    {options with cli = fst cli}, self_upgrade_status
   in
   Term.(const self_upgrade $ no_self_upgrade $ global_options cli)
 
@@ -3875,7 +3875,7 @@ let commands cli =
     help;
   ]
 
-let current_commands = commands OpamCLIVersion.current
+let current_commands = commands OpamCLIVersion.Sourced.current
 
 let is_builtin_command prefix =
   List.exists (fun (_,info) ->

--- a/src/client/opamCommands.mli
+++ b/src/client/opamCommands.mli
@@ -21,4 +21,5 @@ val is_builtin_command: string -> bool
     sub-command. *)
 val is_admin_subcommand: string -> bool
 
-val get_cmdliner_parser: OpamCLIVersion.t -> OpamArg.command * OpamArg.command list
+val get_cmdliner_parser:
+  OpamCLIVersion.Sourced.t -> OpamArg.command * OpamArg.command list

--- a/tests/reftests/cli-versioning.test
+++ b/tests/reftests/cli-versioning.test
@@ -13,8 +13,8 @@ The following actions would be performed:
 opam: assume-depexts was added in version 2.1 of the opam CLI, but version 2.0 has been requested, which is older.
 # Return code 2 #
 ### opam config set cli version
-opam: set was removed in version 2.1 of the opam CLI, but version 2.1 has been requested. Use opam var instead or set OPAMCLI environment variable to 2.0.
-# Return code 2 #
+[WARNING] set was deprecated in version 2.1 of the opam CLI. Use opam var instead or set OPAMCLI environment variable to 2.0.
+Added 'cli: "version"' to field variables in switch cli-versioning
 ### OPAMCLI=2.0 opam config set cli version
 Added 'cli: "version"' to field variables in switch cli-versioning
 ### opam switch set-invariant ocaml.4.05.0


### PR DESCRIPTION
Some deprecated options need to still be accepted (cf. #4503). The default cli is here to allow them when used with no specified cli (not from environment or from option `--cli`). Opam prints then a removal warning notice.
The default version is set to 2.0, it will be upgraded at each major release.
Default cli options are ftm `opam config` deprecated commands.

Example with `config var`:
```
$ opam config var prefix
[WARNING] var is deprecated since version 2.1 of the opam CLI, but version 2.1 has been requested. Use opam var instead or set OPAMCLI environment variable to 2.0.
.opam/switch

$ opam config var prefix --cli 2.0
.opam/switch

$ opam config var prefix --cli 2.1
opam: var was removed in version 2.1 of the opam CLI, but version 2.1 has been requested. Use opam var instead or set OPAMCLI environment variable to 2.0.

$ OPAMCLI="2.0" opam config var prefix
.opam/switch

$ OPAMCLI="2.1" opam config var prefix
opam: var was removed in version 2.1 of the opam CLI, but version 2.1 has been requested. Use opam var instead or set OPAMCLI environment variable to 2.0.
```