### PR TITLE
Delete plugin links on root upgrade

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -141,6 +141,7 @@ New option/command/subcommand are prefixed with ◈.
   * Externalise cli versioning tools from `OpamArg` into `OpamArgTools` [#4606 @rjbou]
   * Each library defines its own environment variables, that fills the config record [#4606 @rjbou]
   * Harden cygpath wrapper [#4625 @dra27]
+  * Reset the plugin symlinks when the root is upgraded [#4641 @dra27 - partial fix for #4619]
 
 ## Test
   * Make the reference tests dune-friendly [#4376 @emillon]

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -136,7 +136,24 @@ let check_and_run_external_commands () =
     OpamCoreConfig.init ~answer ();
     OpamFormatConfig.init ();
     let root_dir = OpamStateConfig.opamroot () in
-    let has_init = OpamStateConfig.load_defaults root_dir <> None in
+    let has_init, root_upgraded =
+      match OpamStateConfig.load_defaults root_dir with
+      | None -> (false, false)
+      | Some config ->
+          let root_upgraded =
+            let config_version = OpamFile.Config.opam_version config in
+            let cmp =
+              OpamVersion.(compare OpamFile.Config.format_version config_version)
+            in
+            if cmp < 0 then
+              OpamConsole.error_and_exit `Configuration_error
+                "%s reports a newer opam version, aborting."
+                 (OpamFilename.Dir.to_string root_dir)
+            else
+              cmp = 0
+          in
+            (true, root_upgraded)
+    in
     let plugins_bin = OpamPath.plugins_bin root_dir in
     let plugin_symlink_present =
       OpamFilename.is_symlink (OpamPath.plugin_bin root_dir (OpamPackage.Name.of_string name))
@@ -157,7 +174,7 @@ let check_and_run_external_commands () =
         Unix.environment ()
     in
     match OpamSystem.resolve_command ~env command with
-    | Some command when plugin_symlink_present ->
+    | Some command when plugin_symlink_present && root_upgraded ->
       let argv = Array.of_list (command :: args) in
       raise (OpamStd.Sys.Exec (command, argv, env))
     | None when not has_init -> (cli, argv)
@@ -202,9 +219,12 @@ let check_and_run_external_commands () =
              (OpamPackage.to_string (OpamPackage.Set.max_elt candidates));
            exit (OpamStd.Sys.get_exit_code `Bad_arguments))
         else if
-          OpamConsole.confirm "Opam plugin \"%s\" is not installed. \
-                               Install it on the current switch?"
-            name
+          (if cmd = None then
+             OpamConsole.confirm "Opam plugin \"%s\" is not installed. \
+                                  Install it on the current switch?"
+           else
+             OpamConsole.confirm "Opam plugin \"%s\" may require upgrading/reinstalling. \
+                                  Reinstall the plugin on the current switch?") name
         then
           let nv =
             try
@@ -228,8 +248,10 @@ let check_and_run_external_commands () =
               OpamSwitchState.drop @@ (
               if cmd = None then
                 OpamClient.install st [OpamSolution.eq_atom_of_package nv]
+              else if root_upgraded then
+                OpamClient.reinstall st [OpamSolution.eq_atom_of_package nv]
               else
-                OpamClient.reinstall st [OpamSolution.eq_atom_of_package nv])
+                OpamClient.upgrade st ~all:false [OpamSolution.eq_atom_of_package nv])
             );
           match OpamSystem.resolve_command ~env command with
           | None ->

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -238,6 +238,10 @@ let files d =
   let fs = OpamSystem.files (Dir.to_string d) in
   List.rev_map of_string fs
 
+let files_and_links d =
+  let fs = OpamSystem.files_all_not_dir (Dir.to_string d) in
+  List.rev_map of_string fs
+
 let copy ~src ~dst =
   if src <> dst then OpamSystem.copy_file (to_string src) (to_string dst)
 

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -170,6 +170,10 @@ val rec_files: Dir.t -> t list
 (** List all the filename. Do not recurse. *)
 val files: Dir.t -> t list
 
+(** Returns alll the files, including dangling symlinks (which means that
+    not all entries will satisfy {!exists}). *)
+val files_and_links: Dir.t -> t list
+
 (** Apply a function on the contents of a file *)
 val with_contents: (string -> 'a) -> t -> 'a
 

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -140,6 +140,10 @@ val rec_files: string -> string list
 (** Return the list of files in the current directory. *)
 val files: string -> string list
 
+(** Return the list of files in the current directory, inclduing any
+    dangling symlinks. *)
+val files_all_not_dir: string -> string list
+
 (** [rec_dirs dir] return the list list of all directories recursively
     (going through symbolink links). *)
 val rec_dirs: string -> string list

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -1099,18 +1099,9 @@ let as_necessary requested_lock global_lock root config =
         OpamVersion.compare v latest_hard_upgrade <= 0)
   in
   let erase_plugin_links root =
-    let root = OpamPath.plugins_bin root in
-    if OpamFilename.exists_dir root then begin
-      let root = OpamFilename.Dir.to_string root in
-      let files = Sys.readdir root in
-      let erase_link file =
-        (* Sys.file_exists will be false for a dangling symlink *)
-        let file = Filename.concat root file in
-        if not (Sys.file_exists file && Sys.is_directory file) then
-          try Unix.unlink file
-          with Unix.Unix_error _ -> ()
-      in
-      Array.iter erase_link files
+    let plugins_bin = OpamPath.plugins_bin root in
+    if OpamFilename.exists_dir plugins_bin then begin
+      List.iter OpamFilename.remove @@ OpamFilename.files_and_links plugins_bin
     end
   in
   let light config =


### PR DESCRIPTION
This is the last part of #4619, which it turns out is a bit simpler and less dirty than I feared.

This `Dockerfile` demonstrates the problem:

```Dockerfile
FROM ocaml/opam:debian-ocaml-4.12
WORKDIR /src/test
RUN sudo chown opam /src/test
RUN opam pin add -n dose3 5.0.1-1 ; opam install dune dose3 opam-file-format mccs cmdliner ; opam install opam-dune-lint --deps-only
RUN opam exec -- dune init project foo
RUN echo > dune-project '(lang dune 2.8)\n(generate_opam_files true)(source (github foo/bar))(package (name foo))'
RUN opam exec -- dune build
WORKDIR /src
RUN sudo chown opam /src
#RUN git clone https://github.com/dra27/opam.git -b clear-plugins
#Comment out the line below and uncomment the line above to get the fix
RUN git clone https://github.com/ocaml/opam.git
WORKDIR /src/opam
RUN opam exec -- ./configure && opam exec -- make
WORKDIR /src/test
RUN opam install opam-state.2.0.8
RUN opam pin -yn opam-dune-lint 'https://github.com/ocurrent/opam-dune-lint.git#bf451c8cf2d4f2be3c7d979b613c79588b55a172'
RUN opam dune-lint
RUN sudo rm /usr/bin/opam && sudo cp /src/opam/opam /usr/bin/opam
RUN opam update
RUN opam dune-lint
```
and swapping the cloned repo over fixes the problem.