### PR TITLE
Fix sys-ocaml-* variables with no system compiler

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -32,6 +32,7 @@ New option/command/subcommand are prefixed with ◈.
   * Send the 'opam root layout update' message to stderr [#4692 @AltGr]
   * If opam root is different from the binary, allow reading it and try to read in best effort mode  [#4638 @rjbou - fix #4636]
   * Don't check opam system dependencies on reinit after a format upgrade [#4638 @rjbou]
+  * Fix sys-ocaml-cc, sys-ocaml-arch and sys-ocaml-libc when no system compiler installed [#4706 @dra27]
 
 ## Config report
   * Fix `Not_found` (config file) error [#4570 @rjbou]

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -35,11 +35,11 @@ let default_invariant =
 let eval_variables = [
   OpamVariable.of_string "sys-ocaml-version", ["ocamlc"; "-vnum"],
   "OCaml version present on your system independently of opam, if any";
-  OpamVariable.of_string "sys-ocaml-arch", ["sh"; "-c"; "ocamlc -config | tr -d '\\r' | grep '^architecture: ' | sed -e 's/.*: //' -e 's/i386/i686/' -e 's/amd64/x86_64/'"],
+  OpamVariable.of_string "sys-ocaml-arch", ["sh"; "-c"; "ocamlc -config 2>/dev/null | tr -d '\\r' | grep '^architecture: ' | sed -e 's/.*: //' -e 's/i386/i686/' -e 's/amd64/x86_64/'"],
   "Target architecture of the OCaml compiler present on your system";
-  OpamVariable.of_string "sys-ocaml-cc", ["sh"; "-c"; "ocamlc -config | tr -d '\\r' | grep '^ccomp_type: ' | sed -e 's/.*: //'"],
+  OpamVariable.of_string "sys-ocaml-cc", ["sh"; "-c"; "ocamlc -config 2>/dev/null | tr -d '\\r' | grep '^ccomp_type: ' | sed -e 's/.*: //'"],
   "Host C Compiler type of the OCaml compiler present on your system";
-  OpamVariable.of_string "sys-ocaml-libc", ["sh"; "-c"; "ocamlc -config | tr -d '\\r' | grep '^os_type: ' | sed -e 's/.*: //' -e 's/Win32/msvc/' -e '/^msvc$/!s/.*/libc/'"],
+  OpamVariable.of_string "sys-ocaml-libc", ["sh"; "-c"; "ocamlc -config 2>/dev/null | tr -d '\\r' | grep '^os_type: ' | sed -e 's/.*: //' -e 's/Win32/msvc/' -e '/^msvc$/!s/.*/libc/'"],
   "Host C Runtime Library type of the OCaml compiler present on your system";
 ]
 


### PR DESCRIPTION
`/usr/bin/sh: ocamlc: command not found` returned for `sys-ocaml-arch`, `sys-ocaml-cc` and `sys-ocaml-libc` if there's no system compiler