### PR TITLE
Make sure that OPAMROOT and OPAMSWITCH are properly set when executing build commands

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -14,6 +14,8 @@ New option/command/subcommand are prefixed with ◈.
   * Add cli versioning for enums of flags with predefined enums [#4606 @rjbou]
   * Ensure the symlink for a plugin is maintained on each invocation [#4621 @dra27 - partially fixes #4619]
   * Clearer messages about using --cli and OPAMCLI [#4655 @dra27]
+  * The options `--root` and `--switch` are now reflected in environment variables when building packages
+    so that calls to `opam` during build access the correct root and switch [#4668 @LasseBlaauwbroek]
 
 ## Init
   * Introduce a `default-invariant` config field, restore the 2.0 semantics for

--- a/master_changes.md
+++ b/master_changes.md
@@ -159,7 +159,8 @@ New option/command/subcommand are prefixed with ◈.
   * GHA: Ignore opam-rt pin depends, opam libs are already pinned locally [#4610 @AltGr @rjbou]
   * GHA: The bootstrap cache also depends on the precise version! [#4618 @dra27]
   * GHA: fix opam-rt specific PR branch use [#4606 @rjbou]
-  * Add switch creation tests: (dead)locking and switch defitinion at action time [#4612 @rjbou]
+  * Add switch creation tests: (dead)locking and switch definition at action time [#4612 @rjbou]
+    * updated with undefined switch values in opam inner calls (undefined for switch creation or not propagated) [#4668 @rjbou]
   * Remove debug information from reftest [#4612 @rjbou]
   * Add preserved format test [#4634 @rjbou]
 

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -482,7 +482,7 @@ let prepare_package_source st nv dir =
 
 let compilation_env t opam =
   let open OpamParserTypes in
-  OpamEnv.get_full ~force_path:true t ~updates:([
+  OpamEnv.get_full ~set_opamroot:true ~set_opamswitch:true ~force_path:true t ~updates:([
       "CDPATH", Eq, "", Some "shell env sanitization";
       "MAKEFLAGS", Eq, "", Some "make env sanitization";
       "MAKELEVEL", Eq, "", Some "make env sanitization";

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -231,7 +231,7 @@ let expand gt str =
     (OpamFilter.expand_string ~default:(fun _ -> "")
        (OpamPackageVar.resolve st) str)
 
-let exec gt ?set_opamroot ?set_opamswitch ~inplace_path command =
+let exec gt ~set_opamroot ~set_opamswitch ~inplace_path command =
   log "config-exec command=%a" (slog (String.concat " ")) command;
   let switch = OpamStateConfig.get_switch () in
   let st_lazy = lazy (
@@ -243,11 +243,11 @@ let exec gt ?set_opamroot ?set_opamswitch ~inplace_path command =
     if OpamFile.exists env_file then
       let base = List.map (fun (v,va) -> v,va,None) (OpamStd.Env.list ()) in
       OpamEnv.get_opam_raw ~base
-        ?set_opamroot ?set_opamswitch ~force_path:(not inplace_path)
+        ~set_opamroot ~set_opamswitch ~force_path:(not inplace_path)
         gt.root switch
     else
-      OpamEnv.get_full
-        ?set_opamroot ?set_opamswitch ~force_path:(not inplace_path)
+      OpamEnv.get_full ~set_opamroot ~set_opamswitch
+        ~force_path:(not inplace_path)
         (Lazy.force st_lazy)
   in
   let env = OpamTypesBase.env_array env in

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -46,7 +46,7 @@ val expand: 'a global_state -> string -> unit
 (** Execute a command in a subshell, after variable expansion *)
 val exec:
   [< unlocked ] global_state ->
-  ?set_opamroot:bool -> ?set_opamswitch:bool -> inplace_path:bool ->
+  set_opamroot:bool -> set_opamswitch:bool -> inplace_path:bool ->
   string list -> unit
 
 (** {2 Variables and options display and setting } *)

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -954,7 +954,7 @@ let confirmation ?ask requested solution =
     || OpamConsole.confirm "Do you want to continue?"
 
 let run_hook_job t name ?(local=[]) ?(allow_stdout=false) w =
-  let shell_env = OpamEnv.get_full ~force_path:true t in
+  let shell_env = OpamEnv.get_full ~set_opamroot:true ~set_opamswitch:true ~force_path:true t in
   let mk_cmd = function
     | cmd :: args ->
       let text = OpamProcess.make_command_text name ~args cmd in

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -235,7 +235,7 @@ let updates_common ~set_opamroot ~set_opamswitch root switch =
     else [] in
   root @ switch
 
-let updates ?(set_opamroot=false) ?(set_opamswitch=false) ?force_path st =
+let updates ~set_opamroot ~set_opamswitch ?force_path st =
   updates_common ~set_opamroot ~set_opamswitch st.switch_global.root st.switch @
   compute_updates ?force_path st
 
@@ -243,10 +243,10 @@ let get_pure ?(updates=[]) () =
   let env = List.map (fun (v,va) -> v,va,None) (OpamStd.Env.list ()) in
   add env updates
 
-let get_opam ?(set_opamroot=false) ?(set_opamswitch=false) ~force_path st =
+let get_opam ~set_opamroot ~set_opamswitch ~force_path st =
   add [] (updates ~set_opamroot ~set_opamswitch ~force_path st)
 
-let get_opam_raw ?(set_opamroot=false) ?(set_opamswitch=false) ?(base=[])
+let get_opam_raw ~set_opamroot ~set_opamswitch ?(base=[])
     ~force_path
     root switch =
   let env_file = OpamPath.Switch.environment root switch in
@@ -276,7 +276,7 @@ let get_opam_raw ?(set_opamroot=false) ?(set_opamswitch=false) ?(base=[])
      upd)
 
 let get_full
-    ?(set_opamroot=false) ?(set_opamswitch=false) ~force_path ?updates:(u=[])
+    ~set_opamroot ~set_opamswitch ~force_path ?updates:(u=[])
     st =
   let env0 = List.map (fun (v,va) -> v,va,None) (OpamStd.Env.list ()) in
   let updates = u @ updates ~set_opamroot ~set_opamswitch ~force_path st in

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -21,7 +21,7 @@ open OpamStateTypes
     [set_opamswitch] can be additionally used to set the [OPAMROOT] and
     [OPAMSWITCH] variables. *)
 val get_full:
-  ?set_opamroot:bool -> ?set_opamswitch:bool -> force_path:bool ->
+  set_opamroot:bool -> set_opamswitch:bool -> force_path:bool ->
   ?updates:env_update list -> 'a switch_state -> env
 
 (** Get only environment modified by OPAM. If [force_path], the PATH is modified
@@ -30,7 +30,7 @@ val get_full:
 
     With [base], apply the modifications to the specified base environment *)
 val get_opam:
-  ?set_opamroot:bool -> ?set_opamswitch:bool -> force_path:bool ->
+  set_opamroot:bool -> set_opamswitch:bool -> force_path:bool ->
   'a switch_state -> env
 
 (** Like [get_opam], but reads the cache file from the given opam root and
@@ -38,7 +38,7 @@ val get_opam:
 
     With [base], apply the modifications to the specified base environment *)
 val get_opam_raw:
-  ?set_opamroot:bool -> ?set_opamswitch:bool -> ?base:env ->
+  set_opamroot:bool -> set_opamswitch:bool -> ?base:env ->
   force_path:bool ->
   dirname -> switch -> env
 
@@ -54,7 +54,7 @@ val add: env -> env_update list -> env
 (** Like [get_opam] computes environment modification by OPAM , but returns
     these [updates] instead of the new environment. *)
 val updates:
-  ?set_opamroot:bool -> ?set_opamswitch:bool -> ?force_path:bool ->
+  set_opamroot:bool -> set_opamswitch:bool -> ?force_path:bool ->
   'a switch_state -> env_update list
 
 (** Check if the shell environment is in sync with the current OPAM switch,

--- a/tests/reftests/switch-creation.test
+++ b/tests/reftests/switch-creation.test
@@ -17,12 +17,17 @@ install: ["cp" "pref" "%{lib}%/prefix"]
 opam var prefix --safe > pref
 ### opam repository add sw-lock ./sw-lock --set-default
 [sw-lock] Initialised
-### # switch undefined for opam calls in build, on build creation
-### opam switch create undef-prefix baz | grep ERROR | unordered
-[ERROR] The compilation of baz.1 failed at "sh ./prefix".
-#=== ERROR while compiling baz.1 ==============================================#
-# [ERROR] No switch is currently set. Please use 'opam switch' to set or install a switch
-# Return code 31 #
+### # switch not undefined for opam calls in build, on build creation
+### opam switch create undef-prefix baz
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["baz"]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed baz.1
+Done.
+### cat $OPAMROOT/undef-prefix/lib/prefix
+${BASEDIR}/OPAM/undef-prefix
 ### # No deadlock on concurent opam calls in build
 ### opam switch create nohang foo bar | unordered
 
@@ -44,4 +49,4 @@ The following actions will be performed:
 -> installed baz.1
 Done.
 ### cat $OPAMROOT/undef-switch/lib/prefix
-${BASEDIR}/OPAM/nohang
+${BASEDIR}/OPAM/undef-switch

--- a/tests/reftests/switch-creation.test
+++ b/tests/reftests/switch-creation.test
@@ -11,14 +11,19 @@ build: ["opam" "option" "jobs" "--safe" "--cli=2.1"]
 ### <sw-lock/packages/baz/baz.1/opam>
 opam-version: "2.0"
 flags: compiler
-build: ["opam" "var" "prefix" "--safe"]
+build: ["sh" "./prefix"]
+install: ["cp" "pref" "%{lib}%/prefix"]
+### <sw-lock/packages/baz/baz.1/files/prefix>
+opam var prefix --safe > pref
 ### opam repository add sw-lock ./sw-lock --set-default
 [sw-lock] Initialised
+### # switch undefined for opam calls in build, on build creation
 ### opam switch create undef-prefix baz | grep ERROR | unordered
-[ERROR] The compilation of baz.1 failed at "opam var prefix --safe".
+[ERROR] The compilation of baz.1 failed at "sh ./prefix".
 #=== ERROR while compiling baz.1 ==============================================#
 # [ERROR] No switch is currently set. Please use 'opam switch' to set or install a switch
 # Return code 31 #
+### # No deadlock on concurent opam calls in build
 ### opam switch create nohang foo bar | unordered
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
@@ -28,3 +33,15 @@ Switch invariant: ["foo" "bar"]
 -> installed bar.1
 -> installed foo.1
 Done.
+### # switch propagation to opam calls in build
+### opam switch create undef-switch --empty
+### opam switch nohang
+### opam install baz --sw undef-switch
+The following actions will be performed:
+  - install baz 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed baz.1
+Done.
+### cat $OPAMROOT/undef-switch/lib/prefix
+${BASEDIR}/OPAM/nohang


### PR DESCRIPTION
If one installs a package in a root or switch that is not currently active, and that package calls the `opam` binary during installation, it will not see the correct root/switch because the environment variables are not set.

Examples:

``` shell
opam install coq-tactician-stdlib --root=my-root
opam install coq-tactician-stdlib --switch=my-switch
```