### PR TITLE
Reinstall plugin package if the symlink is missing

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -12,6 +12,7 @@ New option/command/subcommand are prefixed with ◈.
   * Add cli versioning for opam environment variables [#4606 @rjbou]
   * Deprecated `build-doc`, `build-test`, `make` [#4581 @rjbou]
   * Add cli versioning for enums of flags with predefined enums [#4606 @rjbou]
+  * Ensure the symlink for a plugin is maintained on each invocation [#4621 @dra27 - partially fixes #4619]
 
 ## Init
   * Introduce a `default-invariant` config field, restore the 2.0 semantics for

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -88,7 +88,6 @@ let rec preprocess_argv cli yes args =
 
 (* Handle git-like plugins *)
 let check_and_run_external_commands () =
-  let plugin_prefix = "opam-" in
   (* Pre-process the --yes and --cli options *)
   let (cli, yes, argv) =
     match Array.to_list Sys.argv with
@@ -132,7 +131,7 @@ let check_and_run_external_commands () =
     then (cli, argv)
     else
     (* No such command, check if there is a matching plugin *)
-    let command = plugin_prefix ^ name in
+    let command = OpamPath.plugin_prefix ^ name in
     let answer = if yes then Some true else OpamCoreConfig.E.yes () in
     OpamCoreConfig.init ~answer ();
     OpamFormatConfig.init ();
@@ -166,7 +165,7 @@ let check_and_run_external_commands () =
       | Some sw ->
         OpamGlobalState.with_ `Lock_none @@ fun gt ->
         OpamSwitchState.with_ `Lock_none gt ~switch:sw @@ fun st ->
-        let prefixed_name = plugin_prefix ^ name in
+        let prefixed_name = OpamPath.plugin_prefix ^ name in
         let candidates =
           OpamPackage.packages_of_names
             (Lazy.force st.available_packages)

--- a/src/format/opamPath.ml
+++ b/src/format/opamPath.ml
@@ -57,6 +57,8 @@ let backup_dir t = t / "backup"
 
 let backup t = backup_dir t /- backup_file ()
 
+let plugin_prefix = "opam-"
+
 let plugins t = t / "plugins"
 
 let plugins_bin t = plugins t / "bin"
@@ -64,8 +66,8 @@ let plugins_bin t = plugins t / "bin"
 let plugin_bin t name =
   let sname = OpamPackage.Name.to_string name in
   let basename =
-    if OpamStd.String.starts_with ~prefix:"opam-" sname then sname
-    else "opam-" ^ sname
+    if OpamStd.String.starts_with ~prefix:plugin_prefix sname then sname
+    else plugin_prefix ^ sname
   in
   plugins_bin t // basename
 

--- a/src/format/opamPath.mli
+++ b/src/format/opamPath.mli
@@ -64,6 +64,9 @@ val backup_dir: t -> dirname
 (** Backup file for state export *)
 val backup: t -> switch_selections OpamFile.t
 
+(** The prefix for plugin commands (["opam-"]) *)
+val plugin_prefix : string
+
 (** The directory for plugins data {i $opam/plugins} *)
 val plugins: t -> dirname
 

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -498,7 +498,7 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
        match t.OpamFile.OPAM.name with
        | None -> false
        | Some name ->
-         not (OpamStd.String.starts_with ~prefix:"opam-"
+         not (OpamStd.String.starts_with ~prefix:OpamPath.plugin_prefix
                 (OpamPackage.Name.to_string name)));
     (let unclosed =
        List.fold_left (fun acc s ->


### PR DESCRIPTION
This is a partial fix for #4619 (the other part would be to remove the plugin symlinks at format upgrade).

This tweaks the plugin detection slightly so that if the symlink is missing, the command is still resolved, but package will be reinstalled in the current switch. This will recreate the symlink and also apply any changes to dependencies (e.g. after an opam client upgrade).

It's demonstrated by this slightly convoluted Dockerfile - commenting out the final `rm` command shows the existing error.

```
FROM ocaml/opam:debian-ocaml-4.12
WORKDIR /src
RUN sudo chown opam /src
RUN git clone https://github.com/dra27/opam.git
WORKDIR /src/opam
RUN opam pin add -n dose3 5.0.1-1
RUN git checkout reinstall-plugins ; opam install dose3 opam-file-format mccs cmdliner
RUN opam exec -- ./configure && opam exec -- make
WORKDIR /src/test
RUN sudo chown opam /src/test
RUN opam install dune
RUN opam exec -- dune init project foo
RUN echo > dune-project '(lang dune 2.8)\n(generate_opam_files true)(source (github foo/bar))(package (name foo))'
RUN opam exec -- dune build
RUN opam install opam-state.2.0.8
RUN opam install opam-dune-lint --deps-only
RUN opam pin -yn opam-dune-lint 'https://github.com/ocurrent/opam-dune-lint.git#bf451c8cf2d4f2be3c7d979b613c79588b55a172'
RUN opam dune-lint
#RUN sudo rm /usr/bin/opam && sudo ln /usr/bin/opam-2.1 /usr/bin/opam
RUN sudo rm /usr/bin/opam && sudo cp /src/opam/opam /usr/bin/opam
RUN opam update
RUN rm ~/.opam/plugins/bin/*
RUN opam dune-lint
```