### PR TITLE
Downgrade global write lock after upgrading format

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -26,6 +26,7 @@ New option/command/subcommand are prefixed with ◈.
 ## Switch
   * Don't exclude base packages from rebuilds (made some sense in opam 2.0
     with base packages but doesn't make sense with 2.1 switch invariants) [#4569 @dra27]
+  * Don't hog the global write lock during switch creation [dra27 - fix #4597]
 
 ## Pin
   * Don't look for lock files for pin depends [#4511 @rjbou - fix #4505]

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -176,6 +176,22 @@
    (run ./run.exe %{bin:opam} %{dep:show.test} %{read-lines:testing-env}))))
 
 (alias
+ (name reftest-switch-locking)
+ (action
+  (diff switch-locking.test switch-locking.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-switch-locking)))
+
+(rule
+ (deps root-0370d92b)
+ (action
+  (with-stdout-to
+   switch-locking.out
+   (run ./run.exe %{bin:opam} %{dep:switch-locking.test} %{read-lines:testing-env}))))
+
+(alias
  (name reftest-upgrade-format)
  (action
   (diff upgrade-format.test upgrade-format.out)))
@@ -225,6 +241,25 @@
     (run %{bin:opam} init --root=%{targets}
            --no-setup --bypass-checks --no-opamrc --bare -vv --debug
            file://%{dep:opam-repo-009e00fa}))))
+
+(rule
+ (targets opam-archive-0370d92b.tar.gz)
+ (action (run wget --quiet -O %{targets} https://github.com/ocaml/opam-repository/archive/0370d92b.tar.gz)))
+
+(rule
+  (targets opam-repo-0370d92b)
+  (action
+   (progn
+    (run mkdir %{targets})
+    (run tar -C %{targets} -xzf %{dep:opam-archive-0370d92b.tar.gz} --strip-components=1))))
+
+(rule
+  (targets root-0370d92b)
+  (action
+   (progn
+    (run %{bin:opam} init --root=%{targets}
+           --no-setup --bypass-checks --no-opamrc --bare -vv --debug
+           file://%{dep:opam-repo-0370d92b}))))
 
 (rule
  (targets opam-archive-632bc2e.tar.gz)

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -205,7 +205,7 @@ let erase_file path =
 
 let rm_rf path =
   let rec erase path =
-    if Sys.is_directory path then begin
+    if Sys.file_exists path && Sys.is_directory path then begin
       Array.iter (fun entry -> erase (Filename.concat path entry))
                  (Sys.readdir path);
       Unix.rmdir path

--- a/tests/reftests/switch-locking.test
+++ b/tests/reftests/switch-locking.test
@@ -1,0 +1,40 @@
+0370d92b
+### opam switch create nohang ocaml-variants.4.12.0+options ocaml-option-bytecode-only mirage-crypto bigstringaf | unordered
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: [
+  "ocaml-variants" {= "4.12.0+options"}
+  "ocaml-option-bytecode-only"
+  "mirage-crypto"
+  "bigstringaf"
+]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed base-bigarray.base
+-> installed base-threads.base
+-> installed base-unix.base
+-> retrieved bigarray-compat.1.0.0  (https://github.com/mirage/bigarray-compat/archive/v1.0.0.tar.gz)
+-> retrieved bigstringaf.0.7.0  (https://github.com/inhabitedtype/bigstringaf/archive/0.7.0.tar.gz)
+-> installed conf-pkg-config.2
+-> retrieved csexp.1.4.0  (https://github.com/ocaml-dune/csexp/releases/download/1.4.0/csexp-1.4.0.tbz)
+-> retrieved cstruct.6.0.0  (https://github.com/mirage/ocaml-cstruct/releases/download/v6.0.0/cstruct-v6.0.0.tbz)
+-> retrieved dune.2.8.4  (https://github.com/ocaml/dune/releases/download/2.8.4/dune-2.8.4.tbz)
+-> retrieved dune-configurator.2.8.4  (cached)
+-> retrieved eqaf.0.7  (https://github.com/mirage/eqaf/releases/download/v0.7/eqaf-v0.7.tbz)
+-> retrieved mirage-crypto.0.8.10  (https://github.com/mirage/mirage-crypto/releases/download/v0.8.10/mirage-crypto-v0.8.10.tbz)
+-> installed ocaml-option-bytecode-only.1
+-> retrieved ocaml-variants.4.12.0+options  (https://github.com/ocaml/ocaml/archive/4.12.0.tar.gz)
+-> retrieved result.1.5  (https://github.com/janestreet/result/releases/download/1.5/result-1.5.tbz)
+-> installed ocaml-variants.4.12.0+options
+-> installed ocaml-config.2
+-> installed ocaml.4.12.0
+-> installed dune.2.8.4
+-> installed bigarray-compat.1.0.0
+-> installed result.1.5
+-> installed bigstringaf.0.7.0
+-> installed csexp.1.4.0
+-> installed cstruct.6.0.0
+-> installed eqaf.0.7
+-> installed dune-configurator.2.8.4
+-> installed mirage-crypto.0.8.10
+Done.


### PR DESCRIPTION
Tentative fix for #4597 - is it strictly necessary to retain the lock at all after loading the global config?

This definitely needs a shiny new reftest - "all" that's required is a dummy package which calls `opam var prefix` as part of its build and to create a switch with that package.