### PR TITLE
Speedup installation when the package has no conflict

### DIFF
--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -1413,11 +1413,7 @@ let actions_of_diff (install, remove) =
 
 let resolve ~extern ~version_map universe request =
   log "resolve request=%a" (slog string_of_request) request;
-  let resp =
-    match check_request ~version_map universe request with
-    | Success _ when extern -> get_final_universe ~version_map universe request
-    | resp -> resp
-  in
+  let resp = get_final_universe ~version_map universe request in
   let cleanup univ =
     Cudf.remove_package univ opam_invariant_package
   in


### PR DESCRIPTION
e.g. when calling `opam install utop` on a 4.12 switch, opam spends 4s in Dose3 before calling the actual solver

Partly fixes an issue detected by @talex5 in https://github.com/ocurrent/docker-base-images/pull/102#issuecomment-837221525