### PR TITLE
Bump to opam-file-format 2.1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ env:
   OPAMBSROOT: ~/.cache/.opam.cached
   OPAM12CACHE: ~/.cache/opam1.2/cache
   # This should be identical to the value in appveyor.yml
-  OPAM_TEST_REPO_SHA: 75ff83837547183f000e1c18d42260d7d6cc5fbc
-  OPAM_REPO_SHA: 75ff83837547183f000e1c18d42260d7d6cc5fbc
+  OPAM_TEST_REPO_SHA: b02110b549a0b5275806ce27444fabac71093a0e
+  OPAM_REPO_SHA: b02110b549a0b5275806ce27444fabac71093a0e
   # Default ocaml version for some jobs
   OCAML_VERSION: 4.11.2
   ## variables for cache paths

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ environment:
     CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
     DEP_MODE: lib-ext
     # This should be identical to the value in .travis.yml
-    OPAM_REPO_SHA: 75ff83837547183f000e1c18d42260d7d6cc5fbc
-    OPAM_TEST_REPO_SHA: 75ff83837547183f000e1c18d42260d7d6cc5fbc
+    OPAM_REPO_SHA: b02110b549a0b5275806ce27444fabac71093a0e
+    OPAM_TEST_REPO_SHA: b02110b549a0b5275806ce27444fabac71093a0e
   matrix:
     - CYG_ROOT: cygwin
       CYG_ARCH: x86

--- a/master_changes.md
+++ b/master_changes.md
@@ -74,6 +74,8 @@ New option/command/subcommand are prefixed with ◈.
   * Fix `features` parser [#4507 @rjbou]
   * Rename `hidden-version` to `avoid-version` [#4527 @dra27]
   * Fix rewriting with preserved format empty field error [#4634 @rjbou - fix #4628]
+  * Fix rewrtiting with preserved format empty field error [#4633 @rjbou - fix #4628]
+  * Require opam-file-format 2.1.3+ in order to enforce opam-version: "2.1" as first non-comment line [#4639 @dra27 - fix #4394]
 
 ## External dependencies
   * Handle macport variants [#4509 @rjbou - fix #4297]

--- a/opam-admin.opam
+++ b/opam-admin.opam
@@ -18,5 +18,5 @@ bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
   "dune" {>= "1.11.0"}
   "re" {>= "1.9.0"}
-  "opam-file-format" {>= "2.1.2"}
+  "opam-file-format" {>= "2.1.3"}
 ]

--- a/opam-format.opam
+++ b/opam-format.opam
@@ -27,7 +27,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "opam-core" {= version}
-  "opam-file-format" {>= "2.1.2"}
+  "opam-file-format" {>= "2.1.3"}
   "re" {>= "1.9.0"}
   "dune" {>= "1.11.0"}
 ]

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -48,8 +48,8 @@ MD5_0install-solver = 50daf035b04b29399a3c6e6f965ac447
 
 $(call PKG_SAME,0install-solver)
 
-URL_opam-file-format = https://github.com/ocaml/opam-file-format/archive/2.1.2.tar.gz
-MD5_opam-file-format = f16ed774167fc1881876b8185087e0ab
+URL_opam-file-format = https://github.com/ocaml/opam-file-format/archive/2.1.3.tar.gz
+MD5_opam-file-format = b805562dd2d86fc3c8e6d47884fd1da6
 
 $(call PKG_SAME,opam-file-format)
 


### PR DESCRIPTION
Needs opam-file-format 2.1.3 to be released first (and `src_ext/Makefile.sources` updated with it).

This then automatically closes #4394. If you put `opam-version: "2.1"` as the second line of an opam file instead of:

```
    error  2: File format error: unsupported or missing file format version; should be 2.0 or older
```

you now get the correct:

```
    error  2: File format error at line 2, column 0: Parse error
```