### PR TITLE
Error-free opam root changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ uninstall: opam.install
 	$(OPAMINSTALLER) -u $(OPAMINSTALLER_FLAGS) opam-installer.install
 
 .PHONY: tests
-tests: $(DUNE_DEP)
+tests: $(DUNE_DEP) src/client/no-git-version
 	@$(DUNE) runtest $(DUNE_PROFILE_ARG) --root . $(DUNE_ARGS) src/ tests/ --no-buffer; \
 	ret=$$?; \
 	echo "###     TESTS RESULT SUMMARY     ###"; \
@@ -203,20 +203,24 @@ crowbar-afl: $(DUNE_DEP)
 	echo foo > /tmp/opam-crowbar-input/foo
 	afl-fuzz -i /tmp/opam-crowbar-input -o /tmp/opam-crowbar-output dune exec src/crowbar/test.exe @@
 
+INTERMEDIATE: src/client/no-git-version
+src/client/no-git-version:
+	touch src/client/no-git-version
+
 # tests-local, tests-git
-tests-%: $(DUNE_DEP)
+tests-%: $(DUNE_DEP) src/client/no-git-version
 	$(DUNE) build $(DUNE_ARGS) $(DUNE_PROFILE_ARG) --root . @reftest-legacy-$* --force
 
-reftest-gen: $(DUNE_DEP)
+reftest-gen: $(DUNE_DEP) src/client/no-git-version
 	$(DUNE) build $(DUNE_ARGS) $(DUNE_PROFILE_ARG) --root . @reftest-gen --auto-promote --force
 
-reftest-runner: $(DUNE_DEP)
+reftest-runner: $(DUNE_DEP) src/client/no-git-version
 	$(DUNE) build $(DUNE_ARGS) $(DUNE_PROFILE_ARG) --root . tests/reftests/run.exe
 
-reftests: $(DUNE_DEP)
+reftests: $(DUNE_DEP) src/client/no-git-version
 	$(DUNE) build $(DUNE_ARGS) $(DUNE_PROFILE_ARG) --root . @reftest
 
-reftests-%: $(DUNE_DEP)
+reftests-%: $(DUNE_DEP) src/client/no-git-version
 	$(DUNE) build $(DUNE_ARGS) $(DUNE_PROFILE_ARG) --root . @reftest-$* --force
 
 reftests-meld:

--- a/master_changes.md
+++ b/master_changes.md
@@ -25,6 +25,9 @@ New option/command/subcommand are prefixed with ◈.
   * Introduce a `default-invariant` config field, restore the 2.0 semantics for
     `default-compiler` [#4607 @AltGr]
   * Fix default invariant with no system compiler [#4644 @AltGr - fix #4640]
+  * Perform an hard upgrade on intermediate roots, ie root from `2.1~alpha/beta`, and keep a light upgrade from `2.0` [#4638 @rjbou]
+  * If opam root is different from the binary, allow reading it and try to read in best effort mode  [#4638 @rjbou - fix #4636]
+  * Don't check opam system dependencies on reinit after a format upgrade [#4638 @rjbou]
 
 ## Config report
   * Fix `Not_found` (config file) error [#4570 @rjbou]
@@ -47,6 +50,7 @@ New option/command/subcommand are prefixed with ◈.
     with base packages but doesn't make sense with 2.1 switch invariants) [#4569 @dra27]
   * Don't refer to base packages in messages any more [#4623 @dra27 - fixes #4572]
   * Give the correct command when demonstrating switch creation [#4675 @dra27 - fixes #4673]
+  * On switch loading, if invariant is inferred and a write lock required, write the file [#4638 @rjbou]
 
 ## Pin
   * Don't look for lock files for pin depends [#4511 @rjbou - fix #4505]
@@ -71,6 +75,7 @@ New option/command/subcommand are prefixed with ◈.
   * Fix W59 & E60 with conf flag handling (no url required) [#4550 @rjbou - fix #4549]
   * Fix W59 & E60 with VCS urls, don't check upstream if url has VCS backend [#4635 @rjbou]
   * Add E67 checksum specified with non archive url [#4635 @rjbou]
+  * Disable subpath warning E63,W64 [#4638 @rjbou]
 
 ## Lock
   * Don't write lock file with `--read-only', `--safe`, and `--dryrun` [#4562 @rjbou - fix #4320]
@@ -82,6 +87,11 @@ New option/command/subcommand are prefixed with ◈.
   * Fix rewriting with preserved format empty field error [#4634 @rjbou - fix #4628]
   * Fix rewrtiting with preserved format empty field error [#4633 @rjbou - fix #4628]
   * Require opam-file-format 2.1.3+ in order to enforce opam-version: "2.1" as first non-comment line [#4639 @dra27 - fix #4394]
+  * Switch config: Defined `invariant` field as an option to differentiate when it is not defined [#4638 @rjbou]
+  * Differentiate bad format from bad (opam) version with `Bad_version` exception, raised from `OpamFormat.check_opam_version` [#4638 @rjbou]
+  * Always print the `opam-version` field on files [#4638 @rjbou]
+  * Config: add `opam-root-version` field as a marker for the whole opam root [#4638 @rjbou - fix #4636]
+  * Add `BestEffort` modules with reading functions that don't show errors, given the `opam_file_format` internal field [#4638 @rjbou - fix #4636]
 
 ## External dependencies
   * Handle macport variants [#4509 @rjbou - fix #4297]
@@ -119,6 +129,7 @@ New option/command/subcommand are prefixed with ◈.
   * Fix build from source when a dune-project file is presented in the parent directory [#4545 @kit-ty-kate - fix #4537]
   * Fix opam-devel.install not to install two files called opam [#4664 @dra27]
   * Build release tags as non-dev versions, as for release tarballs [#4665 @dra27 - fix #4656]
+  * Disable dev version for tests (needed for format upgrade test) [#4638 @rjbou]
 
 ## Infrastructure
   * Release scripts: switch to OCaml 4.10.2 by default, add macos/arm64 builds by default [#4559 @AltGr]
@@ -177,6 +188,7 @@ New option/command/subcommand are prefixed with ◈.
   * Remove debug information from reftest [#4612 @rjbou]
   * Add preserved format test [#4634 @rjbou]
   * Use the dev profile when testing [#4672 @dra27]
+  * Add a test to test various case of opam root loading (several version, and several lock kinds) [#4638 @rjbou]
 
 ## Shell
   *

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -126,7 +126,7 @@ let index_command cli =
 
 let cache_urls repo_root repo_def =
   let global_dl_cache =
-    OpamStd.Option.Op.(OpamStateConfig.(load !r.root_dir) +!
+    OpamStd.Option.Op.(OpamStateConfig.(load ~lock_kind:`Lock_read !r.root_dir) +!
                        OpamFile.Config.empty)
     |> OpamFile.Config.dl_cache
   in
@@ -771,7 +771,8 @@ let get_virtual_switch_state repo_root env =
   let gt = {
     global_lock = OpamSystem.lock_none;
     root = OpamStateConfig.(!r.root_dir);
-    config = OpamStd.Option.Op.(OpamStateConfig.(load !r.root_dir) +!
+    config = OpamStd.Option.Op.(OpamStateConfig.(
+        load ~lock_kind:`Lock_read !r.root_dir) +!
                                 OpamFile.Config.empty);
     global_variables = OpamVariable.Map.empty;
   } in

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -302,8 +302,8 @@ let rec main_catch_all f =
   | OpamFormatUpgrade.Upgrade_done conf ->
     main_catch_all @@ fun () ->
     OpamConsole.header_msg "Rerunning init and update";
-    OpamClient.reinit ~interactive:true ~update_config:false conf
-      (OpamStd.Sys.guess_shell_compat ());
+    OpamClient.reinit ~interactive:true ~update_config:false ~bypass_checks:true
+      conf (OpamStd.Sys.guess_shell_compat ());
     OpamConsole.msg
       "Update done, please now retry your command.\n";
     exit (OpamStd.Sys.get_exit_code `Aborted)

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -141,7 +141,7 @@ let check_and_run_external_commands () =
     OpamFormatConfig.init ();
     let root_dir = OpamStateConfig.opamroot () in
     let has_init, root_upgraded =
-      match OpamStateConfig.load_defaults root_dir with
+      match OpamStateConfig.load_defaults ~lock_kind:`Lock_read root_dir with
       | None -> (false, false)
       | Some config ->
           let root_upgraded =

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -146,10 +146,8 @@ let check_and_run_external_commands () =
       | Some config ->
         let root_upgraded =
           let cmp =
-            match  OpamFile.Config.opam_root_version config with
-            | Some root_version ->
-              OpamVersion.compare OpamFile.Config.root_version root_version
-            | None -> 1 (* older opam root *)
+            OpamVersion.compare OpamFile.Config.root_version
+              (OpamFile.Config.opam_root_version config)
           in
           if cmp < 0 then
             OpamConsole.error_and_exit `Configuration_error

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -843,7 +843,9 @@ let init
           | None -> OpamFile.InitConfig.repositories init_config
         in
         let config =
-          update_with_init_config OpamFile.Config.empty init_config |>
+          update_with_init_config
+            OpamFile.Config.(with_opam_root_version root_version empty)
+            init_config |>
           OpamFile.Config.with_repositories (List.map fst repos)
         in
 

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -773,11 +773,14 @@ let update_with_init_config ?(overwrite=false) config init_config =
 
 let reinit ?(init_config=OpamInitDefaults.init_config()) ~interactive
     ?dot_profile ?update_config ?env_hook ?completion ?inplace
-    ?(check_sandbox=true)
+    ?(check_sandbox=true) ?(bypass_checks=false)
     config shell =
   let root = OpamStateConfig.(!r.root_dir) in
   let config = update_with_init_config config init_config in
-  let _all_ok = init_checks ~hard_fail_exn:false init_config in
+  let _all_ok =
+    if bypass_checks then false else
+      init_checks ~hard_fail_exn:false init_config
+  in
   let custom_init_scripts =
     let env v =
       let vs = OpamVariable.Full.variable v in

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -43,7 +43,7 @@ val init:
 val reinit:
   ?init_config:OpamFile.InitConfig.t -> interactive:bool -> ?dot_profile:filename ->
   ?update_config:bool -> ?env_hook:bool -> ?completion:bool -> ?inplace:bool ->
-  ?check_sandbox:bool ->
+  ?check_sandbox:bool -> ?bypass_checks:bool ->
   OpamFile.Config.t -> shell -> unit
 
 (** Install the given list of packages. [add_to_roots], if given, specifies that

--- a/src/client/opamClientConfig.ml
+++ b/src/client/opamClientConfig.ml
@@ -215,7 +215,7 @@ let opam_init ?root_dir ?strict ?solver =
   (* the init for OpamFormat is done in advance since (a) it has an effect on
      loading the global config (b) the global config has no effect on it *)
   OpamFormatConfig.initk ?strict @@ fun ?log_dir ->
-  let config = OpamStateConfig.load_defaults root in
+  let config = OpamStateConfig.load_defaults ~lock_kind:`Lock_read root in
   let initialised = config <> None in
   (* !X fixme: don't drop the loaded config file to reload it afterwards (when
      loading the global_state) like that... *)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -372,9 +372,9 @@ let init cli =
             ~no_default_config_file:no_config_file ~add_config_file:config_file
         in
         OpamClient.reinit ~init_config ~interactive ~dot_profile
-           ?update_config ?env_hook ?completion ~inplace
-           ~check_sandbox:(not no_sandboxing)
-           (OpamFile.Config.safe_read config_f) shell;
+          ?update_config ?env_hook ?completion ~inplace
+          ~check_sandbox:(not no_sandboxing)
+          (OpamStateConfig.safe_load ~lock_kind:`Lock_write root) shell;
       else
         (if not interactive &&
             update_config <> Some true && completion <> Some true && env_hook <> Some true then
@@ -2237,7 +2237,7 @@ let repository cli =
       let names = List.map OpamRepositoryName.of_string names in
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
       let repos =
-        OpamFile.Repos_config.safe_read (OpamPath.repos_config gt.root)
+        OpamStateConfig.Repos.safe_read ~lock_kind:`Lock_read gt
       in
       let not_found =
         List.filter (fun r -> not (OpamRepositoryName.Map.mem r repos)) names
@@ -2677,7 +2677,7 @@ let switch cli =
          OpamSwitchState.drop st;
          `Ok ())
     | Some `export, [filename] ->
-      OpamGlobalState.with_ `Lock_write @@ fun gt ->
+      OpamGlobalState.with_ `Lock_none @@ fun gt ->
       OpamRepositoryState.with_ `Lock_none gt @@ fun rt ->
       OpamSwitchCommand.export rt
         ~full:(full || freeze) ~freeze
@@ -3667,7 +3667,7 @@ let clean cli =
       (OpamFilename.with_flock `Lock_write (OpamPath.repos_lock gt.root)
        @@ fun _lock ->
        let repos_config =
-         OpamFile.Repos_config.safe_read (OpamPath.repos_config gt.root)
+         OpamStateConfig.Repos.safe_read ~lock_kind:`Lock_write gt
        in
        let all_repos =
          OpamRepositoryName.Map.keys repos_config |>
@@ -3680,8 +3680,8 @@ let clean cli =
        let unused_repos =
          List.fold_left (fun repos sw ->
              let switch_config =
-               OpamFile.Switch_config.safe_read
-                 (OpamPath.Switch.switch_config root sw)
+               OpamStateConfig.Switch.safe_load
+                 ~lock_kind:`Lock_read gt sw
              in
              let used_repos =
                OpamStd.Option.default []

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -833,7 +833,8 @@ let show cli =
             print_just_file None opam;
             `Ok ()
           with
-          | Parsing.Parse_error | OpamLexer.Error _ | OpamPp.Bad_format _ as exn ->
+          | Parsing.Parse_error | OpamLexer.Error _
+          | OpamPp.Bad_version _ | OpamPp.Bad_format _ as exn ->
             OpamConsole.error_and_exit `File_error
               "Stdin parsing failed:\n%s" (Printexc.to_string exn))
        | atom_locs, false ->
@@ -884,7 +885,8 @@ let show cli =
                try
                  errors, (Some opamf, (OpamFile.OPAM.read opamf))::opams
                with
-               | Parsing.Parse_error | OpamLexer.Error _ | OpamPp.Bad_format _ as exn ->
+               | Parsing.Parse_error | OpamLexer.Error _
+               | OpamPp.Bad_version _ | OpamPp.Bad_format _ as exn ->
                  (opamf, exn)::errors, opams)
              ([],[]) opamfs
          in
@@ -3536,6 +3538,7 @@ let lint cli =
           with
           | Parsing.Parse_error
           | OpamLexer.Error _
+          | OpamPp.Bad_version _
           | OpamPp.Bad_format _ ->
             msg "File format error\n";
             (true, json))

--- a/src/client/opamRepositoryCommand.ml
+++ b/src/client/opamRepositoryCommand.ml
@@ -145,8 +145,8 @@ let print_selection rt ~short repos_list =
 
 let switch_repos rt sw =
   let switch_config =
-    OpamFile.Switch_config.safe_read
-      (OpamPath.Switch.switch_config rt.repos_global.root sw)
+    OpamStateConfig.Switch.safe_load
+      ~lock_kind:`Lock_read rt.repos_global sw
   in
   match switch_config.OpamFile.Switch_config.repos with
   | None -> OpamGlobalState.repos_list rt.repos_global

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -338,7 +338,10 @@ let parallel_apply t
 
   (* only needed when --update-invariant is set. Use the configured invariant,
      not the current one which will be empty. *)
-  let original_invariant = t.switch_config.OpamFile.Switch_config.invariant in
+  let original_invariant =
+    OpamStd.Option.default OpamFormula.Empty
+      t.switch_config.OpamFile.Switch_config.invariant
+  in
   let original_invariant_packages =
     OpamFormula.packages t.installed original_invariant
   in
@@ -406,7 +409,8 @@ let parallel_apply t
        bypass_ref := bypass;
        invariant_ref := invariant;
        let switch_config =
-         {!t_ref.switch_config with invariant; depext_bypass = bypass }
+         {!t_ref.switch_config with
+          invariant = Some invariant; depext_bypass = bypass }
        in
        t_ref := {!t_ref with switch_invariant = invariant; switch_config};
        if not OpamStateConfig.(!r.dryrun) then
@@ -775,7 +779,7 @@ let parallel_apply t
             | _ -> OpamFormula.Empty)
           t.switch_invariant
       in
-      let switch_config = {t.switch_config with invariant} in
+      let switch_config = {t.switch_config with invariant = Some invariant} in
       if not OpamStateConfig.(!r.dryrun) then
         OpamSwitchAction.install_switch_config t.switch_global.root t.switch
           switch_config;

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -54,8 +54,7 @@ let list gt ~print_short =
           |> ifempty comp
         in
         let conf =
-          OpamFile.Switch_config.read_opt
-            (OpamPath.Switch.switch_config gt.root sw)
+          OpamStateConfig.Switch.read_opt ~lock_kind:`Lock_read gt sw
         in
         let descr = match conf with
           | Some c -> c.OpamFile.Switch_config.synopsis
@@ -558,7 +557,10 @@ let export rt ?(freeze=false) ?(full=false)
   let export =
     OpamFilename.with_flock `Lock_none (OpamPath.Switch.lock root switch)
     @@ fun _ ->
-    let selections = S.safe_read (OpamPath.Switch.selections root switch) in
+    let selections =
+      OpamStateConfig.Switch.safe_read_selections
+        ~lock_kind:`Lock_none rt.repos_global switch
+    in
     let opams =
       let read_opams read pkgs =
         let src_dir nv =

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -186,7 +186,7 @@ let remove gt ?(confirm = true) switch =
   else gt
 
 let set_invariant_raw st invariant =
-  let switch_config = {st.switch_config with invariant} in
+  let switch_config = {st.switch_config with invariant = Some invariant} in
   let st = {st with switch_invariant = invariant; switch_config } in
   if not (OpamStateConfig.(!r.dryrun) || OpamClientConfig.(!r.show)) then
     OpamSwitchAction.install_switch_config st.switch_global.root st.switch

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1179,12 +1179,12 @@ end
 module ConfigSyntax = struct
 
   let internal = "config"
-  (* This version is used as a marker for the whole opam root, so it's not
-     strictly speaking the actual format of the config file *)
   let format_version = OpamVersion.of_string "2.1"
+  let root_version = OpamVersion.of_string "2.1~rc"
 
   type t = {
     opam_version : opam_version;
+    opam_root_version: opam_version option;
     repositories : repository_name list;
     installed_switches : switch list;
     switch : switch option;
@@ -1208,6 +1208,7 @@ module ConfigSyntax = struct
   }
 
   let opam_version t = t.opam_version
+  let opam_root_version t = t.opam_root_version
   let repositories t = t.repositories
   let installed_switches t = t.installed_switches
   let switch t = t.switch
@@ -1237,6 +1238,8 @@ module ConfigSyntax = struct
 
 
   let with_opam_version opam_version t = { t with opam_version }
+  let with_opam_root_version opam_root_version t =
+    { t with opam_root_version = Some opam_root_version }
   let with_repositories repositories t = { t with repositories }
   let with_installed_switches installed_switches t =
     { t with installed_switches }
@@ -1273,6 +1276,7 @@ module ConfigSyntax = struct
 
   let empty = {
     opam_version = format_version;
+    opam_root_version = None;
     repositories = [];
     installed_switches = [];
     switch = None;
@@ -1308,6 +1312,9 @@ module ConfigSyntax = struct
     [
       "opam-version", Pp.ppacc
         with_opam_version opam_version
+        (Pp.V.string -| Pp.of_module "opam-version" (module OpamVersion));
+      "opam-root-version", Pp.ppacc_opt
+        with_opam_root_version opam_root_version
         (Pp.V.string -| Pp.of_module "opam-version" (module OpamVersion));
       "repositories", Pp.ppacc
         with_repositories repositories
@@ -1416,6 +1423,19 @@ end
 module Config = struct
   include ConfigSyntax
   include SyntaxFile(ConfigSyntax)
+
+  let raw_root_version f =
+    let open OpamParserTypes.FullPos in
+    try
+      let opamfile = OpamParser.file (OpamFilename.to_string (filename f)) in
+      Some (OpamStd.List.find_map (function
+          | { pelem = Variable ({ pelem = "opam-root-version"; _},
+                                {pelem = String version; _}); _} ->
+            Some (OpamVersion.of_string version)
+          | _ -> None)
+          opamfile.file_contents)
+    with
+    | Sys_error _ | Not_found -> None
 end
 
 module InitConfigSyntax = struct

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1054,7 +1054,9 @@ module type BestEffortArg = sig
   include SyntaxFileArg
 
   (* Version of file format, as understood by [opam-file-format] *)
-  val file_format_version: OpamVersion.t
+  (* This attribute can be deleted when 4.02 is ditched *)
+  [@@@ocaml.warning "-32"]
+  val file_format_version: OpamVersion.t [@@ocaml.warning "-32"]
 
   (* Construct the syntax pp, under some conditions. If [condition] is given,
      it is passed to [OpamFormat.show_erros] call, for error display
@@ -1474,7 +1476,6 @@ module Config = struct
   module BestEffort = MakeBestEffort(ConfigSyntax)
 
   let raw_root_version f =
-    let open OpamParserTypes.FullPos in
     try
       let opamfile = OpamParser.file (OpamFilename.to_string (filename f)) in
       Some (OpamStd.List.find_map (function

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1701,7 +1701,7 @@ module Switch_configSyntax = struct
     opam_root: dirname option;
     wrappers: Wrappers.t;
     env: env_update list;
-    invariant: OpamFormula.t;
+    invariant: OpamFormula.t option;
     depext_bypass: OpamSysPkg.Set.t;
   }
 
@@ -1714,7 +1714,7 @@ module Switch_configSyntax = struct
     opam_root = None;
     wrappers = Wrappers.empty;
     env = [];
-    invariant = OpamFormula.Empty;
+    invariant = None;
     depext_bypass = OpamSysPkg.Set.empty;
   }
 
@@ -1756,8 +1756,8 @@ module Switch_configSyntax = struct
     "setenv", Pp.ppacc
       (fun env t -> {t with env}) (fun t -> t.env)
       (Pp.V.map_list ~depth:2 Pp.V.env_binding);
-    "invariant", Pp.ppacc
-      (fun invariant t -> {t with invariant}) (fun t -> t.invariant)
+    "invariant", Pp.ppacc_opt
+      (fun inv t -> {t with invariant = Some inv }) (fun t -> t.invariant)
       (Pp.V.package_formula `Conj Pp.V.(constraints version));
     "depext-bypass", Pp.ppacc
       (fun depext_bypass t -> { t with depext_bypass})

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1407,6 +1407,7 @@ module ConfigSyntax = struct
     let name = internal in
     Pp.I.map_file @@
     Pp.I.check_opam_version ~format_version () -|
+    Pp.I.opam_version ~format_version () -|
     Pp.I.fields ~name ~empty fields -|
     Pp.I.show_errors ~name ~strict:OpamCoreConfig.(not !r.safe_mode) ()
 
@@ -1677,6 +1678,7 @@ module Repos_configSyntax = struct
     let name = internal in
     Pp.I.map_file @@
     Pp.I.check_opam_version ~optional:true ~format_version () -|
+    Pp.I.opam_version ~format_version ~undefined:true () -|
     Pp.I.fields ~name ~empty fields -|
     Pp.I.show_errors ~name ()
 
@@ -1775,6 +1777,7 @@ module Switch_configSyntax = struct
     let name = internal in
     Pp.I.map_file @@
     Pp.I.check_opam_version ~format_version () -|
+    Pp.I.opam_version ~format_version () -|
     Pp.I.fields ~name ~empty ~sections fields -|
     Pp.I.show_errors ~name ()
 
@@ -1847,6 +1850,7 @@ module SwitchSelectionsSyntax = struct
     let name = "switch-state" in
     Pp.I.map_file @@
     Pp.I.check_opam_version ~optional:true ~format_version () -|
+    Pp.I.opam_version ~format_version () -|
     Pp.I.fields ~name ~empty fields -|
     Pp.I.show_errors ~name ()
 
@@ -1974,6 +1978,7 @@ module Dot_configSyntax = struct
   let pp =
     Pp.I.map_file @@
     Pp.I.check_opam_version ~format_version ~optional:true () -|
+    Pp.I.opam_version ~format_version () -|
     Pp.I.field "opam-version"
       (Pp.parse
          (Pp.V.string -| Pp.of_module "opam-version" (module OpamVersion)))
@@ -2084,6 +2089,7 @@ module RepoSyntax = struct
     let name = internal in
     Pp.I.map_file @@
     Pp.I.check_opam_version ~format_version ~optional:true () -|
+    Pp.I.opam_version ~format_version () -|
     Pp.I.fields ~name ~empty fields -|
     Pp.I.show_errors ~name
       ~condition:(function
@@ -2974,6 +2980,7 @@ module OPAMSyntax = struct
   (* Doesn't handle package name encoded in directory name *)
   let pp_raw_fields =
     Pp.I.check_opam_version ~format_version () -|
+    Pp.I.opam_version ~format_version () -|
     Pp.I.partition_fields ~section:true (is_ext_field @> not) -| Pp.map_pair
       (Pp.I.fields ~name:"opam-file" ~empty ~sections fields -|
        Pp.I.on_errors (fun t e -> {t with format_errors=e::t.format_errors}) -|
@@ -3368,6 +3375,7 @@ module Dot_installSyntax = struct
     let name = internal in
     Pp.I.map_file @@
     Pp.I.check_opam_version ~optional:true ~format_version () -|
+    Pp.I.opam_version ~format_version ~undefined:true () -|
     Pp.I.fields ~name ~empty fields -|
     Pp.I.show_errors ~name () -|
     Pp.check ~errmsg:"man file without destination or recognised suffix"
@@ -3436,6 +3444,7 @@ module ChangesSyntax = struct
 
   let pp_contents =
     Pp.I.check_opam_version ~format_version ~optional:true () -|
+    Pp.I.opam_version ~format_version ~undefined:true () -|
     Pp.I.fields ~name:internal ~empty fields -|
     Pp.I.show_errors ~name:internal ()
 
@@ -3484,6 +3493,7 @@ module SwitchExportSyntax = struct
     let name = "export-file" in
     Pp.I.map_file @@
     Pp.I.check_opam_version ~format_version () -|
+    Pp.I.opam_version ~format_version ~undefined:true () -|
     Pp.I.partition (fun i -> match i.pelem with
         | Section ({ section_kind={pelem="package";_}; section_name=Some _; _ }) ->
           false
@@ -3663,6 +3673,7 @@ module CompSyntax = struct
     let name = internal in
     Pp.I.map_file @@
     Pp.I.check_opam_version ~format_version () -|
+    Pp.I.opam_version ~format_version () -|
     Pp.I.fields ~name ~empty fields -|
     Pp.I.show_errors ~name () -|
     Pp.check ~errmsg:"fields 'build:' and 'configure:'+'make:' are mutually \

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -163,14 +163,14 @@ module MakeIO (F : IO_Arg) = struct
         log ~level:2 "Cannot find %a" (slog OpamFilename.to_string) f;
         F.empty
     with
-    | Pp.Bad_format _ as e->
+    | (Pp.Bad_version _ | Pp.Bad_format _) as e->
       OpamConsole.error "%s [skipped]\n"
         (Pp.string_of_bad_format ~file:(OpamFilename.to_string f) e);
       F.empty
 
   let read_from_f f input =
     try f input with
-    | Pp.Bad_format _ as e ->
+    | (Pp.Bad_version _ | Pp.Bad_format _) as e->
       if OpamFormatConfig.(!r.strict) then
         (OpamConsole.error "%s" (Pp.string_of_bad_format e);
          OpamConsole.error_and_exit `File_error "Strict mode: aborting")

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -927,7 +927,7 @@ module Switch_config: sig
     opam_root: dirname option;
     wrappers: Wrappers.t;
     env: env_update list;
-    invariant: OpamFormula.t;
+    invariant: OpamFormula.t option;
     depext_bypass: OpamSysPkg.Set.t;
   }
   val variable: t -> variable -> variable_contents option

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -172,8 +172,12 @@ module Config: sig
   (** Return the opam version *)
   val opam_version: t  -> opam_version
 
-  (** Return the opam root version *)
-  val opam_root_version: t -> opam_version option
+  (** Return the opam root version, if not defined returns the default version
+      value [2.1~~previous] *)
+  val opam_root_version: t -> opam_version
+
+  (** Return the opam root version if defined *)
+  val opam_root_version_opt: t -> opam_version option
 
   (** Return the list of repository *)
   val repositories: t  -> repository_name list

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -113,6 +113,9 @@ module Config: sig
 
   include IO_FILE
 
+  (** Current root version *)
+  val root_version: opam_version
+
   (** OCaml switch updates *)
   val with_switch: switch -> t -> t
   val with_switch_opt: switch option -> t -> t
@@ -124,6 +127,7 @@ module Config: sig
 
   (** Update opam-version *)
   val with_opam_version: OpamVersion.t -> t -> t
+  val with_opam_root_version: OpamVersion.t -> t -> t
 
   val with_criteria: (solver_criteria * string) list -> t -> t
   val with_best_effort_prefix: string -> t -> t
@@ -155,8 +159,11 @@ module Config: sig
   val with_depext_cannot_install: bool -> t -> t
   val with_depext_bypass: OpamSysPkg.Set.t -> t -> t
 
-  (** Return the OPAM version *)
+  (** Return the opam version *)
   val opam_version: t  -> opam_version
+
+  (** Return the opam root version *)
+  val opam_root_version: t -> opam_version option
 
   (** Return the list of repository *)
   val repositories: t  -> repository_name list
@@ -206,6 +213,8 @@ module Config: sig
       accessed through dot-separated paths *)
   val to_list: ?filename:'a typed_file -> t -> (string * value) list
 
+  (** Raw read the config file to extract [opam-root-version] field value. *)
+  val raw_root_version: 'a typed_file -> OpamVersion.t option
 end
 
 (** Init config file [/etc/opamrc] *)

--- a/src/format/opamFormat.ml
+++ b/src/format/opamFormat.ml
@@ -862,7 +862,7 @@ module I = struct
         (OpamVersion.to_string format_version)
     in
     field name (parse opam_v) -|
-    map_fst (check ~name ~errmsg f) -|
+    map_fst (check ~name ~raise:OpamPp.bad_version ~errmsg f) -|
     pp
       (fun ~pos:_ (_,x) -> x)
       (fun x ->

--- a/src/format/opamFormat.ml
+++ b/src/format/opamFormat.ml
@@ -850,7 +850,7 @@ module I = struct
       ()
     =
     let name = "opam-version" in
-    let opam_v = V.string -| of_module "opam-version" (module OpamVersion) in
+    let opam_v = V.string -| of_module name (module OpamVersion) in
     let f v =
       OpamFormatConfig.(!r.skip_version_checks) || match v with
       | Some v -> f v
@@ -863,11 +863,39 @@ module I = struct
     in
     field name (parse opam_v) -|
     map_fst (check ~name ~raise:OpamPp.bad_version ~errmsg f) -|
-    pp
+    pp ~name
       (fun ~pos:_ (_,x) -> x)
       (fun x ->
          (* re-extract the field using parse when printing, to check *)
-         parse ~pos:pos_null (field name (parse opam_v)) x)
+         match parse ~pos:pos_null (field name (parse opam_v)) x with
+         | None, _ -> failwith "opam version must be printed"
+         | v, l -> v, l)
+
+  let opam_version ?(undefined=false) ~format_version () =
+    let name = "opam-version" in
+    pp
+      (fun ~pos:_ items ->
+         if not undefined then items else
+           List.filter (function
+               | { pelem = Variable ({ pelem = fname; _},
+                                     { pelem = String _version; _}); _}
+                 when fname = name ->
+                 (* check opam version already called, we don't need to check
+                    that it is the same version *)
+                 false
+               | _ -> true) items)
+      (fun items ->
+         let opam_v = V.string -| of_module name (module OpamVersion) in
+         match parse ~pos:pos_null (field name (parse opam_v)) items with
+         | None, items ->
+           let opam_v =
+             nullify_pos @@
+             Variable (nullify_pos name,
+                       nullify_pos @@
+                       String (OpamVersion.to_string format_version))
+           in
+           opam_v :: items
+         | Some _, items -> items)
 
   type signature = string * string * string
 

--- a/src/format/opamFormat.ml
+++ b/src/format/opamFormat.ml
@@ -866,7 +866,8 @@ module I = struct
     pp ~name
       (fun ~pos:_ (_,x) -> x)
       (fun x ->
-         (* re-extract the field using parse when printing, to check *)
+         (* re-extract the field using parse when printing, to check that it is
+            not undefined *)
          match parse ~pos:pos_null (field name (parse opam_v)) x with
          | None, _ -> failwith "opam version must be printed"
          | v, l -> v, l)

--- a/src/format/opamFormat.mli
+++ b/src/format/opamFormat.mli
@@ -266,6 +266,12 @@ sig
     -> unit ->
     (opamfile_item list, opamfile_item list) t
 
+  (** Add [opam-version] field printing at printing, and removes it from parsed
+      fields if [undefined] (default is false) *)
+  val opam_version :
+    ?undefined:bool -> format_version:opam_version -> unit ->
+    (opamfile_item list, opamfile_item list) t
+
   (** Signature handling (wip) *)
 
   (** A signature is a keyid, an algorithm and the signature proper *)

--- a/src/format/opamPp.ml
+++ b/src/format/opamPp.ml
@@ -15,6 +15,7 @@ open OpamStd.Op
 
 type bad_format = pos option * string
 
+exception Bad_version of bad_format
 exception Bad_format of bad_format
 exception Bad_format_list of bad_format list
 
@@ -24,20 +25,35 @@ let bad_format ?pos fmt =
        raise (Bad_format (pos,str)))
     fmt
 
+let bad_version ?pos fmt =
+  Printf.ksprintf
+    (fun str ->
+       raise (Bad_version (pos,str)))
+    fmt
+
 let add_pos pos = function
   | Bad_format (pos_opt,msg) as e ->
     if pos_opt = None || pos_opt = Some pos_null
     then Bad_format (Some pos, msg)
     else e
+  | Bad_version (pos_opt,msg) as e ->
+    if pos_opt = None || pos_opt = Some pos_null
+    then Bad_version (Some pos, msg)
+    else e
+
   | e -> e
 
 let rec string_of_bad_format ?file e =
   match e, file with
+  | Bad_version (None, msg), Some filename
   | Bad_format (None, msg), Some filename
+  | Bad_version (Some {filename; start = -1, -1 ; stop = -1,-1 }, msg), _
   | Bad_format (Some {filename; start = -1, -1 ; stop = -1,-1 }, msg), _ ->
     Printf.sprintf "In %s:\n%s" filename msg
+  | Bad_version (Some pos, msg), _
   | Bad_format (Some pos, msg), _ ->
     Printf.sprintf "At %s:\n%s" (string_of_pos pos) msg
+  | Bad_version (None, msg), None
   | Bad_format (None, msg), None ->
     Printf.sprintf "Input error:\n%s" msg
   | Bad_format_list bfl, _ ->
@@ -46,7 +62,7 @@ let rec string_of_bad_format ?file e =
   | _ -> Printexc.to_string e
 
 let () = Printexc.register_printer @@ function
-  | (Bad_format _ | Bad_format_list _ as e) ->
+  | (Bad_version _ | Bad_format _ | Bad_format_list _ as e) ->
     Some (string_of_bad_format ?file:None e)
   | _ -> None
 
@@ -73,7 +89,8 @@ let unexpected ?pos () = raise (Unexpected pos)
 (** Basic pp usage *)
 
 let parse pp ~pos x = try pp.parse ~pos x with
-  | Bad_format _ | Bad_format_list _ as e -> raise (add_pos pos e)
+  | Bad_version _ | Bad_format _ | Bad_format_list _ as e ->
+    raise (add_pos pos e)
   | Unexpected (Some pos) -> bad_format ~pos "expected %s" pp.ppname
   | Unexpected None -> bad_format ~pos "expected %s" pp.ppname
   | Failure msg ->
@@ -120,13 +137,13 @@ let ignore = {
   name_constr = (fun _ -> "<ignored>");
 }
 
-let check ?name ?errmsg f =
+let check ?name ?(raise=bad_format) ?errmsg f =
   pp
     ?name
     (fun ~pos x ->
        if not (f x) then
          match errmsg with
-         | Some m -> bad_format ~pos "%s" m
+         | Some m -> raise ~pos "%s" m
          | None -> unexpected ()
        else x)
     (fun x ->

--- a/src/format/opamPp.mli
+++ b/src/format/opamPp.mli
@@ -22,9 +22,13 @@ type bad_format = pos option * string
     input does not have the right format. *)
 exception Bad_format of bad_format
 exception Bad_format_list of bad_format list
+exception Bad_version of bad_format
 
 (** Raise [Bad_format]. *)
 val bad_format: ?pos:pos -> ('a, unit, string, 'b) format4 -> 'a
+
+(** Raise [Bad_version]. *)
+val bad_version: ?pos:pos -> ('a, unit, string, 'b) format4 -> 'a
 
 val string_of_bad_format: ?file:string -> exn -> string
 
@@ -92,8 +96,14 @@ val identity : ('a, 'a) t
 val ignore : ('a, 'b option) t
 
 (** Identity pp, unless the check fails. The check is turned into an assertion
-    when printing *)
-val check : ?name:string -> ?errmsg:string -> ('a -> bool) -> ('a, 'a) t
+    when printing. If no [errmsg] is given, raises [Unexpected], otherwise
+    call [raise] with the given [errmsg]. By default [raise] raises
+    [Bad_format]. *)
+val check :
+  ?name:string ->
+  ?raise:(?pos:pos -> (string -> 'a, unit, string, 'a) format4
+          -> string -> 'a) ->
+  ?errmsg:string -> ('a -> bool) -> ('a, 'a) t
 
 val map_pair :
   ?name:string ->

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -323,8 +323,8 @@ let is_up_to_date_switch root switch =
 let switch_path_update ~force_path root switch =
   let bindir =
     OpamPath.Switch.bin root switch
-      (OpamFile.Switch_config.safe_read
-         (OpamPath.Switch.switch_config root switch))
+      (OpamStateConfig.Switch.safe_load_t
+         ~lock_kind:`Lock_read root switch)
   in
   [
     "PATH",
@@ -605,6 +605,9 @@ let write_custom_init_scripts root custom =
 let write_dynamic_init_scripts st =
   let updates = updates ~set_opamroot:false ~set_opamswitch:false st in
   try
+    if OpamStateConfig.is_newer_than_self
+        ~lock_kind:`Lock_write st.switch_global then
+      raise OpamSystem.Locked;
     OpamFilename.with_flock_upgrade `Lock_write ~dontblock:true
       st.switch_global.global_lock
     @@ fun _ ->

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -751,6 +751,7 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
        "License doesn't adhere to the SPDX standard, see https://spdx.org/licenses/"
        ~detail:bad_licenses
        (bad_licenses <> []));
+(*
     (let subpath =
        match OpamStd.String.Map.find_opt "x-subpath" (extensions t) with
        | Some {pelem = String _; _} -> true
@@ -780,6 +781,7 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
      cond 64 `Warning
        "`x-subpath` must be a simple string to be considered as a subpath`"
        subpath_string);
+*)
     (let relative =
        let open OpamUrl in
        List.filter (fun u ->

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -950,7 +950,7 @@ let lint_gen ?check_extra_files ?check_upstream ?(handle_dirname=false)
       [0, `Error, "File does not exist"], None
     | OpamLexer.Error _ | Parsing.Parse_error ->
       [1, `Error, "File does not parse"], None
-    | OpamPp.Bad_format bf -> [warn_of_bad_format bf], None
+    | OpamPp.Bad_version bf | OpamPp.Bad_format bf -> [warn_of_bad_format bf], None
     | OpamPp.Bad_format_list bfl -> List.map warn_of_bad_format bfl, None
   in
   let check_extra_files = match check_extra_files with

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -1048,7 +1048,8 @@ let from_2_0_beta5_to_2_0 _ conf = conf
 
 let v2_1 = OpamVersion.of_string "2.1"
 
-let from_2_0_to_2_1 _ conf = conf
+let from_2_0_to_2_1 _ conf =
+  OpamFile.Config.with_opam_root_version v2_1 conf
 
 let latest_version = OpamFile.Config.format_version
 

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -1067,9 +1067,6 @@ let as_necessary requested_lock global_lock root config =
         "%s reports a newer opam version, aborting."
         (OpamFilename.Dir.to_string root)
   else
-  if OpamVersion.compare config_version OpamFile.Config.format_version >= 0 then
-    config
-  else
   let need_hard_upg =
     OpamVersion.compare config_version latest_hard_upgrade < 0
   in

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -937,7 +937,7 @@ let from_2_0_alpha2_to_2_0_alpha3 root conf =
             repos = None;
             opam_root; paths; variables; wrappers = OpamFile.Wrappers.empty;
             env = [];
-            invariant = OpamFormula.Empty;
+            invariant = None;
             depext_bypass = OpamSysPkg.Set.empty;
           }
         in

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -1046,29 +1046,86 @@ let from_2_0_beta_to_2_0_beta5 root conf =
 
 let from_2_0_beta5_to_2_0 _ conf = conf
 
-let v2_1 = OpamVersion.of_string "2.1"
+(* swiitch config with opam-version 2.1 *)
+let v2_1_alpha = OpamVersion.of_string "2.1~alpha"
+(* config with opam-version 2.1 *)
+let v2_1_alpha2 = OpamVersion.of_string "2.1~alpha2"
+(* config & sw config downgrade opam-version to 2.0 and add opam root version *)
+let v2_1_rc = OpamVersion.of_string "2.1~rc"
 
-let from_2_0_to_2_1 _ conf =
-  OpamFile.Config.with_opam_root_version v2_1 conf
+let _v2_1 = OpamVersion.of_string "2.1"
 
-let latest_version = OpamFile.Config.format_version
+let from_2_0_to_2_1_alpha _ conf = conf
+
+let downgrade_2_1_switches root conf =
+  let downgrade f =
+    let filename = OpamFile.filename f in
+    let str_f = OpamFilename.to_string filename in
+    let opamfile = OpamParser.FullPos.file str_f in
+    let opamfile' =
+      let open OpamParserTypes.FullPos in
+      { opamfile with
+        file_contents =
+          List.map (fun item ->
+              match item.pelem with
+              | Variable (({pelem = "opam-version"; _} as opam_v),
+                          ({pelem = String "2.1"; _} as v)) ->
+                { item with
+                  pelem = Variable ({opam_v with pelem = "opam-version"},
+                                    {v with pelem = String "2.0"})}
+              | _ -> item) opamfile.file_contents}
+    in
+    let updated = opamfile' <> opamfile in
+    if updated then
+      OpamFilename.write filename (OpamPrinter.FullPos.opamfile opamfile')
+  in
+  List.iter (fun switch ->
+      let f = OpamPath.Switch.switch_config root switch in
+      downgrade f;
+      ignore @@ OpamFile.Switch_config.BestEffort.read f)
+    (OpamFile.Config.installed_switches conf)
+
+let from_2_1_alpha_to_2_1_alpha2 root conf =
+  downgrade_2_1_switches root conf;
+  conf
+
+let from_2_1_alpha2_to_v2_1_rc root conf =
+  downgrade_2_1_switches root conf;
+  conf
+
+let from_2_0_to_v2_1_rc _ conf = conf
+
+let latest_version = OpamFile.Config.root_version
 
 let latest_hard_upgrade = (* to *) v2_0_beta5
 
+(* intermediates roots that need an hard upgrade *)
+let intermediate_roots = [
+  v2_1_alpha; v2_1_alpha2
+]
+
 let as_necessary requested_lock global_lock root config =
-  let config_version = OpamFile.Config.opam_version config in
-  let cmp =
-    OpamVersion.(compare OpamFile.Config.format_version config_version)
+  let root_version =
+    match OpamFile.Config.opam_root_version config with
+    | Some v -> v
+    | None ->
+      let v = OpamFile.Config.opam_version config in
+      if OpamVersion.compare v v2_0 <> 0 then v else
+      try
+        List.iter (fun switch ->
+            ignore @@
+            OpamFile.Switch_config.read_opt
+              (OpamPath.Switch.switch_config root switch))
+          (OpamFile.Config.installed_switches config);
+        v
+      with OpamPp.Bad_version _ -> v2_1_alpha
   in
-  if cmp = 0 then config else
-  if cmp < 0 then
-    if OpamFormatConfig.(!r.skip_version_checks) then config else
-      OpamConsole.error_and_exit `Configuration_error
-        "%s reports a newer opam version, aborting."
-        (OpamFilename.Dir.to_string root)
-  else
+  let cmp = OpamVersion.(compare OpamFile.Config.root_version root_version) in
+  if cmp <= 0 then config (* newer or same *) else
+  let is_intermdiate_root = List.mem root_version intermediate_roots in
   let need_hard_upg =
-    OpamVersion.compare config_version latest_hard_upgrade < 0
+    OpamVersion.compare root_version latest_hard_upgrade < 0
+    || is_intermdiate_root
   in
   let on_the_fly, global_lock_kind =
     if not need_hard_upg && requested_lock <> `Lock_write then
@@ -1076,25 +1133,32 @@ let as_necessary requested_lock global_lock root config =
     else
       false, `Lock_write
   in
+  (* to generalise *)
+  let intermediates = [
+    v2_1_alpha,  from_2_0_to_2_1_alpha;
+    v2_1_alpha2, from_2_1_alpha_to_2_1_alpha2;
+    v2_1_rc,     from_2_1_alpha2_to_v2_1_rc;
+  ] in
   let hard_upg, light_upg =
-    [
-      v1_1,        from_1_0_to_1_1;
-      v1_2,        from_1_1_to_1_2;
-      v1_3_dev2,   from_1_2_to_1_3_dev2;
-      v1_3_dev5,   from_1_3_dev2_to_1_3_dev5;
-      v1_3_dev6,   from_1_3_dev5_to_1_3_dev6;
-      v1_3_dev7,   from_1_3_dev6_to_1_3_dev7;
-      v2_0_alpha,  from_1_3_dev7_to_2_0_alpha;
-      v2_0_alpha2, from_2_0_alpha_to_2_0_alpha2;
-      v2_0_alpha3, from_2_0_alpha2_to_2_0_alpha3;
-      v2_0_beta,   from_2_0_alpha3_to_2_0_beta;
-      v2_0_beta5,  from_2_0_beta_to_2_0_beta5;
-      v2_0,        from_2_0_beta5_to_2_0;
-      v2_1,        from_2_0_to_2_1;
-    ]
-    |> List.filter (fun (v,_) -> OpamVersion.compare config_version v < 0)
-    |> List.partition (fun (v,_) ->
-        OpamVersion.compare v latest_hard_upgrade <= 0)
+    if is_intermdiate_root then intermediates, [] else
+      [
+        v1_1,        from_1_0_to_1_1;
+        v1_2,        from_1_1_to_1_2;
+        v1_3_dev2,   from_1_2_to_1_3_dev2;
+        v1_3_dev5,   from_1_3_dev2_to_1_3_dev5;
+        v1_3_dev6,   from_1_3_dev5_to_1_3_dev6;
+        v1_3_dev7,   from_1_3_dev6_to_1_3_dev7;
+        v2_0_alpha,  from_1_3_dev7_to_2_0_alpha;
+        v2_0_alpha2, from_2_0_alpha_to_2_0_alpha2;
+        v2_0_alpha3, from_2_0_alpha2_to_2_0_alpha3;
+        v2_0_beta,   from_2_0_alpha3_to_2_0_beta;
+        v2_0_beta5,  from_2_0_beta_to_2_0_beta5;
+        v2_0,        from_2_0_beta5_to_2_0;
+        v2_1_rc,     from_2_0_to_v2_1_rc;
+      ]
+      |> List.filter (fun (v,_) -> OpamVersion.compare root_version v < 0)
+      |> List.partition (fun (v,_) ->
+          OpamVersion.compare v latest_hard_upgrade <= 0)
   in
   let erase_plugin_links root =
     let plugins_bin = OpamPath.plugins_bin root in
@@ -1105,7 +1169,7 @@ let as_necessary requested_lock global_lock root config =
   let light config =
     let config =
       List.fold_left (fun config (v, from) ->
-          from root config |> OpamFile.Config.with_opam_version v)
+          from root config |> OpamFile.Config.with_opam_root_version v)
         config light_upg
     in
     if not on_the_fly then begin
@@ -1116,7 +1180,7 @@ let as_necessary requested_lock global_lock root config =
   in
   let hard config =
     List.fold_left (fun config (v, from) ->
-        let config = from root config |> OpamFile.Config.with_opam_version v in
+        let config = from root config |> OpamFile.Config.with_opam_root_version v in
         (* save the current version to mitigate damage is the upgrade goes
            wrong afterwards *)
         OpamFile.Config.write (OpamPath.config root) config;
@@ -1128,7 +1192,7 @@ let as_necessary requested_lock global_lock root config =
   log "%s config upgrade, from %s to %s"
     (if on_the_fly then "On-the-fly" else
      if need_hard_upg then "Hard" else "Light")
-    (OpamVersion.to_string config_version)
+    (OpamVersion.to_string root_version)
     (OpamVersion.to_string latest_version);
   if not on_the_fly then
     OpamConsole.formatted_msg
@@ -1137,7 +1201,7 @@ let as_necessary requested_lock global_lock root config =
        You may want to back it up before going further.\n"
       (if is_dev then "development " else "")
       (OpamFilename.Dir.to_string root)
-      (OpamVersion.to_string config_version)
+      (OpamVersion.to_string root_version)
       (OpamVersion.to_string latest_version);
   let dontblock =
     (* Deadlock until one is killed in interactive mode, but abort in batch *)
@@ -1174,6 +1238,44 @@ let as_necessary requested_lock global_lock root config =
   with OpamSystem.Locked ->
     OpamConsole.error_and_exit `Locked
       "Could not acquire lock for performing format upgrade."
+
+let hard_upgrade_from_2_1_intermediates ?global_lock root =
+  let config_f = OpamPath.config root in
+  let opam_root_version = OpamFile.Config.raw_root_version config_f in
+  match opam_root_version with
+  | Some v when OpamVersion.compare v v2_0 <= 0
+             || OpamVersion.compare v2_1_rc v <= 0 ->
+    () (* do nothing, need to reraise parsing exception *)
+  | _ ->
+    log "Intermediate opam root detected%s, launch hard upgrade"
+      (match opam_root_version with
+         None -> ""
+       | Some v -> "("^(OpamVersion.to_string v)^")");
+    let filename = OpamFile.filename config_f in
+    let opamfile = OpamParser.FullPos.file (OpamFilename.to_string filename) in
+    let opamfile' =
+      let open OpamParserTypes.FullPos in
+      { opamfile with
+        file_contents =
+          List.map (fun item ->
+              match item.pelem with
+              | Variable (({pelem = "opam-version"; _} as opam_v),
+                          ({pelem = String "2.1"; _} as v)) ->
+                { item with
+                  pelem = Variable ({opam_v with pelem = "opam-version"},
+                                    {v with pelem = String "2.0"})}
+              | _ -> item) opamfile.file_contents}
+    in
+    log "Downgrade config opam-version to fix up";
+    OpamFilename.write filename (OpamPrinter.FullPos.opamfile opamfile');
+    let config = OpamFile.Config.read config_f in
+    let global_lock = match global_lock with
+      | Some g -> g
+      | None -> OpamFilename.flock `Lock_read (OpamPath.lock root)
+    in
+    (* it will trigger only hard upgrades that won't get back *)
+    ignore @@ as_necessary `Lock_write global_lock root
+      (OpamFile.Config.with_opam_root_version v2_1_alpha2 config)
 
 let opam_file ?(quiet=false) ?filename opam =
   let v = OpamFile.OPAM.opam_version opam in

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -771,6 +771,7 @@ let from_1_3_dev7_to_2_0_alpha root conf =
   in
   let repositories_list = List.map (fun (_, r, _) -> r) prio_repositories in
   OpamFile.Config.with_repositories repositories_list conf
+  |> OpamFile.Config.with_opam_version v2_0
 
 let v2_0_alpha2 = OpamVersion.of_string "2.0~alpha2"
 

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -1107,7 +1107,7 @@ let intermediate_roots = [
 
 let as_necessary requested_lock global_lock root config =
   let root_version =
-    match OpamFile.Config.opam_root_version config with
+    match OpamFile.Config.opam_root_version_opt config with
     | Some v -> v
     | None ->
       let v = OpamFile.Config.opam_version config in

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -705,7 +705,7 @@ let from_1_3_dev6_to_1_3_dev7 root conf =
       let switch_dir = root / OpamSwitch.to_string switch in
       let meta_dir =  switch_dir / ".opam-switch" in
       let installed =
-        (OpamFile.SwitchSelections.safe_read
+        (OpamFile.SwitchSelections.BestEffort.safe_read
            (OpamFile.make (meta_dir // "switch-state")))
         .sel_installed
       in
@@ -808,7 +808,7 @@ let from_2_0_alpha_to_2_0_alpha2 root conf =
          let the wrapper 'ocaml' package be pulled from the repository later
          on to detect and set the 'ocaml:*' variables *)
       let selections_file = OpamFile.make (meta_dir // "switch-state") in
-      let selections = OpamFile.SwitchSelections.safe_read selections_file in
+      let selections = OpamFile.SwitchSelections.BestEffort.safe_read selections_file in
       let new_compilers =
         OpamPackage.Set.map (fun nv ->
             if nv.name <> OpamPackage.Name.of_string "ocaml" then nv else
@@ -957,7 +957,7 @@ let from_2_0_alpha3_to_2_0_beta root conf =
       let packages_dev_dir = switch_meta_dir / "packages.dev" in (* old *)
       let sources_dir = switch_meta_dir / "sources" in (* new *)
       let state =
-        OpamFile.SwitchSelections.safe_read
+        OpamFile.SwitchSelections.BestEffort.safe_read
           (OpamFile.make (switch_meta_dir // "switch-state"))
       in
       OpamFilename.mkdir sources_dir;
@@ -1011,7 +1011,7 @@ let from_2_0_beta_to_2_0_beta5 root conf =
       in
       let switch_config = OpamFile.make (switch_meta_dir // "switch-config") in
       let module C = OpamFile.Switch_config in
-      let config = C.safe_read switch_config in
+      let config = C.BestEffort.safe_read switch_config in
       let rem_variables = List.map OpamVariable.of_string ["os"; "make"] in
       let config =
         { config with

--- a/src/state/opamFormatUpgrade.mli
+++ b/src/state/opamFormatUpgrade.mli
@@ -29,10 +29,18 @@ val latest_version: OpamVersion.t
     (loaded state, not written) if possible: no hard upgrade needed, and no
     write lock required ([requested_lock]). If upgrade need to be written (hard
     upgrade), a write lock on the global state ([global_lock]) is taken and
-    when it's done raises [Upgrade_done updated_config].  Otherwise, it returns
+    when it's done raises [Upgrade_done updated_config]. Otherwise, it returns
     the upgraded or unchanged config file.*)
 val as_necessary:
   'a lock -> OpamSystem.lock -> dirname -> OpamFile.Config.t -> OpamFile.Config.t
+
+(* Try to launch a hard upgrade from 2;1 alpha's & beta's root
+   to 2.1~rc one. Raises [Upgrade_done] (catched by main
+   function) if an upgrade is done, otherwise do nothing.
+   It is intend to be called after a config file that error with
+   [OpamPp.Bad_version] *)
+val hard_upgrade_from_2_1_intermediates:
+  ?global_lock: OpamSystem.lock -> dirname -> unit
 
 (** Converts the opam file format, including rewriting availability conditions
     based on OCaml-related variables into dependencies. The filename is used to

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -19,8 +19,12 @@ let log fmt = OpamConsole.log "GSTATE" fmt
 let slog = OpamConsole.slog
 
 let load_config lock_kind global_lock root =
-  let config = match OpamStateConfig.load root with
+  let config =
+    match OpamStateConfig.load ~lock_kind root with
     | Some c -> c
+    | exception (OpamPp.Bad_version _ as e) ->
+      OpamFormatUpgrade.hard_upgrade_from_2_1_intermediates ~global_lock root;
+      raise e
     | None ->
       if OpamFilename.exists (root // "aliases") then
         OpamFile.Config.(with_opam_version (OpamVersion.of_string "1.1") empty)
@@ -57,6 +61,12 @@ let load lock_kind =
       "Opam has not been initialised, please run `opam init'";
   let config_lock = OpamFilename.flock lock_kind (OpamPath.config_lock root) in
   let config = load_config lock_kind global_lock root in
+  if OpamStateConfig.is_newer config && lock_kind <> `Lock_write then
+    log "root version (%s) is greater than running binary's (%s); \
+         load with best-effort (read-only)"
+      (OpamStd.Option.to_string OpamVersion.to_string
+         (OpamFile.Config.opam_root_version config))
+      (OpamVersion.to_string (OpamFile.Config.root_version));
   let switches =
     List.filter
       (fun sw -> not (OpamSwitch.is_external sw) ||
@@ -68,8 +78,8 @@ let load lock_kind =
     List.fold_left (fun acc (v,value) ->
         OpamVariable.Map.add v
           (lazy (Some (OpamStd.Option.default (S "unknown") (Lazy.force value))),
-          (* Careful on changing it, it is used to determine user defined
-             variables on `config report`. See [OpamConfigCommand.help]. *)
+           (* Careful on changing it, it is used to determine user defined
+              variables on `config report`. See [OpamConfigCommand.help]. *)
            inferred_from_system)
           acc)
       OpamVariable.Map.empty
@@ -118,13 +128,14 @@ let switches gt =
 let fold_switches f gt acc =
   List.fold_left (fun acc switch ->
       f switch
-        (OpamFile.SwitchSelections.safe_read
-           (OpamPath.Switch.selections gt.root switch))
+        (OpamStateConfig.Switch.safe_read_selections
+           ~lock_kind:`Lock_read gt switch)
         acc
     ) acc (OpamFile.Config.installed_switches gt.config)
 
 let switch_exists gt switch =
-  if OpamSwitch.is_external switch then OpamStateConfig.local_switch_exists gt.root switch
+  if OpamSwitch.is_external switch then
+    OpamStateConfig.local_switch_exists gt.root switch
   else List.mem switch (switches gt)
 
 let all_installed gt =
@@ -154,6 +165,10 @@ let drop gt =
   let _ = unlock gt in ()
 
 let with_write_lock ?dontblock gt f =
+  if OpamStateConfig.is_newer_than_self gt then
+    OpamConsole.error_and_exit `Locked
+      "The opam root has been upgraded by a newer version of opam-state \
+       and cannot be written to";
   let ret, gt =
     OpamFilename.with_flock_upgrade `Lock_write ?dontblock gt.global_lock
     @@ fun _ -> f ({ gt with global_lock = gt.global_lock } : rw global_state)

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -64,8 +64,7 @@ let load lock_kind =
   if OpamStateConfig.is_newer config && lock_kind <> `Lock_write then
     log "root version (%s) is greater than running binary's (%s); \
          load with best-effort (read-only)"
-      (OpamStd.Option.to_string OpamVersion.to_string
-         (OpamFile.Config.opam_root_version config))
+      (OpamVersion.to_string (OpamFile.Config.opam_root_version config))
       (OpamVersion.to_string (OpamFile.Config.root_version));
   let switches =
     List.filter

--- a/src/state/opamGlobalState.mli
+++ b/src/state/opamGlobalState.mli
@@ -27,6 +27,9 @@ val all_installed: 'a global_state -> package_set
 
 val switches: 'a global_state -> switch list
 
+(** Fold over switches, using switch selections. Switch selection file
+   [switch-state] is loaded only read-only; no further checks are done on the opam root
+   version. *)
 val fold_switches:
   (switch -> switch_selections -> 'a -> 'a) -> 'b global_state -> 'a -> 'a
 

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -147,9 +147,13 @@ let get_repo_root rt repo =
 let load lock_kind gt =
   log "LOAD-REPOSITORY-STATE %@ %a" (slog OpamFilename.Dir.to_string) gt.root;
   let lock = OpamFilename.flock lock_kind (OpamPath.repos_lock gt.root) in
-  let repos_map =
-    OpamFile.Repos_config.safe_read (OpamPath.repos_config gt.root)
-  in
+  let repos_map = OpamStateConfig.Repos.safe_read ~lock_kind gt in
+  if OpamStateConfig.is_newer_than_self gt then
+    log "root version (%s) is greater than running binary's (%s); \
+         load with best-effort (read-only)"
+      (OpamStd.Option.to_string OpamVersion.to_string
+         (OpamFile.Config.opam_root_version gt.config))
+      (OpamVersion.to_string (OpamFile.Config.root_version));
   let mk_repo name url_opt = {
     repo_name = name;
     repo_url = OpamStd.Option.Op.((url_opt >>| fst) +! OpamUrl.empty);
@@ -265,6 +269,10 @@ let drop ?cleanup rt =
   let _ = unlock ?cleanup rt in ()
 
 let with_write_lock ?dontblock rt f =
+  if OpamStateConfig.is_newer_than_self rt.repos_global then
+    OpamConsole.error_and_exit `Locked
+      "The opam root has been upgraded by a newer version of opam-state \
+       and cannot be written to";
   let ret, rt =
     OpamFilename.with_flock_upgrade `Lock_write ?dontblock rt.repos_lock
     @@ fun _ -> f ({ rt with repos_lock = rt.repos_lock } : rw repos_state)

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -151,8 +151,7 @@ let load lock_kind gt =
   if OpamStateConfig.is_newer_than_self gt then
     log "root version (%s) is greater than running binary's (%s); \
          load with best-effort (read-only)"
-      (OpamStd.Option.to_string OpamVersion.to_string
-         (OpamFile.Config.opam_root_version gt.config))
+      (OpamVersion.to_string (OpamFile.Config.opam_root_version gt.config))
       (OpamVersion.to_string (OpamFile.Config.root_version));
   let mk_repo name url_opt = {
     repo_name = name;

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -182,12 +182,109 @@ let opamroot ?root_dir () =
    OpamStd.Env.getopt "OPAMROOT" >>| OpamFilename.Dir.of_string)
   +! default.root_dir
 
-let load opamroot =
-  OpamFile.Config.read_opt (OpamPath.config opamroot)
+let is_newer_raw = function
+  | Some v ->
+    OpamVersion.compare v OpamFile.Config.root_version > 0
+  | None -> false
+
+let is_newer config =
+    is_newer_raw (OpamFile.Config.opam_root_version config)
+
+(** none -> shouldn't load (write attempt in readonly)
+    Some true -> everything is fine normal read
+    Some false -> readonly accorded, load with best effort *)
+let is_readonly_opamroot_raw ?(lock_kind=`Lock_write) version =
+  let newer = is_newer_raw version in
+  let write = lock_kind = `Lock_write in
+  if newer && write then None else
+    Some (newer && not write)
+
+let is_readonly_opamroot_t ?lock_kind gt =
+  is_readonly_opamroot_raw ?lock_kind
+    (OpamFile.Config.opam_root_version gt.config)
+
+let is_newer_than_self ?lock_kind gt =
+  is_readonly_opamroot_t ?lock_kind gt <> Some false
+
+let load_if_possible_raw ?lock_kind root version (read,read_wo_err) f =
+  match is_readonly_opamroot_raw ?lock_kind version with
+  | None ->
+    OpamConsole.error_and_exit `Locked
+      "Refusing write access to %s, which is more recent than this version of \
+       opam (%s > %s), aborting."
+      (OpamFilename.Dir.to_string root)
+      (OpamStd.Option.to_string OpamVersion.to_string version)
+      OpamVersion.(to_string current_nopatch)
+  | Some true -> read_wo_err f
+  | Some false -> read f
+
+let load_if_possible_t ?lock_kind opamroot config readf f =
+  load_if_possible_raw ?lock_kind
+    opamroot (OpamFile.Config.opam_root_version config) readf f
+
+let load_if_possible ?lock_kind gt =
+  load_if_possible_t ?lock_kind gt.root gt.config
+
+let load_config_root ?lock_kind readf opamroot =
+  let f = OpamPath.config opamroot in
+  load_if_possible_raw ?lock_kind
+    opamroot
+    (OpamFile.Config.raw_root_version f)
+    readf f
+
+let safe_load ?lock_kind opamroot =
+  load_config_root ?lock_kind
+    OpamFile.Config.(safe_read, BestEffort.safe_read) opamroot
+
+let load ?lock_kind opamroot =
+  load_config_root ?lock_kind
+    OpamFile.Config.(read_opt, BestEffort.read_opt) opamroot
+
+(* switches *)
+module Switch = struct
+
+  let load_raw ?lock_kind root config readf switch =
+    load_if_possible_t ?lock_kind root config readf
+      (OpamPath.Switch.switch_config root switch)
+
+  let safe_load_t ?lock_kind root switch =
+    let config = safe_load ~lock_kind:`Lock_read root in
+    load_raw ?lock_kind root config
+      OpamFile.Switch_config.(safe_read, BestEffort.safe_read)
+      switch
+
+  let load ?lock_kind gt readf switch =
+    load_raw ?lock_kind gt.root gt.config readf switch
+
+  let safe_load ?lock_kind gt switch =
+    load ?lock_kind gt
+      OpamFile.Switch_config.(safe_read, BestEffort.safe_read)
+      switch
+
+  let read_opt ?lock_kind gt switch =
+    load ?lock_kind gt
+      OpamFile.Switch_config.(read_opt, BestEffort.read_opt)
+      switch
+
+  let safe_read_selections ?lock_kind gt switch =
+    load_if_possible ?lock_kind gt
+      OpamFile.SwitchSelections.(safe_read, BestEffort.safe_read)
+      (OpamPath.Switch.selections gt.root switch)
+
+end
+
+(* repos *)
+module Repos = struct
+  let safe_read ?lock_kind gt =
+    load_if_possible ?lock_kind gt
+      OpamFile.Repos_config.(safe_read, BestEffort.safe_read)
+      (OpamPath.repos_config gt.root)
+end
 
 let local_switch_exists root switch =
+  (* we don't use safe loading function to avoid errors displaying *)
   OpamPath.Switch.switch_config root switch |>
-  OpamFile.Switch_config.read_opt |> function
+  OpamFile.Switch_config.BestEffort.read_opt |> function
   | None -> false
   | Some conf -> conf.OpamFile.Switch_config.opam_root = Some root
 
@@ -206,13 +303,14 @@ let get_current_switch_from_cwd root =
   >>| OpamSwitch.of_dirname
   >>| resolve_local_switch root
 
-let load_defaults root_dir =
+(* do we want `load_defaults` to fail / run a format upgrade ? *)
+let load_defaults ?lock_kind root_dir =
   let current_switch =
     match E.switch () with
     | Some "" | None -> get_current_switch_from_cwd root_dir
     | _ -> (* OPAMSWITCH is set, no need to lookup *) None
   in
-  match load root_dir with
+  match try load ?lock_kind root_dir with OpamPp.Bad_version _ -> None with
   | None ->
     update ?current_switch ();
     None

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -188,7 +188,7 @@ let is_newer_raw = function
   | None -> false
 
 let is_newer config =
-    is_newer_raw (OpamFile.Config.opam_root_version config)
+    is_newer_raw (Some (OpamFile.Config.opam_root_version config))
 
 (** none -> shouldn't load (write attempt in readonly)
     Some true -> everything is fine normal read
@@ -201,7 +201,7 @@ let is_readonly_opamroot_raw ?(lock_kind=`Lock_write) version =
 
 let is_readonly_opamroot_t ?lock_kind gt =
   is_readonly_opamroot_raw ?lock_kind
-    (OpamFile.Config.opam_root_version gt.config)
+    (Some (OpamFile.Config.opam_root_version gt.config))
 
 let is_newer_than_self ?lock_kind gt =
   is_readonly_opamroot_t ?lock_kind gt <> Some false
@@ -220,7 +220,7 @@ let load_if_possible_raw ?lock_kind root version (read,read_wo_err) f =
 
 let load_if_possible_t ?lock_kind opamroot config readf f =
   load_if_possible_raw ?lock_kind
-    opamroot (OpamFile.Config.opam_root_version config) readf f
+    opamroot (Some (OpamFile.Config.opam_root_version config)) readf f
 
 let load_if_possible ?lock_kind gt =
   load_if_possible_t ?lock_kind gt.root gt.config

--- a/src/state/opamStateConfig.mli
+++ b/src/state/opamStateConfig.mli
@@ -79,7 +79,8 @@ include OpamStd.Config.Sig
 val opamroot: ?root_dir:dirname -> unit -> dirname
 
 (** Loads the global configuration file, protecting against concurrent writes *)
-val load: dirname -> OpamFile.Config.t option
+val load: ?lock_kind: 'a lock -> dirname -> OpamFile.Config.t option
+val safe_load: ?lock_kind: 'a lock -> dirname -> OpamFile.Config.t
 
 (** Loads the config file from the OPAM root and updates default values for all
     related OpamXxxConfig modules. Doesn't read the env yet, the [init]
@@ -87,7 +88,8 @@ val load: dirname -> OpamFile.Config.t option
     initialised beforehand, as it may impact the config file loading.
 
     Returns the config file that was found, if any *)
-val load_defaults: OpamFilename.Dir.t -> OpamFile.Config.t option
+val load_defaults:
+  ?lock_kind:'a lock -> OpamFilename.Dir.t -> OpamFile.Config.t option
 
 (** Returns the current switch, failing with an error message is none is set. *)
 val get_switch: unit -> switch
@@ -106,3 +108,32 @@ val local_switch_exists: OpamFilename.Dir.t -> switch -> bool
 (** Resolves the switch if it is a link to a global switch in the given root
     (return unchanged otherwise) *)
 val resolve_local_switch: OpamFilename.Dir.t -> switch -> switch
+
+(** Given the required lock, returns [true] if the opam root is newer than the
+    binary, so that it can only be loaded read-only by the current binary. *)
+val is_newer_than_self: ?lock_kind:'a lock -> 'b global_state -> bool
+
+(** Check config root version regarding self-defined one *)
+val is_newer: OpamFile.Config.t ->  bool
+
+val load_config_root:
+  ?lock_kind:'a lock ->
+  ((OpamFile.Config.t OpamFile.t -> 'b) * (OpamFile.Config.t OpamFile.t -> 'b)) ->
+  dirname -> 'b
+
+module Switch : sig
+  val safe_load_t:
+    ?lock_kind: 'a lock -> dirname -> switch -> OpamFile.Switch_config.t
+  val safe_load:
+    ?lock_kind: 'a lock -> 'b global_state -> switch -> OpamFile.Switch_config.t
+  val safe_read_selections:
+    ?lock_kind: 'a lock -> 'b global_state -> switch -> switch_selections
+  val read_opt:
+    ?lock_kind: 'a lock -> 'b global_state -> switch ->
+    OpamFile.Switch_config.t option
+end
+
+module Repos : sig
+  val safe_read:
+    ?lock_kind: 'a lock -> 'b global_state -> OpamFile.Repos_config.t
+end

--- a/src/state/opamSwitchAction.ml
+++ b/src/state/opamSwitchAction.ml
@@ -29,7 +29,7 @@ let gen_switch_config
     ]
   in
   { OpamFile.Switch_config.
-    opam_version = OpamFile.Switch_config.format_version;
+    opam_version = OpamFile.Switch_config.file_format_version;
     synopsis;
     variables = vars;
     paths = [];

--- a/src/state/opamSwitchAction.ml
+++ b/src/state/opamSwitchAction.ml
@@ -17,7 +17,7 @@ let log fmt = OpamConsole.log "SWACT" fmt
 let slog = OpamConsole.slog
 
 let gen_switch_config
-    root ?(synopsis="") ?repos ?(invariant=OpamFormula.Empty) _switch =
+    root ?(synopsis="") ?repos ?invariant _switch =
   let vars =
     List.map (fun (s,p) -> OpamVariable.of_string s, S p) [
       ("user" ,

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -18,18 +18,21 @@ let slog = OpamConsole.slog
 
 open OpamStateTypes
 
-let load_selections gt switch =
-  OpamFile.SwitchSelections.safe_read (OpamPath.Switch.selections gt.root switch)
+let load_selections ?lock_kind gt switch =
+  OpamStateConfig.Switch.safe_read_selections ?lock_kind gt switch
 
-let load_switch_config gt switch =
-  let f = OpamPath.Switch.switch_config gt.root switch in
-  match OpamFile.Switch_config.read_opt f with
+let load_switch_config ?lock_kind gt switch =
+  match OpamStateConfig.Switch.read_opt ?lock_kind gt switch with
   | Some c -> c
+  | exception (OpamPp.Bad_version _ as e) ->
+    OpamFormatUpgrade.hard_upgrade_from_2_1_intermediates
+      ~global_lock:gt.global_lock gt.root;
+    raise e
   | None ->
-    OpamConsole.error
-      "No config file found for switch %s. Switch broken?"
-      (OpamSwitch.to_string switch);
-    OpamFile.Switch_config.empty
+    (OpamConsole.error
+       "No config file found for switch %s. Switch broken?"
+       (OpamSwitch.to_string switch);
+     OpamFile.Switch_config.empty)
 
 let compute_available_packages gt switch switch_config ~pinned ~opams =
   (* remove all versions of pinned packages, but the pinned-to version *)
@@ -245,7 +248,13 @@ let load lock_kind gt rt switch =
   let lock =
     OpamFilename.flock lock_kind (OpamPath.Switch.lock gt.root switch)
   in
-  let switch_config = load_switch_config gt switch in
+  let switch_config = load_switch_config ~lock_kind gt switch in
+  if OpamStateConfig.is_newer_than_self gt then
+    log "root version (%s) is greater than running binary's (%s); \
+         load with best-effort (read-only)"
+      (OpamStd.Option.to_string OpamVersion.to_string
+         (OpamFile.Config.opam_root_version gt.config))
+      (OpamVersion.to_string (OpamFile.Config.root_version));
   if OpamVersion.compare
       switch_config.opam_version
       OpamFile.Switch_config.oldest_compatible_format_version
@@ -259,7 +268,7 @@ let load lock_kind gt rt switch =
          OpamFile.Switch_config.oldest_compatible_format_version);
   let { sel_installed = installed; sel_roots = installed_roots;
         sel_pinned = pinned; sel_compiler = compiler_packages; } =
-    load_selections gt switch
+    load_selections ~lock_kind gt switch
   in
   let pinned, pinned_opams =
     OpamPackage.Set.fold (fun nv (pinned,opams) ->
@@ -632,6 +641,10 @@ let drop st =
   let _ = unlock st in ()
 
 let with_write_lock ?dontblock st f =
+  if OpamStateConfig.is_newer_than_self st.switch_global then
+    OpamConsole.error_and_exit `Locked
+      "The opam root has been upgraded by a newer version of opam-state \
+       and cannot be written to";
   let ret, st =
     OpamFilename.with_flock_upgrade `Lock_write ?dontblock st.switch_lock
     @@ fun _ -> f ({ st with switch_lock = st.switch_lock } : rw switch_state)
@@ -1145,7 +1158,9 @@ let do_backup lock st = match lock with
       | true -> OpamFilename.remove (OpamFile.filename file)
       | false ->
         (* Reload, in order to skip the message if there were no changes *)
-        let new_selections = load_selections st.switch_global st.switch in
+        let new_selections =
+          load_selections ~lock_kind:lock st.switch_global st.switch
+        in
         if new_selections.sel_installed = previous_selections.sel_installed
         then OpamFilename.remove (OpamFile.filename file)
         else
@@ -1180,7 +1195,7 @@ let with_ lock ?rt ?(switch=OpamStateConfig.get_switch ()) gt f =
 let update_repositories gt update_fun switch =
   OpamFilename.with_flock `Lock_write (OpamPath.Switch.lock gt.root switch)
   @@ fun _ ->
-  let conf = load_switch_config gt switch in
+  let conf = load_switch_config ~lock_kind:`Lock_write gt switch in
   let repos =
     match conf.OpamFile.Switch_config.repos with
     | None -> OpamGlobalState.repos_list gt

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -247,15 +247,14 @@ let load lock_kind gt rt switch =
   in
   let switch_config = load_switch_config gt switch in
   if OpamVersion.compare
-      switch_config.OpamFile.Switch_config.opam_version
+      switch_config.opam_version
       OpamFile.Switch_config.oldest_compatible_format_version
      < 0 then
     OpamConsole.error_and_exit `Configuration_error
       "Could not load opam switch %s: it reports version %s while >= %s was \
        expected"
       (OpamSwitch.to_string switch)
-      (OpamVersion.to_string
-         (switch_config.OpamFile.Switch_config.opam_version))
+      (OpamVersion.to_string (switch_config.opam_version))
       (OpamVersion.to_string
          OpamFile.Switch_config.oldest_compatible_format_version);
   let { sel_installed = installed; sel_roots = installed_roots;
@@ -372,7 +371,7 @@ let load lock_kind gt rt switch =
   (* Detect and initialise missing switch description *)
   let switch_config =
     if switch_config <> OpamFile.Switch_config.empty &&
-       switch_config.OpamFile.Switch_config.synopsis = "" then
+       switch_config.synopsis = "" then
       let synopsis =
         match OpamPackage.Set.elements (compiler_packages %% installed_roots)
         with
@@ -383,7 +382,7 @@ let load lock_kind gt rt switch =
           OpamPackage.to_string nv
         | pkgs -> OpamStd.List.concat_map " " OpamPackage.to_string pkgs
       in
-      let conf = { switch_config with OpamFile.Switch_config.synopsis } in
+      let conf = { switch_config with synopsis } in
       if lock_kind = `Lock_write then (* auto-repair *)
         OpamFile.Switch_config.write
           (OpamPath.Switch.switch_config gt.root switch)
@@ -392,7 +391,7 @@ let load lock_kind gt rt switch =
     else switch_config
   in
   let switch_config, switch_invariant =
-    match switch_config.OpamFile.Switch_config.invariant with
+    match switch_config.invariant with
     | Some invariant -> switch_config, invariant
     | None ->
       let invariant =

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -252,8 +252,7 @@ let load lock_kind gt rt switch =
   if OpamStateConfig.is_newer_than_self gt then
     log "root version (%s) is greater than running binary's (%s); \
          load with best-effort (read-only)"
-      (OpamStd.Option.to_string OpamVersion.to_string
-         (OpamFile.Config.opam_root_version gt.config))
+      (OpamVersion.to_string (OpamFile.Config.opam_root_version gt.config))
       (OpamVersion.to_string (OpamFile.Config.root_version));
   if OpamVersion.compare
       switch_config.opam_version

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -411,8 +411,14 @@ let load lock_kind gt rt switch =
         then min_opam_version
         else switch_config.opam_version
       in
-      {switch_config with invariant = Some invariant; opam_version},
-      invariant
+      let switch_config =
+        {switch_config with invariant = Some invariant; opam_version}
+      in
+      if lock_kind = `Lock_write then
+        OpamFile.Switch_config.write
+          (OpamPath.Switch.switch_config gt.root switch)
+          switch_config;
+      switch_config, invariant
   in
   let conf_files =
     let conf_files =

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -44,7 +44,8 @@ val load_virtual:
 
 (** Load the switch's state file, without constructing the package maps: much
     faster than loading the full switch state *)
-val load_selections: 'a global_state -> switch -> switch_selections
+val load_selections:
+  ?lock_kind: 'a lock -> 'b global_state -> switch -> switch_selections
 
 (** Raw function to compute the availability of all packages, in [opams], given
     the switch configuration and the set of pinned packages. (The result is

--- a/tests/reftests/dot-install.test
+++ b/tests/reftests/dot-install.test
@@ -91,6 +91,7 @@ Done.
 ==> nodot installed file
 hellow
 ==> nodot changes
+opam-version: "2.0"
 added: [
   "share" {"D"}
   "share-nodot" {"D"}
@@ -118,6 +119,7 @@ Done.
 ==> dot installed file
 hellow
 ==> dot changes
+opam-version: "2.0"
 added: [
   "share-dot" {"D"}
   "share-dot-file" {"F:12fc204edeae5b57713c5ad7dcb97d39"}

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -192,6 +192,22 @@
    (run ./run.exe %{bin:opam} %{dep:legacy-local.test} %{read-lines:testing-env}))))
 
 (alias
+ (name reftest-opamroot-versions)
+ (action
+  (diff opamroot-versions.test opamroot-versions.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-opamroot-versions)))
+
+(rule
+ (deps root-632bc2e)
+ (action
+  (with-stdout-to
+   opamroot-versions.out
+   (run ./run.exe %{bin:opam} %{dep:opamroot-versions.test} %{read-lines:testing-env}))))
+
+(alias
  (name reftest-pat-sub)
  (action
   (diff pat-sub.test pat-sub.out)))

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -1,0 +1,912 @@
+632bc2e
+### OPAMYES=1 OPAMDEBUG=-1 OPAMSTRICT=0 OPAMDEBUGSECTIONS="FMT_UPG FORMAT GSTATE RSTATE STATE"
+### : setup
+### <generate.ml>
+let opam_version = Printf.sprintf "opam-version: %S"
+let root_version = Printf.sprintf "opam-root-version: %S"
+let switches = {|
+installed-switches: "foo"
+switch: "foo"
+|}
+let neant = "neant: 0"
+let repo = {|repositories: [ "default" {"file:///${BASEDIR/dontexist"} ]|}
+let switch_config = {|synopsis: "foo"|}
+let _ =
+  let configs =
+    ( let opam_v = opam_version "2.0" in
+      List.map (fun v -> [
+            "config."^v, [ opam_v ; root_version v ];
+            "config-w-swfoo."^v, [ opam_v; root_version v; switches ];
+          ]) ["2.0"; "2.1~rc"; "2.2"]
+      |> List.flatten)
+    @ (let opam_v = opam_version "2.1" in
+       let v = "2.3" in [
+         "config."^v, [ opam_v; root_version v ];
+         "config-w-swfoo."^v, [ opam_v; root_version v; switches ];
+       ])
+  in
+  let files = [
+    "repos-config", [ repo ];
+    "switch-config", [ opam_version "2.0"; switch_config ];
+  ] @ configs
+  in
+  let errs =
+    List.map (fun (n,c) -> n^".err" , c@[neant]) files
+    @ (let v = "2.1~rc" in
+       let opam_v = opam_version "2.1" in [
+         "config."^v^".wrong", [ opam_v; root_version v ];
+         "switch-config.wrong", [ opam_v; switch_config ];
+       ])
+  in
+  List.iter (fun (name, content) ->
+      let fd = open_out name in
+      List.iter (fun l -> output_string fd (l^"\n")) content;
+      close_out fd)
+    (files @ errs)
+### ocaml generate.ml
+### <root-config/repo>
+opam-version: "2.0"
+### mkdir root-config/packages
+### :                     :
+### :I: Current opam root :
+### :                     :
+### :I:1:a: Bad config file
+### cp config.2.1~rc.err $OPAMROOT/config
+### # ro global state
+### opam switch
+[WARNING] Errors in ${BASEDIR}/OPAM/config, some fields have been ignored:
+            - At ${BASEDIR}/OPAM/config:3:0-3:8::
+              Invalid field neant
+
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Errors in ${BASEDIR}/OPAM/config, some fields have been ignored:
+            - At ${BASEDIR}/OPAM/config:3:0-3:8::
+              Invalid field neant
+
+#  switch  compiler  description
+### :I:1:b: Good config file
+### cp config.2.1~rc $OPAMROOT/config
+### # ro global state
+### opam switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+#  switch  compiler  description
+### :I:2:a: Bad repo config file :
+### cp repos-config.err $OPAMROOT/repo/repos-config
+### # ro global state, ro repo state
+### opam list --no-switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+[WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
+            - At ${BASEDIR}/OPAM/repo/repos-config:2:0-2:8::
+              Invalid field neant
+
+RSTATE                          Cache found
+# No matches found
+### # ro global state, rw repo state
+### opam repo add root-config ./root-config --set-default
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+[WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
+            - At ${BASEDIR}/OPAM/repo/repos-config:2:0-2:8::
+              Invalid field neant
+
+RSTATE                          Cache found
+[root-config] Initialised
+### opam repo remove root-config --all --debug-level=0
+### :I:2:b: Good repo config file :
+### cp repos-config $OPAMROOT/repo/repos-config
+### # ro global state, ro repo state
+### opam list --no-switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+# No matches found
+### # ro global state, rw repo state
+### opam repo add root-config ./root-config --set-default
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[root-config] Initialised
+### opam switch create foo --empty --debug-level=0
+### :I:3:a: Bad switch config file :
+### cp switch-config.err $OPAMROOT/foo/.opam-switch/switch-config
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ foo
+[WARNING] Errors in ${BASEDIR}/OPAM/foo/.opam-switch/switch-config, some fields have been ignored:
+            - At ${BASEDIR}/OPAM/foo/.opam-switch/switch-config:3:0-3:8::
+              Invalid field neant
+
+STATE                           Inferred invariant: from base packages {}, (roots {}) => []
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# No matches found
+### # ro global state, ro repo state, rw switch state
+### opam install bar
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ foo
+[WARNING] Errors in ${BASEDIR}/OPAM/foo/.opam-switch/switch-config, some fields have been ignored:
+            - At ${BASEDIR}/OPAM/foo/.opam-switch/switch-config:3:0-3:8::
+              Invalid field neant
+
+STATE                           Inferred invariant: from base packages {}, (roots {}) => []
+STATE                           Switch state loaded in 0.000s
+[ERROR] No package named bar found.
+# Return code 5 #
+### :I:3:b: Good switch config file :
+### cp switch-config $OPAMROOT/foo/.opam-switch/switch-config
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ foo
+STATE                           Inferred invariant: from base packages {}, (roots {}) => []
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# No matches found
+### # ro global state, ro repo state, rw switch state
+### opam install bar
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ foo
+STATE                           Inferred invariant: from base packages {}, (roots {}) => []
+STATE                           Switch state loaded in 0.000s
+[ERROR] No package named bar found.
+# Return code 5 #
+### :I:1:a: Bad config file
+### cp config-w-swfoo.2.1~rc.err $OPAMROOT/config
+### # rw global state
+### opam switch remove foo
+[WARNING] Errors in ${BASEDIR}/OPAM/config, some fields have been ignored:
+            - At ${BASEDIR}/OPAM/config:7:0-7:8::
+              Invalid field neant
+
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Errors in ${BASEDIR}/OPAM/config, some fields have been ignored:
+            - At ${BASEDIR}/OPAM/config:7:0-7:8::
+              Invalid field neant
+
+Switch foo and all its packages will be wiped. Are you sure? [Y/n] y
+### :I:1:b: Good config file
+### opam switch create foo --empty --debug-level=0
+### cp config-w-swfoo.2.1~rc $OPAMROOT/config
+### # rw global state
+### opam switch remove foo
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Switch foo and all its packages will be wiped. Are you sure? [Y/n] y
+### :                                                :
+### :II: Current opam root & newer opam file version :
+### :                                                :
+### :II:1: config with newer opam version file & no update of root version
+### cp config.2.1~rc.wrong $OPAMROOT/config
+### # cat $OPAMROOT/config
+### # ro global state
+### opam switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Fatal error:
+In ${BASEDIR}/OPAM/config:
+unsupported or missing file format version; should be 2.0 or older
+# Return code 99 #
+### opam option jobs
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Fatal error:
+In ${BASEDIR}/OPAM/config:
+unsupported or missing file format version; should be 2.0 or older
+# Return code 99 #
+### # rw global state
+### opam switch bar
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Fatal error:
+In ${BASEDIR}/OPAM/config:
+unsupported or missing file format version; should be 2.0 or older
+# Return code 99 #
+### :II:2: switch-config with newer opam version file & no update of root version
+### cp config.2.1~rc $OPAMROOT/config
+### opam switch create foo --empty --debug-level=0
+### cp switch-config.wrong $OPAMROOT/foo/.opam-switch/switch-config
+### # ro global state
+### opam option jobs
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+### # rw global state
+### # opam option synopsis="bar" --switch foo
+### opam switch foo
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ foo
+Fatal error:
+In ${BASEDIR}/OPAM/foo/.opam-switch/switch-config:
+unsupported or missing file format version; should be 2.0 or older
+# Return code 99 #
+### :                 :
+### : Newer opam root :
+### :                 :
+### :III:1:a: Bad config file
+### cp config.2.2.err $OPAMROOT/config
+### # ro global state
+### opam switch
+FORMAT                          File errors in ${BASEDIR}/OPAM/config, ignored fields: At ${BASEDIR}/OPAM/config:3:0-3:8::
+Invalid field neant
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FORMAT                          File errors in ${BASEDIR}/OPAM/config, ignored fields: At ${BASEDIR}/OPAM/config:3:0-3:8::
+Invalid field neant
+GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+#  switch  compiler  description
+### :III:1:b: Good config file
+### cp config.2.2 $OPAMROOT/config
+### # ro global state
+### opam switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+#  switch  compiler  description
+### :III:2:a: Bad repo config file :
+### cp repos-config.err $OPAMROOT/repo/repos-config
+### # ro global state, ro repo state
+### opam list --no-switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+FORMAT                          File errors in ${BASEDIR}/OPAM/repo/repos-config, ignored fields: At ${BASEDIR}/OPAM/repo/repos-config:2:0-2:8::
+Invalid field neant
+RSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          Cache found
+# No matches found
+### # ro global state, rw repo state
+### opam repo add root-config ./root-config --set-default
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+[ERROR] Refusing write access to ${BASEDIR}/OPAM, which is more recent than this version of opam (2.2 > 2.1), aborting.
+# Return code 15 #
+### :III:2:b: Good repo config file :
+### cp repos-config $OPAMROOT/repo/repos-config
+### # ro global state, ro repo state
+### opam list --no-switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          Cache found
+# No matches found
+### # ro global state, rw repo state
+### opam repo add root-config ./root-config --set-default
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+[ERROR] Refusing write access to ${BASEDIR}/OPAM, which is more recent than this version of opam (2.2 > 2.1), aborting.
+# Return code 15 #
+### cp config.2.1~rc $OPAMROOT/config
+### cp config-w-swfoo.2.2 $OPAMROOT/config
+### :III:3:a: Bad switch config file :
+### cp switch-config.err $OPAMROOT/foo/.opam-switch/switch-config
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ foo
+FORMAT                          File errors in ${BASEDIR}/OPAM/foo/.opam-switch/switch-config, ignored fields: At ${BASEDIR}/OPAM/foo/.opam-switch/switch-config:3:0-3:8::
+Invalid field neant
+STATE                           root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+STATE                           Inferred invariant: from base packages {}, (roots {}) => []
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# No matches found
+### # ro global state, ro repo state, rw switch state
+### opam install bar
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ foo
+[ERROR] Refusing write access to ${BASEDIR}/OPAM, which is more recent than this version of opam (2.2 > 2.1), aborting.
+# Return code 15 #
+### :III:3:b: Good switch config file :
+### cp switch-config $OPAMROOT/foo/.opam-switch/switch-config
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ foo
+STATE                           root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+STATE                           Inferred invariant: from base packages {}, (roots {}) => []
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# No matches found
+### # ro global state, ro repo state, rw switch state
+### opam install bar
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ foo
+[ERROR] Refusing write access to ${BASEDIR}/OPAM, which is more recent than this version of opam (2.2 > 2.1), aborting.
+# Return code 15 #
+### :III:1:a: Bad config file
+### cp config-w-swfoo.2.2.err $OPAMROOT/config
+### # rw global state
+### opam switch remove foo
+FORMAT                          File errors in ${BASEDIR}/OPAM/config, ignored fields: At ${BASEDIR}/OPAM/config:7:0-7:8::
+Invalid field neant
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[ERROR] Refusing write access to ${BASEDIR}/OPAM, which is more recent than this version of opam (2.2 > 2.1), aborting.
+# Return code 15 #
+### :III:1:b: Good config file
+### cp config-w-swfoo.2.2 $OPAMROOT/config
+### # rw global state
+### opam switch remove foo
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[ERROR] Refusing write access to ${BASEDIR}/OPAM, which is more recent than this version of opam (2.2 > 2.1), aborting.
+# Return code 15 #
+### :                                    :
+### : Newer opam root & new file version :
+### :                                    :
+### :IV:1:a: Bad config file
+### cp config.2.3.err $OPAMROOT/config
+### # ro global state
+### opam switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Fatal error:
+In ${BASEDIR}/OPAM/config:
+unsupported or missing file format version; should be 2.0 or older
+# Return code 99 #
+### :IV:1:b: Good config file
+### cp config.2.3 $OPAMROOT/config
+### # ro global state
+### opam switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Fatal error:
+In ${BASEDIR}/OPAM/config:
+unsupported or missing file format version; should be 2.0 or older
+# Return code 99 #
+### :IV:2:a: Bad repo config file :
+### cp repos-config.err $OPAMROOT/repo/repos-config
+### # ro global state, ro repo state
+### opam list --no-switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Fatal error:
+In ${BASEDIR}/OPAM/config:
+unsupported or missing file format version; should be 2.0 or older
+# Return code 99 #
+### # ro global state, rw repo state
+### opam repo add root-config ./root-config --set-default
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Fatal error:
+In ${BASEDIR}/OPAM/config:
+unsupported or missing file format version; should be 2.0 or older
+# Return code 99 #
+### :IV:2:b: Good repo config file :
+### cp repos-config $OPAMROOT/repo/repos-config
+### # ro global state, ro repo state
+### opam list --no-switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Fatal error:
+In ${BASEDIR}/OPAM/config:
+unsupported or missing file format version; should be 2.0 or older
+# Return code 99 #
+### # ro global state, rw repo state
+### opam repo add root-config ./root-config --set-default
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Fatal error:
+In ${BASEDIR}/OPAM/config:
+unsupported or missing file format version; should be 2.0 or older
+# Return code 99 #
+### cp config.2.1~rc $OPAMROOT/config
+### #opam switch create foo --empty --debug-level=0
+### cp config-w-swfoo.2.3 $OPAMROOT/config
+### :IV:3:a: Bad switch config file :
+### cp switch-config.err $OPAMROOT/foo/.opam-switch/switch-config
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Fatal error:
+In ${BASEDIR}/OPAM/config:
+unsupported or missing file format version; should be 2.0 or older
+# Return code 99 #
+### # ro global state, ro repo state, rw switch state
+### opam install bar
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Fatal error:
+In ${BASEDIR}/OPAM/config:
+unsupported or missing file format version; should be 2.0 or older
+# Return code 99 #
+### :IV:3:b: Good switch config file :
+### cp switch-config $OPAMROOT/foo/.opam-switch/switch-config
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Fatal error:
+In ${BASEDIR}/OPAM/config:
+unsupported or missing file format version; should be 2.0 or older
+# Return code 99 #
+### # ro global state, ro repo state, rw switch state
+### opam install bar
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Fatal error:
+In ${BASEDIR}/OPAM/config:
+unsupported or missing file format version; should be 2.0 or older
+# Return code 99 #
+### :IV:1:a: Bad config file
+### cp config-w-swfoo.2.3.err $OPAMROOT/config
+### # rw global state
+### opam switch remove foo
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[ERROR] Refusing write access to ${BASEDIR}/OPAM, which is more recent than this version of opam (2.3 > 2.1), aborting.
+# Return code 15 #
+### :IV:1:b: Good config file
+### cp config-w-swfoo.2.3 $OPAMROOT/config
+### # rw global state
+### opam switch remove foo
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[ERROR] Refusing write access to ${BASEDIR}/OPAM, which is more recent than this version of opam (2.3 > 2.1), aborting.
+# Return code 15 #
+### :                 :
+### : Older opam root :
+### :                 :
+### <generate_repo.ml>
+let content = {|opam-version: "2.0"
+synopsis: "One-line description"
+maintainer: "Name <email>"
+authors: "Name <email>"
+license: "MIT"
+homepage: " "
+bug-reports: " "
+dev-repo: "git://url.net/name"|}
+let compiler="flags: compiler"
+let files = [
+  "repo", [{|opam-version: "2.0"|}];
+  "packages/i-am-compiler/i-am-compiler.1/opam", [ content; compiler ];
+  "packages/i-am-compiler/i-am-compiler.2/opam", [ content; compiler ];
+  "packages/i-am-sys-compiler/i-am-sys-compiler.1/opam", [ content; compiler; {|available: sys-comp-version = "1"|}];
+  "packages/i-am-sys-compiler/i-am-sys-compiler.2/opam", [ content; compiler; {|available: sys-comp-version = "2"|}];
+  "packages/i-am-package/i-am-package.1/opam", [ content; {|depends: ["i-am-compiler"|"i-am-sys-compiler"]|} ];
+  "packages/i-am-package/i-am-package.2/opam", [ content; {|depends: ["i-am-compiler"|"i-am-sys-compiler"]|} ];
+  "packages/i-am-another-package/i-am-another-package.1/opam", [ content; {|depends: "i-am-package"|} ];
+  "packages/i-am-another-package/i-am-another-package.2/opam", [ content; {|depends: "i-am-package"|} ];
+]
+let _ =
+  List.iter (fun (name, content) ->
+      let fd = open_out name in
+      List.iter (fun l -> output_string fd (l^"\n")) content;
+      close_out fd)
+    (List.map (fun (n,c) -> "default/"^n, c) files)
+### <generate_dirs.sh>
+for d in i-am-compiler i-am-sys-compiler i-am-package i-am-another-package; do
+  for v in 1 2 ; do
+    mkdir -p default/packages/$d/$d.$v
+  done
+done
+### sh generate_dirs.sh
+### ocaml generate_repo.ml
+### <generate.ml>
+let opam_version = Printf.sprintf "opam-version: %S"
+let opam_version_2_0 = opam_version "2.0"
+let opam_version_2_1 = opam_version "2.1"
+let repo = {|repositories: "default"|}
+let installed_switches = {|
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+switch: "sw-sys-comp"
+|}
+let default_compiler = {|default-compiler: ["i-am-sys-compiler" "i-am-compiler"]|}
+let default_invariant = {|default-invariant: ["i-am-sys-compiler"]|}
+let depext = {|
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+|}
+let eval = {|eval-variables: [ sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version" ]|}
+let sw_state_default = {|
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-sys-compiler.2"]
+installed: ["i-am-sys-compiler.2"]
+|}
+let sw_state_sw_comp = {|
+compiler: ["i-am-compiler.2"]
+roots: ["i-am-package.2" "i-am-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2"]
+|}
+let sw_state_sw_sys_comp = {|
+compiler: ["i-am-sys-compiler.1"]
+roots: ["i-am-another-package.2" "i-am-sys-compiler.1"]
+installed: ["i-am-another-package.2" "i-am-package.2" "i-am-sys-compiler.1"]
+|}
+let invariant_default = {|invariant: ["i-am-sys-compiler" | "i-am-compiler"]|}
+let invariant_sw_comp = {|invariant: ["i-am-compiler"]|}
+let invariant_sw_sys_comp = {|invariant: ["i-am-sys-compiler"]|}
+let root_version =  {|opam-root-version: "2.1~rc"|}
+let synopsis = Printf.sprintf "synopsis: %S"
+let opam_20 =
+[ "config", [ opam_version_2_0; repo; installed_switches; eval; default_compiler ];
+  "switch-config.default", [ opam_version_2_0; synopsis "default switch" ];
+  "switch-state.default", [ opam_version_2_0; sw_state_default ];
+  "switch-config.sw-comp", [ opam_version_2_0; synopsis "switch with compiler" ];
+  "switch-state.sw-comp", [ opam_version_2_0; sw_state_sw_comp ];
+  "switch-config.sw-sys-comp", [ opam_version_2_0; synopsis "switch with system compiler" ];
+  "switch-state.sw-sys-comp", [ opam_version_2_0; sw_state_sw_sys_comp ]
+]
+let opam_21alpha =
+[ "config", [ opam_version_2_0; repo; installed_switches; eval; default_compiler ];
+  "switch-config.default", [ opam_version_2_1; synopsis "default switch"; invariant_default ];
+  "switch-state.default", [ opam_version_2_0; sw_state_default ];
+  "switch-config.sw-comp", [ opam_version_2_1; synopsis "switch with compiler"; invariant_sw_comp ];
+  "switch-state.sw-comp", [ opam_version_2_0; sw_state_sw_comp ];
+  "switch-config.sw-sys-comp", [ opam_version_2_1; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
+  "switch-state.sw-sys-comp", [ opam_version_2_0; sw_state_sw_sys_comp ]
+]
+let opam_21alpha2 =
+[ "config", [ opam_version_2_1; repo; installed_switches; eval; default_compiler; depext; ];
+  "switch-config.default", [ opam_version_2_1; synopsis "default switch"; invariant_default ];
+  "switch-state.default", [ opam_version_2_0; sw_state_default ];
+  "switch-config.sw-comp", [ opam_version_2_1; synopsis "switch with compiler"; invariant_sw_comp ];
+  "switch-state.sw-comp", [ opam_version_2_0; sw_state_sw_comp ];
+  "switch-config.sw-sys-comp", [ opam_version_2_1; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
+  "switch-state.sw-sys-comp", [ opam_version_2_0; sw_state_sw_sys_comp ]
+]
+let opam_21rc =
+[ "config", [ opam_version_2_0; root_version; repo; installed_switches; eval; default_compiler; default_invariant; depext ];
+  "switch-config.default", [ opam_version_2_0; synopsis "default switch"; invariant_default ];
+  "switch-state.default", [ opam_version_2_0; sw_state_default ];
+  "switch-config.sw-comp", [ opam_version_2_0; synopsis "switch with compiler"; invariant_sw_comp ];
+  "switch-state.sw-comp", [ opam_version_2_0; sw_state_sw_comp ];
+  "switch-config.sw-sys-comp", [ opam_version_2_0; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
+  "switch-state.sw-sys-comp", [ opam_version_2_0; sw_state_sw_sys_comp ]
+]
+let _ =
+  let append v (f,c) = f^"."^v, c in
+  List.iter (fun (name, content) ->
+      let fd = open_out name in
+      List.iter (fun l -> output_string fd (l^"\n")) content;
+      close_out fd)
+    (List.map (append "2.0") opam_20
+     @ List.map (append "2.1~alpha") opam_21alpha
+     @ List.map (append "2.1~alpha2") opam_21alpha2
+     @ List.map (append "2.1~rc") opam_21rc)
+### ocaml generate.ml
+### <switch-root.sh>
+version=$1
+cp config.$version $OPAMROOT/config
+cp switch-config.default.$version $OPAMROOT/default/.opam-switch/switch-config
+cp switch-state.default.$version $OPAMROOT/default/.opam-switch/switch-state
+cp switch-config.sw-comp.$version $OPAMROOT/sw-comp/.opam-switch/switch-config
+cp switch-state.sw-comp.$version $OPAMROOT/sw-comp/.opam-switch/switch-state
+cp switch-config.sw-sys-comp.$version $OPAMROOT/sw-sys-comp/.opam-switch/switch-config
+cp switch-state.sw-sys-comp.$version $OPAMROOT/sw-sys-comp/.opam-switch/switch-state
+### # OPAMDEBUG=0 OPAMDEBUGLEVEL=0
+### rm -rf $OPAMROOT
+### opam init -na default ./default --bare --bypass-checks --no-opamrc --debug-level=0
+No configuration file found, using built-in defaults.
+
+<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+[default] Initialised
+### mkdir -p $OPAMROOT $OPAMROOT/repo $OPAMROOT/default/.opam-switch  $OPAMROOT/sw-comp/.opam-switch $OPAMROOT/sw-sys-comp/.opam-switch
+### :V:1: From 2.0 root
+### sh switch-root.sh 2.0
+### # ro global state
+### opam option jobs
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.0 to 2.1~rc
+FMT_UPG                         Format upgrade done
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.0 to 2.1~rc
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.1 }, (roots { i-am-sys-compiler.1 }) => ["i-am-sys-compiler"]
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name               # Installed # Synopsis
+i-am-another-package 2           One-line description
+i-am-package         2           One-line description
+i-am-sys-compiler    1           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-another-package --switch sw-comp
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.0 to 2.1~rc
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Definition missing for installed package i-am-compiler.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Inferred invariant: from base packages { i-am-compiler.2 }, (roots { i-am-compiler.2 }) => ["i-am-compiler" {>= "2"}]
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-another-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-another-package.2
+Done.
+### # rw global state
+### opam switch sw-comp
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         Light config upgrade, from 2.0 to 2.1~rc
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.0 to version 2.1~rc, which can't be reverted.
+You may want to back it up before going further.
+Continue? [Y/n] y
+Format upgrade done.
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1~rc"
+repositories: "default"
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+switch: "sw-comp"
+download-jobs: 1
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+### cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "switch with compiler"
+invariant: [
+  "i-am-compiler" {>= "2"}
+]
+paths {
+  
+}
+variables {
+  
+}
+### cat $OPAMROOT/sw-comp/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-compiler.2"]
+roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+### :V:2: From 2.1~alpha root
+### sh switch-root.sh 2.1~alpha
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         Hard config upgrade, from 2.1~alpha to 2.1~rc
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~alpha to version 2.1~rc, which can't be reverted.
+You may want to back it up before going further.
+Perform the update and continue? [Y/n] y
+Format upgrade done.
+
+<><> Rerunning init and update ><><><><><><><><><><><><><><><><><><><><><><><><>
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[default] no changes from file://${BASEDIR}/default
+Update done, please now retry your command.
+# Return code 10 #
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name               # Installed # Synopsis
+i-am-another-package 2           One-line description
+i-am-package         2           One-line description
+i-am-sys-compiler    1           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-another-package --switch sw-comp
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-another-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-another-package.2
+Done.
+### # rw global state
+### opam switch sw-comp
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1~rc"
+repositories: "default"
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+switch: "sw-comp"
+download-jobs: 3
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: [
+  "ocaml" {>= "4.05.0"}
+]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+wrap-build-commands:
+  ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands:
+  ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands:
+  ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
+### cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "switch with compiler"
+invariant: ["i-am-compiler"]
+### cat $OPAMROOT/sw-comp/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-compiler.2"]
+roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+### :V:3: From 2.1~alpha2 root
+### sh switch-root.sh 2.1~alpha2
+### # ro global state
+### opam option jobs
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         Intermediate opam root detected, launch hard upgrade
+FMT_UPG                         Downgrade config opam-version to fix up
+FMT_UPG                         Hard config upgrade, from 2.1~alpha2 to 2.1~rc
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~alpha2 to version 2.1~rc, which can't be reverted.
+You may want to back it up before going further.
+Perform the update and continue? [Y/n] y
+Format upgrade done.
+
+<><> Rerunning init and update ><><><><><><><><><><><><><><><><><><><><><><><><>
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[default] no changes from file://${BASEDIR}/default
+Update done, please now retry your command.
+# Return code 10 #
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name               # Installed # Synopsis
+i-am-another-package 2           One-line description
+i-am-package         2           One-line description
+i-am-sys-compiler    1           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-another-package --switch sw-comp
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-another-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-another-package.2
+Done.
+### # rw global state
+### opam switch sw-comp
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1~rc"
+repositories: "default"
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+switch: "sw-comp"
+download-jobs: 3
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: [
+  "ocaml" {>= "4.05.0"}
+]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+wrap-build-commands:
+  ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands:
+  ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands:
+  ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
+### cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "switch with compiler"
+invariant: ["i-am-compiler"]
+### cat $OPAMROOT/sw-comp/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-compiler.2"]
+roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+### :V:4: From 2.1~rc root
+### sh switch-root.sh 2.1~rc
+### # ro global state
+### opam option jobs
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name               # Installed # Synopsis
+i-am-another-package 2           One-line description
+i-am-package         2           One-line description
+i-am-sys-compiler    1           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-another-package --switch sw-comp
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-another-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-another-package.2
+Done.
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1~rc"
+repositories: "default"
+
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+switch: "sw-sys-comp"
+
+eval-variables: [ sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version" ]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+
+### cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "switch with compiler"
+invariant: ["i-am-compiler"]
+### cat $OPAMROOT/sw-comp/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-compiler.2"]
+roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]


### PR DESCRIPTION
Permit a non blocking call from older versions of opam binary or lib.

On files, it adds `opam-root-version` field in root `config` file to discriminate root version and opam file version. The field `opam-version` is the `opam-file-format` version of the file. In `OpamFile` modules, `format_version` field is set on some modules to specify the file format version (eg. new field), and `opam_file_format` the `opam-file-format` version. An internal `OpamFile.Config.root_version` permit to determine the current root version of the binary. it need to be bumped at each `opam_file_format` bump (regardless of the file), according opam binary version. 
`opam-root-version` is checked for all states loading, and for most state files reading. Also for root format upgrade mechanism.
The check/printing on the `opam-version` field is updated too. It must be printed on all files, and it is checked that it will be printed (`OpamFormat.opam_version`).

On format upgrade, latest compatible hard upgrade is still 2.0~beta5, but intermediate roots (from 2.1~alpha's) are set as hard upgrade: all files with `opam-version: 2.1` downgraded to `2.0`.

On state files should no more use `OpamFile` to read them outside state loading, there is functions to safely read them in `OpamStateConfig`. It concerns `config`, `switch-config`, `switch-state`, and `repos-config`.


Fixes #4636