### PR TITLE
Allow multiple state caches

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -111,7 +111,9 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## State
-  *
+  * Rename state.cache to include the OpamVersion.magic() string. All .cache files are deleted if any
+    cache file is written to, allowing multiple versions of the library to co-exist without constantly
+    regenerating it [#4642 @dra27 - fix #4554]
 
 # Opam file format
   *

--- a/src/format/opamPath.ml
+++ b/src/format/opamPath.ml
@@ -27,7 +27,7 @@ let init_config_files () =
 
 let state_cache_dir t = t / "repo"
 
-let state_cache t = state_cache_dir t // "state.cache"
+let state_cache t = state_cache_dir t // Printf.sprintf "state-%s.cache" (OpamVersion.magic ())
 
 let lock t = t // "lock"
 

--- a/src/format/opamPath.ml
+++ b/src/format/opamPath.ml
@@ -25,7 +25,9 @@ let init_config_files () =
     OpamFilename.Dir.of_string (OpamStd.Sys.home ()) // ".opamrc";
   ]
 
-let state_cache t = t / "repo" // "state.cache"
+let state_cache_dir t = t / "repo"
+
+let state_cache t = state_cache_dir t // "state.cache"
 
 let lock t = t // "lock"
 

--- a/src/format/opamPath.mli
+++ b/src/format/opamPath.mli
@@ -21,6 +21,9 @@ type t = dirname
 (** State cache *)
 val state_cache: t -> filename
 
+(** Directory containing state cache *)
+val state_cache_dir: t -> dirname
+
 (** Global lock file for the whole opamroot. Opam should generally read-lock
     this (e.g. initialisation and format upgrades require a write lock) *)
 val lock: t -> filename

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -27,6 +27,15 @@ module Cache = struct
       let name = "repository"
     end)
 
+  let remove () =
+    let root = OpamStateConfig.(!r.root_dir) in
+    let cache_dir = OpamPath.state_cache_dir root in
+    let remove_cache_file file =
+      if OpamFilename.check_suffix file ".cache" then
+        OpamFilename.remove file
+    in
+    List.iter remove_cache_file (OpamFilename.files cache_dir)
+
   let save rt =
     let file = OpamPath.state_cache rt.repos_global.root in
     (* Repository without remote are not cached, they are intended to be
@@ -49,6 +58,7 @@ module Cache = struct
             (filter_out_nourl rt.repo_opams);
       }
     in
+    remove ();
     C.save file t
 
   let load root =
@@ -59,11 +69,6 @@ module Cache = struct
         (OpamRepositoryName.Map.of_list cache.cached_repofiles,
          OpamRepositoryName.Map.of_list cache.cached_opams)
     | None -> None
-
-  let remove () =
-    let root = OpamStateConfig.(!r.root_dir) in
-    let file = OpamPath.state_cache root in
-    C.remove file
 
 end
 


### PR DESCRIPTION
At present `$OPAMROOT/repo/state.cache` will be reset if the magic string does not match the version of opam-state / opam. This is tedious when developing and also visible to users as opam-state has a slightly different version from an opam binary.

The fix is quite simple: include the magic string in the filename as well, and tolerate having multiple cache files. `state.cache` is only ever written if something changed, and all that happens now is that `$OPAMROOT/repo/*.cache` is erased prior to writing the new cache (since other opam-state / opam binaries actually must regenerate the file).

As the cache files are all reset at `opam update`, even developers shouldn't see too many of them accumulating.

Fixes #4554. It can't directly be backported to 2.0.9, because 2.0.8 and earlier don't delete *.cache on a write. The "algorithm" could be adapted where opam 2.0.9 always erases its own cache of `state.cache` is newer, but I'm not convinced this is worth it. opam 2.1 does not require this kind of change, because even if opam 2.0.9 can _read_ an opam root, it's never going to write to it, so the cache can't be invalidated.