### PR TITLE
Fix `opam exec` on Windows

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -7,7 +7,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Global CLI
-  *
+  * Fix `opam exec` on native Windows when calling cygwin executables (@AltGr)
 
 ## Init
   *

--- a/master_changes.md
+++ b/master_changes.md
@@ -7,7 +7,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Global CLI
-  * Fix `opam exec` on native Windows when calling cygwin executables (@AltGr)
+  * Fix `opam exec` on native Windows when calling cygwin executables [#4588 @AltGr]
 
 ## Init
   *

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -310,6 +310,13 @@ let set_resolve_command =
     resolve_command_fn := resolve_command
 let resolve_command cmd = !resolve_command_fn cmd
 
+let create_process_env cmd args env cin cout cerr =
+  let resolve cmd = OpamStd.Option.default cmd @@ resolve_command cmd in
+  if Sys.win32 && OpamStd.Sys.is_cygwin_variant (resolve cmd) = `Cygwin then
+    cygwin_create_process_env cmd args env cin cout cerr
+  else
+    Unix.create_process_env cmd args env cin cout cerr
+
 (** [create cmd args] create a new process to execute the command
     [cmd] with arguments [args]. If [stdout_file] or [stderr_file] are
     set, the channels are redirected to the corresponding files.  The

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -317,7 +317,7 @@ let create_process_env =
       if OpamStd.(Option.map_default Sys.is_cygwin_variant `Native resolved_cmd) = `Cygwin then
         cygwin_create_process_env cmd
       else
-        Unix.create_process_env
+        Unix.create_process_env cmd
   else
     Unix.create_process_env
 

--- a/src/core/opamProcess.mli
+++ b/src/core/opamProcess.mli
@@ -214,3 +214,10 @@ type 'a job = 'a Job.Op.job
 (**/**)
 val set_resolve_command :
   (?env:string array -> ?dir:string -> string -> string option) -> unit
+
+(** Like Unix.create_process_env, but with correct escaping of arguments when
+    invoking cygwin executables *)
+val create_process_env :
+  string -> string array -> string array ->
+  Unix.file_descr -> Unix.file_descr -> Unix.file_descr ->
+  int

--- a/src/core/opamProcess.mli
+++ b/src/core/opamProcess.mli
@@ -216,7 +216,7 @@ val set_resolve_command :
   (?env:string array -> ?dir:string -> string -> string option) -> unit
 
 (** Like Unix.create_process_env, but with correct escaping of arguments when
-    invoking cygwin executables *)
+    invoking a cygwin executable from a native Windows executable. *)
 val create_process_env :
   string -> string array -> string array ->
   Unix.file_descr -> Unix.file_descr -> Unix.file_descr ->


### PR DESCRIPTION
split out from #4504

Expose `OpamProcess.create_process_env`, which has the correct way of calling 
cygwin executables from a Windows native opam (without unwanted expansion of 
arguments, etc.)

And use that for `opam exec` (instead of `Unix.execv`) so that it has the 
correct behaviour.