### PR TITLE
Plugins should end .exe on Windows

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -23,6 +23,7 @@ New option/command/subcommand are prefixed with ◈.
   * Initialise environment variables for plugins call/install [#4582 @rjbou]
   * `OPAMCONFIRMLEVEL` and `OPAMYES` now override "lower" CLI flags [#4683 @dra27 - fix #4682]
   * Preprocess `--confirm-level` for plugins calls/install [#4694 @rjbou]
+  * Expect plugins to end in .exe on Windows [#4709 @dra27]
 
 ## Init
   * Introduce a `default-invariant` config field, restore the 2.0 semantics for

--- a/src/format/opamPath.ml
+++ b/src/format/opamPath.ml
@@ -67,7 +67,7 @@ let plugins t = t / "plugins"
 let plugins_bin t = plugins t / "bin"
 
 let plugin_bin t name =
-  let sname = OpamPackage.Name.to_string name in
+  let sname = OpamPackage.Name.to_string name ^ OpamStd.Sys.executable_name "" in
   let basename =
     if OpamStd.String.starts_with ~prefix:plugin_prefix sname then sname
     else plugin_prefix ^ sname


### PR DESCRIPTION
Allows `opam depext` to continue working with opam-repository-mingw.