### PR TITLE
Clean-up our opam files

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -119,6 +119,7 @@ New option/command/subcommand are prefixed with ◈.
   * Fix temporary file with a too long name causing errors on Windows [#4590 @AltGr]
   * CLI: Add flag deprecation and replacement helper [#4595 @rjbou]
   * Win32 Console: fix VT100 support [#3897 @dra27]
+  * Tidied the opam files [#4620 @dra27]
 
 ## Test
   * Make the reference tests dune-friendly [#4376 @emillon]

--- a/opam-admin.opam
+++ b/opam-admin.opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "Meta-package for Dune"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "dune" {>= "1.11.0"}
+  "re" {>= "1.9.0"}
+  "opam-file-format" {>= "2.1.2"}
+]

--- a/opam-client.opam
+++ b/opam-client.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 version: "2.1.0~beta4"
-synopsis: "opam 2.1 development libraries (client)"
+synopsis: "Client library for opam 2.1"
 description: """
 Actions on the opam root, switches, installations, and front-end.
 """

--- a/opam-core.opam
+++ b/opam-core.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 version: "2.1.0~beta4"
-synopsis: "opam 2.1 development libraries (core)"
+synopsis: "Core library for opam 2.1"
 description: """
 Small standard library extensions, and generic system interaction modules used by opam.
 """

--- a/opam-devel.opam
+++ b/opam-devel.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 version: "2.1.0~beta4"
-synopsis: "opam 2.1 bootstrapped binary"
+synopsis: "Bootstrapped development binary for opam 2.1"
 description: """
 This package compiles (bootstraps) opam. For consistency and safety of the installation, the binaries are not installed into the PATH, but into lib/opam-devel, from where the user can manually install them system-wide.
 """

--- a/opam-format.opam
+++ b/opam-format.opam
@@ -28,5 +28,6 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= version}
   "opam-file-format" {>= "2.1.2"}
+  "re" {>= "1.9.0"}
   "dune" {>= "1.11.0"}
 ]

--- a/opam-format.opam
+++ b/opam-format.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 version: "2.1.0~beta4"
-synopsis: "opam 2.1 development libraries (format)"
+synopsis: "Format library for opam 2.1"
 description: """
 Definition of opam datastructures and its file interface.
 """

--- a/opam-repository.opam
+++ b/opam-repository.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 version: "2.1.0~beta4"
-synopsis: "opam 2.1 development libraries (repository)"
+synopsis: "Repository library for opam 2.1"
 description: """
 This library includes repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends.
 """

--- a/opam-solver.opam
+++ b/opam-solver.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 version: "2.1.0~beta4"
-synopsis: "opam 2.1 development libraries (solver)"
+synopsis: "Solver library for opam 2.1"
 description: """
 Solver and Cudf interaction. This library is based on the Cudf and Dose libraries, and handles calls to the external solver from opam.
 """

--- a/opam-state.opam
+++ b/opam-state.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 version: "2.1.0~beta4"
-synopsis: "opam 2.1 development libraries (state)"
+synopsis: "State library for opam 2.1"
 description: """
 Handling of the ~/.opam hierarchy, repository and switch states.
 """

--- a/opam.opam
+++ b/opam.opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "Meta-package for Dune"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "dune" {>= "1.11.0"}
+  "opam-client" {= version}
+]

--- a/opam.opam
+++ b/opam.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "2.1.0~beta4"
 synopsis: "Meta-package for Dune"
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [


### PR DESCRIPTION
A few house-keeping amendments:

- Our own opam files should really pass `opam lint` 🙈 (re-wrote the `synopsis` fields not to have `opam` as the first word)
- `opam-format` should pedantically have an explicit dependency on `re`
- `opam.opam` and `opam-admin.opam` changed from being empty files to be minimally populated (they pass both opam lint and opam dune-lint)