### PR TITLE
Don't connect stdin to sub-processes

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -112,7 +112,10 @@ users)
 ## Internal
   * Add license and lowerbounds to opam files [#4714 @kit-ty-kate]
   * Bump version to 2.2.0~alpha~dev [#4725 @dra27]
+
+## Internal: Windows
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]
+  * Process control: close stdin by default for Windows subprocesses and on all platforms for the download command [#4615 @dra27]
 
 ## Test
 

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -326,7 +326,7 @@ let create_process_env =
     environment can also be overridden if [env] is set. The environment
     which is used to run the process is recorded into [env_file] (if
     set). *)
-let create ?info_file ?env_file ?(allow_stdin=true) ?stdout_file ?stderr_file ?env ?(metadata=[]) ?dir
+let create ?info_file ?env_file ?(allow_stdin=not Sys.win32) ?stdout_file ?stderr_file ?env ?(metadata=[]) ?dir
     ~verbose ~tmp_files cmd args =
   let nothing () = () in
   let tee f =
@@ -739,7 +739,7 @@ let dry_wait_one = function
 let run command =
   let command =
     { command with
-      cmd_stdin = OpamStd.Option.Op.(command.cmd_stdin ++ Some true) }
+      cmd_stdin = OpamStd.Option.Op.(command.cmd_stdin ++ Some (not Sys.win32)) }
   in
   let p = run_background command in
   try wait p with e ->

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -470,7 +470,7 @@ let resolve_command ?env ?dir name =
 let apply_cygpath name =
   let r =
     OpamProcess.run
-      (OpamProcess.command ~name:(temp_file "command") ~verbose:false "cygpath" ["--"; name])
+      (OpamProcess.command ~name:(temp_file "command") ~allow_stdin:false ~verbose:false "cygpath" ["--"; name])
   in
   OpamProcess.cleanup ~force:true r;
   if OpamProcess.is_success r then

--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -132,7 +132,7 @@ let download_command ~compress ?checksum ~url ~dst () =
       OpamConsole.error_and_exit `Configuration_error
         "Empty custom download command"
   in
-  OpamSystem.make_command cmd args @@> tool_return url
+  OpamSystem.make_command ~allow_stdin:false cmd args @@> tool_return url
 
 let really_download
     ?(quiet=false) ~overwrite ?(compress=false) ?checksum ?(validate=true)


### PR DESCRIPTION
Split off from #3897. @AltGr agreed this was worth doing in https://github.com/ocaml/opam/pull/3897#pullrequestreview-348824024, but it's too close to the 2.1 release for a change which isn't a critical part of that fix, so this can be merged post-2.1