### PR TITLE
Add missing shell quoting to support space and special shell characters in switch directory path

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -220,3 +220,6 @@ New option/command/subcommand are prefixed with ◈.
   * Fix typo [#4637 @UnixJunkie]
   * Add some release docs [#4681 @rjbou]
   * Fix distributions page link in install [#4702 @rjbou - fix #4693]
+
+## Security fixes
+  * Add missing shell quoting to support space and special shell characters in switch directory path [#4707 @kit-ty-kate]

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -90,7 +90,7 @@ let rm_command =
 let remove_dir dir =
   log "rmdir %s" dir;
   if Sys.file_exists dir then (
-    let err = Sys.command (Printf.sprintf "%s %s" rm_command dir) in
+    let err = Sys.command (Printf.sprintf "%s %s" rm_command (Filename.quote dir)) in
       if err <> 0 then
         internal_error "Cannot remove %s (error %d)." dir err
   )


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/4705
Introduced in opam 1.1.0~rc https://github.com/ocaml/opam/commit/fb108835e5182ee17620a724aa3f552822e04052