### PR TITLE
Rename opam list --silent to opam list --check

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -112,6 +112,7 @@ New option/command/subcommand are prefixed with ◈.
   * Generalise `mk_tristate_opt' to mk_state_opt [#4575 @rjbou]
   * Fix `opam exec` on native Windows when calling cygwin executables [#4588 @AltGr]
   * Fix temporary file with a too long name causing errors on Windows [#4590 @AltGr]
+  * CLI: Add flag deprecation and replacement helper [#4595 @rjbou]
 
 ## Test
   * Make the reference tests dune-friendly [#4376 @emillon]

--- a/master_changes.md
+++ b/master_changes.md
@@ -34,7 +34,7 @@ New option/command/subcommand are prefixed with ◈.
     sense with 2.1 switch invariants) [#4571 @dra27]
 
 ## List
-  *
+  * --silent renamed to --check [#4595 @dra27 - fix #4323]
 
 ## Show
   *

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1001,7 +1001,7 @@ end = struct
     let doc = Arg.info ?docs:section ~docv:value ~doc flags in
     let check elem =
       check_cli_validity cli validity
-        ~cond:(fun c -> c && default != elem) elem flags
+        ~cond:(fun c -> c && default <> elem) elem flags
     in
     term_cli_check ~check Arg.(opt ?vopt kind default & doc)
 
@@ -1011,7 +1011,7 @@ end = struct
     let doc = Arg.info ?docs:section ~docv:value ~doc flags in
     let check elem =
       check_cli_validity cli validity
-        ~cond:(fun c -> c && default != elem) elem flags
+        ~cond:(fun c -> c && default <> elem) elem flags
     in
     term_cli_check ~check Arg.(opt_all ?vopt kind default & doc)
 

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -51,6 +51,12 @@ val mk_flag:
   ?section:string -> string list -> string ->
   bool Term.t
 
+(* Deprecate and replace a [flags]. Constructs a [vflag] with the deprecated
+   option and the new one *)
+val mk_flag_replaced:
+  cli:OpamCLIVersion.Sourced.t -> ?section:string -> (validity * string list) list ->
+  string -> bool Term.t
+
 val mk_opt:
   cli:OpamCLIVersion.Sourced.t -> validity ->
   ?section:string -> ?vopt:'a -> string list -> string -> string ->

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -532,8 +532,10 @@ let list ?(force_search=false) cli =
       OpamArg.variable_bindings []
   in
   let silent =
-    mk_flag ~cli cli_original ["silent"]
-      "Don't write anything in the output, exit with return code 0 if the list \
+    mk_flag_replaced ~cli [
+      cli_between ~default:true cli2_0 cli2_1 ~replaced:"--check", ["silent"];
+      cli_from cli2_1, ["check"]
+    ] "Don't write anything in the output, exit with return code 0 if the list \
        is not empty, 1 otherwise."
   in
   let no_depexts =


### PR DESCRIPTION
This is sat on #4581 and #4575 both of which need merging first. The actual commit itself is tiny - `--silent` is of course retained in the default CLI.

Fixes #4323.