### PR TITLE
Fix generation of temporary path with a looooong name

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -91,7 +91,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Internal
-  *
+  * Fix temporary file with a too long name causing errors on Windows [#4590 @AltGr]
 
 ## Test
   *

--- a/src/repository/opamRepositoryPath.ml
+++ b/src/repository/opamRepositoryPath.ml
@@ -26,9 +26,11 @@ let pin_cache_dir =
 
 let pin_cache u =
   pin_cache_dir () /
-  (OpamHash.contents @@
-   OpamHash.compute_from_string ~kind:`SHA512 @@
-   OpamUrl.to_string u)
+  String.sub
+    (OpamHash.contents @@
+     OpamHash.compute_from_string ~kind:`SHA512 @@
+     OpamUrl.to_string u)
+    0 16
 
 let repo repo_root = repo_root // "repo" |> OpamFile.make
 


### PR DESCRIPTION
Windows *really* doesn't like that.