### PR TITLE
depext: ignore `--yes` on asking to run install commands

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -107,6 +107,7 @@ New option/command/subcommand are prefixed with ◈.
   * Handling of packages of tagged repositories for alpine [#4700 @rjbou - fix #4670]
   * Clarify some `assume-depexts` related messages [#4671 @AltGr - partial fix #4662]
   * Warn the user if epel-release is missing and unavailable depexts are detected [#4679 @dra27 fix #4669]
+  * Ignore config yes automatic answering when asking confirmation to run install commands [#4698 @rjbou - fix #4680]
 
 ## Sandbox
   * Fix the conflict with the environment variable name used by dune [#4535 @smorimoto - fix ocaml/dune#4166]

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1121,7 +1121,8 @@ let install_depexts ?(force_depext=false) ?(confirm=true) t packages =
        sys_packages)
   else if OpamClientConfig.(!r.fake) then (print (); t)
   else if
-    not confirm || OpamConsole.confirm
+    not confirm
+    || OpamConsole.confirm ~require_unsafe_yes:true
       "Let opam run your package manager to install the required system \
        packages?\n(answer 'n' for other options)"
   then

--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -695,14 +695,15 @@ let header_error fmt =
     ) fmt
 
 
-let confirm ?(default=true) fmt =
+let confirm ?(require_unsafe_yes=false) ?(default=true) fmt =
   Printf.ksprintf (fun s ->
       try
         if OpamCoreConfig.(!r.safe_mode) then false else
         let prompt () =
           formatted_msg "%s [%s] " s (if default then "Y/n" else "y/N")
         in
-        if OpamCoreConfig.answer_is_yes () then
+        if (require_unsafe_yes && OpamCoreConfig.answer_is `unsafe_yes)
+        || (not require_unsafe_yes && OpamCoreConfig.answer_is_yes ()) then
           (prompt (); msg "y\n"; true)
         else if OpamCoreConfig.answer_is `all_no ||
                 OpamStd.Sys.(not tty_in)

--- a/src/core/opamConsole.mli
+++ b/src/core/opamConsole.mli
@@ -114,8 +114,14 @@ val status_line : ('a, unit, string, unit) format4 -> 'a
 val clear_status : unit -> unit
 
 (** Ask the user to press Y/y/N/n to continue (returns a boolean).
-    Defaults to true (yes) if unspecified *)
-val confirm: ?default:bool -> ('a, unit, string, bool) format4 -> 'a
+    Defaults to true (yes) if unspecified.
+    If [require_unsafe_yes] is true, it automatically answer yes to the
+    question if automatic answering is set to [`unsafe_yes] ; otherwise it will
+    prompt and wait user input if it is set [`all_yes] (interactive). Its
+    default is false. *)
+val confirm:
+  ?require_unsafe_yes:bool -> ?default:bool ->
+  ('a, unit, string, bool) format4 -> 'a
 
 (** Read some input from the user (returns a string option) *)
 val read: ('a, unit, string, string option) format4 -> 'a


### PR DESCRIPTION
Fix #4680 
