### PR TITLE
Add support for non-interactive mode in macports

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -100,6 +100,7 @@ New option/command/subcommand are prefixed with ◈.
   * Handle some additional environment variables (`OPAMASSUMEDEPEXTS`, `OPAMNODEPEXTS`) [#4587 @AltGr]
   * Improve messages to hint that answering `no` doesn't abort installation [@AltGr]
   * Improve messages to hint that answering `no` doesn't abort installation [#4591 @AltGr]
+  * Add support for non-interactive mode in macports [#4676 @kit-ty-kate]
 
 ## Sandbox
   * Fix the conflict with the environment variable name used by dune [#4535 @smorimoto - fix ocaml/dune#4166]

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -556,7 +556,7 @@ let install_packages_commands_t sys_packages =
       List.map (fun p -> OpamStd.String.split p ' ')  packages
       |> List.flatten
     in
-    ["port", "install"::packages], (* NOTE: Does not have any interactive mode *)
+    ["port", yes ["-N"] ("install"::packages)],
     None
   | Netbsd -> ["pkgin", yes ["-y"] ("install" :: packages)], None
   | Openbsd -> ["pkg_add", yes ~no:["-i"] ["-I"] packages], None


### PR DESCRIPTION
The default behaviour as I understand it is that if only one package is being installed it will not prompt for anything (same behaviour as apt) but will prompt if dependencies are required