### PR TITLE
MacOS sandbox: fix realpath use

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -68,6 +68,7 @@ New option/command/subcommand are prefixed with ◈.
   * Fix the sandbox check [#4589 @AltGr]
   * Fix sandbox script shell mistake that made `PWD` read-write on remove actions [#4589 @AltGr]
   * Port bwrap improvements to sandbox_exec [#4589 @AltGr]
+  * Fix realpath use for macos, partial revert of #4589 [#4609 @AltGr]
 
 ## Repository management
   *

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -50,11 +50,7 @@ add_ccache_mount() {
 }
 
 add_dune_cache_mount() {
-  local u_cache=${XDG_CACHE_HOME:-$HOME/.cache}
-  local u_dune_cache=$u_cache/dune
-  local cache=$(readlink -m "$u_cache")
-  local dune_cache=$cache/dune
-  local dune_cache=$(readlink -m "$u_dune_cache")
+  local dune_cache=${XDG_CACHE_HOME:-$HOME/.cache}/dune
   mkdir -p "${dune_cache}"
   add_mounts rw "$dune_cache"
 }


### PR DESCRIPTION
Oops, had this fix lying around on the mac but it got lost in the final reftests PR.