### PR TITLE
Change global lock only if format upgrade is performed

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -20,6 +20,7 @@ New option/command/subcommand are prefixed with ◈.
 ## Install
   * Don't patch twice [#4529 @rjbou]
   * With `--deps-only`, set dependencies as root packages [#4964 @rjbou - fix #4502]
+  * Keep global lock only if root format upgrade is performed [#4612 @rjbou - fix #4597]
 
 ## Remove
   *
@@ -127,6 +128,8 @@ New option/command/subcommand are prefixed with ◈.
   * GHA: Fix opam-rt on macos, set ocaml-system as switch compiler [#4610 @dra27 @rjbou]
   * GHA: Ignore opam-rt pin depends, opam libs are already pinned locally [#4610 @AltGr @rjbou]
   * GHA: The bootstrap cache also depends on the precise version! [#4618 @dra27]
+  * Add switch creation tests: (dead)locking and switch defitinion at action time [#4612 @rjbou]
+  * Remove debug information from reftest [#4612 @rjbou]
 
 ## Shell
   *

--- a/src/state/opamFormatUpgrade.mli
+++ b/src/state/opamFormatUpgrade.mli
@@ -13,6 +13,7 @@
     versions to the current one *)
 
 open OpamTypes
+open OpamStateTypes
 
 (** Raised when the opam root has been updated to a newer format, and further
     action (opam init/update) is needed. *)
@@ -22,10 +23,16 @@ exception Upgrade_done of OpamFile.Config.t
     instance of opam requires *)
 val latest_version: OpamVersion.t
 
-(** Runs the upgrade from its current format to the latest compatible version
-    for the opam root at the given directory. A global write lock must be supplied.
-    If an upgrade has been done, raises [Upgrade_done updated_config]. *)
-val as_necessary: OpamSystem.lock -> dirname -> OpamFile.Config.t -> OpamFile.Config.t
+(** [as_necessary requested_lock global_lock root config]
+    Runs the upgrade from its current format to the latest compatible version
+    for the opam root at [root] directory. Performs an on-the-fly upgrade
+    (loaded state, not written) if possible: no hard upgrade needed, and no
+    write lock required ([requested_lock]). If upgrade need to be written (hard
+    upgrade), a write lock on the global state ([global_lock]) is taken and
+    when it's done raises [Upgrade_done updated_config].  Otherwise, it returns
+    the upgraded or unchanged config file.*)
+val as_necessary:
+  'a lock -> OpamSystem.lock -> dirname -> OpamFile.Config.t -> OpamFile.Config.t
 
 (** Converts the opam file format, including rewriting availability conditions
     based on OCaml-related variables into dependencies. The filename is used to

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -223,7 +223,7 @@
   (action
    (progn
     (run %{bin:opam} init --root=%{targets}
-           --no-setup --bypass-checks --no-opamrc --bare -vv --debug
+           --no-setup --bypass-checks --no-opamrc --bare
            file://%{dep:opam-repo-009e00fa}))))
 
 (rule
@@ -242,7 +242,7 @@
   (action
    (progn
     (run %{bin:opam} init --root=%{targets}
-           --no-setup --bypass-checks --no-opamrc --bare -vv --debug
+           --no-setup --bypass-checks --no-opamrc --bare
            file://%{dep:opam-repo-632bc2e}))))
 
 (rule
@@ -261,7 +261,7 @@
   (action
    (progn
     (run %{bin:opam} init --root=%{targets}
-           --no-setup --bypass-checks --no-opamrc --bare -vv --debug
+           --no-setup --bypass-checks --no-opamrc --bare
            file://%{dep:opam-repo-c1d23f0e}))))
 
 (rule
@@ -280,5 +280,5 @@
   (action
    (progn
     (run %{bin:opam} init --root=%{targets}
-           --no-setup --bypass-checks --no-opamrc --bare -vv --debug
+           --no-setup --bypass-checks --no-opamrc --bare
            file://%{dep:opam-repo-f372039d}))))

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -153,7 +153,7 @@
  (deps (alias reftest-pat-sub)))
 
 (rule
- (deps root-009e00fa)
+ (deps root-632bc2e)
  (action
   (with-stdout-to
    pat-sub.out
@@ -174,6 +174,22 @@
   (with-stdout-to
    show.out
    (run ./run.exe %{bin:opam} %{dep:show.test} %{read-lines:testing-env}))))
+
+(alias
+ (name reftest-switch-creation)
+ (action
+  (diff switch-creation.test switch-creation.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-switch-creation)))
+
+(rule
+ (deps root-632bc2e)
+ (action
+  (with-stdout-to
+   switch-creation.out
+   (run ./run.exe %{bin:opam} %{dep:switch-creation.test} %{read-lines:testing-env}))))
 
 (alias
  (name reftest-upgrade-format)

--- a/tests/reftests/gen.ml
+++ b/tests/reftests/gen.ml
@@ -62,7 +62,7 @@ let opam_init_rule archive_hash =
   (action
    (progn
     (run %%{bin:opam} init --root=%%{targets}
-           --no-setup --bypass-checks --no-opamrc --bare -vv --debug
+           --no-setup --bypass-checks --no-opamrc --bare
            file://%%{dep:%s}))))
 |} (opamroot_directory ~archive_hash) (repo_directory ~archive_hash)
 

--- a/tests/reftests/pat-sub.test
+++ b/tests/reftests/pat-sub.test
@@ -1,4 +1,4 @@
-009e00fa
+632bc2e
 ### mkdir ps
 ### <ps/bar>
 blabla

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -205,7 +205,7 @@ let erase_file path =
 
 let rm_rf path =
   let rec erase path =
-    if Sys.is_directory path then begin
+    if Sys.file_exists path && Sys.is_directory path then begin
       Array.iter (fun entry -> erase (Filename.concat path entry))
                  (Sys.readdir path);
       Unix.rmdir path

--- a/tests/reftests/switch-creation.test
+++ b/tests/reftests/switch-creation.test
@@ -1,0 +1,26 @@
+632bc2e
+### <test-repo/packages/foo/foo.1/opam>
+opam-version: "2.0"
+build: ["opam" "option" "jobs" "--safe" "--cli=2.1"]
+flags: compiler
+### <test-repo/packages/bar/bar.1/opam>
+opam-version: "2.0"
+build: ["opam" "option" "jobs" "--safe" "--cli=2.1"]
+### <test-repo/packages/baz/baz.1/opam>
+opam-version: "2.0"
+flags: compiler
+build: ["opam" "var" "prefix" "--safe"]
+### opam switch create undef-prefix --repo=sw-lock=test-repo baz | grep ERROR | unordered
+[ERROR] The compilation of baz.1 failed at "opam var prefix --safe".
+#=== ERROR while compiling baz.1 ==============================================#
+# [ERROR] No switch is currently set. Please use 'opam switch' to set or install a switch
+# Return code 31 #
+### opam switch create nohang --repo=sw-lock=test-repo foo bar | unordered
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["foo" "bar"]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed bar.1
+-> installed foo.1
+Done.


### PR DESCRIPTION
The global lock is no more taken regarding opam root format upgrade needs. It is upgraded to the needed one (read ou write) according the kind of upgrade to perform (light/hard, on the fly or not), and released afterwards.

fix #4597