### PR TITLE
Introduce 'default-invariant' besides 'default-compiler'

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -757,7 +757,8 @@ seen with `opam init --show-default-opamrc`.
   [`best-effort-prefix-criteria:`](#configfield-best-effort-prefix-criteria),
   [`solver:`](#configfield-solver),
   [`global-variables:`](#configfield-global-variables),
-  [`default-compiler:`](#configfield-default-compiler):
+  [`default-compiler:`](#configfield-default-compiler),
+  [`default-invariant:`](#configfield-default-invariant):
   these have the same format as the same-named fields in the [config](#config)
   file, and will be imported to that file on `opam init`.
   [`default-compiler:`](#configfield-default-compiler) is additionally used to
@@ -1443,7 +1444,12 @@ them modified with [`opam option --global`](man/opam-option.html).
 - <a id="configfield-default-compiler">`default-compiler: [ <package-formula> ... ]`</a>:
   a list of compiler package choices. On `opam init`, the first available
   compiler in the list will be chosen for creating the initial switch if
-  `--bare` wasn't specified.
+  `--bare` wasn't specified. Note that `default-invariant:` will still be used,
+  so the alternatives listed here should be compatible with it.
+
+- <a id="configfield-default-invariant">`default-invariant: [ <package-formula> ... ]`</a>:
+  the default switch invariant that will be set on newly created switches, in
+  cases where nothing else was specified.
 
 - <a id="configfield-depext">`depext: <bool>`</a>:
   enable or disable system dependency handling. When packages declare

--- a/master_changes.md
+++ b/master_changes.md
@@ -11,7 +11,8 @@ New option/command/subcommand are prefixed with ◈.
   * Add `opam config` deprecated subcommands in the default cli  [#4575 @rjbou - fix #4503]
 
 ## Init
-  *
+  * Introduce a `default-invariant` config field, restore the 2.0 semantics for
+    `default-compiler` [#4607 @AltGr]
 
 ## Config report
   * Fix `Not_found` (config file) error [#4570 @rjbou]

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -896,6 +896,7 @@ let init
              "Initial download of repository failed.");
         let default_compiler =
           if dontswitch then [] else
+          let chrono = OpamConsole.timer () in
           let alternatives =
             OpamFormula.to_dnf
               (OpamFile.InitConfig.default_compiler init_config)
@@ -907,10 +908,16 @@ let init
               ~requested:OpamPackage.Name.Set.empty Query
           in
           let univ = { univ with u_invariant = invariant } in
-          OpamStd.List.find_opt
-            (OpamSolver.atom_coinstallability_check univ)
+          let default_compiler =
+            OpamStd.List.find_opt
+              (OpamSolver.atom_coinstallability_check univ)
             alternatives
-          |> OpamStd.Option.default []
+            |> OpamStd.Option.default []
+          in
+          log "Selected default compiler %s in %0.3fs"
+            (OpamFormula.string_of_atoms default_compiler)
+            (chrono ());
+          default_compiler
         in
         gt, OpamRepositoryState.unlock ~cleanup:false rt, default_compiler
       with e ->

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -890,8 +890,10 @@ let init
             (List.map fst repos)
         in
         if failed <> [] then
-          OpamConsole.error_and_exit `Sync_error
-            "Initial download of repository failed";
+          (if root_empty then
+             (try OpamFilename.rmdir root with _ -> ());
+           OpamConsole.error_and_exit `Sync_error
+             "Initial download of repository failed.");
         let default_compiler =
           if dontswitch then [] else
           let alternatives =

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -15,7 +15,9 @@
 open OpamTypes
 open OpamStateTypes
 
-(** Initialize the client to a consistent state. *)
+(** Initialize the client to a consistent state.
+    Returns the initial state and, in case a switch is to be created, its
+    initial set of packages *)
 val init:
   init_config:OpamFile.InitConfig.t ->
   interactive:bool ->
@@ -27,7 +29,7 @@ val init:
   ?completion:bool ->
   ?check_sandbox:bool ->
   shell ->
-  rw global_state * unlocked repos_state * formula
+  rw global_state * unlocked repos_state * atom list
 
 (* (\** Gets the initial config (opamrc) to be used *\)
  * val get_init_config:

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -373,8 +373,14 @@ let init cli =
            ~check_sandbox:(not no_sandboxing)
            (OpamFile.Config.safe_read config_f) shell;
       else
-        OpamEnv.setup root ~interactive ~dot_profile ?update_config ?env_hook
-          ?completion ~inplace shell
+        (if not interactive &&
+            update_config <> Some true && completion <> Some true && env_hook <> Some true then
+           OpamConsole.msg
+             "Opam was already initialised. If you want to set it up again, \
+              use `--interactive', `--reinit', or choose a different \
+              `--root'.\n";
+         OpamEnv.setup root ~interactive ~dot_profile ?update_config ?env_hook
+           ?completion ~inplace shell)
     else
     let init_config =
       get_init_config ~no_sandboxing

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -428,6 +428,7 @@ let init cli =
         (fun st ->
            (),
            OpamSwitchCommand.install_compiler st
+             ~ask:false
              ~additional_installs:default_compiler)
       with e ->
         OpamStd.Exn.finalise e @@ fun () ->
@@ -2659,7 +2660,10 @@ let switch cli =
              else st, []
            in
            (),
-           OpamSwitchCommand.install_compiler st ~additional_installs ~deps_only
+           OpamSwitchCommand.install_compiler st
+             ~additional_installs
+             ~deps_only
+             ~ask:(additional_installs <> [])
          in
          OpamSwitchState.drop st;
          `Ok ())

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -19,6 +19,14 @@ let repository_url = {
 }
 
 let default_compiler =
+  OpamFormula.ors [
+    OpamFormula.Atom (OpamPackage.Name.of_string "ocaml-system",
+                      OpamFormula.Empty);
+    OpamFormula.Atom (OpamPackage.Name.of_string "ocaml-base-compiler",
+                      OpamFormula.Empty);
+  ]
+
+let default_invariant =
   OpamFormula.Atom
     (OpamPackage.Name.of_string "ocaml",
      OpamFormula.Atom
@@ -150,6 +158,7 @@ let init_config ?(sandboxing=true) () =
   I.with_repositories
     [OpamRepositoryName.of_string "default", (repository_url, None)] |>
   I.with_default_compiler default_compiler |>
+  I.with_default_invariant default_invariant |>
   I.with_eval_variables eval_variables |>
   I.with_wrappers @| wrappers ~sandboxing |>
   I.with_recommended_tools @| recommended_tools |>

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -193,7 +193,8 @@ let set_invariant_raw st invariant =
       switch_config;
   st
 
-let install_compiler ?(additional_installs=[]) ?(deps_only=false) t =
+let install_compiler
+    ?(additional_installs=[]) ?(deps_only=false) ?(ask=false) t =
   let invariant = t.switch_invariant in
   if invariant = OpamFormula.Empty && additional_installs = [] then begin
     (if not OpamClientConfig.(!r.show) &&
@@ -299,12 +300,9 @@ let install_compiler ?(additional_installs=[]) ?(deps_only=false) t =
         solution
     else solution
   in
-  let ask =
-    OpamClientConfig.(!r.show) || additional_installs <> []
-  in
   let t, result =
     OpamSolution.apply t
-      ~ask
+      ~ask:(OpamClientConfig.(!r.show) || ask)
       ~requested:roots
       ~add_roots:roots
       solution in

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -258,20 +258,18 @@ let install_compiler
                  (OpamSwitchState.opam t nv))))
       base_comp
   in
-  if OpamPackage.Set.is_empty has_comp_flag then
-    (OpamConsole.warning
-       "Packages %s don't have the 'compiler' flag set (nor any of their \
-        direct dependencies)."
-       (OpamStd.List.concat_map ", " OpamPackage.to_string
-          (OpamPackage.Set.elements base_comp));
-    if OpamClientConfig.(!r.show) || OpamStateConfig.(!r.dryrun) ||
-       OpamConsole.confirm
-         "Are you sure you want to define them as the invariant base for this \
-          switch?"
-    then ()
-    else
-      OpamConsole.error_and_exit `Aborted
-        "Aborted installation of non-compiler packages as switch base.");
+  if invariant = OpamFormula.Empty then
+    OpamConsole.note
+      "No invariant was set, you may want to use `opam switch set-invariant' \
+       to keep a stable compiler version on upgrades."
+  else if OpamPackage.Set.is_empty has_comp_flag then
+    OpamConsole.note
+      "Packages %s don't have the 'compiler' flag set (nor any of their \
+       direct dependencies).\n\
+       You may want to use `opam switch set-invariant' to keep a stable \
+       compiler version on upgrades."
+      (OpamStd.List.concat_map ", " OpamPackage.to_string
+         (OpamPackage.Set.elements base_comp));
   let t =
     if t.switch_config.OpamFile.Switch_config.synopsis = "" then
       let synopsis =

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -693,7 +693,7 @@ let set_invariant ?(force=false) st invariant =
   let not_comp =
     OpamPackage.Set.filter (fun nv ->
         match OpamSwitchState.opam_opt st nv with
-        | Some opam -> OpamFile.OPAM.has_flag Pkgflag_Compiler opam
+        | Some opam -> not (OpamFile.OPAM.has_flag Pkgflag_Compiler opam)
         | None -> false)
       packages
   in

--- a/src/client/opamSwitchCommand.mli
+++ b/src/client/opamSwitchCommand.mli
@@ -33,9 +33,10 @@ val create:
   'ret * rw switch_state
 
 (** Used to initially install a compiler's base packages, according to its
-    invariant. *)
+    invariant. [ask] triggers prompting the user as for normal installs;
+    defaults to [false]. *)
 val install_compiler:
-  ?additional_installs:atom list -> ?deps_only:bool ->
+  ?additional_installs:atom list -> ?deps_only:bool -> ?ask:bool ->
   rw switch_state -> rw switch_state
 
 (** Import a file which contains the packages to install.  *)

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1188,6 +1188,7 @@ module ConfigSyntax = struct
     eval_variables : (variable * string list * string) list;
     validation_hook : arg list option;
     default_compiler : formula;
+    default_invariant : formula;
     depext: bool;
     depext_run_installs : bool;
     depext_cannot_install : bool;
@@ -1215,6 +1216,7 @@ module ConfigSyntax = struct
 
   let validation_hook t = t.validation_hook
   let default_compiler t = t.default_compiler
+  let default_invariant t = t.default_invariant
 
   let depext t = t.depext
   let depext_run_installs t = t.depext_run_installs
@@ -1249,6 +1251,7 @@ module ConfigSyntax = struct
     { t with validation_hook = Some validation_hook}
   let with_validation_hook_opt validation_hook t = { t with validation_hook }
   let with_default_compiler default_compiler t = { t with default_compiler }
+  let with_default_invariant default_invariant t = { t with default_invariant }
   let with_depext depext t = { t with depext }
   let with_depext_run_installs depext_run_installs t =
     { t with depext_run_installs }
@@ -1273,6 +1276,7 @@ module ConfigSyntax = struct
     eval_variables = [];
     validation_hook = None;
     default_compiler = OpamFormula.Empty;
+    default_invariant = OpamFormula.Empty;
     depext = true;
     depext_run_installs = true;
     depext_cannot_install = false;
@@ -1353,6 +1357,9 @@ module ConfigSyntax = struct
       "default-compiler", Pp.ppacc
         with_default_compiler default_compiler
         (Pp.V.package_formula `Disj Pp.V.(constraints Pp.V.version));
+      "default-invariant", Pp.ppacc
+        with_default_invariant default_invariant
+        (Pp.V.package_formula `Conj Pp.V.(constraints Pp.V.version));
       "depext", Pp.ppacc
         with_depext depext
         Pp.V.bool;
@@ -1406,6 +1413,7 @@ module InitConfigSyntax = struct
     opam_version : opam_version;
     repositories : (repository_name * (url * trust_anchors option)) list;
     default_compiler : formula;
+    default_invariant : formula;
     jobs : int option;
     dl_tool : arg list option;
     dl_jobs : int option;
@@ -1423,6 +1431,7 @@ module InitConfigSyntax = struct
   let opam_version t = t.opam_version
   let repositories t = t.repositories
   let default_compiler t = t.default_compiler
+  let default_invariant t = t.default_invariant
   let jobs t = t.jobs
   let dl_tool t = t.dl_tool
   let dl_jobs t = t.dl_jobs
@@ -1439,6 +1448,7 @@ module InitConfigSyntax = struct
   let with_opam_version opam_version t = {t with opam_version}
   let with_repositories repositories t = {t with repositories}
   let with_default_compiler default_compiler t = {t with default_compiler}
+  let with_default_invariant default_invariant t = {t with default_invariant}
   let with_jobs jobs t = {t with jobs}
   let with_dl_tool dl_tool t = {t with dl_tool}
   let with_dl_jobs dl_jobs t = {t with dl_jobs}
@@ -1464,6 +1474,7 @@ module InitConfigSyntax = struct
     opam_version = format_version;
     repositories = [];
     default_compiler = OpamFormula.Empty;
+    default_invariant = OpamFormula.Empty;
     jobs = None;
     dl_tool = None;
     dl_jobs = None;
@@ -1511,6 +1522,9 @@ module InitConfigSyntax = struct
            (fun (name, (url, ta)) -> (name, Some url, ta)));
       "default-compiler", Pp.ppacc
         with_default_compiler default_compiler
+        (Pp.V.package_formula `Disj Pp.V.(constraints Pp.V.version));
+      "default-invariant", Pp.ppacc
+        with_default_invariant default_invariant
         (Pp.V.package_formula `Disj Pp.V.(constraints Pp.V.version));
       "jobs", Pp.ppacc_opt
         (with_jobs @* OpamStd.Option.some) jobs
@@ -1594,6 +1608,9 @@ module InitConfigSyntax = struct
       default_compiler =
         if t2.default_compiler <> Empty
         then t2.default_compiler else t1.default_compiler;
+      default_invariant =
+        if t2.default_invariant <> Empty
+        then t2.default_invariant else t1.default_invariant;
       jobs = opt t2.jobs t1.jobs;
       dl_tool = opt t2.dl_tool t1.dl_tool;
       dl_jobs = opt t2.dl_jobs t1.dl_jobs;

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -148,6 +148,8 @@ module Config: sig
     arg list option -> t -> t
   val with_default_compiler:
     formula -> t -> t
+  val with_default_invariant:
+    formula -> t -> t
   val with_depext: bool -> t -> t
   val with_depext_run_installs: bool -> t -> t
   val with_depext_cannot_install: bool -> t -> t
@@ -191,6 +193,7 @@ module Config: sig
   val validation_hook: t -> arg list option
 
   val default_compiler: t -> formula
+  val default_invariant: t -> formula
 
   val depext: t -> bool
   val depext_run_installs: t -> bool
@@ -212,6 +215,7 @@ module InitConfig: sig
   val opam_version: t -> opam_version
   val repositories: t -> (repository_name * (url * trust_anchors option)) list
   val default_compiler: t -> formula
+  val default_invariant: t -> formula
   val jobs: t -> int option
   val dl_tool: t -> arg list option
   val dl_jobs: t -> int option
@@ -229,6 +233,7 @@ module InitConfig: sig
   val with_repositories:
     (repository_name * (url * trust_anchors option)) list -> t -> t
   val with_default_compiler: formula -> t -> t
+  val with_default_invariant: formula -> t -> t
   val with_jobs: int option -> t -> t
   val with_dl_tool: arg list option -> t -> t
   val with_dl_jobs: int option -> t -> t

--- a/src/format/opamFormula.ml
+++ b/src/format/opamFormula.ml
@@ -120,7 +120,7 @@ let string_of_formula string_of_a f =
       else s
     in
     match f with
-    | Empty    -> "0"
+    | Empty    -> "[]"
     | Atom a   -> paren_if (string_of_a a)
     | Block x  -> Printf.sprintf "(%s)" (aux x)
     | And(x,y) ->

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -615,7 +615,7 @@ let dependency_sort ~depopts ~build ~post universe packages =
 let coinstallability_check universe packages =
   let version_map = cudf_versions_map universe universe.u_packages in
   let cudf_universe =
-    load_cudf_universe ~build:true ~post:true ~version_map
+    load_cudf_universe ~build:true ~post:true ~version_map ~add_invariant:true
       universe universe.u_packages ()
   in
   let cudf_packages =
@@ -639,7 +639,7 @@ let atom_coinstallability_check universe atoms =
   List.for_all (fun (n, _) -> OpamPackage.Name.Map.mem n map) atoms &&
   let version_map = cudf_versions_map universe universe.u_packages in
   let cudf_universe =
-    load_cudf_universe ~build:true ~post:true ~version_map
+    load_cudf_universe ~build:true ~post:true ~version_map ~add_invariant:true
       universe universe.u_packages ()
   in
   let cudf_ll =

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -280,6 +280,7 @@ let write_config rt =
         rt.repositories)
 
 let check_last_update () =
+  if OpamCoreConfig.(!r.debug_level) < 0 then () else
   let last_update =
     OpamFilename.written_since
       (OpamPath.state_cache (OpamStateConfig.(!r.root_dir)))

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -142,9 +142,17 @@ let infer_switch_invariant_raw
   | [] -> OpamFormula.Empty
 
 let infer_switch_invariant st =
+  let compiler_packages =
+    if OpamPackage.Set.is_empty st.compiler_packages then
+      OpamPackage.Set.filter (fun nv ->
+          OpamFile.OPAM.has_flag Pkgflag_Compiler
+            (OpamPackage.Map.find nv st.opams))
+        st.installed
+    else st.compiler_packages
+  in
   infer_switch_invariant_raw
     st.switch_global st.switch st.switch_config st.opams
-    st.packages st.compiler_packages st.installed_roots st.available_packages
+    st.packages compiler_packages st.installed_roots st.available_packages
 
 let depexts_raw ~env nv opams =
   try

--- a/tests/reftests/cli-versioning.test
+++ b/tests/reftests/cli-versioning.test
@@ -18,6 +18,7 @@ Added 'cli: "version"' to field variables in switch cli-versioning
 ### OPAMCLI=2.0 opam config set cli version
 Added 'cli: "version"' to field variables in switch cli-versioning
 ### opam switch set-invariant ocaml.4.05.0
+The switch invariant was set to ocaml = 4.05.0
 ### OPAMCLI=2.0 opam install ocaml.4.10.0
 [ERROR] Package conflict!
   * No agreement on the version of ocaml:
@@ -101,6 +102,7 @@ env-2-0 is now pinned to file://${BASEDIR}/opams (version ~dev)
 Package env-2-1 does not exist, create as a NEW package? [Y/n] y
 env-2-1 is now pinned to file://${BASEDIR}/opams (version ~dev)
 ### opam switch set-invariant --formula "[]"
+The switch invariant was set to []
 ### opam install env-2-0
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -96,6 +96,22 @@
    (run ./run.exe %{bin:opam} %{dep:conflict-solo5.test} %{read-lines:testing-env}))))
 
 (alias
+ (name reftest-init)
+ (action
+  (diff init.test init.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-init)))
+
+(rule
+ (deps root-009e00fa)
+ (action
+  (with-stdout-to
+   init.out
+   (run ./run.exe %{bin:opam} %{dep:init.test} %{read-lines:testing-env}))))
+
+(alias
  (name reftest-install-pgocaml)
  (action
   (diff install-pgocaml.test install-pgocaml.out)))

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -254,9 +254,10 @@
   (targets root-009e00fa)
   (action
    (progn
+    (ignore-stdout
     (run %{bin:opam} init --root=%{targets}
            --no-setup --bypass-checks --no-opamrc --bare
-           file://%{dep:opam-repo-009e00fa}))))
+           file://%{dep:opam-repo-009e00fa})))))
 
 (rule
  (targets opam-archive-632bc2e.tar.gz)
@@ -273,9 +274,10 @@
   (targets root-632bc2e)
   (action
    (progn
+    (ignore-stdout
     (run %{bin:opam} init --root=%{targets}
            --no-setup --bypass-checks --no-opamrc --bare
-           file://%{dep:opam-repo-632bc2e}))))
+           file://%{dep:opam-repo-632bc2e})))))
 
 (rule
  (targets opam-archive-c1d23f0e.tar.gz)
@@ -292,9 +294,10 @@
   (targets root-c1d23f0e)
   (action
    (progn
+    (ignore-stdout
     (run %{bin:opam} init --root=%{targets}
            --no-setup --bypass-checks --no-opamrc --bare
-           file://%{dep:opam-repo-c1d23f0e}))))
+           file://%{dep:opam-repo-c1d23f0e})))))
 
 (rule
  (targets opam-archive-f372039d.tar.gz)
@@ -311,6 +314,7 @@
   (targets root-f372039d)
   (action
    (progn
+    (ignore-stdout
     (run %{bin:opam} init --root=%{targets}
            --no-setup --bypass-checks --no-opamrc --bare
-           file://%{dep:opam-repo-f372039d}))))
+           file://%{dep:opam-repo-f372039d})))))

--- a/tests/reftests/gen.ml
+++ b/tests/reftests/gen.ml
@@ -61,9 +61,10 @@ let opam_init_rule archive_hash =
   (targets %s)
   (action
    (progn
+    (ignore-stdout
     (run %%{bin:opam} init --root=%%{targets}
            --no-setup --bypass-checks --no-opamrc --bare
-           file://%%{dep:%s}))))
+           file://%%{dep:%s})))))
 |} (opamroot_directory ~archive_hash) (repo_directory ~archive_hash)
 
 module StringSet = Set.Make(String)

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -3,9 +3,8 @@
 ### tar xzf ${OPAMROOT}/repo/default.tar.gz
 ### rm -rf ${OPAMROOT}
 ### OPAMVAR_sys_ocaml_version=''
-### opam init --no-setup default default/ --fake
+### opam init --no-setup --bypass-checks default default/ --fake
 No configuration file found, using built-in defaults.
-Checking for available remotes: rsync and local, git, mercurial, darcs. Perfect!
 
 <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
 [default] Initialised
@@ -35,9 +34,8 @@ Done.
 ["ocaml" {>= "4.05.0"}]
 ### rm -rf ${OPAMROOT}
 ### OPAMVAR_sys_ocaml_version=4.02.3
-### opam init --no-setup default default/ --fake
+### opam init --no-setup --bypass-checks default default/ --fake
 No configuration file found, using built-in defaults.
-Checking for available remotes: rsync and local, git, mercurial, darcs. Perfect!
 
 <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
 [default] Initialised
@@ -67,9 +65,8 @@ Done.
 ["ocaml" {>= "4.05.0"}]
 ### rm -rf ${OPAMROOT}
 ### OPAMVAR_sys_ocaml_version=4.07.0
-### opam init --no-setup default default/ --fake
+### opam init --no-setup --bypass-checks default default/ --fake
 No configuration file found, using built-in defaults.
-Checking for available remotes: rsync and local, git, mercurial, darcs. Perfect!
 
 <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
 [default] Initialised

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -13,14 +13,6 @@ No configuration file found, using built-in defaults.
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
 Switch invariant: ["ocaml" {>= "4.05.0"}]
-The following actions will be faked:
-  - install base-bigarray       base
-  - install ocaml-base-compiler 4.10.0
-  - install base-threads        base
-  - install base-unix           base
-  - install ocaml-config        1      [required by ocaml]
-  - install ocaml               4.10.0
-===== 6 to install =====
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Faking installation of base-bigarray.base
@@ -44,14 +36,6 @@ No configuration file found, using built-in defaults.
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
 Switch invariant: ["ocaml" {>= "4.05.0"}]
-The following actions will be faked:
-  - install base-bigarray       base
-  - install ocaml-base-compiler 4.10.0
-  - install base-threads        base
-  - install base-unix           base
-  - install ocaml-config        1      [required by ocaml]
-  - install ocaml               4.10.0
-===== 6 to install =====
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Faking installation of base-bigarray.base
@@ -75,14 +59,6 @@ No configuration file found, using built-in defaults.
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
 Switch invariant: ["ocaml" {>= "4.05.0"}]
-The following actions will be faked:
-  - install base-bigarray base
-  - install base-threads  base
-  - install ocaml-system  4.07.0
-  - install base-unix     base
-  - install ocaml-config  1      [required by ocaml]
-  - install ocaml         4.07.0
-===== 6 to install =====
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Faking installation of base-bigarray.base

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -1,0 +1,116 @@
+009e00fa
+### OPAMYES=1
+### tar xzf ${OPAMROOT}/repo/default.tar.gz
+### rm -rf ${OPAMROOT}
+### OPAMVAR_sys_ocaml_version=''
+### opam init --no-setup default default/ --fake
+No configuration file found, using built-in defaults.
+Checking for available remotes: rsync and local, git, mercurial, darcs. Perfect!
+
+<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+[default] Initialised
+
+<><> Creating initial switch 'default' (invariant ["ocaml" {>= "4.05.0"}] - initially with ocaml-base-compiler) 
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml" {>= "4.05.0"}]
+The following actions will be faked:
+  - install base-bigarray       base
+  - install ocaml-base-compiler 4.10.0
+  - install base-threads        base
+  - install base-unix           base
+  - install ocaml-config        1      [required by ocaml]
+  - install ocaml               4.10.0
+===== 6 to install =====
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-base-compiler.4.10.0
+Faking installation of ocaml-config.1
+Faking installation of ocaml.4.10.0
+Done.
+### opam switch invariant
+["ocaml" {>= "4.05.0"}]
+### rm -rf ${OPAMROOT}
+### OPAMVAR_sys_ocaml_version=4.02.3
+### opam init --no-setup default default/ --fake
+No configuration file found, using built-in defaults.
+Checking for available remotes: rsync and local, git, mercurial, darcs. Perfect!
+
+<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+[default] Initialised
+
+<><> Creating initial switch 'default' (invariant ["ocaml" {>= "4.05.0"}] - initially with ocaml-base-compiler) 
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml" {>= "4.05.0"}]
+The following actions will be faked:
+  - install base-bigarray       base
+  - install ocaml-base-compiler 4.10.0
+  - install base-threads        base
+  - install base-unix           base
+  - install ocaml-config        1      [required by ocaml]
+  - install ocaml               4.10.0
+===== 6 to install =====
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-base-compiler.4.10.0
+Faking installation of ocaml-config.1
+Faking installation of ocaml.4.10.0
+Done.
+### opam switch invariant
+["ocaml" {>= "4.05.0"}]
+### rm -rf ${OPAMROOT}
+### OPAMVAR_sys_ocaml_version=4.07.0
+### opam init --no-setup default default/ --fake
+No configuration file found, using built-in defaults.
+Checking for available remotes: rsync and local, git, mercurial, darcs. Perfect!
+
+<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+[default] Initialised
+
+<><> Creating initial switch 'default' (invariant ["ocaml" {>= "4.05.0"}] - initially with ocaml-system) 
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml" {>= "4.05.0"}]
+The following actions will be faked:
+  - install base-bigarray base
+  - install base-threads  base
+  - install ocaml-system  4.07.0
+  - install base-unix     base
+  - install ocaml-config  1      [required by ocaml]
+  - install ocaml         4.07.0
+===== 6 to install =====
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-system.4.07.0
+Faking installation of ocaml-config.1
+Faking installation of ocaml.4.07.0
+Done.
+### opam switch invariant
+["ocaml" {>= "4.05.0"}]
+### opam upgrade --fake
+Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
+However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
+Nothing to do.
+### opam upgrade ocaml --fake
+The following actions will be faked:
+  - remove    ocaml-system        4.07.0           [conflicts with ocaml]
+  - install   ocaml-base-compiler 4.10.0           [required by ocaml]
+  - recompile ocaml-config        1                [uses ocaml-system]
+  - upgrade   ocaml               4.07.0 to 4.10.0
+===== 1 to install | 1 to recompile | 1 to upgrade | 1 to remove =====
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of ocaml-base-compiler.4.10.0
+Faking installation of ocaml-config.1
+Faking installation of ocaml.4.10.0
+Done.

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -167,6 +167,11 @@ let command
     in
       maybe_resolved_cmd, cmd
   in
+  let args =
+    if orig_cmd = "tar" || orig_cmd = "tar.exe" then
+      List.map (Lazy.force (OpamSystem.get_cygpath_function ~command:cmd)) args
+    else args
+  in
   let pid =
     OpamProcess.create_process_env cmd (Array.of_list (cmd::args)) env
       Unix.stdin stdout stdout

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -158,6 +158,15 @@ let command
   Unix.set_close_on_exec input;
   let ic = Unix.in_channel_of_descr input in
   set_binary_mode_in ic false;
+  let cmd, orig_cmd =
+    let maybe_resolved_cmd =
+      if Sys.win32 then
+        OpamStd.Option.default cmd @@ OpamSystem.resolve_command cmd
+      else
+        cmd
+    in
+      maybe_resolved_cmd, cmd
+  in
   let pid =
     OpamProcess.create_process_env cmd (Array.of_list (cmd::args)) env
       Unix.stdin stdout stdout


### PR DESCRIPTION
(todo: add tests)

compared to 2.0, this just adds the new 'default-invariant', and keeps
similar semantics for 'default-compiler', which is only used for 'opam
init' (but must now be compatible with the invariant).

previously the 2.1 branch completely replaced the older meaning of
'default-compiler', using it as 'default-invariant' instead, but the order
of priority was lost.