### PR TITLE
Scrub OPAM* for variables added since 2.0

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -31,6 +31,7 @@ New option/command/subcommand are prefixed with ◈.
   * With `--deps-only`, set dependencies as root packages [#4964 @rjbou - fix #4502]
   * Keep global lock only if root format upgrade is performed [#4612 @rjbou - fix #4597]
   * Improve installation times by only tracking files listed in `.install` instead of the whole switch prefix when there are no `install:` instructions (and no preinstall commands) [#4494 @kit-ty-kate @rjbou - fix #4422]
+  * Scrub OPAM* environment variables added since 2.0 from package builds to prevent warnings when a package calls opam [#4663 @dra27 - fix #4660]
 
 ## Remove
   *

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -482,6 +482,7 @@ let prepare_package_source st nv dir =
 
 let compilation_env t opam =
   let open OpamParserTypes in
+  let scrub = OpamClientConfig.(!r.scrubbed_environment_variables) in
   OpamEnv.get_full ~set_opamroot:true ~set_opamswitch:true ~force_path:true t ~updates:([
       "CDPATH", Eq, "", Some "shell env sanitization";
       "MAKEFLAGS", Eq, "", Some "make env sanitization";

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -287,9 +287,17 @@ let environment_variables =
     ] in
   core @ format @ solver @ repository @ state @ client
 
+let scrubbed_environment_variables =
+  let f (name, validity, _, _) =
+    if is_original_cli validity then
+      None
+    else
+      Some ("OPAM" ^ name)
+  in
+    OpamStd.List.filter_map f environment_variables
+
 let doc_opam_envvariables, init_opam_envvariabes =
   env_with_cli environment_variables
-
 
 (** Help sections common to all commands *)
 
@@ -604,6 +612,7 @@ let apply_build_options b =
     ?fake:(flag b.fake)
     ?skip_dev_update:(flag b.skip_update)
     ?assume_depexts:(flag (b.assume_depexts || b.no_depexts))
+    ~scrubbed_environment_variables
     ()
 
 

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -343,3 +343,4 @@ val help_sections: OpamCLIVersion.Sourced.t -> Manpage.block list
 
 val preinit_opam_envvariables: unit -> unit
 val init_opam_envvariabes: OpamCLIVersion.Sourced.t -> unit
+val scrubbed_environment_variables: string list

--- a/src/client/opamArgTools.ml
+++ b/src/client/opamArgTools.ml
@@ -34,6 +34,9 @@ let contented_validity (validity:validity) content : 'a contented_validity =
   | None -> { validity with content = `Valid content}
   | Some _ -> { validity with content = `Removed content}
 
+let is_original_cli validity =
+  OpamCLIVersion.compare validity.valid cli2_0 = 0
+
 let cli_from valid = { valid ; removed = None; content = (); default = false }
 let cli_between since ?(default=false) ?replaced removal =
   if since >= removal then

--- a/src/client/opamArgTools.mli
+++ b/src/client/opamArgTools.mli
@@ -100,3 +100,5 @@ val env_with_cli:
   (string * validity * (string -> OpamStd.Config.E.t) * string) list ->
   (OpamCLIVersion.Sourced.t -> Manpage.block list) *
   (OpamCLIVersion.Sourced.t -> unit)
+
+val is_original_cli: validity -> bool

--- a/src/client/opamCLIVersion.ml
+++ b/src/client/opamCLIVersion.ml
@@ -43,6 +43,7 @@ let of_json = function
 
 let ( >= ) = Stdlib.( >= )
 let ( < ) = Stdlib.( < )
+let compare = Stdlib.compare
 
 let previous cli =
   let f previous version =

--- a/src/client/opamCLIVersion.mli
+++ b/src/client/opamCLIVersion.mli
@@ -32,6 +32,8 @@ val ( >= ) : t -> int * int -> bool
 (** Comparison [<] with [(major, minor)] *)
 val ( < ) : t -> int * int -> bool
 
+val compare : t -> t -> int
+
 (** Returns previous supported version.
     @raise Not_found if there isn't one. *)
 val previous: t -> t

--- a/src/client/opamClientConfig.ml
+++ b/src/client/opamClientConfig.ml
@@ -75,6 +75,7 @@ type t = {
   no_auto_upgrade: bool;
   assume_depexts: bool;
   cli: OpamCLIVersion.t;
+  scrubbed_environment_variables: string list;
 }
 
 let default = {
@@ -96,6 +97,7 @@ let default = {
   no_auto_upgrade = false;
   assume_depexts = false;
   cli = OpamCLIVersion.current;
+  scrubbed_environment_variables = [];
 }
 
 type 'a options_fun =
@@ -117,6 +119,7 @@ type 'a options_fun =
   ?no_auto_upgrade:bool ->
   ?assume_depexts:bool ->
   ?cli:OpamCLIVersion.t ->
+  ?scrubbed_environment_variables:string list ->
   'a
 
 let setk k t
@@ -138,6 +141,7 @@ let setk k t
     ?no_auto_upgrade
     ?assume_depexts
     ?cli
+    ?scrubbed_environment_variables
   =
   let (+) x opt = match opt with Some x -> x | None -> x in
   k {
@@ -159,6 +163,7 @@ let setk k t
     no_auto_upgrade = t.no_auto_upgrade + no_auto_upgrade;
     assume_depexts = t.assume_depexts + assume_depexts;
     cli = t.cli + cli;
+    scrubbed_environment_variables = t.scrubbed_environment_variables + scrubbed_environment_variables
   }
 
 let set t = setk (fun x () -> x) t
@@ -192,6 +197,7 @@ let initk k =
     ?no_auto_upgrade:(E.noautoupgrade ())
     ?assume_depexts:(E.assumedepexts ())
     ?cli:None
+    ?scrubbed_environment_variables:None
 
 let init ?noop:_ = initk (fun () -> ())
 

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -58,6 +58,7 @@ type t = private {
   no_auto_upgrade: bool;
   assume_depexts: bool;
   cli: OpamCLIVersion.t;
+  scrubbed_environment_variables: string list;
 }
 
 type 'a options_fun =
@@ -80,6 +81,7 @@ type 'a options_fun =
   ?no_auto_upgrade:bool ->
   ?assume_depexts:bool ->
   ?cli:OpamCLIVersion.t ->
+  ?scrubbed_environment_variables:string list ->
   'a
   (* constraint 'a = 'b -> 'c *)
 
@@ -117,6 +119,7 @@ val opam_init:
   ?no_auto_upgrade:bool ->
   ?assume_depexts:bool ->
   ?cli:OpamCLIVersion.t ->
+  ?scrubbed_environment_variables:string list ->
   ?current_switch:OpamSwitch.t ->
   ?switch_from:OpamStateTypes.provenance ->
   ?jobs:int Lazy.t ->

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -276,9 +276,20 @@ let get_opam_raw ~set_opamroot ~set_opamswitch ?(base=[])
      upd)
 
 let get_full
-    ~set_opamroot ~set_opamswitch ~force_path ?updates:(u=[])
+    ~set_opamroot ~set_opamswitch ~force_path ?updates:(u=[]) ?(scrub=[])
     st =
-  let env0 = List.map (fun (v,va) -> v,va,None) (OpamStd.Env.list ()) in
+  let env =
+    let env = OpamStd.Env.list () in
+    let map =
+      if Sys.win32 then
+        String.uppercase_ascii
+      else
+        (fun x -> x)
+    in
+    let scrub = List.rev_map map scrub |> OpamStd.String.Set.of_list in
+    List.filter (fun (name, _) -> not (OpamStd.String.Set.mem (map name) scrub)) env
+  in
+  let env0 = List.map (fun (v,va) -> v,va,None) env in
   let updates = u @ updates ~set_opamroot ~set_opamswitch ~force_path st in
   add env0 updates
 

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -19,10 +19,11 @@ open OpamStateTypes
 (** Get the current environment with OPAM specific additions. If [force_path],
     the PATH is modified to ensure opam dirs are leading. [set_opamroot] and
     [set_opamswitch] can be additionally used to set the [OPAMROOT] and
-    [OPAMSWITCH] variables. *)
+    [OPAMSWITCH] variables. [scrub] is a list of environment variables to
+    remove from the environment. *)
 val get_full:
   set_opamroot:bool -> set_opamswitch:bool -> force_path:bool ->
-  ?updates:env_update list -> 'a switch_state -> env
+  ?updates:env_update list -> ?scrub:string list -> 'a switch_state -> env
 
 (** Get only environment modified by OPAM. If [force_path], the PATH is modified
     to ensure opam dirs are leading. [set_opamroot] and [set_opamswitch] can be


### PR DESCRIPTION
Packages build with OPAMCLI=2.0. If the user sets an opam 2.1-specific environment variable, this is passed through to the package and will cause a warning to be displayed in the build log if the package calls opam.

All new environment variables are now scrubbed from the build environment.