### PR TITLE
Fix installation order when processing .install files

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -38,6 +38,7 @@ New option/command/subcommand are prefixed with ◈.
   * Scrub OPAM* environment variables added since 2.0 from package builds to prevent warnings when a package calls opam [#4663 @dra27 - fix #4660]
   * Correct the message when more than one depext is missing [#4678 @dra27]
   * Only display one conflict message when they are all owing to identical missing depexts [#4678 @dra27]
+  * Improve installation times by only tracking files listed in `.install` instead of the whole switch prefix when there are no `install:` instructions (and no preinstall commands) [#4494 @kit-ty-kate @rjbou; #4667 @dra27 - fix #4422]
 
 ## Remove
   *

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -82,8 +82,8 @@ let preprocess_dot_install_t st nv build_dir =
       in
       [dir, inst]
     in
-    dir_and_install @
-    List.map (fun (base, dst) ->
+    dir_and_install @ List.rev @@
+    List.rev_map (fun (base, dst) ->
         let (base, append) =
           if exec &&
              not (OpamFilename.exists (OpamFilename.create build_dir base.c))
@@ -158,7 +158,10 @@ let preprocess_dot_install_t st nv build_dir =
   ]
   in
 
-  let to_install = List.map install_files to_install in
+  let files_and_installs =
+    List.fold_left (fun acc toi -> List.rev_append (install_files toi) acc)
+      files_and_installs to_install
+  in
 
   (* misc *)
   let misc_files =
@@ -179,7 +182,8 @@ let preprocess_dot_install_t st nv build_dir =
         in
         (file, inst)) (I.misc install)
   in
-  List.flatten ((files_and_installs :: to_install) @ [misc_files])
+
+  List.rev_append files_and_installs misc_files
 
 (* Returns function to install package files from [.install] *)
 let preprocess_dot_install st nv build_dir =

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -27,8 +27,6 @@ let preprocess_dot_install_t st nv build_dir =
   let switch_prefix = OpamPath.Switch.root root st.switch in
   let file_wo_prefix f = OpamFilename.remove_prefix switch_prefix f in
 
-  let files_and_installs = [] in
-
   let name = nv.name in
   let install_f = OpamPath.Builddir.install build_dir nv in
   let install = OpamFile.Dot_install.safe_read install_f in
@@ -53,8 +51,8 @@ let preprocess_dot_install_t st nv build_dir =
          let dot_config = OpamPath.Switch.config root st.switch name in
          OpamFile.Dot_config.write dot_config config; None
        in
-       (file, inst) :: files_and_installs
-     | None -> files_and_installs)
+       [(file, inst)]
+     | None -> [])
   in
 
   let check ~src ~dst base =
@@ -71,7 +69,7 @@ let preprocess_dot_install_t st nv build_dir =
   in
 
   (* Install a list of files *)
-  let install_files exec dst_fn files_fn =
+  let install_files (exec, dst_fn, files_fn) =
     let dst_dir = dst_fn root st.switch name in
     let files = files_fn install in
     let dir_and_install =
@@ -160,15 +158,11 @@ let preprocess_dot_install_t st nv build_dir =
   ]
   in
 
-  let files_and_installs =
-    List.fold_left (fun files_and_installs (exec, dst_fn, files_fn) ->
-        install_files exec dst_fn files_fn @ files_and_installs)
-      files_and_installs to_install
-  in
+  let to_install = List.map install_files to_install in
 
   (* misc *)
-  let files_and_installs =
-    List.fold_left (fun files_and_installs (src, dst) ->
+  let misc_files =
+    List.map (fun (src, dst) ->
         let file = file_wo_prefix dst in
         let inst warning =
           let src_file = OpamFilename.create (OpamFilename.cwd ()) src.c in
@@ -183,10 +177,9 @@ let preprocess_dot_install_t st nv build_dir =
           end;
           None
         in
-        (file, inst) :: files_and_installs)
-      files_and_installs (I.misc install)
+        (file, inst)) (I.misc install)
   in
-  files_and_installs
+  List.flatten ((files_and_installs :: to_install) @ [misc_files])
 
 (* Returns function to install package files from [.install] *)
 let preprocess_dot_install st nv build_dir =

--- a/tests/reftests/dot-install.test
+++ b/tests/reftests/dot-install.test
@@ -61,15 +61,45 @@ dev-repo: "git://nodo.t"
 install: [ "echo" "hellow" ]
 ### <dotty/nodot.install>
 share: [ "file" ]
+### <dotty/lot-of-files.opam>
+opam-version: "2.0"
+synopsis: "One-line description"
+description: """
+Longer description
+"""
+maintainer: "Name <email>"
+authors: "Name <email>"
+license: "MIT"
+homepage: " "
+bug-reports: " "
+dev-repo: "git://nodo.t"
+install: [ "echo" "hellow" ]
+substs: "lot-of-files.install"
+### <dotty/lot-of-files.install.in>
+lib: [ "file" "fichier" "dosiero" ]
+bin: [ "fichier" ]
+etc: [ "dosiero" "file" ]
+share: [ "fichier" "dosiero" ]
+misc: [ "file" {"%{root}%/dosiero"} ]
+### <dotty/lot-of-files.config>
+opam-version: "2.0"
+variables { lot: true }
+### <dotty/fichier>
+bonjour
+### <dotty/dosiero>
+saluton
+### OPAMYES=1
 ### opam switch create inst --empty
-### opam pin ./dotty -yn
-This will pin the following packages: dot, nodot. Continue? [Y/n] y
+### opam pin ./dotty -n
+This will pin the following packages: dot, lot-of-files, nodot. Continue? [Y/n] y
 Package dot does not exist, create as a NEW package? [Y/n] y
 dot is now pinned to file://${BASEDIR}/dotty (version ~dev)
+Package lot-of-files does not exist, create as a NEW package? [Y/n] y
+lot-of-files is now pinned to file://${BASEDIR}/dotty (version ~dev)
 Package nodot does not exist, create as a NEW package? [Y/n] y
 nodot is now pinned to file://${BASEDIR}/dotty (version ~dev)
 ### OPAMPRECISETRACKING=1 OPAMDEBUGSECTIONS="TRACK ACTION" OPAMDEBUG=-1
-### opam install nodot -y
+### opam install nodot
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 [nodot.~dev] synchronised (no changes)
@@ -96,7 +126,7 @@ added: [
   "share-nodot" {"D"}
   "share-nodot-file" {"F:12fc204edeae5b57713c5ad7dcb97d39"}
 ]
-### opam install dot -y
+### opam install dot
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 [dot.~dev] synchronised (no changes)
@@ -122,3 +152,24 @@ added: [
   "share-dot" {"D"}
   "share-dot-file" {"F:12fc204edeae5b57713c5ad7dcb97d39"}
 ]
+### OPAMDEBUGSECTIONS="SYSTEM FILE(.config)" OPAMDEBUG=-1
+### : check install files ordering :
+### opam install lot-of-files | grep "mkdir\|install\|FILE"
+  - install lot-of-files ~dev*
+SYSTEM                          mkdir ${BASEDIR}/OPAM/inst/.opam-switch/sources/lot-of-files
+FILE(.config)                   Wrote ${BASEDIR}/OPAM/inst/.opam-switch/config/lot-of-files.config in 0.000s
+SYSTEM                          install ${BASEDIR}/OPAM/inst/.opam-switch/build/lot-of-files.~dev/fichier -> ${BASEDIR}/OPAM/inst/bin/fichier (755)
+SYSTEM                          mkdir ${BASEDIR}/OPAM/inst/lib/lot-of-files
+SYSTEM                          install ${BASEDIR}/OPAM/inst/.opam-switch/build/lot-of-files.~dev/file -> ${BASEDIR}/OPAM/inst/lib/lot-of-files/file (644)
+SYSTEM                          install ${BASEDIR}/OPAM/inst/.opam-switch/build/lot-of-files.~dev/fichier -> ${BASEDIR}/OPAM/inst/lib/lot-of-files/fichier (644)
+SYSTEM                          install ${BASEDIR}/OPAM/inst/.opam-switch/build/lot-of-files.~dev/dosiero -> ${BASEDIR}/OPAM/inst/lib/lot-of-files/dosiero (644)
+SYSTEM                          mkdir ${BASEDIR}/OPAM/inst/share/lot-of-files
+SYSTEM                          install ${BASEDIR}/OPAM/inst/.opam-switch/build/lot-of-files.~dev/fichier -> ${BASEDIR}/OPAM/inst/share/lot-of-files/fichier (644)
+SYSTEM                          install ${BASEDIR}/OPAM/inst/.opam-switch/build/lot-of-files.~dev/dosiero -> ${BASEDIR}/OPAM/inst/share/lot-of-files/dosiero (644)
+SYSTEM                          mkdir ${BASEDIR}/OPAM/inst/etc
+SYSTEM                          mkdir ${BASEDIR}/OPAM/inst/etc/lot-of-files
+SYSTEM                          install ${BASEDIR}/OPAM/inst/.opam-switch/build/lot-of-files.~dev/dosiero -> ${BASEDIR}/OPAM/inst/etc/lot-of-files/dosiero (644)
+SYSTEM                          install ${BASEDIR}/OPAM/inst/.opam-switch/build/lot-of-files.~dev/file -> ${BASEDIR}/OPAM/inst/etc/lot-of-files/file (644)
+SYSTEM                          install ${BASEDIR}/OPAM/inst/.opam-switch/build/lot-of-files.~dev/file -> ${BASEDIR}/OPAM/dosiero (644)
+-> installed lot-of-files.~dev
+SYSTEM                          mkdir ${BASEDIR}/OPAM/inst/.opam-switch/packages/lot-of-files.~dev


### PR DESCRIPTION
#4657 exposed no fewer than 3 bugs! 🐛

- `OpamSystem.install` doesn't the file permissions correctly if the file already exists (since `open_out_gen` only uses the mode if it actually creates the file). The first commit here fixes that and also the case of a symlink being overwritten which is handled by `OpamSystem.copy_file` but wasn't being handled by `OpamSystem.install`.
- `opam-devel.install` installs a file called `opam` twice to `lib/opam-devel` (fixed in #4664)
- The updates in #4494 changed the order in which sections were processed - the second commit here reverses (excuse pun!) that slip

NB `List.flatten` blows the stack w.r.t. the number of lists (which is fundamentally small) and the length of the longest sub-list - this would already blow the stack in an earlier `List.map` call, so I convinced myself that a crazy opam .install file with gazillions of entries is already exploding.