### PR TITLE
Sandbox script: change handling of TMPDIR

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -63,6 +63,10 @@ New option/command/subcommand are prefixed with ◈.
 ## Sandbox
   * Fix the conflict with the environment variable name used by dune [#4535 @smorimoto - fix ocaml/dune#4166]
   * Kill builds on Ctrl-C with bubblewrap [#4530 @kit-ty-kate - fix #4400]
+  * Linux: mount existing TMPDIR read-only, re-bind `$TMPDIR` to a separate tmpfs [#4589 @AltGr]
+  * Fix the sandbox check [#4589 @AltGr]
+  * Fix sandbox script shell mistake that made `PWD` read-write on remove actions [@4589 @AltGr]
+  * Port bwrap improvements to sandbox_exec [@4589 @AltGr]
 
 ## Repository management
   *

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -503,12 +503,12 @@ let check_and_revert_sandboxing root config =
   match OpamFilter.commands env sdbx_wrappers with
   | [] -> config
   | cmd::_ ->
-    OpamFilename.with_tmp_dir @@ fun tmp ->
-    let test_file = OpamFilename.(to_string Op.(tmp // "check")) in
+    (* All the provided sandboxing scripts are expected to define [TMPDIR] *)
+    let test_file = "$TMPDIR/opam-sandbox-check-out" in
     let test_cmd =
       [ "sh"; "-c";
-        Printf.sprintf "echo SUCCESS >%s && cat %s"
-          test_file test_file ]
+        Printf.sprintf "echo SUCCESS >%s && cat %s; rm -f %s"
+          test_file test_file test_file ]
     in
     let working_or_noop =
       let env =

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -15,8 +15,8 @@ fi
 # --die-with-parent requires bubblewrap 0.1.8
 ARGS=(--unshare-net --new-session --die-with-parent)
 ARGS=("${ARGS[@]}" --proc /proc --dev /dev)
-ARGS=("${ARGS[@]}" --bind "${TMPDIR:-/tmp}" /tmp)
-ARGS=("${ARGS[@]}" --setenv TMPDIR /tmp --setenv TMP /tmp --setenv TEMPDIR /tmp --setenv TEMP /tmp)
+ARGS=("${ARGS[@]}" --setenv TMPDIR /opam-tmp --setenv TMP /opam-tmp --setenv TEMPDIR /opam-tmp --setenv TEMP /opam-tmp)
+ARGS=("${ARGS[@]}" --tmpfs /opam-tmp)
 ARGS=("${ARGS[@]}" --tmpfs /run)
 
 add_mount() {
@@ -57,7 +57,7 @@ add_sys_mounts() {
 # use OPAM_USER_PATH_RO variable to add them
 # the OPAM_USER_PATH_RO format is the same as PATH
 # ie: export OPAM_USER_PATH_RO=/nix/store:/rw/usrlocal
-add_sys_mounts /usr /bin /lib /lib32 /lib64 /etc /opt /home /var
+add_sys_mounts /usr /bin /lib /lib32 /lib64 /etc /opt /home /var /tmp
 
 # C compilers using `ccache` will write to a shared cache directory
 # that remain writeable. ccache seems widespread in some Fedora systems.

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -119,7 +119,7 @@ case "$COMMAND" in
         fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"
-        if [ "X${PWD#$OPAM_SWITCH_PREFIX}/.opam-switch/" != "X${PWD}" ]; then
+        if [ "X${PWD#$OPAM_SWITCH_PREFIX/.opam-switch/}" != "X${PWD}" ]; then
           add_mounts rw "$PWD"
         fi
         ;;

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -129,4 +129,5 @@ case "$COMMAND" in
 esac
 
 # Note: we assume $1 can be trusted, see https://github.com/projectatomic/bubblewrap/issues/259
+# As of now we are compatible up to 0.1.8, '--' can be added here when we require >= 0.3.0
 exec bwrap "${ARGS[@]}" "$@"

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -87,6 +87,11 @@ add_dune_cache_mount() {
   add_mount rw "$u_dune_cache" "$dune_cache"
 }
 
+# mount unusual path in ro
+if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
+   add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
+fi
+
 # When using opam variable that must be defined at action time, add them also
 # at init check in OpamAuxCommands.check_and_revert_sandboxing (like
 # OPAM_SWITCH_PREFIX).
@@ -94,29 +99,17 @@ add_dune_cache_mount() {
 COMMAND="$1"; shift
 case "$COMMAND" in
     build)
-        # mount unusual path in ro
-        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-           add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
-        fi
         add_mounts ro "$OPAM_SWITCH_PREFIX"
         add_mounts rw "$PWD"
         add_ccache_mount
         add_dune_cache_mount
         ;;
     install)
-        # mount unusual path in ro
-        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-           add_mounts ro  $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
-        fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"
         add_mounts rw "$PWD"
         ;;
     remove)
-        # mount unusual path in ro
-        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-           add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
-        fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"
         if [ "X${PWD#$OPAM_SWITCH_PREFIX/.opam-switch/}" != "X${PWD}" ]; then

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -23,8 +23,9 @@ if [ -z ${TMPDIR+x} ]; then
   # directory differently; the latter should be made readable/writable
   # too and getconf seems to be a robust way to get it
   if [ -z /usr/bin/getconf ]; then
-    TMP=$(getconf DARWIN_USER_TEMP_DIR)
-    add_mounts rw "$TMP"
+    TMPDIR=$(getconf DARWIN_USER_TEMP_DIR)
+    add_mounts rw "$TMPDIR"
+    export TMPDIR
   fi
 else
   add_mounts rw "$TMPDIR"

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -59,6 +59,11 @@ add_dune_cache_mount() {
   add_mounts rw "$dune_cache"
 }
 
+# mount unusual path in ro
+if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
+   add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
+fi
+
 # When using opam variable that must be defined at action time, add them also
 # at init check in OpamAuxCommands.check_and_revert_sandboxing (like
 # OPAM_SWITCH_PREFIX).
@@ -66,29 +71,17 @@ add_dune_cache_mount() {
 COMMAND="$1"; shift
 case "$COMMAND" in
     build)
-        # mount unusual path in ro
-        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-           add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
-        fi
         add_mounts ro "$OPAM_SWITCH_PREFIX"
         add_mounts rw "$PWD"
         add_ccache_mount
         add_dune_cache_mount
         ;;
     install)
-        # mount unusual path in ro
-        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-           add_mounts ro  $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
-        fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"
         add_mounts rw "$PWD"
         ;;
     remove)
-        # mount unusual path in ro
-        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
-           add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
-        fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"
         if [ "X${PWD#$OPAM_SWITCH_PREFIX/.opam-switch/}" != "X${PWD}" ]; then

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -49,7 +49,11 @@ add_ccache_mount() {
 }
 
 add_dune_cache_mount() {
-  local dune_cache=${XDG_CACHE_HOME:-$HOME/.cache}/dune
+  local u_cache=${XDG_CACHE_HOME:-$HOME/.cache}
+  local u_dune_cache=$u_cache/dune
+  local cache=$(readlink -m "$u_cache")
+  local dune_cache=$cache/dune
+  local dune_cache=$(readlink -m "$u_dune_cache")
   mkdir -p "${dune_cache}"
   add_mounts rw "$dune_cache"
 }
@@ -61,20 +65,32 @@ add_dune_cache_mount() {
 COMMAND="$1"; shift
 case "$COMMAND" in
     build)
+        # mount unusual path in ro
+        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
+           add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
+        fi
         add_mounts ro "$OPAM_SWITCH_PREFIX"
         add_mounts rw "$PWD"
         add_ccache_mount
         add_dune_cache_mount
         ;;
     install)
+        # mount unusual path in ro
+        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
+           add_mounts ro  $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
+        fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"
         add_mounts rw "$PWD"
         ;;
     remove)
+        # mount unusual path in ro
+        if  [ -n "${OPAM_USER_PATH_RO-}" ]; then
+           add_mounts ro $(echo "${OPAM_USER_PATH_RO}" | sed 's|:| |g')
+        fi
         add_mounts rw "$OPAM_SWITCH_PREFIX"
         add_mounts ro "$OPAM_SWITCH_PREFIX/.opam-switch"
-        if [ "X${PWD#$OPAM_SWITCH_PREFIX/.opam-switch}" != "X${PWD}" ]; then
+        if [ "X${PWD#$OPAM_SWITCH_PREFIX/.opam-switch/}" != "X${PWD}" ]; then
           add_mounts rw "$PWD"
         fi
         ;;


### PR DESCRIPTION
(also: port improvements from bwrap to sandbox_exec, and fix a few
bugs, in particular for detection of the sandbox and newer dune)

The `bwrap` script now bind-mounts the existing `$TMPDIR` read-only,
allowing proper communication from outside the sandbox to the inside;
and re-creates a tmpfs someplace else, re-defining `TMPDIR`.
It might break scripts that accessed `/tmp` directly (instead of
`TMPDIR`) though, since it won't be writeable from within the sandbox.

The previous behaviour was to bind-mount $TMPDIR to /tmp within the
sandbox, and re-set TMPDIR accordingly ; however, this meant that absolute
paths within TMPDIR could be incompatible between the outside and the
inside of the sandbox.

This became a visible problem with dune 2.8, which redefines TMPDIR to a
subdirectory (e.g. `/tmp/buildXXXX.dune`). If you happen to be running
tests with an OPAMROOT within $TMPDIR, your opam root will no longer be
accessible, and packages that run opam commands from within the sandbox
(which is discouraged, but well...) will break.

In our tests, run through dune, OPAMROOT gets created in
`/tmp/buildXXXX.dune/OPAM`, then packages get installed within a sandbox,
this is relocated to `/tmp/OPAM` but `OPAMROOT` and `OPAM_SWITCH_PREFIX`
remained set to below `/tmp/buildXXXX.dune`, and things broke.