### PR TITLE
Fix opam-devel.install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ endif
 
 opam-devel.install: $(DUNE_DEP)
 	$(DUNE) build $(DUNE_ARGS) -p opam opam.install
-	sed -e "s/bin:/libexec:/" opam.install > $@
+	sed -e "/lib\/opam\/opam/d" -e "s/bin:/libexec:/" opam.install > $@
 
 opam-%.install: $(DUNE_DEP)
 	$(DUNE) build $(DUNE_ARGS) -p opam-$* $@

--- a/master_changes.md
+++ b/master_changes.md
@@ -104,6 +104,7 @@ New option/command/subcommand are prefixed with ◈.
   * Cold compiler updated to 4.12 [#4616 @dra27]
   * Fix build from source when a dune-project file is presented in the parent directory [#4545 @kit-ty-kate]
   * Fix build from source when a dune-project file is presented in the parent directory [#4545 @kit-ty-kate - fix #4537]
+  * Fix opam-devel.install not to install two files called opam [#4664 @dra27]
 
 ## Infrastructure
   * Release scripts: switch to OCaml 4.10.2 by default, add macos/arm64 builds by default [#4559 @AltGr]


### PR DESCRIPTION
Both the libexec and lib sections install a file called `opam` which of course installs to the same place.

This _doesn't_ fix #4657, the original `opam-devel.install` has merely exposed a bug.