### PR TITLE
var: display package hash

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -69,6 +69,7 @@ New option/command/subcommand are prefixed with ◈.
 
 ## Var
   * Fix `switch` global variable resolving [#4685 @rjbou - fix #4684]
+  * Fix `hash` package variable resolving [#4687 @rjbou]
 
 ## Option
   *

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3712,7 +3712,6 @@ let clean cli =
        if not dry_run then OpamRepositoryState.Cache.remove ());
     if download_cache then
       (OpamConsole.msg "Clearing cache of downloaded files\n";
-       rmdir (OpamPath.archives_dir root);
        List.iter (fun dir ->
            match OpamFilename.(Base.to_string (basename_dir dir)) with
            | "git" ->

--- a/src/format/opamPath.ml
+++ b/src/format/opamPath.ml
@@ -33,9 +33,10 @@ let lock t = t // "lock"
 
 let config_lock t = t // "config.lock"
 
+(*
 let archives_dir t = t / "archives"
-
 let archive t nv = archives_dir t // (OpamPackage.to_string nv ^ "+opam.tar.gz")
+*)
 
 let repos_lock t = t / "repo" // "lock"
 

--- a/src/format/opamPath.mli
+++ b/src/format/opamPath.mli
@@ -39,12 +39,6 @@ val init_config_files: unit -> OpamFile.InitConfig.t OpamFile.t list
     switches, repositories lists are expected. No lock needed otherwise) *)
 val config_lock: t -> filename
 
-(** Archives dir *)
-val archives_dir: t -> dirname
-
-(** Archive file: {i $opam/archives/$NAME.$VERSION+opam.tar.gz} *)
-val archive: t -> package -> filename
-
 (** Global lock file for the repositories mirrors: {i $opam/repo/lock} *)
 val repos_lock: t -> filename
 

--- a/tests/reftests/var-option.test
+++ b/tests/reftests/var-option.test
@@ -168,7 +168,6 @@ ocaml:doc ${BASEDIR}/OPAM/var-option/doc/ocaml # Doc directory for this package
 ocaml:share ${BASEDIR}/OPAM/var-option/share/ocaml # Share directory for this package
 ocaml:etc ${BASEDIR}/OPAM/var-option/etc/ocaml # Etc directory for this package
 ocaml:build ${BASEDIR}/OPAM/var-option/.opam-switch/build/ocaml.4.08.0 # Directory where the package was built
-ocaml:hash # Hash of the package archive
 ocaml:dev false # True if this is a development package
 ### opam option
 


### PR DESCRIPTION
Piece of code that resolve the `hash` variables was still relying on the old archiving format (`archive` directory & `pkg+opam.tgz` archive).