### PR TITLE
confirm level/yes/no: better answer computation

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -18,6 +18,7 @@ New option/command/subcommand are prefixed with ◈.
     so that calls to `opam` during build access the correct root and switch [#4668 @LasseBlaauwbroek]
   * Add cli versioning for enums of flags with predefined enums [#4626 @rjbou]
   * ◈ Add `--confirm-level` and `OPAMCONFIRMLEVEL` [#4582 @rjbou - fix #4168]
+    * Take content of cli flags over environment variables, instead of already computed answer [#4691 @rjbou - fix #4682]
   * ◈ Add `--no` [#4582 @rjbou]
   * Initialise environment variables for plugins call/install [#4582 @rjbou]
   * `OPAMCONFIRMLEVEL` and `OPAMYES` now override "lower" CLI flags [#4683 @dra27 - fix #4682]
@@ -192,6 +193,8 @@ New option/command/subcommand are prefixed with ◈.
   * Add preserved format test [#4634 @rjbou]
   * Use the dev profile when testing [#4672 @dra27]
   * Add a test to test various case of opam root loading (several version, and several lock kinds) [#4638 @rjbou]
+  * GHA: Bump bootstrap opam version to beta4 [#4695 @rjbou]
+  * GHA: fix tilde expansion that was blockign opam bootstrap cache regeneration [#4695 @rjbou]
 
 ## Shell
   *

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -143,7 +143,8 @@ type global_options = {
   quiet : bool;
   color : OpamStd.Config.when_ option;
   opt_switch : string option;
-  answer : (OpamStd.Config.answer * [`Level | `Yes | `No]) option;
+  confirm_level : OpamStd.Config.answer option;
+  yes: bool option;
   strict : bool;
   opt_root : dirname option;
   git_version : bool;

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -136,8 +136,8 @@ let check_and_run_external_commands () =
     let command = OpamPath.plugin_prefix ^ name in
     OpamArg.init_opam_env_variabes cli;
     (* if --yes is given, OPAMCONFIRMLEVEL/NO is not taken into account *)
-    let answer = if yes then Some `all_yes else None in
-    OpamCoreConfig.init ?answer ();
+    let yes = if yes then Some (Some true) else None in
+    OpamCoreConfig.init ?yes ();
     OpamFormatConfig.init ();
     let root_dir = OpamStateConfig.opamroot () in
     let has_init, root_upgraded =

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -155,7 +155,8 @@ val opam_init:
   ?color:OpamStd.Config.when_ ->
   ?utf8:OpamStd.Config.when_ext ->
   ?disp_status_line:OpamStd.Config.when_ ->
-  ?answer:OpamStd.Config.answer ->
+  ?confirm_level:OpamStd.Config.answer ->
+  ?yes:bool option ->
   ?safe_mode:bool ->
   ?keep_log_dir:bool ->
   ?errlog_length:int ->

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -952,7 +952,7 @@ let simulate_new_state state t =
 (* Ask confirmation whenever the packages to modify are not exactly
    the packages in the user request *)
 let confirmation ?ask requested solution =
-  OpamCoreConfig.is_answer_yes () ||
+  OpamCoreConfig.answer_is_yes () ||
   match ask with
   | Some false -> true
   | Some true -> OpamConsole.confirm "Do you want to continue?"
@@ -1092,7 +1092,7 @@ let install_depexts ?(force_depext=false) ?(confirm=true) t packages =
          system packages altogether.\n";
       OpamStd.Sys.exit_because `Aborted
     in
-    if not OpamStd.Sys.tty_in || OpamCoreConfig.answer () <> `ask then
+    if not (OpamStd.Sys.tty_in && OpamCoreConfig.answer_is `ask) then
       give_up ()
     else if OpamConsole.confirm
         "%s\nWhen you are done: check again and continue?"

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1092,7 +1092,7 @@ let install_depexts ?(force_depext=false) ?(confirm=true) t packages =
          system packages altogether.\n";
       OpamStd.Sys.exit_because `Aborted
     in
-    if not OpamStd.Sys.tty_in || OpamCoreConfig.(!r.answer <> `ask) then
+    if not OpamStd.Sys.tty_in || OpamCoreConfig.answer () <> `ask then
       give_up ()
     else if OpamConsole.confirm
         "%s\nWhen you are done: check again and continue?"

--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -702,9 +702,9 @@ let confirm ?(default=true) fmt =
         let prompt () =
           formatted_msg "%s [%s] " s (if default then "Y/n" else "y/N")
         in
-        if OpamCoreConfig.is_answer_yes () then
+        if OpamCoreConfig.answer_is_yes () then
           (prompt (); msg "y\n"; true)
-        else if OpamCoreConfig.answer () = `all_no ||
+        else if OpamCoreConfig.answer_is `all_no ||
                 OpamStd.Sys.(not tty_in)
         then
           (prompt (); msg "n\n"; false)
@@ -758,7 +758,7 @@ let confirm ?(default=true) fmt =
 let read fmt =
   Printf.ksprintf (fun s ->
       formatted_msg "%s " s;
-      if OpamCoreConfig.(answer () = `ask && not !r.safe_mode) then (
+      if OpamCoreConfig.(answer_is `ask && not !r.safe_mode) then (
         try match read_line () with
           | "" -> None
           | s  -> Some s

--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -704,7 +704,7 @@ let confirm ?(default=true) fmt =
         in
         if OpamCoreConfig.is_answer_yes () then
           (prompt (); msg "y\n"; true)
-        else if OpamCoreConfig.(!r.answer) = `all_no ||
+        else if OpamCoreConfig.answer () = `all_no ||
                 OpamStd.Sys.(not tty_in)
         then
           (prompt (); msg "n\n"; false)
@@ -758,7 +758,7 @@ let confirm ?(default=true) fmt =
 let read fmt =
   Printf.ksprintf (fun s ->
       formatted_msg "%s " s;
-      if OpamCoreConfig.(!r.answer = `ask && not !r.safe_mode) then (
+      if OpamCoreConfig.(answer () = `ask && not !r.safe_mode) then (
         try match read_line () with
           | "" -> None
           | s  -> Some s

--- a/src/core/opamCoreConfig.ml
+++ b/src/core/opamCoreConfig.ml
@@ -59,7 +59,8 @@ type t = {
   color: OpamStd.Config.when_;
   utf8: OpamStd.Config.when_ext;
   disp_status_line: OpamStd.Config.when_;
-  answer: OpamStd.Config.answer;
+  confirm_level: [ OpamStd.Config.answer | `undefined ];
+  yes: bool option;
   safe_mode: bool;
   log_dir: string;
   keep_log_dir: bool;
@@ -77,7 +78,8 @@ type 'a options_fun =
   ?color:OpamStd.Config.when_ ->
   ?utf8:OpamStd.Config.when_ext ->
   ?disp_status_line:OpamStd.Config.when_ ->
-  ?answer:OpamStd.Config.answer ->
+  ?confirm_level:OpamStd.Config.answer ->
+  ?yes:bool option ->
   ?safe_mode:bool ->
   ?log_dir:string ->
   ?keep_log_dir:bool ->
@@ -94,7 +96,8 @@ let default = {
   color = `Auto;
   utf8 = `Auto;
   disp_status_line = `Auto;
-  answer = `ask;
+  confirm_level = `undefined;
+  yes = None;
   safe_mode = false;
   log_dir =
     (let user = try Unix.getlogin() with Unix.Unix_error _ -> "xxx" in
@@ -115,7 +118,8 @@ let setk k t
     ?color
     ?utf8
     ?disp_status_line
-    ?answer
+    ?confirm_level
+    ?yes
     ?safe_mode
     ?log_dir
     ?keep_log_dir
@@ -132,7 +136,11 @@ let setk k t
     color = t.color + color;
     utf8 = t.utf8 + utf8;
     disp_status_line = t.disp_status_line + disp_status_line;
-    answer = t.answer + answer;
+    confirm_level =
+      (match confirm_level with
+       | Some (`all_yes|`all_no|`ask|`unsafe_yes as c) -> c
+       | None ->  t.confirm_level);
+    yes = t.yes + yes;
     safe_mode = t.safe_mode + safe_mode;
     log_dir = t.log_dir + log_dir;
     keep_log_dir = t.keep_log_dir + keep_log_dir;
@@ -159,20 +167,11 @@ let initk k =
         | true -> Some `Extended
         | false -> None)
     ) in
-  let answer =
-    (* priorities: confirm level > yes > no *)
-    match E.confirmlevel (), E.yes (), E.no () with
-    | Some c, _,  _ -> Some c
-    | _, Some true, _ -> Some `all_yes
-    | _, _, Some true -> Some `all_no
-    | _ -> None
-(*
-  let answer = match E.yes (), E.no () with
+  let yes =
+    match E.yes (), E.no () with
     | Some true, _ -> Some (Some true)
     | _, Some true -> Some (Some false)
-    | None, None -> None
-    | _ -> Some None
-*)
+    | _, _ -> None
   in
   (setk (setk (fun c -> r := c; k)) !r)
     ?debug_level:(E.debug ())
@@ -181,7 +180,8 @@ let initk k =
     ?color:(E.color ())
     ?utf8
     ?disp_status_line:(E.statusline ())
-    ?answer
+    ?confirm_level:(E.confirmlevel ())
+    ?yes
     ?safe_mode:(E.safe ())
     ?log_dir:(E.logs ())
     ?keep_log_dir:(E.keeplogs ())
@@ -192,8 +192,18 @@ let initk k =
 
 let init ?noop:_ = initk (fun () -> ())
 
+let answer =
+  let answer = lazy (
+      match !r.confirm_level, !r.yes with
+      | #OpamStd.Config.answer as c, _ -> c
+      | _, Some true -> `all_yes
+      | _, Some false -> `all_no
+      | _ -> `ask
+  ) in
+  fun () -> Lazy.force answer
+
 let is_answer_yes () =
-  match !r.answer with
+  match answer () with
   | `all_yes | `unsafe_yes -> true
   | _ -> false
 

--- a/src/core/opamCoreConfig.ml
+++ b/src/core/opamCoreConfig.ml
@@ -192,20 +192,19 @@ let initk k =
 
 let init ?noop:_ = initk (fun () -> ())
 
-let answer =
-  let answer = lazy (
-      match !r.confirm_level, !r.yes with
-      | #OpamStd.Config.answer as c, _ -> c
-      | _, Some true -> `all_yes
-      | _, Some false -> `all_no
-      | _ -> `ask
-  ) in
-  fun () -> Lazy.force answer
+let answer () =
+  match !r.confirm_level, !r.yes with
+  | #OpamStd.Config.answer as c, _ -> c
+  | _, Some true -> `all_yes
+  | _, Some false -> `all_no
+  | _ -> `ask
 
-let is_answer_yes () =
-  match answer () with
-  | `all_yes | `unsafe_yes -> true
-  | _ -> false
+let answer_is =
+  let answer = lazy (answer ()) in
+  fun a -> Lazy.force answer = a
+
+let answer_is_yes () =
+  answer_is `all_yes || answer_is `unsafe_yes
 
 #ifdef DEVELOPER
 let developer = true

--- a/src/core/opamCoreConfig.mli
+++ b/src/core/opamCoreConfig.mli
@@ -115,20 +115,22 @@ val init: ?noop:_ -> (unit -> unit) options_fun
     stacking *)
 val initk: 'a -> 'a options_fun
 
-(** Affects interactive questions in OpamConsole:
-    * ask: prompt and ask user
-    * no: answer no to all opam questions
-    * yes: answer yes to all opam questions
-    * unsafe-yes: answer yes to all opam question and launch system package
-                  command wit non interactive options
+(** Automatic answering levels
+    * [`ask]: prompt and ask user
+    * [`no]: answer no to all opam questions
+    * [`yes]: answer yes to all opam questions
+    * [`unsafe_yes]: answer yes to all opam question and launch system package
+                     command wit non interactive options
     If confirm-level is set (from cli or environment variable), its value is
     returned. Otherwise, is takes last yes/no cli flag. For environment
     variables, if [OPAMYES] is set to true, it has priority over [OPAMNO]. As
     other environment variables, cli flags content is taken if given.
-    *)
+    [answer_is] and [answer_is_yes] computes the answer lazily, use [answer] in
+    case of config update.
+*)
+val answer_is: OpamStd.Config.answer -> bool
+val answer_is_yes : unit -> bool
 val answer: unit -> OpamStd.Config.answer
-
-val is_answer_yes : unit -> bool
 
 (** [true] if OPAM was compiled in developer mode *)
 val developer : bool

--- a/src/core/opamCoreConfig.mli
+++ b/src/core/opamCoreConfig.mli
@@ -54,9 +54,10 @@ type t = private {
   disp_status_line: OpamStd.Config.when_;
   (** Controls on-line display of parallel commands being run, using ANSI
       escapes *)
-  answer : OpamStd.Config.answer;
-  (** Affects interactive questions in OpamConsole: auto-answer with the given
-      bool if Some *)
+  confirm_level : [ OpamStd.Config.answer | `undefined ];
+  yes: bool option;
+  (** Affects interactive questions in OpamConsole: used to compute the
+      automatic ansering level *)
   safe_mode : bool;
   (** Fail on writes or delays, don't ask questions (for quick queries, e.g.
       for shell completion) *)
@@ -85,7 +86,8 @@ type 'a options_fun =
   ?color:OpamStd.Config.when_ ->
   ?utf8:OpamStd.Config.when_ext ->
   ?disp_status_line:OpamStd.Config.when_ ->
-  ?answer:OpamStd.Config.answer ->
+  ?confirm_level:OpamStd.Config.answer ->
+  ?yes:bool option ->
   ?safe_mode:bool ->
   ?log_dir:string ->
   ?keep_log_dir:bool ->
@@ -112,6 +114,19 @@ val init: ?noop:_ -> (unit -> unit) options_fun
 (** Like [init], but returns the given value. For optional argument
     stacking *)
 val initk: 'a -> 'a options_fun
+
+(** Affects interactive questions in OpamConsole:
+    * ask: prompt and ask user
+    * no: answer no to all opam questions
+    * yes: answer yes to all opam questions
+    * unsafe-yes: answer yes to all opam question and launch system package
+                  command wit non interactive options
+    If confirm-level is set (from cli or environment variable), its value is
+    returned. Otherwise, is takes last yes/no cli flag. For environment
+    variables, if [OPAMYES] is set to true, it has priority over [OPAMNO]. As
+    other environment variables, cli flags content is taken if given.
+    *)
+val answer: unit -> OpamStd.Config.answer
 
 val is_answer_yes : unit -> bool
 

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -728,7 +728,7 @@ let setup
         (OpamConsole.colorise `cyan @@ OpamFilename.prettify dot_profile)
         (OpamConsole.colorise `bold @@ source root shell (init_file shell))
         (OpamConsole.colorise `bold @@ shell_eval_invocation shell (opam_env_invocation ()));
-      if OpamCoreConfig.is_answer_yes () then begin
+      if OpamCoreConfig.answer_is_yes () then begin
         OpamConsole.warning "Shell not updated in non-interactive mode: use --shell-setup";
         None
       end else

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -519,7 +519,7 @@ let packages_status packages =
 
 let install_packages_commands_t sys_packages =
   let yes ?(no=[]) yes r =
-    if OpamCoreConfig.(!r.answer) = `unsafe_yes then
+    if OpamCoreConfig.answer () = `unsafe_yes then
       yes @ r else no @ r
   in
   let packages =

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -519,7 +519,7 @@ let packages_status packages =
 
 let install_packages_commands_t sys_packages =
   let yes ?(no=[]) yes r =
-    if OpamCoreConfig.answer () = `unsafe_yes then
+    if OpamCoreConfig.answer_is `unsafe_yes then
       yes @ r else no @ r
   in
   let packages =


### PR DESCRIPTION
Automatic answering depends on several parameters: confirm-level, yes, and no cli flags and environment variables.
In #4582, environment computes an answer, cli flags another one, and those answers were compared to set the run answering (cli > env var). That lead to #4682.
One solution is to check each parameters against its environment variable / cli flags, and then compute the automatic answering. So in  `OpamCore.Config.!r`, answer is no more set, but `confirm_level` and `yes` fields, and a new function permits to retrieve this answer `OpamCoreConfig.answer` (lazy).
One side effect of this mechanism is that if `OPAMCONFIRMLEVEL` is set in the environment, `--yes/--no` are ignored (as confirm-level > yes/no), and it can be resset only by using `--confirm-level`.
