### PR TITLE
Link archives in cache when several checksum are given

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -60,6 +60,9 @@ users)
   * W68: add warning for missing license field [#4766 @kit-ty-kate - partial fix #4598]
   * W62: use the spdx_licenses library to check for valid licenses. This allows to use compound expressions such as "MIT AND (GPL-2.0-only OR LGPL-2.0-only)", as well as user defined licenses e.g. "LicenseRef-my-custom-license" [#4768 @kit-ty-kate - fixes #4598]
 
+## Repository
+  * When several checksums are specified, instead of adding in the cache only the archive by first checksum, name by best one and link others to this archive [#4696 rjbou]
+
 ## Lock
   *
 
@@ -211,4 +214,5 @@ users)
 ## opam-core
   * OpamSystem: avoid calling Unix.environment at top level [#4789 @hannesm]
   * `OpamStd.ABSTRACT`: add `compare` and `equal`, that added those functions to `OpamFilename`, `OpamHash`, `OpamStd`, `OpamStd`, `OpamUrl`, and `OpamVersion` [#4918 @rjbou]
+  * `OpamHash`: add `sort` from strongest to weakest kind
 

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -154,14 +154,17 @@ let package_files_to_cache repo_root cache_dir cache_urls
         OpamPackage.to_string nv ^
         OpamStd.Option.to_string ((^) "/") name
       in
-      match OpamFile.URL.checksum urlf with
+      let checksums =
+        OpamHash.sort (OpamFile.URL.checksum urlf)
+      in
+      match checksums with
       | [] ->
         OpamConsole.warning "[%s] no checksum, not caching"
           (OpamConsole.colorise `green label);
         Done errors
-      | (first_checksum :: _) as checksums ->
+      | best_chks :: _ ->
         let cache_file =
-          OpamRepository.cache_file cache_dir first_checksum
+          OpamRepository.cache_file cache_dir best_chks
         in
         let error_opt =
           if not recheck && OpamFilename.exists cache_file then Done None

--- a/src/core/opamHash.mli
+++ b/src/core/opamHash.mli
@@ -32,6 +32,9 @@ val of_string_opt: string -> t option
     "md5/d4/d41d8cd98f00b204e9800998ecf8427e", as a list *)
 val to_path: t -> string list
 
+(** Sorts the list from best hash (SHA512, ...) to weakest (..., MD5) *)
+val sort : t list -> t list
+
 val check_file: string -> t -> bool
 
 (** Like [check_file], but returns the actual mismatching hash of the file, or

--- a/src/state/opamPackageVar.ml
+++ b/src/state/opamPackageVar.ml
@@ -301,7 +301,7 @@ let resolve st ?opam:opam_arg ?(local=OpamVariable.Map.empty) v =
       OpamStd.Option.Op.(
         OpamFile.OPAM.url opam
         >>| OpamFile.URL.checksum
-        (* on download, the cache is populated with the first checksum found *)
+        >>| OpamHash.sort
         >>= (function [] -> None
                     | h::_ -> Some (string (OpamHash.to_string h))))
     | "dev", Some opam -> Some (bool (is_dev_package st opam))


### PR DESCRIPTION
Add link for other checksum on downloading, if possible. `OpamSystem.link` fallback is to copy, so for some systems, it can lead to multiples copies of a single archive/file.