### PR TITLE
Clearer warnings and messages about --cli / OPAMCLI

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -13,6 +13,7 @@ New option/command/subcommand are prefixed with ◈.
   * Deprecated `build-doc`, `build-test`, `make` [#4581 @rjbou]
   * Add cli versioning for enums of flags with predefined enums [#4606 @rjbou]
   * Ensure the symlink for a plugin is maintained on each invocation [#4621 @dra27 - partially fixes #4619]
+  * Clearer messages about using --cli and OPAMCLI [#4655 @dra27]
 
 ## Init
   * Introduce a `default-invariant` config field, restore the 2.0 semantics for

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1109,9 +1109,9 @@ let global_options cli =
       "Use the command-line interface syntax and semantics of $(docv). \
        Intended for any persistent use of opam (scripts, blog posts, etc.), \
        any version of opam in the same MAJOR series will behave as for the \
-       specified MINOR release. The flag was not available in opam 2.0, so for \
-       2.0, use $(b,\\$OPAMCLI). This is equivalent to setting $(b,\\$OPAMCLI) \
-       to $(i,MAJOR.MINOR)."
+       specified MINOR release. The flag was not available in opam 2.0, so to \
+       select the 2.0 CLI, set the $(b,OPAMCLI) environment variable to \
+       $(i,2.0) instead of using this parameter."
       Arg.string (OpamCLIVersion.to_string OpamCLIVersion.current) in
   let switch =
     mk_opt ~cli cli_original ~section ["switch"]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -321,16 +321,16 @@ let help_sections cli =
           "Although opam only supports roots ($(i,~%s.opam%s)) for the current \
            version, it does provide backwards compatibility for its \
            command-line interface." dir_sep dir_sep);
-    `P "The command-line version is selected by using the `--cli' option or \
-        the $(i,OPAMCLI) environment variable. `--cli' may be specified more\
-        than once, where the last instance takes precedence. $(i,OPAMCLI) is \
-        only inspected if `--cli' is not given.";
     `P "Since CLI version support was only added in opam 2.1, use $(i,OPAMCLI) \
         to select 2.0 support (as opam 2.0 will just ignore it), \
         and `--cli=2.1' for 2.1 later versions, since an environment variable \
         controlling the parsing of syntax is brittle. To this end, opam \
         displays a warning if $(i,OPAMCLI) specifies a valid version other \
         than 2.0, and also if `--cli=2.0' is specified.";
+    `P "The command-line version is selected by using the `--cli' option or \
+        the $(i,OPAMCLI) environment variable. `--cli' may be specified more\
+        than once, where the last instance takes precedence. $(i,OPAMCLI) is \
+        only inspected if `--cli' is not given.";
 
     `S Manpage.s_exit_status;
     `P "As an exception to the following, the `exec' command returns 127 if the \

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -323,7 +323,7 @@ let help_sections cli =
            command-line interface." dir_sep dir_sep);
     `P "Since CLI version support was only added in opam 2.1, use $(i,OPAMCLI) \
         to select 2.0 support (as opam 2.0 will just ignore it), \
-        and `--cli=2.1' for 2.1 later versions, since an environment variable \
+        and `--cli=2.1' for 2.1 (or later) versions, since an environment variable \
         controlling the parsing of syntax is brittle. To this end, opam \
         displays a warning if $(i,OPAMCLI) specifies a valid version other \
         than 2.0, and also if `--cli=2.0' is specified.";

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -110,9 +110,11 @@ let check_and_run_external_commands () =
             if OpamCLIVersion.is_supported cli then
               let () =
                 if OpamCLIVersion.(cli >= (2, 1)) then
+                  let flag = "--cli=" ^ OpamCLIVersion.(to_string cli) in
                   OpamConsole.warning
-                    "Setting OPAMCLI is brittle - consider using the \
-                     '--cli <major>.<minor>' flag."
+                    "OPAMCLI should only ever be set to %s - use '%s' instead."
+                      (OpamConsole.colorise `bold "2.0")
+                      (OpamConsole.colorise `bold flag)
               in
               ocli
             else

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -99,9 +99,9 @@ let check_and_run_external_commands () =
           if OpamCLIVersion.(cli < (2, 1)) then begin
             let cli = OpamCLIVersion.to_string cli in
             OpamConsole.warning
-              "--cli is not supported by opam %s; setting OPAMCLI=%s \
-               is more portable"
-              cli cli
+              "%s cannot be understood by opam %s; set %s to %s instead."
+              (OpamConsole.colorise `bold ("--cli=" ^ cli)) cli
+              (OpamConsole.colorise `bold "OPAMCLI") (OpamConsole.colorise `bold cli)
           end;
           ocli
         | None ->


### PR DESCRIPTION
- Swap the two paragraphs in the explanation of CLI versioning - i.e. tell the user _what_ to do first and then _why_ to do it second
- More specific message in the help for `--cli` about `OPAMCLI` - they're not entirely equivalent, so we don't claim it.
- Bossier message when `OPAMCLI` is set to anything other than `2.0`: e.g. "`OPAMCLI` should only ever be set to `2.0` - use '`--cli=2.1`' instead."
- Bossier (and clearer) message when `--cli=2.0` is given: "`--cli=2.0` cannot be understood by opam 2.0; set `OPAMCLI` to `2.0` instead"

cc @avsm