### PR TITLE
Display a message on CentOS if EPEL isn't enabled and depexts aren't available

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -102,11 +102,11 @@ New option/command/subcommand are prefixed with ◈.
   * Handle macport variants [#4509 @rjbou - fix #4297]
   * Always upgrade all the installed packages when installing a new package on Archlinux [#4556 @kit-ty-kate]
   * Handle some additional environment variables (`OPAMASSUMEDEPEXTS`, `OPAMNODEPEXTS`) [#4587 @AltGr]
-  * Improve messages to hint that answering `no` doesn't abort installation [@AltGr]
   * Improve messages to hint that answering `no` doesn't abort installation [#4591 @AltGr]
   * Add support for non-interactive mode in macports [#4676 @kit-ty-kate]
   * Handling of packages of tagged repositories for alpine [#4700 @rjbou - fix #4670]
   * Clarify some `assume-depexts` related messages [#4671 @AltGr - partial fix #4662]
+  * Warn the user if epel-release is missing and unavailable depexts are detected [#4679 @dra27 fix #4669]
 
 ## Sandbox
   * Fix the conflict with the environment variable name used by dune [#4535 @smorimoto - fix ocaml/dune#4166]

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -150,9 +150,11 @@ let check_availability ?permissive t set atoms =
       Some
         (Printf.sprintf
            "Package %s depends on the unavailable system package%s. You \
-            can use `--no-depexts' to attempt installation anyway."
+            can use `--no-depexts' to attempt installation anyway.%s"
            (OpamFormula.short_string_of_atom atom)
-           msg)
+           msg
+           (OpamStd.Option.map_default (Printf.sprintf "\n%s.") ""
+              (OpamSysInteract.repo_enablers ())))
     | None -> None
   in
   let check_atom (name, cstr as atom) =

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -718,8 +718,14 @@ module ChainSet = struct
   let length cs = fold (fun l acc -> min (List.length l) acc) cs max_int
 end
 
+type explanation =
+  [ `Conflict of string option * string list * bool
+  | `Missing of string option * string *
+                (OpamPackage.Name.t * OpamFormula.version_formula)
+                  OpamFormula.formula
+  ]
 
-let extract_explanations packages cudfnv2opam unav_reasons reasons =
+let extract_explanations packages cudfnv2opam reasons : explanation list =
   log "Conflict reporting";
   let open Algo.Diagnostic in
   let open Set.Op in
@@ -939,44 +945,15 @@ let extract_explanations packages cudfnv2opam unav_reasons reasons =
       ([], ct_chains) reasons
   in
 
-  let explanations =
-    let same_depexts sdeps fdeps =
-      List.for_all (function
-          | `Missing (_, sdeps', fdeps') -> sdeps = sdeps' && fdeps = fdeps'
-          | _ -> false)
-    in
-    match explanations with
-    | `Missing (_, sdeps, fdeps) :: rest when same_depexts sdeps fdeps rest ->
-      [`Missing (None, sdeps, fdeps)]
-    | _ -> explanations
+  let same_depexts sdeps fdeps =
+    List.for_all (function
+        | `Missing (_, sdeps', fdeps') -> sdeps = sdeps' && fdeps = fdeps'
+        | _ -> false)
   in
-
-  let format_explanation = function
-  | `Conflict (kind, packages, has_invariant) ->
-      let msg1 =
-        let format_package_name p =
-          Printf.sprintf "No agreement on the version of %s:" (OpamConsole.colorise `bold p)
-        in
-        OpamStd.Option.map_default format_package_name "Incompatible packages:" kind
-      and msg3 =
-        if has_invariant then
-          ["You can temporarily relax the switch invariant with \
-            `--update-invariant'"]
-        else
-          []
-      in
-        (msg1, packages, msg3)
-  | `Missing (csp, sdeps, fdeps) ->
-      let sdeps = OpamConsole.colorise' [`red;`bold] sdeps in
-      let msg1 = "Missing dependency:"
-      and msg2 =
-        OpamStd.Option.map_default (fun csp -> arrow_concat [csp; sdeps]) sdeps csp
-      and msg3 = OpamFormula.fold_right (fun a x -> unav_reasons x::a) [] fdeps
-      in
-        (msg1, [msg2], msg3)
-  in
-
-  List.rev_map format_explanation explanations
+  match explanations with
+  | `Missing (_, sdeps, fdeps) :: rest when same_depexts sdeps fdeps rest ->
+    [`Missing (None, sdeps, fdeps)]
+  | _ -> explanations
 
 let strings_of_cycles cycles =
   List.map arrow_concat cycles
@@ -989,19 +966,53 @@ let string_of_conflict ?(start_column=0) (msg1, msg2, msg3) =
   OpamStd.List.concat_map ~left:"\n" ~nil:"" "\n"
     (fun s -> OpamStd.Format.reformat ~indent:2 ~width s) msg3
 
+let conflict_explanations_raw packages = function
+  | univ, version_map, Conflict_dep reasons ->
+    let r = reasons () in
+    let cudfnv2opam = cudfnv2opam ~cudf_universe:univ ~version_map in
+    List.rev (extract_explanations packages cudfnv2opam r),
+    []
+  | _univ, _version_map, Conflict_cycle cycles ->
+    [], cycles
+
+let string_of_explanation unav_reasons = function
+  | `Conflict (kind, packages, has_invariant) ->
+    let msg1 =
+      let format_package_name p =
+        Printf.sprintf "No agreement on the version of %s:"
+          (OpamConsole.colorise `bold p)
+      in
+      OpamStd.Option.map_default format_package_name
+        "Incompatible packages:" kind
+    and msg3 =
+      if has_invariant then
+        ["You can temporarily relax the switch invariant with \
+          `--update-invariant'"]
+      else
+        []
+    in
+    (msg1, packages, msg3)
+  | `Missing (csp, sdeps, fdeps) ->
+    let sdeps = OpamConsole.colorise' [`red;`bold] sdeps in
+    let msg1 = "Missing dependency:"
+    and msg2 =
+      OpamStd.Option.map_default (fun csp -> arrow_concat [csp; sdeps]) sdeps csp
+    and msg3 = OpamFormula.fold_right (fun a x -> unav_reasons x::a) [] fdeps
+    in
+    (msg1, [msg2], msg3)
+
 let conflict_explanations packages unav_reasons = function
   | univ, version_map, Conflict_dep reasons ->
     let r = reasons () in
     let cudfnv2opam = cudfnv2opam ~cudf_universe:univ ~version_map in
-    extract_explanations packages cudfnv2opam unav_reasons r,
-    []
+    let explanations = extract_explanations packages cudfnv2opam r in
+    List.rev_map (string_of_explanation unav_reasons) explanations, []
   | _univ, _version_map, Conflict_cycle cycles ->
     [], strings_of_cycles cycles
 
-let string_of_conflicts packages unav_reasons conflict =
-  let cflts,  cycles =
-    conflict_explanations packages unav_reasons conflict
-  in
+let string_of_explanations unav_reasons (cflts, cycles) =
+  let cflts = List.map (string_of_explanation unav_reasons) cflts in
+  let cycles = strings_of_cycles cycles in
   let b = Buffer.create 1024 in
   let pr_items b l =
     Buffer.add_string b
@@ -1021,6 +1032,10 @@ let string_of_conflicts packages unav_reasons conflict =
        there seems to be a problem with your request.\n";
   Buffer.add_string b "\n";
   Buffer.contents b
+
+let string_of_conflicts packages unav_reasons conflict =
+  string_of_explanations unav_reasons
+    (conflict_explanations_raw packages conflict)
 
 let check flag p =
   try Cudf.lookup_typed_package_property p flag = `Bool true

--- a/src/solver/opamCudf.mli
+++ b/src/solver/opamCudf.mli
@@ -203,6 +203,13 @@ val cycle_conflict:
   version_map:int package_map -> Cudf.universe ->
   string list list -> ('a, conflict) result
 
+type explanation =
+  [ `Conflict of string option * string list * bool
+  | `Missing of string option * string *
+                (OpamPackage.Name.t * OpamFormula.version_formula)
+                  OpamFormula.formula
+  ]
+
 (** Convert a conflict to something readable by the user. The second argument
     should return a string explaining the unavailability, or the empty string,
     when called on an unavailable package (the reason can't be known this deep
@@ -211,12 +218,24 @@ val string_of_conflicts:
   package_set -> (name * OpamFormula.version_formula -> string) -> conflict ->
   string
 
+val string_of_explanations:
+  (name * OpamFormula.version_formula -> string) ->
+  explanation list * string list list ->
+  string
+
 (** Returns two lists:
     - the reasons why the request can't be satisfied with conflict explanations
     - the cycles in the actions to process (exclusive with the first) *)
 val conflict_explanations:
   package_set -> (name * OpamFormula.version_formula -> string) -> conflict ->
   (string * string list * string list) list * string list
+
+val string_of_explanation:
+  (name * OpamFormula.version_formula -> string) -> explanation ->
+  string * string list * string list
+
+val conflict_explanations_raw:
+  package_set -> conflict -> explanation list * string list list
 
 (** Properly concat a single conflict as returned by [conflict_explanations] for
    display *)

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -232,6 +232,19 @@ val is_switch_globally_set: 'a switch_state -> bool
 (** Returns a message about a package or version that couldn't be found *)
 val not_found_message: 'a switch_state -> atom -> string
 
+val unavailable_reason_raw:
+  'a switch_state -> name * OpamFormula.version_formula ->
+  [ `UnknownVersion
+  | `UnknownPackage
+  | `NoDefinition
+  | `Pinned of OpamPackage.t
+  | `Unavailable of string
+  | `ConflictsBase
+  | `ConflictsInvariant of string
+  | `MissingDepexts of string list
+  | `Default
+  ]
+
 (** Returns a printable explanation why a package is not currently available
     (pinned to an incompatible version, unmet [available:] constraints...).
     [default] is returned if no reason why it wouldn't be available was found

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -689,3 +689,17 @@ let update () =
   | Some (cmd, args) ->
     try sudo_run_command cmd args
     with Failure msg -> failwith ("System package update " ^ msg)
+
+let repo_enablers () =
+  if family () <> Centos then None else
+  let (needed, _) =
+    packages_status (OpamSysPkg.raw_set
+                       (OpamStd.String.Set.singleton "epel-release"))
+  in
+  if OpamSysPkg.Set.is_empty needed then None
+  else
+    Some
+      "On CentOS/RHEL, many packages may assume that the Extra Packages for \
+       Enterprise Linux (EPEL) repository has been enabled. \
+       This is typically done by installing the 'epel-release' package. \
+       Please see https://fedoraproject.org/wiki/EPEL for more information"

--- a/src/state/opamSysInteract.mli
+++ b/src/state/opamSysInteract.mli
@@ -24,3 +24,8 @@ val install_packages_commands: OpamSysPkg.Set.t -> (string * string list) list
 val install: OpamSysPkg.Set.t -> unit
 
 val update: unit -> unit
+
+(* Determine if special packages may need installing to enable other
+   repositories.
+   Presently used to check for epel-release on CentOS and RHEL. *)
+val repo_enablers : unit -> string option


### PR DESCRIPTION
Provides the workaround for #4669 discussed last week. This PR temporarily sits on #4678, as it uses some of the refactorings - only https://github.com/ocaml/opam/commit/34d5cafba78d626e565bfe72cb8e1ab4ea6c4188 is new.

With this patch, on CentOS without EPEL enabled you now see:

```
dra@thor:~/opam$ opam install conf-capnproto
[ERROR] Package conf-capnproto depends on the unavailable system package
        'capnproto'. You can use `--no-depexts' to attempt installation anyway.
        On CentOS/RHEL, many packages may assume that the Extra Packages for
        Enterprise Linux (EPEL) repository has been enabled. This is typically
        done by installing the 'epel-release' package. Please see
        https://fedoraproject.org/wiki/EPEL for more information.
```

Most of the change is refactoring the existing API to separate the computation of what's happened from formatting the message (so that `OpamClient` can semantically what happened).

I've only applied this to `OpamClient.install_t` and `OpamSolution.check_availability` - I'm not sure if some of the other functions in `OpamClient` want this or not.