### PR TITLE
Make of OCaml 4.08 the new minimal requirement

### DIFF
--- a/.github/scripts/ocaml-cache.sh
+++ b/.github/scripts/ocaml-cache.sh
@@ -13,11 +13,7 @@ if [[ $OPAM_TEST -ne 1 ]] ; then
       CONFIGURE_SWITCHES="$CONFIGURE_SWITCHES --disable-graph-lib"
     fi
   else
-    CONFIGURE_SWITCHES="-no-graph -no-debugger -no-ocamldoc"
-    if [[ "$OCAML_VERSION" != "4.02.3" ]] ; then
-      CONFIGURE_SWITCHES="$CONFIGURE_SWITCHES -no-ocamlbuild"
-    fi
-
+    CONFIGURE_SWITCHES="-no-graph -no-debugger -no-ocamldoc -no-ocamlbuild"
   fi
 fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        ocamlv: [ 4.02.3, 4.03.0, 4.04.2, 4.05.0, 4.06.1, 4.07.1, 4.08.1, 4.09.1, 4.10.1, 4.11.1 ]
+        ocamlv: [ 4.08.1, 4.09.1, 4.10.1, 4.11.1 ]
         include:
           - os: macos-latest
             ocamlv: 4.11.1

--- a/configure
+++ b/configure
@@ -645,6 +645,7 @@ MANIFEST_ARCH
 fetch
 LN_S
 DUNE_SECONDARY
+AWK
 BUNZIP2
 PATCH
 CPPO
@@ -672,7 +673,6 @@ LDFLAGS
 CFLAGS
 CC
 SYSTEM
-AWK
 LIBRARY_PATH
 CPATH
 LIB_PREFIX
@@ -2177,8 +2177,7 @@ if  test -x bootstrap/ocaml/bin/ocamlc -o -x bootstrap/ocaml/bin/ocamlopt ; then
 
 fi
 
-# XXX This isn't strictly correct for Windows
-MIN_OCAML_VERSION=4.02.3
+MIN_OCAML_VERSION=4.08.0
 
   # checking for ocamlc
   if test -n "$ac_tool_prefix"; then
@@ -3489,93 +3488,6 @@ CPATH=$CPATH
 
 LIBRARY_PATH=$LIBRARY_PATH
 
-
-# Check that OCaml version is greater or equal to 4.02.3
-# Native Windows builds require at least 4.06.0 for the Unicode runtime.
-for ac_prog in gawk mawk nawk awk
-do
-  # Extract the first word of "$ac_prog", so it can be a program name with args.
-set dummy $ac_prog; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_AWK+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$AWK"; then
-  ac_cv_prog_AWK="$AWK" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_AWK="$ac_prog"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-AWK=$ac_cv_prog_AWK
-if test -n "$AWK"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $AWK" >&5
-$as_echo "$AWK" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-  test -n "$AWK" && break
-done
-
-if test "x${enable_version_check}" != "xno"; then :
-
-  if  test ${WIN32} -eq 1 ; then :
-  MIN_OCAML_VERSION=4.06.0
-fi
-
-
-
-  # Used to indicate true or false condition
-  ax_compare_version=false
-
-  # Convert the two version strings to be compared into a format that
-  # allows a simple string comparison.  The end result is that a version
-  # string of the form 1.12.5-r617 will be converted to the form
-  # 0001001200050617.  In other words, each number is zero padded to four
-  # digits, and non digits are removed.
-
-  ax_compare_version_A=`echo "$OCAMLVERSION" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
-                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
-                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
-                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
-                     -e 's/[^0-9]//g'`
-
-
-  ax_compare_version_B=`echo "$MIN_OCAML_VERSION" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
-                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
-                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
-                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
-                     -e 's/[^0-9]//g'`
-
-
-    ax_compare_version=`echo "x$ax_compare_version_A
-x$ax_compare_version_B" | sed 's/^ *//' | sort -r | sed "s/x${ax_compare_version_A}/false/;s/x${ax_compare_version_B}/true/;1q"`
-
-
-
-    if test "$ax_compare_version" = "true" ; then
-    as_fn_error $? "Your version of OCaml: $OCAMLVERSION is not supported" "$LINENO" 5
-      fi
-
-
-fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for compiler type" >&5
 $as_echo_n "checking for compiler type... " >&6; }
@@ -5617,6 +5529,50 @@ else
   BUNZIP2="$ac_cv_prog_BUNZIP2"
 fi
 
+
+# NOTE: Currently we require OCaml >= 4.08 so this is not used
+# however it might be useful in the future so it is kept here.
+for ac_prog in gawk mawk nawk awk
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_AWK+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$AWK"; then
+  ac_cv_prog_AWK="$AWK" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_AWK="$ac_prog"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+AWK=$ac_cv_prog_AWK
+if test -n "$AWK"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $AWK" >&5
+$as_echo "$AWK" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+  test -n "$AWK" && break
+done
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -14,8 +14,7 @@ AS_IF([ test -x bootstrap/ocaml/bin/ocamlc -o -x bootstrap/ocaml/bin/ocamlopt ],
   export PATH="$PATH_PREPEND$PATH"
 ])
 
-# XXX This isn't strictly correct for Windows
-MIN_OCAML_VERSION=4.02.3
+MIN_OCAML_VERSION=4.08.0
 
 AC_PROG_OCAML
 if test "x$OCAMLC" = "xno"; then
@@ -80,15 +79,6 @@ AS_IF([test "x" != "x$LIB_PREFIX"], [
 AC_SUBST(LIB_PREFIX,$LIB_PREFIX)
 AC_SUBST(CPATH,$CPATH)
 AC_SUBST(LIBRARY_PATH,$LIBRARY_PATH)
-
-# Check that OCaml version is greater or equal to 4.02.3
-# Native Windows builds require at least 4.06.0 for the Unicode runtime.
-AS_IF([test "x${enable_version_check}" != "xno"], [
-  AS_IF([ test ${WIN32} -eq 1 ],[MIN_OCAML_VERSION=4.06.0])
-  AX_COMPARE_VERSION(
-    [$OCAMLVERSION], [lt], [$MIN_OCAML_VERSION],
-    AC_MSG_ERROR([Your version of OCaml: $OCAMLVERSION is not supported]))
-])
 
 AC_MSG_CHECKING([for compiler type])
 CCOMP_TYPE=`$OCAML shell/print_config.ml ccomp_type 2>/dev/null | fgrep -v "Cannot find" || $OCAMLC -config | tr -d '\r' | sed -n -e "s/ccomp_type: //p"`
@@ -254,6 +244,8 @@ AC_CHECK_TOOL(CPPO,cppo)
 AC_CHECK_TOOL(PATCH,patch)
 AC_CHECK_TOOL(BUNZIP2,bunzip2)
 
+# NOTE: Currently we require OCaml >= 4.08 so this is not used
+# however it might be useful in the future so it is kept here.
 AX_COMPARE_VERSION([$OCAMLVERSION], [lt], [4.07.0],
   [DUNE_SECONDARY=src_ext/secondary/ocaml/bin/ocaml],
   [DUNE_SECONDARY=])

--- a/opam-client.opam
+++ b/opam-client.opam
@@ -25,7 +25,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.08"}
   "opam-state" {= version}
   "opam-solver" {= version}
   "extlib" {>= "1.7.3" & < "1.7.8"}

--- a/opam-core.opam
+++ b/opam-core.opam
@@ -25,7 +25,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.08"}
   "base-unix"
   "base-bigarray"
   "ocamlgraph"

--- a/opam-devel.opam
+++ b/opam-devel.opam
@@ -26,7 +26,7 @@ build: [
   [make "tests"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.08"}
   "opam-client" {= version}
   "cmdliner" {>= "0.9.8"}
   "dune" {>= "1.5.0"}

--- a/opam-format.opam
+++ b/opam-format.opam
@@ -25,7 +25,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.08"}
   "opam-core" {= version}
   "opam-file-format" {>= "2.1.2"}
   "dune" {>= "1.5.0"}

--- a/opam-installer.opam
+++ b/opam-installer.opam
@@ -27,7 +27,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.08"}
   "opam-format" {= version}
   "cmdliner" {>= "0.9.8"}
   "dune" {>= "1.5.0"}

--- a/opam-repository.opam
+++ b/opam-repository.opam
@@ -25,7 +25,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.08"}
   "opam-format" {= version}
   "dune" {>= "1.5.0"}
 ]

--- a/opam-solver.opam
+++ b/opam-solver.opam
@@ -25,7 +25,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.08"}
   "opam-format" {= version}
   "mccs" {>= "1.1+9"}
   "dose3" {>= "5" & < "6.0"}

--- a/opam-state.opam
+++ b/opam-state.opam
@@ -25,7 +25,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.08"}
   "opam-repository" {= version}
   "dune" {>= "1.5.0"}
 ]

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -6,15 +6,15 @@ LABEL Description="opam release builds" Vendor="OCamlPro" Version="1.0"
 RUN apt-get update && apt-get install bzip2 g++ make patch wget libltdl-dev --yes && apt-get clean --yes
 RUN useradd -U --create-home opam
 
-ADD https://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.1.tar.gz /root/
+ADD https://caml.inria.fr/pub/distrib/ocaml-4.08/ocaml-4.08.1.tar.gz /root/
 
 WORKDIR /root
-RUN tar xzf ocaml-4.07.1.tar.gz
-WORKDIR ocaml-4.07.1
+RUN tar xzf ocaml-4.08.1.tar.gz
+WORKDIR ocaml-4.08.1
 RUN ./configure %CONF% -prefix /usr/local
 RUN make world opt.opt
 RUN make install
-RUN rm -rf /root/ocaml-4.07.1 /root/ocaml-4.07.1.tar.gz
+RUN rm -rf /root/ocaml-4.08.1 /root/ocaml-4.08.1.tar.gz
 
 ENV PATH /usr/local/bin:/usr/bin:/bin
 USER opam

--- a/shell/bundle.sh
+++ b/shell/bundle.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ue
 
-OCAMLV=4.04.1
+OCAMLV=4.08.1
 OPAMV=2.0.0
 OPAM_REPO=https://opam.ocaml.org/2.0
 DEBUG=


### PR DESCRIPTION
OCaml 4.08 is required to get `opam-0install` out of the box inside opam by default.
https://github.com/ocaml/opam/issues/4448 also shows that old compilers are not well tested and can results in bugs hard to debug.
This proposal makes OCaml 4.08 the new minimal requirement for opam.

This brings a few caveats however. Mainly that users of the opam libraries will now require OCaml >= 4.08 if they wish to use the latest version of the opam libraries.