### PR TITLE
Bump lib-ext mccs to 1.1+13 [2.0]

### DIFF
--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -33,8 +33,8 @@ MD5_dose3 = e7d4b1840383c6732f29a47c08ba5650
 
 $(call PKG_SAME,dose3)
 
-URL_mccs = https://github.com/AltGr/ocaml-mccs/archive/1.1+11.tar.gz
-MD5_mccs = 9c0038d0e945f742b9320a662566288b
+URL_mccs = https://github.com/AltGr/ocaml-mccs/archive/1.1+13.tar.gz
+MD5_mccs = 13504d3b5dcbf0bdc6d95a62de20af4a
 
 $(call PKG_SAME,mccs)
 


### PR DESCRIPTION
GLPK 4.63 doesn't appear to build on Fedora 34.