### PR TITLE
OPAMCONFIRMLEVEL overrides --yes and --no, etc.

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -20,6 +20,7 @@ New option/command/subcommand are prefixed with ◈.
   * ◈ Add `--confirm-level` and `OPAMCONFIRMLEVEL` [#4582 @rjbou - fix #4168]
   * ◈ Add `--no` [#4582 @rjbou]
   * Initialise environment variables for plugins call/install [#4582 @rjbou]
+  * `OPAMCONFIRMLEVEL` and `OPAMYES` now override "lower" CLI flags [#4683 @dra27 - fix #4682]
 
 ## Init
   * Introduce a `default-invariant` config field, restore the 2.0 semantics for

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -143,7 +143,7 @@ type global_options = {
   quiet : bool;
   color : OpamStd.Config.when_ option;
   opt_switch : string option;
-  answer : OpamStd.Config.answer option;
+  answer : (OpamStd.Config.answer * [`Level | `Yes | `No]) option;
   strict : bool;
   opt_root : dirname option;
   git_version : bool;


### PR DESCRIPTION
Fixes #4582. It's possible that this can be done in a different order - I've had the global options record where the answer came from (to allow the environment to override it)