### PR TITLE
Format upgrade fix: remove missing switches from config file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,12 @@ are not marked). Those prefixed with "(+)" are new command/option (since
 2.1.0~alpha2).
 
 2.1.0~rc2:
-  * Remove OPAMZ3DEBUG evironment variable [#4720 @rjbou - fix #4718]
+* Remove OPAMZ3DEBUG evironment variable [#4720 @rjbou - fix #4717]
+* Fix format upgrade when there is missing local switches in the config file
+  [#4715 @rjbou - fix #4713]
+* Fix not recorded local switch handling, with format upgrade [#4715 @rjbou]
+* Set opam root version to 2.1 [#4715 @rjbou]
+* Improved and extended tests [#4715 @rjbou]
 
 2.1.0~rc:
 * (*) Environment variables initialised only at opam client launch, no more via

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1225,7 +1225,7 @@ module ConfigSyntax = struct
   let internal = "config"
   let format_version = OpamVersion.of_string "2.1"
   let file_format_version = OpamVersion.of_string "2.0"
-  let root_version = OpamVersion.of_string "2.1~rc"
+  let root_version = OpamVersion.of_string "2.1"
 
   let default_old_root_version = OpamVersion.of_string "2.1~~previous"
 

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1020,7 +1020,7 @@ module SyntaxFile(X: SyntaxFileArg) : IO_FILE with type t := X.t = struct
     | {file_contents = [{pelem = Variable({pelem = "opam-version"; _}, {pelem = String ver; _}); _ };
                         {pelem = Section {section_kind = {pelem = "#"; _}; _}; pos}]; _}
       when OpamVersion.(compare (nopatch (of_string ver)) (nopatch X.format_version)) <= 0 ->
-        raise (OpamPp.Bad_format (Some pos, "Parse error"))
+        raise (OpamPp.Bad_version (Some pos, "Parse error"))
     | opamfile -> opamfile
 
     let of_channel filename (ic:in_channel) =

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -1133,16 +1133,6 @@ let as_necessary requested_lock global_lock root config =
   let cmp = OpamVersion.(compare OpamFile.Config.root_version root_version) in
   if cmp <= 0 then config (* newer or same *) else
   let is_intermdiate_root = List.mem root_version intermediate_roots in
-  let need_hard_upg =
-    OpamVersion.compare root_version latest_hard_upgrade < 0
-    || is_intermdiate_root
-  in
-  let on_the_fly, global_lock_kind =
-    if not need_hard_upg && requested_lock <> `Lock_write then
-      true, `Lock_read
-    else
-      false, `Lock_write
-  in
   (* to generalise *)
   let intermediates = [
     v2_1_alpha,  from_2_0_to_2_1_alpha;
@@ -1169,6 +1159,13 @@ let as_necessary requested_lock global_lock root config =
       |> List.filter (fun (v,_) -> OpamVersion.compare root_version v < 0)
       |> List.partition (fun (v,_) ->
           OpamVersion.compare v latest_hard_upgrade <= 0)
+  in
+  let need_hard_upg = hard_upg <> [] in
+  let on_the_fly, global_lock_kind =
+    if not need_hard_upg && requested_lock <> `Lock_write then
+      true, `Lock_read
+    else
+      false, `Lock_write
   in
   let erase_plugin_links root =
     let plugins_bin = OpamPath.plugins_bin root in

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -1211,6 +1211,7 @@ let as_necessary requested_lock global_lock root config =
             | _ -> "they no longer exist");
          config
   in
+  if hard_upg = [] && light_upg = [] then config (* no upgrade to do *) else
   let is_dev = OpamVersion.is_dev_version () in
   log "%s config upgrade, from %s to %s"
     (if on_the_fly then "On-the-fly" else

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -1059,40 +1059,18 @@ let v2_1 = OpamVersion.of_string "2.1"
 let from_2_0_to_2_1_alpha _ conf = conf
 
 let downgrade_2_1_switches root conf =
-  let downgrade f =
-    let filename = OpamFile.filename f in
-    let str_f = OpamFilename.to_string filename in
-    let opamfile = OpamParser.FullPos.file str_f in
-    let opamfile' =
-      let open OpamParserTypes.FullPos in
-      { opamfile with
-        file_contents =
-          List.map (fun item ->
-              match item.pelem with
-              | Variable (({pelem = "opam-version"; _} as opam_v),
-                          ({pelem = String "2.1"; _} as v)) ->
-                { item with
-                  pelem = Variable ({opam_v with pelem = "opam-version"},
-                                    {v with pelem = String "2.0"})}
-              | _ -> item) opamfile.file_contents}
-    in
-    let updated = opamfile' <> opamfile in
-    if updated then
-      OpamFilename.write filename (OpamPrinter.FullPos.opamfile opamfile')
-  in
   List.iter (fun switch ->
       let f = OpamPath.Switch.switch_config root switch in
-      downgrade f;
-      ignore @@ OpamFile.Switch_config.BestEffort.read f)
-    (OpamFile.Config.installed_switches conf)
+      OpamStd.Option.iter (OpamFile.Switch_config.write f)
+        (OpamStateConfig.downgrade_2_1_switch f))
+    (OpamFile.Config.installed_switches conf);
+  conf
 
 let from_2_1_alpha_to_2_1_alpha2 root conf =
-  downgrade_2_1_switches root conf;
-  conf
+  downgrade_2_1_switches root conf
 
 let from_2_1_alpha2_to_v2_1_rc root conf =
-  downgrade_2_1_switches root conf;
-  conf
+  downgrade_2_1_switches root conf
 
 let from_2_1_rc_to_v2_1 _ conf = conf
 

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -200,7 +200,8 @@ let fix_switch_list gt =
     OpamFile.Config.with_installed_switches known_switches gt.config
   in
   let gt = { gt with config } in
-  if not OpamCoreConfig.(!r.safe_mode) then
+  if not OpamCoreConfig.(!r.safe_mode)
+  && OpamSystem.get_lock_flag gt.global_lock = `Lock_write then
     try
       snd @@ with_write_lock ~dontblock:true gt @@ fun gt ->
       write gt, gt

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -295,13 +295,15 @@ let resolve_local_switch root s =
   else s
 
 let get_current_switch_from_cwd root =
-  let open OpamStd.Option.Op in
-  OpamFilename.find_in_parents (fun dir ->
-      OpamSwitch.of_string (OpamFilename.Dir.to_string dir) |>
-      local_switch_exists root)
-    (OpamFilename.cwd ())
-  >>| OpamSwitch.of_dirname
-  >>| resolve_local_switch root
+  try
+    let open OpamStd.Option.Op in
+    OpamFilename.find_in_parents (fun dir ->
+        OpamSwitch.of_string (OpamFilename.Dir.to_string dir) |>
+        local_switch_exists root)
+      (OpamFilename.cwd ())
+    >>| OpamSwitch.of_dirname
+    >>| resolve_local_switch root
+  with OpamPp.Bad_version _ -> None
 
 (* do we want `load_defaults` to fail / run a format upgrade ? *)
 let load_defaults ?lock_kind root_dir =

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -281,12 +281,45 @@ module Repos = struct
       (OpamPath.repos_config gt.root)
 end
 
+let downgrade_2_1_switch f =
+  let filename = OpamFile.filename f in
+  let str_f = OpamFilename.to_string filename in
+  let opamfile = OpamParser.FullPos.file str_f in
+  let opamfile' =
+    let open OpamParserTypes.FullPos in
+    { opamfile with
+      file_contents =
+        List.map (fun item ->
+            match item.pelem with
+            | Variable (({pelem = "opam-version"; _} as opam_v),
+                        ({pelem = String "2.1"; _} as v)) ->
+              { item with
+                pelem = Variable ({opam_v with pelem = "opam-version"},
+                                  {v with pelem = String "2.0"})}
+            | _ -> item)
+          opamfile.file_contents}
+  in
+  if opamfile' = opamfile then None else
+    Some (opamfile'
+          |> OpamPrinter.FullPos.opamfile
+          |> OpamFile.Switch_config.read_from_string)
+
 let local_switch_exists root switch =
   (* we don't use safe loading function to avoid errors displaying *)
-  OpamPath.Switch.switch_config root switch |>
-  OpamFile.Switch_config.BestEffort.read_opt |> function
+  let f = OpamPath.Switch.switch_config root switch in
+  match OpamFile.Switch_config.BestEffort.read_opt f with
   | None -> false
   | Some conf -> conf.OpamFile.Switch_config.opam_root = Some root
+  | exception (OpamPp.Bad_version _ as e) ->
+    match OpamFile.Config.raw_root_version (OpamPath.config root) with
+    | None -> raise e
+    | Some _ ->
+      match downgrade_2_1_switch f with
+      | None -> raise e
+      | Some conf ->
+        if conf.OpamFile.Switch_config.opam_root = Some root then
+          (OpamFile.Switch_config.write f conf; true)
+        else false
 
 let resolve_local_switch root s =
   let switch_root = OpamSwitch.get_root root s in

--- a/src/state/opamStateConfig.mli
+++ b/src/state/opamStateConfig.mli
@@ -137,3 +137,12 @@ module Repos : sig
   val safe_read:
     ?lock_kind: 'a lock -> 'b global_state -> OpamFile.Repos_config.t
 end
+
+(* Raw read an switch config to downgrade its [opam-version] from 2.1 to 2.0.
+   It is necessary to handle opam root and switch upgrade from 2.1
+   intermediates roots to 2.1: this allows a workaround for a bug in versions
+   2.1~alpha which wrongly updated the declared switch versions, requiring that
+   we fix it during [OpamFormatUpgrade] from these specific intermediate
+   versions, and at switch loading for that specific case. *)
+val downgrade_2_1_switch:
+  OpamFile.Switch_config.t OpamFile.t -> OpamFile.Switch_config.t option

--- a/tests/reftests/dune
+++ b/tests/reftests/dune
@@ -6,7 +6,7 @@
 
 (executable
  (name run)
- (libraries opam-core)
+ (libraries opam-core opam-file-format)
  (modules run))
 
 (executable

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -700,39 +700,33 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ sw-comp
 STATE                           Switch state loaded in 0.000s
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
-switch: "sw-comp"
-download-jobs: 1
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-### cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 1
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-comp"
+### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+invariant: ["i-am-compiler" {>= "2"}]
 opam-version: "2.0"
 synopsis: "switch with compiler"
-invariant: [
-  "i-am-compiler" {>= "2"}
-]
 paths {
-  
+
 }
 variables {
-  
+
 }
-### cat $OPAMROOT/sw-comp/.opam-switch/switch-state
-opam-version: "2.0"
+### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-state
 compiler: ["i-am-compiler.2"]
-roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+opam-version: "2.0"
+roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### :V:1:b: From 2.0 root, local
 ### ocaml generate.ml 2.0 local
 ### # ro global state, ro repo state, ro switch state
@@ -776,44 +770,35 @@ You may want to back it up before going further.
 Continue? [Y/n] y
 Format upgrade done.
 Set to '4' the field jobs in global configuration
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: [
-  "sw-sys-comp"
-  "sw-comp"
-  "${BASEDIR}"
-  "default"
-]
-switch: "sw-sys-comp"
-jobs: 4
-download-jobs: 1
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-### cat _opam/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 1
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "${BASEDIR}" "default"]
+jobs: 4
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+### opam-cat _opam/.opam-switch/switch-config
+invariant: ["i-am-sys-compiler"]
+opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
-opam-root: "${BASEDIR}/OPAM"
-invariant: ["i-am-sys-compiler"]
 paths {
-  
+
 }
 variables {
-  
+
 }
-### cat _opam/.opam-switch/switch-state
-opam-version: "2.0"
+### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:1:c: From 2.0 root, local unknown from config
 ### ocaml generate.ml 2.0 orphaned
@@ -858,39 +843,35 @@ You may want to back it up before going further.
 Continue? [Y/n] y
 Format upgrade done.
 Set to '4' the field jobs in global configuration
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
-switch: "sw-sys-comp"
-jobs: 4
-download-jobs: 1
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-### cat _opam/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 1
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+jobs: 4
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+### opam-cat _opam/.opam-switch/switch-config
+invariant: ["i-am-sys-compiler"]
+opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
-opam-root: "${BASEDIR}/OPAM"
-invariant: ["i-am-sys-compiler"]
 paths {
-  
+
 }
 variables {
-  
+
 }
-### cat _opam/.opam-switch/switch-state
-opam-version: "2.0"
+### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:1:d: Upgraded root and local 2.0 switch not recorded
 ### ocaml generate.ml 2.1 orphaned 2.0
 ### # ro global state, ro repo state, ro switch state
@@ -922,40 +903,36 @@ Done.
 ### opam option jobs=4
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 Set to '4' the field jobs in global configuration
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
-switch: "sw-sys-comp"
-jobs: 4
-download-jobs: 1
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-### cat _opam/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 1
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
+jobs: 4
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+### opam-cat _opam/.opam-switch/switch-config
+invariant: ["i-am-sys-compiler"]
+opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
-opam-root: "${BASEDIR}/OPAM"
-invariant: ["i-am-sys-compiler"]
 paths {
-  
+
 }
 variables {
-  
+
 }
-### cat _opam/.opam-switch/switch-state
-opam-version: "2.0"
+### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:2:a: From 2.1~alpha root, global
 ### ocaml generate.ml 2.1~alpha
@@ -1011,46 +988,37 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ sw-comp
 STATE                           Switch state loaded in 0.000s
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
-switch: "sw-comp"
-download-jobs: 3
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
-default-invariant: [
-  "ocaml" {>= "4.05.0"}
-]
+default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-wrap-build-commands:
-  ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
-wrap-install-commands:
-  ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
-wrap-remove-commands:
-  ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
-### cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 3
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-comp"
+wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
+### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+invariant: ["i-am-compiler"]
 opam-version: "2.0"
 synopsis: "switch with compiler"
-invariant: ["i-am-compiler"]
 paths {
-  
+
 }
 variables {
-  
+
 }
-### cat $OPAMROOT/sw-comp/.opam-switch/switch-state
-opam-version: "2.0"
+### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-state
 compiler: ["i-am-compiler.2"]
-roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+opam-version: "2.0"
+roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### :V:2:b: From 2.1~alpha root, local
 ### ocaml generate.ml 2.1~alpha local
 ### opam list
@@ -1086,52 +1054,38 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
 Done.
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: [
-  "sw-sys-comp"
-  "sw-comp"
-  "${BASEDIR}"
-  "default"
-]
-switch: "sw-sys-comp"
-download-jobs: 3
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
-default-invariant: [
-  "ocaml" {>= "4.05.0"}
-]
+default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-wrap-build-commands:
-  ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
-wrap-install-commands:
-  ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
-wrap-remove-commands:
-  ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
-### cat _opam/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 3
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "${BASEDIR}" "default"]
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
+### opam-cat _opam/.opam-switch/switch-config
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
-opam-root: "${BASEDIR}/OPAM"
-invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 paths {
-  
+
 }
 variables {
-  
+
 }
-### cat _opam/.opam-switch/switch-state
-opam-version: "2.0"
+### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:2:c: From 2.1~alpha root, local unknown from config
 ### ocaml generate.ml 2.1~alpha orphaned
@@ -1169,47 +1123,38 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
 Done.
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
-switch: "sw-sys-comp"
-download-jobs: 3
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
-default-invariant: [
-  "ocaml" {>= "4.05.0"}
-]
+default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-wrap-build-commands:
-  ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
-wrap-install-commands:
-  ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
-wrap-remove-commands:
-  ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
-### cat _opam/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 3
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
+### opam-cat _opam/.opam-switch/switch-config
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
-opam-root: "${BASEDIR}/OPAM"
-invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 paths {
-  
+
 }
 variables {
-  
+
 }
-### cat _opam/.opam-switch/switch-state
-opam-version: "2.0"
+### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:2:d: Upgraded root and local 2.1~alpha switch not recorded
 ### ocaml generate.ml 2.1 orphaned 2.1~alpha
 ### # ro global state, ro repo state, ro switch state
@@ -1240,40 +1185,36 @@ Done.
 ### opam option jobs=4
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 Set to '4' the field jobs in global configuration
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
-switch: "sw-sys-comp"
-jobs: 4
-download-jobs: 1
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-### cat _opam/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 1
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
+jobs: 4
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+### opam-cat _opam/.opam-switch/switch-config
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
-opam-root: "${BASEDIR}/OPAM"
-invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 paths {
-  
+
 }
 variables {
-  
+
 }
-### cat _opam/.opam-switch/switch-state
-opam-version: "2.0"
+### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:3:a: From 2.1~alpha2 root, global
 ### ocaml generate.ml 2.1~alpha2
@@ -1332,46 +1273,37 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ sw-comp
 STATE                           Switch state loaded in 0.000s
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
-switch: "sw-comp"
-download-jobs: 3
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
-default-invariant: [
-  "ocaml" {>= "4.05.0"}
-]
+default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-wrap-build-commands:
-  ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
-wrap-install-commands:
-  ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
-wrap-remove-commands:
-  ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
-### cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 3
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-comp"
+wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
+### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+invariant: ["i-am-compiler"]
 opam-version: "2.0"
 synopsis: "switch with compiler"
-invariant: ["i-am-compiler"]
 paths {
-  
+
 }
 variables {
-  
+
 }
-### cat $OPAMROOT/sw-comp/.opam-switch/switch-state
-opam-version: "2.0"
+### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-state
 compiler: ["i-am-compiler.2"]
-roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+opam-version: "2.0"
+roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### :V:3:b: From 2.1~alpha2 root, local
 ### ocaml generate.ml 2.1~alpha2 local
 ### opam list
@@ -1409,52 +1341,38 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
 Done.
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: [
-  "sw-sys-comp"
-  "sw-comp"
-  "${BASEDIR}"
-  "default"
-]
-switch: "sw-sys-comp"
-download-jobs: 3
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
-default-invariant: [
-  "ocaml" {>= "4.05.0"}
-]
+default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-wrap-build-commands:
-  ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
-wrap-install-commands:
-  ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
-wrap-remove-commands:
-  ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
-### cat _opam/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 3
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "${BASEDIR}" "default"]
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
+### opam-cat _opam/.opam-switch/switch-config
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
-opam-root: "${BASEDIR}/OPAM"
-invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 paths {
-  
+
 }
 variables {
-  
+
 }
-### cat _opam/.opam-switch/switch-state
-opam-version: "2.0"
+### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:3:c: From 2.1~alpha2 root, local unknown from config
 ### ocaml generate.ml 2.1~alpha2 orphaned
@@ -1494,47 +1412,38 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
 Done.
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
-switch: "sw-sys-comp"
-download-jobs: 3
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
-default-invariant: [
-  "ocaml" {>= "4.05.0"}
-]
+default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-wrap-build-commands:
-  ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
-wrap-install-commands:
-  ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
-wrap-remove-commands:
-  ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
-### cat _opam/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 3
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
+### opam-cat _opam/.opam-switch/switch-config
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
-opam-root: "${BASEDIR}/OPAM"
-invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 paths {
-  
+
 }
 variables {
-  
+
 }
-### cat _opam/.opam-switch/switch-state
-opam-version: "2.0"
+### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:3:d: Upgraded root and local 2.1~alpha2 switch not recorded
 ### ocaml generate.ml 2.1 orphaned 2.1~alpha2
 ### # ro global state, ro repo state, ro switch state
@@ -1565,40 +1474,36 @@ Done.
 ### opam option jobs=4
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 Set to '4' the field jobs in global configuration
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
-switch: "sw-sys-comp"
-jobs: 4
-download-jobs: 1
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-### cat _opam/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 1
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
+jobs: 4
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+### opam-cat _opam/.opam-switch/switch-config
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
-opam-root: "${BASEDIR}/OPAM"
-invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 paths {
-  
+
 }
 variables {
-  
+
 }
-### cat _opam/.opam-switch/switch-state
-opam-version: "2.0"
+### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:4:a: From 2.1~rc root, global
 ### ocaml generate.ml 2.1~rc
@@ -1647,33 +1552,29 @@ You may want to back it up before going further.
 Continue? [Y/n] y
 Format upgrade done.
 Set to '4' the field jobs in global configuration
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
-switch: "sw-sys-comp"
-jobs: 4
-download-jobs: 1
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-### cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 1
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+jobs: 4
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+invariant: ["i-am-compiler"]
 opam-version: "2.0"
 synopsis: "switch with compiler"
-invariant: ["i-am-compiler"]
-### cat $OPAMROOT/sw-comp/.opam-switch/switch-state
-opam-version: "2.0"
+### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-state
 compiler: ["i-am-compiler.2"]
-roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+opam-version: "2.0"
+roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### :V:4:b: From 2.1~rc root, local
 ### ocaml generate.ml 2.1~rc local
 ### opam list
@@ -1713,39 +1614,30 @@ You may want to back it up before going further.
 Continue? [Y/n] y
 Format upgrade done.
 Set to '4' the field jobs in global configuration
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: [
-  "sw-sys-comp"
-  "sw-comp"
-  "${BASEDIR}"
-  "default"
-]
-switch: "sw-sys-comp"
-jobs: 4
-download-jobs: 1
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-### cat _opam/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 1
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "${BASEDIR}" "default"]
+jobs: 4
+opam-root-version: "2.1"
 opam-version: "2.0"
-synopsis: "local switch"
+repositories: "default"
+switch: "sw-sys-comp"
+### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
-### cat _opam/.opam-switch/switch-state
 opam-version: "2.0"
+synopsis: "local switch"
+### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:4:c: From 2.1~rc root, local unknown from config
 ### ocaml generate.ml 2.1~rc local
@@ -1786,39 +1678,30 @@ You may want to back it up before going further.
 Continue? [Y/n] y
 Format upgrade done.
 Set to '4' the field jobs in global configuration
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: [
-  "sw-sys-comp"
-  "sw-comp"
-  "${BASEDIR}"
-  "default"
-]
-switch: "sw-sys-comp"
-jobs: 4
-download-jobs: 1
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-### cat _opam/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 1
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "${BASEDIR}" "default"]
+jobs: 4
+opam-root-version: "2.1"
 opam-version: "2.0"
-synopsis: "local switch"
+repositories: "default"
+switch: "sw-sys-comp"
+### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
-### cat _opam/.opam-switch/switch-state
 opam-version: "2.0"
+synopsis: "local switch"
+### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:4:d: Upgraded root and local 2.1~rc switch not recorded
 ### ocaml generate.ml 2.1 orphaned 2.1~rc
 ### # ro global state, ro repo state, ro switch state
@@ -1848,34 +1731,30 @@ Done.
 ### opam option jobs=4
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 Set to '4' the field jobs in global configuration
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
-switch: "sw-sys-comp"
-jobs: 4
-download-jobs: 1
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-### cat _opam/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 1
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
+jobs: 4
+opam-root-version: "2.1"
 opam-version: "2.0"
-synopsis: "local switch"
+repositories: "default"
+switch: "sw-sys-comp"
+### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
-### cat _opam/.opam-switch/switch-state
 opam-version: "2.0"
+synopsis: "local switch"
+### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:5:a: From 2.1 root, global
 ### ocaml generate.ml 2.1
@@ -1908,31 +1787,27 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-another-package.2
 Done.
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-
-installed-switches: ["sw-sys-comp" "sw-comp" "default" "${BASEDIR}/why-did-you-delete-me" "this-internal-error"]
-switch: "sw-sys-comp"
-
-eval-variables: [ sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version" ]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
-
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-
-### cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+depext-run-installs: true
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "${BASEDIR}/why-did-you-delete-me" "this-internal-error"]
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+invariant: ["i-am-compiler"]
 opam-version: "2.0"
 synopsis: "switch with compiler"
-invariant: ["i-am-compiler"]
-### cat $OPAMROOT/sw-comp/.opam-switch/switch-state
-opam-version: "2.0"
+### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-state
 compiler: ["i-am-compiler.2"]
-roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+opam-version: "2.0"
+roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### :V:5:b: From 2.1 root, local
 ### ocaml generate.ml 2.1 local
 ### opam list
@@ -1958,32 +1833,28 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
 Done.
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-
-installed-switches: ["sw-sys-comp" "sw-comp" "${BASEDIR}" "default" "${BASEDIR}/why-did-you-delete-me" "this-internal-error"]
-switch: "sw-sys-comp"
-
-eval-variables: [ sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version" ]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
-
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-
-### cat _opam/.opam-switch/switch-config
+depext-run-installs: true
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "${BASEDIR}" "default" "${BASEDIR}/why-did-you-delete-me" "this-internal-error"]
+opam-root-version: "2.1"
 opam-version: "2.0"
-synopsis: "local switch"
+repositories: "default"
+switch: "sw-sys-comp"
+### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
-### cat _opam/.opam-switch/switch-state
 opam-version: "2.0"
+synopsis: "local switch"
+### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:5:c: From 2.1 root, local unknown from config
 ### ocaml generate.ml 2.1 local
 ### opam list
@@ -2008,32 +1879,28 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
 Done.
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-
-installed-switches: ["sw-sys-comp" "sw-comp" "${BASEDIR}" "default" "${BASEDIR}/why-did-you-delete-me" "this-internal-error"]
-switch: "sw-sys-comp"
-
-eval-variables: [ sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version" ]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
-
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-
-### cat _opam/.opam-switch/switch-config
+depext-run-installs: true
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "${BASEDIR}" "default" "${BASEDIR}/why-did-you-delete-me" "this-internal-error"]
+opam-root-version: "2.1"
 opam-version: "2.0"
-synopsis: "local switch"
+repositories: "default"
+switch: "sw-sys-comp"
+### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
-### cat _opam/.opam-switch/switch-state
 opam-version: "2.0"
+synopsis: "local switch"
+### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:5:d: Upgraded root and local 2.1 switch not recorded
 ### ocaml generate.ml 2.1 orphaned 2.1
 ### # ro global state, ro repo state, ro switch state
@@ -2063,31 +1930,27 @@ Done.
 ### opam option jobs=4
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 Set to '4' the field jobs in global configuration
-### cat $OPAMROOT/config
-opam-version: "2.0"
-opam-root-version: "2.1"
-repositories: "default"
-installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
-switch: "sw-sys-comp"
-jobs: 4
-download-jobs: 1
-eval-variables: [
-  sys-comp-version
-  ["sh" "-c" "echo $OPAMSYSCOMP"]
-  "comp version"
-]
+### opam-cat $OPAMROOT/config
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
-depext-run-installs: true
 depext-cannot-install: false
-### cat _opam/.opam-switch/switch-config
+depext-run-installs: true
+download-jobs: 1
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
+jobs: 4
+opam-root-version: "2.1"
 opam-version: "2.0"
-synopsis: "local switch"
+repositories: "default"
+switch: "sw-sys-comp"
+### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
-### cat _opam/.opam-switch/switch-state
 opam-version: "2.0"
+synopsis: "local switch"
+### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -534,6 +534,8 @@ let opam_20 =
 [ "config", [ opam_version_2_0; repo; installed_switches; eval; default_compiler ];
   "switch-config.default", [ opam_version_2_0; synopsis "default switch" ];
   "switch-state.default", [ opam_version_2_0; sw_state_default ];
+  "switch-config.local", [ opam_version_2_0; synopsis "local switch" ];
+  "switch-state.local", [ opam_version_2_0; sw_state_default ];
   "switch-config.sw-comp", [ opam_version_2_0; synopsis "switch with compiler" ];
   "switch-state.sw-comp", [ opam_version_2_0; sw_state_sw_comp ];
   "switch-config.sw-sys-comp", [ opam_version_2_0; synopsis "switch with system compiler" ];
@@ -543,6 +545,8 @@ let opam_21alpha =
 [ "config", [ opam_version_2_0; repo; installed_switches; eval; default_compiler ];
   "switch-config.default", [ opam_version_2_1; synopsis "default switch"; invariant_default ];
   "switch-state.default", [ opam_version_2_0; sw_state_default ];
+  "switch-config.local", [ opam_version_2_1; synopsis "local switch"; invariant_default ];
+  "switch-state.local", [ opam_version_2_0; sw_state_default ];
   "switch-config.sw-comp", [ opam_version_2_1; synopsis "switch with compiler"; invariant_sw_comp ];
   "switch-state.sw-comp", [ opam_version_2_0; sw_state_sw_comp ];
   "switch-config.sw-sys-comp", [ opam_version_2_1; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
@@ -552,6 +556,8 @@ let opam_21alpha2 =
 [ "config", [ opam_version_2_1; repo; installed_switches; eval; default_compiler; depext; ];
   "switch-config.default", [ opam_version_2_1; synopsis "default switch"; invariant_default ];
   "switch-state.default", [ opam_version_2_0; sw_state_default ];
+  "switch-config.local", [ opam_version_2_1; synopsis "local switch"; invariant_default ];
+  "switch-state.local", [ opam_version_2_0; sw_state_default ];
   "switch-config.sw-comp", [ opam_version_2_1; synopsis "switch with compiler"; invariant_sw_comp ];
   "switch-state.sw-comp", [ opam_version_2_0; sw_state_sw_comp ];
   "switch-config.sw-sys-comp", [ opam_version_2_1; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
@@ -561,6 +567,8 @@ let opam_21rc =
 [ "config", [ opam_version_2_0; root_version; repo; installed_switches; eval; default_compiler; default_invariant; depext ];
   "switch-config.default", [ opam_version_2_0; synopsis "default switch"; invariant_default ];
   "switch-state.default", [ opam_version_2_0; sw_state_default ];
+  "switch-config.local", [ opam_version_2_0; synopsis "local switch"; invariant_default ];
+  "switch-state.local", [ opam_version_2_0; sw_state_default ];
   "switch-config.sw-comp", [ opam_version_2_0; synopsis "switch with compiler"; invariant_sw_comp ];
   "switch-state.sw-comp", [ opam_version_2_0; sw_state_sw_comp ];
   "switch-config.sw-sys-comp", [ opam_version_2_0; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
@@ -570,6 +578,8 @@ let opam_21 =
 [ "config", [ opam_version_2_0; root_version_21; repo; installed_switches; eval; default_compiler; default_invariant; depext ];
   "switch-config.default", [ opam_version_2_0; synopsis "default switch"; invariant_default ];
   "switch-state.default", [ opam_version_2_0; sw_state_default ];
+  "switch-config.local", [ opam_version_2_0; synopsis "local switch"; invariant_default ];
+  "switch-state.local", [ opam_version_2_0; sw_state_default ];
   "switch-config.sw-comp", [ opam_version_2_0; synopsis "switch with compiler"; invariant_sw_comp ];
   "switch-state.sw-comp", [ opam_version_2_0; sw_state_sw_comp ];
   "switch-config.sw-sys-comp", [ opam_version_2_0; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
@@ -596,6 +606,13 @@ cp switch-config.sw-comp.$version $OPAMROOT/sw-comp/.opam-switch/switch-config
 cp switch-state.sw-comp.$version $OPAMROOT/sw-comp/.opam-switch/switch-state
 cp switch-config.sw-sys-comp.$version $OPAMROOT/sw-sys-comp/.opam-switch/switch-config
 cp switch-state.sw-sys-comp.$version $OPAMROOT/sw-sys-comp/.opam-switch/switch-state
+### <switch-local.sh>
+version=$1
+mkdir -p _opam/.opam-switch
+cp switch-config.local.$version _opam/.opam-switch/switch-config
+echo "opam-root: \"$OPAMROOT\"" >> _opam/.opam-switch/switch-config
+cp switch-state.local.$version _opam/.opam-switch/switch-state
+sed "s|\"sw-comp\"|\"sw-comp\" \"$PWD\"|" config.$version > $OPAMROOT/config
 ### # OPAMDEBUG=0 OPAMDEBUGLEVEL=0
 ### rm -rf $OPAMROOT
 ### opam init -na default ./default --bare --bypass-checks --no-opamrc --debug-level=0
@@ -604,7 +621,7 @@ No configuration file found, using built-in defaults.
 <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
 [default] Initialised
 ### mkdir -p $OPAMROOT $OPAMROOT/repo $OPAMROOT/default/.opam-switch  $OPAMROOT/sw-comp/.opam-switch $OPAMROOT/sw-sys-comp/.opam-switch
-### :V:1: From 2.0 root
+### :V:1:a: From 2.0 root, global
 ### sh switch-root.sh 2.0
 ### # ro global state
 ### opam option jobs
@@ -692,7 +709,90 @@ opam-version: "2.0"
 compiler: ["i-am-compiler.2"]
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
-### :V:2: From 2.1~alpha root
+### :V:1:a: From 2.0 root, local
+### sh switch-root.sh 2.0
+### sh switch-local.sh 2.0
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.0 to 2.1
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler"]
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-sys-compiler 2           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-package
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.0 to 2.1
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler"]
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+Done.
+### opam option jobs=4
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Light config upgrade, from 2.0 to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.0 to version 2.1, which can't be reverted.
+You may want to back it up before going further.
+
+Continue? [Y/n] y
+Format upgrade done.
+Set to '4' the field jobs in global configuration
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+installed-switches: [
+  "sw-sys-comp"
+  "sw-comp"
+  "${BASEDIR}"
+  "default"
+]
+switch: "sw-sys-comp"
+jobs: 4
+download-jobs: 1
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+### cat _opam/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "local switch"
+opam-root: "${BASEDIR}/OPAM"
+invariant: ["i-am-sys-compiler"]
+paths {
+  
+}
+variables {
+  
+}
+### cat _opam/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+### rm -rf _opam
+### :V:2:a: From 2.1~alpha root, global
 ### sh switch-root.sh 2.1~alpha
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
@@ -780,7 +880,84 @@ opam-version: "2.0"
 compiler: ["i-am-compiler.2"]
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
-### :V:3: From 2.1~alpha2 root
+### :V:2:b: From 2.1~alpha root, local
+### sh switch-root.sh 2.1~alpha
+### sh switch-local.sh 2.1~alpha
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Hard config upgrade, from 2.1~alpha to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~alpha to version 2.1, which can't be reverted.
+You may want to back it up before going further.
+
+Perform the update and continue? [Y/n] y
+Format upgrade done.
+
+<><> Rerunning init and update ><><><><><><><><><><><><><><><><><><><><><><><><>
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[default] no changes from file://${BASEDIR}/default
+Update done, please now retry your command.
+# Return code 10 #
+### opam install i-am-package
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+Done.
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+installed-switches: [
+  "sw-sys-comp"
+  "sw-comp"
+  "${BASEDIR}"
+  "default"
+]
+switch: "sw-sys-comp"
+download-jobs: 3
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: [
+  "ocaml" {>= "4.05.0"}
+]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+wrap-build-commands:
+  ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands:
+  ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands:
+  ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
+### cat _opam/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "local switch"
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
+### cat _opam/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+### rm -rf _opam
+### :V:3:a: From 2.1~alpha2 root, global
 ### sh switch-root.sh 2.1~alpha2
 ### # ro global state
 ### opam option jobs
@@ -871,7 +1048,86 @@ opam-version: "2.0"
 compiler: ["i-am-compiler.2"]
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
-### :V:4: From 2.1~rc root
+### :V:3:a: From 2.1~alpha2 root, local
+### sh switch-root.sh 2.1~alpha2
+### sh switch-local.sh 2.1~alpha2
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         Intermediate opam root detected, launch hard upgrade
+FMT_UPG                         Downgrade config opam-version to fix up
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Hard config upgrade, from 2.1~alpha2 to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~alpha2 to version 2.1, which can't be reverted.
+You may want to back it up before going further.
+
+Perform the update and continue? [Y/n] y
+Format upgrade done.
+
+<><> Rerunning init and update ><><><><><><><><><><><><><><><><><><><><><><><><>
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[default] no changes from file://${BASEDIR}/default
+Update done, please now retry your command.
+# Return code 10 #
+### opam install i-am-package
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+Done.
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+installed-switches: [
+  "sw-sys-comp"
+  "sw-comp"
+  "${BASEDIR}"
+  "default"
+]
+switch: "sw-sys-comp"
+download-jobs: 3
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: [
+  "ocaml" {>= "4.05.0"}
+]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+wrap-build-commands:
+  ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands:
+  ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands:
+  ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
+### cat _opam/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "local switch"
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
+### cat _opam/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+### rm -rf _opam
+### :V:4:a: From 2.1~rc root, global
 ### sh switch-root.sh 2.1~rc
 ### # ro global state
 ### opam option jobs
@@ -945,7 +1201,81 @@ opam-version: "2.0"
 compiler: ["i-am-compiler.2"]
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
-### :V:5: From 2.1 root
+### :V:4:a: From 2.1~rc root, local
+### sh switch-root.sh 2.1~rc
+### sh switch-local.sh 2.1~rc
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.1~rc to 2.1
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-sys-compiler 2           One-line description
+### opam install i-am-package
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.1~rc to 2.1
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+Done.
+### opam option jobs=4
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Light config upgrade, from 2.1~rc to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~rc to version 2.1, which can't be reverted.
+You may want to back it up before going further.
+
+Continue? [Y/n] y
+Format upgrade done.
+Set to '4' the field jobs in global configuration
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+installed-switches: [
+  "sw-sys-comp"
+  "sw-comp"
+  "${BASEDIR}"
+  "default"
+]
+switch: "sw-sys-comp"
+jobs: 4
+download-jobs: 1
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+### cat _opam/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "local switch"
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
+### cat _opam/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+### rm -rf _opam
+### :V:5:a: From 2.1 root, global
 ### sh switch-root.sh 2.1
 ### # ro global state
 ### opam option jobs
@@ -1001,3 +1331,55 @@ opam-version: "2.0"
 compiler: ["i-am-compiler.2"]
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+### :V:5:a: From 2.1 root, local
+### sh switch-root.sh 2.1
+### sh switch-local.sh 2.1
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-sys-compiler 2           One-line description
+### opam install i-am-package
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+Done.
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+
+installed-switches: ["sw-sys-comp" "sw-comp" "${BASEDIR}" "default" "${BASEDIR}/why-did-you-delete-me" "this-internal-error"]
+switch: "sw-sys-comp"
+
+eval-variables: [ sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version" ]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+
+### cat _opam/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "local switch"
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
+### cat _opam/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -497,10 +497,11 @@ let opam_version = Printf.sprintf "opam-version: %S"
 let opam_version_2_0 = opam_version "2.0"
 let opam_version_2_1 = opam_version "2.1"
 let repo = {|repositories: "default"|}
-let installed_switches = {|
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+let installed_switches =
+Format.sprintf {|
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "%s%swhy-did-you-delete-me" "this-internal-error"]
 switch: "sw-sys-comp"
-|}
+|} (Sys.getcwd ()) Filename.dir_sep
 let default_compiler = {|default-compiler: ["i-am-sys-compiler" "i-am-compiler"]|}
 let default_invariant = {|default-invariant: ["i-am-sys-compiler"]|}
 let depext = {|
@@ -637,6 +638,7 @@ Done.
 ### # rw global state
 ### opam switch sw-comp
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Light config upgrade, from 2.0 to 2.1~rc
 This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.0 to version 2.1~rc, which can't be reverted.
 You may want to back it up before going further.
@@ -684,6 +686,7 @@ installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### sh switch-root.sh 2.1~alpha
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Hard config upgrade, from 2.1~alpha to 2.1~rc
 This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~alpha to version 2.1~rc, which can't be reverted.
 You may want to back it up before going further.
@@ -774,6 +777,7 @@ installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         Intermediate opam root detected, launch hard upgrade
 FMT_UPG                         Downgrade config opam-version to fix up
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Hard config upgrade, from 2.1~alpha2 to 2.1~rc
 This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~alpha2 to version 2.1~rc, which can't be reverted.
 You may want to back it up before going further.
@@ -893,7 +897,7 @@ opam-version: "2.0"
 opam-root-version: "2.1~rc"
 repositories: "default"
 
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "${BASEDIR}/why-did-you-delete-me" "this-internal-error"]
 switch: "sw-sys-comp"
 
 eval-variables: [ sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version" ]

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -612,7 +612,9 @@ mkdir -p _opam/.opam-switch
 cp switch-config.local.$version _opam/.opam-switch/switch-config
 echo "opam-root: \"$OPAMROOT\"" >> _opam/.opam-switch/switch-config
 cp switch-state.local.$version _opam/.opam-switch/switch-state
-sed "s|\"sw-comp\"|\"sw-comp\" \"$PWD\"|" config.$version > $OPAMROOT/config
+if [ -z "$2" ]; then
+  sed "s|\"sw-comp\"|\"sw-comp\" \"$PWD\"|" config.$version > $OPAMROOT/config
+fi
 ### # OPAMDEBUG=0 OPAMDEBUGLEVEL=0
 ### rm -rf $OPAMROOT
 ### opam init -na default ./default --bare --bypass-checks --no-opamrc --debug-level=0
@@ -709,7 +711,7 @@ opam-version: "2.0"
 compiler: ["i-am-compiler.2"]
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
-### :V:1:a: From 2.0 root, local
+### :V:1:b: From 2.0 root, local
 ### sh switch-root.sh 2.0
 ### sh switch-local.sh 2.0
 ### # ro global state, ro repo state, ro switch state
@@ -763,6 +765,84 @@ installed-switches: [
   "${BASEDIR}"
   "default"
 ]
+switch: "sw-sys-comp"
+jobs: 4
+download-jobs: 1
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+### cat _opam/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "local switch"
+opam-root: "${BASEDIR}/OPAM"
+invariant: ["i-am-sys-compiler"]
+paths {
+  
+}
+variables {
+  
+}
+### cat _opam/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+### rm -rf _opam
+### :V:1:c: From 2.0 root, local unknown from config
+### sh switch-root.sh 2.0
+### sh switch-local.sh 2.0 empty
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.0 to 2.1
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler"]
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-sys-compiler 2           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-package
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.0 to 2.1
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler"]
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+Done.
+### opam option jobs=4
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Light config upgrade, from 2.0 to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.0 to version 2.1, which can't be reverted.
+You may want to back it up before going further.
+
+Continue? [Y/n] y
+Format upgrade done.
+Set to '4' the field jobs in global configuration
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
 switch: "sw-sys-comp"
 jobs: 4
 download-jobs: 1
@@ -875,6 +955,12 @@ wrap-remove-commands:
 opam-version: "2.0"
 synopsis: "switch with compiler"
 invariant: ["i-am-compiler"]
+paths {
+  
+}
+variables {
+  
+}
 ### cat $OPAMROOT/sw-comp/.opam-switch/switch-state
 opam-version: "2.0"
 compiler: ["i-am-compiler.2"]
@@ -949,8 +1035,93 @@ wrap-remove-commands:
 ### cat _opam/.opam-switch/switch-config
 opam-version: "2.0"
 synopsis: "local switch"
-invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+paths {
+  
+}
+variables {
+  
+}
+### cat _opam/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+### rm -rf _opam
+### :V:2:c: From 2.1~alpha root, local unknown from config
+### sh switch-root.sh 2.1~alpha
+### sh switch-local.sh 2.1~alpha empty
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Hard config upgrade, from 2.1~alpha to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~alpha to version 2.1, which can't be reverted.
+You may want to back it up before going further.
+
+Perform the update and continue? [Y/n] y
+Format upgrade done.
+
+<><> Rerunning init and update ><><><><><><><><><><><><><><><><><><><><><><><><>
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[default] no changes from file://${BASEDIR}/default
+Update done, please now retry your command.
+# Return code 10 #
+### opam install i-am-package
+FILE(switch-config)             Wrote ${BASEDIR}/_opam/.opam-switch/switch-config in 0.000s
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+Done.
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+switch: "sw-sys-comp"
+download-jobs: 3
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: [
+  "ocaml" {>= "4.05.0"}
+]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+wrap-build-commands:
+  ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands:
+  ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands:
+  ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
+### cat _opam/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "local switch"
+opam-root: "${BASEDIR}/OPAM"
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+paths {
+  
+}
+variables {
+  
+}
 ### cat _opam/.opam-switch/switch-state
 opam-version: "2.0"
 compiler: ["i-am-sys-compiler.2"]
@@ -1043,12 +1214,18 @@ wrap-remove-commands:
 opam-version: "2.0"
 synopsis: "switch with compiler"
 invariant: ["i-am-compiler"]
+paths {
+  
+}
+variables {
+  
+}
 ### cat $OPAMROOT/sw-comp/.opam-switch/switch-state
 opam-version: "2.0"
 compiler: ["i-am-compiler.2"]
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
-### :V:3:a: From 2.1~alpha2 root, local
+### :V:3:b: From 2.1~alpha2 root, local
 ### sh switch-root.sh 2.1~alpha2
 ### sh switch-local.sh 2.1~alpha2
 ### opam list
@@ -1119,8 +1296,95 @@ wrap-remove-commands:
 ### cat _opam/.opam-switch/switch-config
 opam-version: "2.0"
 synopsis: "local switch"
-invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+paths {
+  
+}
+variables {
+  
+}
+### cat _opam/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+### rm -rf _opam
+### :V:3:c: From 2.1~alpha2 root, local unknown from config
+### sh switch-root.sh 2.1~alpha2
+### sh switch-local.sh 2.1~alpha2 empty
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         Intermediate opam root detected, launch hard upgrade
+FMT_UPG                         Downgrade config opam-version to fix up
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Hard config upgrade, from 2.1~alpha2 to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~alpha2 to version 2.1, which can't be reverted.
+You may want to back it up before going further.
+
+Perform the update and continue? [Y/n] y
+Format upgrade done.
+
+<><> Rerunning init and update ><><><><><><><><><><><><><><><><><><><><><><><><>
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[default] no changes from file://${BASEDIR}/default
+Update done, please now retry your command.
+# Return code 10 #
+### opam install i-am-package
+FILE(switch-config)             Wrote ${BASEDIR}/_opam/.opam-switch/switch-config in 0.000s
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+Done.
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+switch: "sw-sys-comp"
+download-jobs: 3
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: [
+  "ocaml" {>= "4.05.0"}
+]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+wrap-build-commands:
+  ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands:
+  ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands:
+  ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
+### cat _opam/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "local switch"
+opam-root: "${BASEDIR}/OPAM"
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+paths {
+  
+}
+variables {
+  
+}
 ### cat _opam/.opam-switch/switch-state
 opam-version: "2.0"
 compiler: ["i-am-sys-compiler.2"]
@@ -1201,7 +1465,81 @@ opam-version: "2.0"
 compiler: ["i-am-compiler.2"]
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
-### :V:4:a: From 2.1~rc root, local
+### :V:4:b: From 2.1~rc root, local
+### sh switch-root.sh 2.1~rc
+### sh switch-local.sh 2.1~rc
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.1~rc to 2.1
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-sys-compiler 2           One-line description
+### opam install i-am-package
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.1~rc to 2.1
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+Done.
+### opam option jobs=4
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Light config upgrade, from 2.1~rc to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~rc to version 2.1, which can't be reverted.
+You may want to back it up before going further.
+
+Continue? [Y/n] y
+Format upgrade done.
+Set to '4' the field jobs in global configuration
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+installed-switches: [
+  "sw-sys-comp"
+  "sw-comp"
+  "${BASEDIR}"
+  "default"
+]
+switch: "sw-sys-comp"
+jobs: 4
+download-jobs: 1
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+### cat _opam/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "local switch"
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
+### cat _opam/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+### rm -rf _opam
+### :V:4:c: From 2.1~rc root, local unknown from config
 ### sh switch-root.sh 2.1~rc
 ### sh switch-local.sh 2.1~rc
 ### opam list
@@ -1331,7 +1669,7 @@ opam-version: "2.0"
 compiler: ["i-am-compiler.2"]
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
-### :V:5:a: From 2.1 root, local
+### :V:5:b: From 2.1 root, local
 ### sh switch-root.sh 2.1
 ### sh switch-local.sh 2.1
 ### opam list
@@ -1349,6 +1687,57 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+Done.
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+
+installed-switches: ["sw-sys-comp" "sw-comp" "${BASEDIR}" "default" "${BASEDIR}/why-did-you-delete-me" "this-internal-error"]
+switch: "sw-sys-comp"
+
+eval-variables: [ sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version" ]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+
+### cat _opam/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "local switch"
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
+### cat _opam/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+### :V:5:c: From 2.1 root, local unknown from config
+### sh switch-root.sh 2.1
+### sh switch-local.sh 2.1
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-sys-compiler 2           One-line description
+### opam install i-am-package
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -891,6 +891,71 @@ opam-version: "2.0"
 compiler: ["i-am-sys-compiler.2"]
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+### :V:1:d: Upgraded root and local 2.0 switch not recorded
+### ocaml generate.ml 2.1 orphaned 2.0
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler"]
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-sys-compiler 2           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-package
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler"]
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+Done.
+### opam option jobs=4
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Set to '4' the field jobs in global configuration
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
+switch: "sw-sys-comp"
+jobs: 4
+download-jobs: 1
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+### cat _opam/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "local switch"
+opam-root: "${BASEDIR}/OPAM"
+invariant: ["i-am-sys-compiler"]
+paths {
+  
+}
+variables {
+  
+}
+### cat _opam/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:2:a: From 2.1~alpha root, global
 ### ocaml generate.ml 2.1~alpha
@@ -1129,6 +1194,70 @@ wrap-install-commands:
   ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
 wrap-remove-commands:
   ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
+### cat _opam/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "local switch"
+opam-root: "${BASEDIR}/OPAM"
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+paths {
+  
+}
+variables {
+  
+}
+### cat _opam/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+### :V:2:d: Upgraded root and local 2.1~alpha switch not recorded
+### ocaml generate.ml 2.1 orphaned 2.1~alpha
+### # ro global state, ro repo state, ro switch state
+### opam list
+FILE(switch-config)             Wrote ${BASEDIR}/_opam/.opam-switch/switch-config in 0.000s
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-sys-compiler 2           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-package
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+Done.
+### opam option jobs=4
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Set to '4' the field jobs in global configuration
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
+switch: "sw-sys-comp"
+jobs: 4
+download-jobs: 1
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
 ### cat _opam/.opam-switch/switch-config
 opam-version: "2.0"
 synopsis: "local switch"
@@ -1406,6 +1535,70 @@ opam-version: "2.0"
 compiler: ["i-am-sys-compiler.2"]
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+### :V:3:d: Upgraded root and local 2.1~alpha2 switch not recorded
+### ocaml generate.ml 2.1 orphaned 2.1~alpha2
+### # ro global state, ro repo state, ro switch state
+### opam list
+FILE(switch-config)             Wrote ${BASEDIR}/_opam/.opam-switch/switch-config in 0.000s
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-sys-compiler 2           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-package
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+Done.
+### opam option jobs=4
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Set to '4' the field jobs in global configuration
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
+switch: "sw-sys-comp"
+jobs: 4
+download-jobs: 1
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+### cat _opam/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "local switch"
+opam-root: "${BASEDIR}/OPAM"
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+paths {
+  
+}
+variables {
+  
+}
+### cat _opam/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:4:a: From 2.1~rc root, global
 ### ocaml generate.ml 2.1~rc
@@ -1626,6 +1819,63 @@ opam-version: "2.0"
 compiler: ["i-am-sys-compiler.2"]
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+### :V:4:d: Upgraded root and local 2.1~rc switch not recorded
+### ocaml generate.ml 2.1 orphaned 2.1~rc
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-sys-compiler 2           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-package
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+Done.
+### opam option jobs=4
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Set to '4' the field jobs in global configuration
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
+switch: "sw-sys-comp"
+jobs: 4
+download-jobs: 1
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+### cat _opam/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "local switch"
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
+### cat _opam/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:5:a: From 2.1 root, global
 ### ocaml generate.ml 2.1
@@ -1774,6 +2024,63 @@ depext: true
 depext-run-installs: true
 depext-cannot-install: false
 
+### cat _opam/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "local switch"
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
+### cat _opam/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-sys-compiler.2"]
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+### :V:5:d: Upgraded root and local 2.1 switch not recorded
+### ocaml generate.ml 2.1 orphaned 2.1
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-sys-compiler 2           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-package
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+Done.
+### opam option jobs=4
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Set to '4' the field jobs in global configuration
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
+switch: "sw-sys-comp"
+jobs: 4
+download-jobs: 1
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
 ### cat _opam/.opam-switch/switch-config
 opam-version: "2.0"
 synopsis: "local switch"

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -492,15 +492,39 @@ done
 ### sh generate_dirs.sh
 ### ocaml generate_repo.ml
 ### <generate.ml>
+#load "unix.cma";;
+
+let rec mkdir_p dir =
+  if Sys.file_exists dir then ()
+  else let () = mkdir_p (Filename.dirname dir) in
+    if not (Sys.file_exists dir) then
+      Unix.mkdir dir 0o777
+    else ()
+
+let mode =
+  if Array.length Sys.argv = 2 then `Root else
+  let version =
+    if Array.length Sys.argv = 3 then Sys.argv.(1) else Sys.argv.(3)
+  in
+  match Sys.argv.(2) with
+  | "local" -> `Local version
+  | "orphaned" -> `Orphaned version
+  | _ -> assert false
+
 let opam_version = Printf.sprintf "opam-version: %S"
 let opam_version_2_0 = opam_version "2.0"
 let opam_version_2_1 = opam_version "2.1"
 let repo = {|repositories: "default"|}
 let installed_switches =
-Format.sprintf {|
-installed-switches: ["sw-sys-comp" "sw-comp" "default" "%s%swhy-did-you-delete-me" "this-internal-error"]
+  let local_switch =
+    match mode with
+    | `Local _ -> Printf.sprintf " %S" (Sys.getcwd ())
+    | _ -> ""
+  in
+  Format.sprintf {|
+installed-switches: ["sw-sys-comp" "sw-comp"%s "default" %S "this-internal-error"]
 switch: "sw-sys-comp"
-|} (Sys.getcwd ()) Filename.dir_sep
+|} local_switch (Filename.concat (Sys.getcwd ()) "why-did-you-delete-me")
 let default_compiler = {|default-compiler: ["i-am-sys-compiler" "i-am-compiler"]|}
 let default_invariant = {|default-invariant: ["i-am-sys-compiler"]|}
 let depext = {|
@@ -530,92 +554,90 @@ let invariant_sw_sys_comp = {|invariant: ["i-am-sys-compiler"]|}
 let root_version =  {|opam-root-version: "2.1~rc"|}
 let root_version_21 =  {|opam-root-version: "2.1"|}
 let synopsis = Printf.sprintf "synopsis: %S"
+let opam_root = Printf.sprintf "opam-root: %S" (Sys.getenv "OPAMROOT")
 let opam_20 =
-[ "config", [ opam_version_2_0; repo; installed_switches; eval; default_compiler ];
-  "switch-config.default", [ opam_version_2_0; synopsis "default switch" ];
-  "switch-state.default", [ opam_version_2_0; sw_state_default ];
-  "switch-config.local", [ opam_version_2_0; synopsis "local switch" ];
-  "switch-state.local", [ opam_version_2_0; sw_state_default ];
-  "switch-config.sw-comp", [ opam_version_2_0; synopsis "switch with compiler" ];
-  "switch-state.sw-comp", [ opam_version_2_0; sw_state_sw_comp ];
-  "switch-config.sw-sys-comp", [ opam_version_2_0; synopsis "switch with system compiler" ];
-  "switch-state.sw-sys-comp", [ opam_version_2_0; sw_state_sw_sys_comp ]
-]
+  [ "config", [ opam_version_2_0; repo; installed_switches; eval; default_compiler ];
+    "default/.opam-switch/switch-config", [ opam_version_2_0; synopsis "default switch" ];
+    "default/.opam-switch/switch-state", [ opam_version_2_0; sw_state_default ];
+    "sw-comp/.opam-switch/switch-config", [ opam_version_2_0; synopsis "switch with compiler" ];
+    "sw-comp/.opam-switch/switch-state", [ opam_version_2_0; sw_state_sw_comp ];
+    "sw-sys-comp/.opam-switch/switch-config", [ opam_version_2_0; synopsis "switch with system compiler" ];
+    "sw-sys-comp/.opam-switch/switch-state", [ opam_version_2_0; sw_state_sw_sys_comp ]
+  ], [
+    "_opam/.opam-switch/switch-config", [ opam_version_2_0; synopsis "local switch"; opam_root ];
+    "_opam/.opam-switch/switch-state", [ opam_version_2_0; sw_state_default ];
+  ]
 let opam_21alpha =
-[ "config", [ opam_version_2_0; repo; installed_switches; eval; default_compiler ];
-  "switch-config.default", [ opam_version_2_1; synopsis "default switch"; invariant_default ];
-  "switch-state.default", [ opam_version_2_0; sw_state_default ];
-  "switch-config.local", [ opam_version_2_1; synopsis "local switch"; invariant_default ];
-  "switch-state.local", [ opam_version_2_0; sw_state_default ];
-  "switch-config.sw-comp", [ opam_version_2_1; synopsis "switch with compiler"; invariant_sw_comp ];
-  "switch-state.sw-comp", [ opam_version_2_0; sw_state_sw_comp ];
-  "switch-config.sw-sys-comp", [ opam_version_2_1; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
-  "switch-state.sw-sys-comp", [ opam_version_2_0; sw_state_sw_sys_comp ]
-]
+  [ "config", [ opam_version_2_0; repo; installed_switches; eval; default_compiler ];
+    "default/.opam-switch/switch-config", [ opam_version_2_1; synopsis "default switch"; invariant_default ];
+    "default/.opam-switch/switch-state", [ opam_version_2_0; sw_state_default ];
+    "sw-comp/.opam-switch/switch-config", [ opam_version_2_1; synopsis "switch with compiler"; invariant_sw_comp ];
+    "sw-comp/.opam-switch/switch-state", [ opam_version_2_0; sw_state_sw_comp ];
+    "sw-sys-comp/.opam-switch/switch-config", [ opam_version_2_1; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
+    "sw-sys-comp/.opam-switch/switch-state", [ opam_version_2_0; sw_state_sw_sys_comp ]
+  ], [
+    "_opam/.opam-switch/switch-config", [ opam_version_2_1; synopsis "local switch"; invariant_default; opam_root ];
+    "_opam/.opam-switch/switch-state", [ opam_version_2_0; sw_state_default ];
+  ]
 let opam_21alpha2 =
-[ "config", [ opam_version_2_1; repo; installed_switches; eval; default_compiler; depext; ];
-  "switch-config.default", [ opam_version_2_1; synopsis "default switch"; invariant_default ];
-  "switch-state.default", [ opam_version_2_0; sw_state_default ];
-  "switch-config.local", [ opam_version_2_1; synopsis "local switch"; invariant_default ];
-  "switch-state.local", [ opam_version_2_0; sw_state_default ];
-  "switch-config.sw-comp", [ opam_version_2_1; synopsis "switch with compiler"; invariant_sw_comp ];
-  "switch-state.sw-comp", [ opam_version_2_0; sw_state_sw_comp ];
-  "switch-config.sw-sys-comp", [ opam_version_2_1; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
-  "switch-state.sw-sys-comp", [ opam_version_2_0; sw_state_sw_sys_comp ]
-]
+  [ "config", [ opam_version_2_1; repo; installed_switches; eval; default_compiler; depext; ];
+    "default/.opam-switch/switch-config", [ opam_version_2_1; synopsis "default switch"; invariant_default ];
+    "default/.opam-switch/switch-state", [ opam_version_2_0; sw_state_default ];
+    "sw-comp/.opam-switch/switch-config", [ opam_version_2_1; synopsis "switch with compiler"; invariant_sw_comp ];
+    "sw-comp/.opam-switch/switch-state", [ opam_version_2_0; sw_state_sw_comp ];
+    "sw-sys-comp/.opam-switch/switch-config", [ opam_version_2_1; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
+    "sw-sys-comp/.opam-switch/switch-state", [ opam_version_2_0; sw_state_sw_sys_comp ]
+  ], [
+    "_opam/.opam-switch/switch-config", [ opam_version_2_1; synopsis "local switch"; invariant_default; opam_root ];
+    "_opam/.opam-switch/switch-state", [ opam_version_2_0; sw_state_default ];
+  ]
 let opam_21rc =
-[ "config", [ opam_version_2_0; root_version; repo; installed_switches; eval; default_compiler; default_invariant; depext ];
-  "switch-config.default", [ opam_version_2_0; synopsis "default switch"; invariant_default ];
-  "switch-state.default", [ opam_version_2_0; sw_state_default ];
-  "switch-config.local", [ opam_version_2_0; synopsis "local switch"; invariant_default ];
-  "switch-state.local", [ opam_version_2_0; sw_state_default ];
-  "switch-config.sw-comp", [ opam_version_2_0; synopsis "switch with compiler"; invariant_sw_comp ];
-  "switch-state.sw-comp", [ opam_version_2_0; sw_state_sw_comp ];
-  "switch-config.sw-sys-comp", [ opam_version_2_0; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
-  "switch-state.sw-sys-comp", [ opam_version_2_0; sw_state_sw_sys_comp ]
-]
+  [ "config", [ opam_version_2_0; root_version; repo; installed_switches; eval; default_compiler; default_invariant; depext ];
+    "default/.opam-switch/switch-config", [ opam_version_2_0; synopsis "default switch"; invariant_default ];
+    "default/.opam-switch/switch-state", [ opam_version_2_0; sw_state_default ];
+    "sw-comp/.opam-switch/switch-config", [ opam_version_2_0; synopsis "switch with compiler"; invariant_sw_comp ];
+    "sw-comp/.opam-switch/switch-state", [ opam_version_2_0; sw_state_sw_comp ];
+    "sw-sys-comp/.opam-switch/switch-config", [ opam_version_2_0; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
+    "sw-sys-comp/.opam-switch/switch-state", [ opam_version_2_0; sw_state_sw_sys_comp ]
+  ], [
+    "_opam/.opam-switch/switch-config", [ opam_version_2_0; synopsis "local switch"; invariant_default; opam_root ];
+    "_opam/.opam-switch/switch-state", [ opam_version_2_0; sw_state_default ];
+  ]
 let opam_21 =
-[ "config", [ opam_version_2_0; root_version_21; repo; installed_switches; eval; default_compiler; default_invariant; depext ];
-  "switch-config.default", [ opam_version_2_0; synopsis "default switch"; invariant_default ];
-  "switch-state.default", [ opam_version_2_0; sw_state_default ];
-  "switch-config.local", [ opam_version_2_0; synopsis "local switch"; invariant_default ];
-  "switch-state.local", [ opam_version_2_0; sw_state_default ];
-  "switch-config.sw-comp", [ opam_version_2_0; synopsis "switch with compiler"; invariant_sw_comp ];
-  "switch-state.sw-comp", [ opam_version_2_0; sw_state_sw_comp ];
-  "switch-config.sw-sys-comp", [ opam_version_2_0; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
-  "switch-state.sw-sys-comp", [ opam_version_2_0; sw_state_sw_sys_comp ]
-]
+  [ "config", [ opam_version_2_0; root_version_21; repo; installed_switches; eval; default_compiler; default_invariant; depext ];
+    "default/.opam-switch/switch-config", [ opam_version_2_0; synopsis "default switch"; invariant_default ];
+    "default/.opam-switch/switch-state", [ opam_version_2_0; sw_state_default ];
+    "sw-comp/.opam-switch/switch-config", [ opam_version_2_0; synopsis "switch with compiler"; invariant_sw_comp ];
+    "sw-comp/.opam-switch/switch-state", [ opam_version_2_0; sw_state_sw_comp ];
+    "sw-sys-comp/.opam-switch/switch-config", [ opam_version_2_0; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
+    "sw-sys-comp/.opam-switch/switch-state", [ opam_version_2_0; sw_state_sw_sys_comp ]
+  ], [
+    "_opam/.opam-switch/switch-config", [ opam_version_2_0; synopsis "local switch"; invariant_default; opam_root ];
+    "_opam/.opam-switch/switch-state", [ opam_version_2_0; sw_state_default ];
+  ]
 let _ =
-  let append v (f,c) = f^"."^v, c in
-  List.iter (fun (name, content) ->
-      let fd = open_out name in
-      List.iter (fun l -> output_string fd (l^"\n")) content;
-      close_out fd)
-    (List.map (append "2.0") opam_20
-     @ List.map (append "2.1~alpha") opam_21alpha
-     @ List.map (append "2.1~alpha2") opam_21alpha2
-     @ List.map (append "2.1~rc") opam_21rc
-     @ List.map (append "2.1") opam_21)
-### ocaml generate.ml
-### <switch-root.sh>
-version=$1
-cp config.$version $OPAMROOT/config
-cp switch-config.default.$version $OPAMROOT/default/.opam-switch/switch-config
-cp switch-state.default.$version $OPAMROOT/default/.opam-switch/switch-state
-cp switch-config.sw-comp.$version $OPAMROOT/sw-comp/.opam-switch/switch-config
-cp switch-state.sw-comp.$version $OPAMROOT/sw-comp/.opam-switch/switch-state
-cp switch-config.sw-sys-comp.$version $OPAMROOT/sw-sys-comp/.opam-switch/switch-config
-cp switch-state.sw-sys-comp.$version $OPAMROOT/sw-sys-comp/.opam-switch/switch-state
-### <switch-local.sh>
-version=$1
-mkdir -p _opam/.opam-switch
-cp switch-config.local.$version _opam/.opam-switch/switch-config
-echo "opam-root: \"$OPAMROOT\"" >> _opam/.opam-switch/switch-config
-cp switch-state.local.$version _opam/.opam-switch/switch-state
-if [ -z "$2" ]; then
-  sed "s|\"sw-comp\"|\"sw-comp\" \"$PWD\"|" config.$version > $OPAMROOT/config
-fi
-### # OPAMDEBUG=0 OPAMDEBUGLEVEL=0
+  let get_files = function
+    | "2.0" -> opam_20
+    | "2.1~alpha" -> opam_21alpha
+    | "2.1~alpha2" -> opam_21alpha2
+    | "2.1~rc" -> opam_21rc
+    | "2.1" -> opam_21
+    | _ -> assert false
+  in
+  let write dir (name, content) =
+    let name = Filename.concat dir name in
+    mkdir_p (Filename.dirname name);
+    let fd = open_out name in
+    List.iter (fun l -> output_string fd (l^"\n")) content;
+    close_out fd
+  in
+  let root,_ = get_files Sys.argv.(1) in
+  List.iter (write (Sys.getenv "OPAMROOT")) root;
+  match mode with
+  | `Local v | `Orphaned v ->
+    let _, local = get_files v in
+    List.iter (write (Sys.getcwd ())) local
+  | _ -> ()
 ### rm -rf $OPAMROOT
 ### opam init -na default ./default --bare --bypass-checks --no-opamrc --debug-level=0
 No configuration file found, using built-in defaults.
@@ -624,7 +646,7 @@ No configuration file found, using built-in defaults.
 [default] Initialised
 ### mkdir -p $OPAMROOT $OPAMROOT/repo $OPAMROOT/default/.opam-switch  $OPAMROOT/sw-comp/.opam-switch $OPAMROOT/sw-sys-comp/.opam-switch
 ### :V:1:a: From 2.0 root, global
-### sh switch-root.sh 2.0
+### ocaml generate.ml 2.0
 ### # ro global state
 ### opam option jobs
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
@@ -712,8 +734,7 @@ compiler: ["i-am-compiler.2"]
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### :V:1:b: From 2.0 root, local
-### sh switch-root.sh 2.0
-### sh switch-local.sh 2.0
+### ocaml generate.ml 2.0 local
 ### # ro global state, ro repo state, ro switch state
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
@@ -795,8 +816,7 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:1:c: From 2.0 root, local unknown from config
-### sh switch-root.sh 2.0
-### sh switch-local.sh 2.0 empty
+### ocaml generate.ml 2.0 orphaned
 ### # ro global state, ro repo state, ro switch state
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
@@ -873,7 +893,7 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:2:a: From 2.1~alpha root, global
-### sh switch-root.sh 2.1~alpha
+### ocaml generate.ml 2.1~alpha
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
@@ -967,8 +987,7 @@ compiler: ["i-am-compiler.2"]
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### :V:2:b: From 2.1~alpha root, local
-### sh switch-root.sh 2.1~alpha
-### sh switch-local.sh 2.1~alpha
+### ocaml generate.ml 2.1~alpha local
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
@@ -1050,8 +1069,7 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:2:c: From 2.1~alpha root, local unknown from config
-### sh switch-root.sh 2.1~alpha
-### sh switch-local.sh 2.1~alpha empty
+### ocaml generate.ml 2.1~alpha orphaned
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
@@ -1129,7 +1147,7 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:3:a: From 2.1~alpha2 root, global
-### sh switch-root.sh 2.1~alpha2
+### ocaml generate.ml 2.1~alpha2
 ### # ro global state
 ### opam option jobs
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
@@ -1226,8 +1244,7 @@ compiler: ["i-am-compiler.2"]
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### :V:3:b: From 2.1~alpha2 root, local
-### sh switch-root.sh 2.1~alpha2
-### sh switch-local.sh 2.1~alpha2
+### ocaml generate.ml 2.1~alpha2 local
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         Intermediate opam root detected, launch hard upgrade
@@ -1311,8 +1328,7 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:3:c: From 2.1~alpha2 root, local unknown from config
-### sh switch-root.sh 2.1~alpha2
-### sh switch-local.sh 2.1~alpha2 empty
+### ocaml generate.ml 2.1~alpha2 orphaned
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         Intermediate opam root detected, launch hard upgrade
@@ -1392,7 +1408,7 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:4:a: From 2.1~rc root, global
-### sh switch-root.sh 2.1~rc
+### ocaml generate.ml 2.1~rc
 ### # ro global state
 ### opam option jobs
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
@@ -1466,8 +1482,7 @@ compiler: ["i-am-compiler.2"]
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### :V:4:b: From 2.1~rc root, local
-### sh switch-root.sh 2.1~rc
-### sh switch-local.sh 2.1~rc
+### ocaml generate.ml 2.1~rc local
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.1~rc to 2.1
@@ -1540,8 +1555,7 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:4:c: From 2.1~rc root, local unknown from config
-### sh switch-root.sh 2.1~rc
-### sh switch-local.sh 2.1~rc
+### ocaml generate.ml 2.1~rc local
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.1~rc to 2.1
@@ -1614,7 +1628,7 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:5:a: From 2.1 root, global
-### sh switch-root.sh 2.1
+### ocaml generate.ml 2.1
 ### # ro global state
 ### opam option jobs
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
@@ -1670,8 +1684,7 @@ compiler: ["i-am-compiler.2"]
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### :V:5:b: From 2.1 root, local
-### sh switch-root.sh 2.1
-### sh switch-local.sh 2.1
+### ocaml generate.ml 2.1 local
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
@@ -1722,8 +1735,7 @@ compiler: ["i-am-sys-compiler.2"]
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:5:c: From 2.1 root, local unknown from config
-### sh switch-root.sh 2.1
-### sh switch-local.sh 2.1
+### ocaml generate.ml 2.1 local
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -17,7 +17,7 @@ let _ =
       List.map (fun v -> [
             "config."^v, [ opam_v ; root_version v ];
             "config-w-swfoo."^v, [ opam_v; root_version v; switches ];
-          ]) ["2.0"; "2.1~rc"; "2.2"]
+          ]) ["2.0"; "2.1"; "2.2"]
       |> List.flatten)
     @ (let opam_v = opam_version "2.1" in
        let v = "2.3" in [
@@ -32,7 +32,7 @@ let _ =
   in
   let errs =
     List.map (fun (n,c) -> n^".err" , c@[neant]) files
-    @ (let v = "2.1~rc" in
+    @ (let v = "2.1" in
        let opam_v = opam_version "2.1" in [
          "config."^v^".wrong", [ opam_v; root_version v ];
          "switch-config.wrong", [ opam_v; switch_config ];
@@ -51,7 +51,7 @@ opam-version: "2.0"
 ### :I: Current opam root :
 ### :                     :
 ### :I:1:a: Bad config file
-### cp config.2.1~rc.err $OPAMROOT/config
+### cp config.2.1.err $OPAMROOT/config
 ### # ro global state
 ### opam switch
 [WARNING] Errors in ${BASEDIR}/OPAM/config, some fields have been ignored:
@@ -65,7 +65,7 @@ GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 
 #  switch  compiler  description
 ### :I:1:b: Good config file
-### cp config.2.1~rc $OPAMROOT/config
+### cp config.2.1 $OPAMROOT/config
 ### # ro global state
 ### opam switch
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
@@ -161,7 +161,7 @@ STATE                           Switch state loaded in 0.000s
 [ERROR] No package named bar found.
 # Return code 5 #
 ### :I:1:a: Bad config file
-### cp config-w-swfoo.2.1~rc.err $OPAMROOT/config
+### cp config-w-swfoo.2.1.err $OPAMROOT/config
 ### # rw global state
 ### opam switch remove foo
 [WARNING] Errors in ${BASEDIR}/OPAM/config, some fields have been ignored:
@@ -176,7 +176,7 @@ GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 Switch foo and all its packages will be wiped. Are you sure? [Y/n] y
 ### :I:1:b: Good config file
 ### opam switch create foo --empty --debug-level=0
-### cp config-w-swfoo.2.1~rc $OPAMROOT/config
+### cp config-w-swfoo.2.1 $OPAMROOT/config
 ### # rw global state
 ### opam switch remove foo
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
@@ -185,8 +185,7 @@ Switch foo and all its packages will be wiped. Are you sure? [Y/n] y
 ### :II: Current opam root & newer opam file version :
 ### :                                                :
 ### :II:1: config with newer opam version file & no update of root version
-### cp config.2.1~rc.wrong $OPAMROOT/config
-### # cat $OPAMROOT/config
+### cp config.2.1.wrong $OPAMROOT/config
 ### # ro global state
 ### opam switch
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
@@ -208,7 +207,7 @@ In ${BASEDIR}/OPAM/config:
 unsupported or missing file format version; should be 2.0 or older
 # Return code 99 #
 ### :II:2: switch-config with newer opam version file & no update of root version
-### cp config.2.1~rc $OPAMROOT/config
+### cp config.2.1 $OPAMROOT/config
 ### opam switch create foo --empty --debug-level=0
 ### cp switch-config.wrong $OPAMROOT/foo/.opam-switch/switch-config
 ### # ro global state
@@ -237,31 +236,31 @@ Invalid field neant
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FORMAT                          File errors in ${BASEDIR}/OPAM/config, ignored fields: At ${BASEDIR}/OPAM/config:3:0-3:8::
 Invalid field neant
-GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+GSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 #  switch  compiler  description
 ### :III:1:b: Good config file
 ### cp config.2.2 $OPAMROOT/config
 ### # ro global state
 ### opam switch
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+GSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 #  switch  compiler  description
 ### :III:2:a: Bad repo config file :
 ### cp repos-config.err $OPAMROOT/repo/repos-config
 ### # ro global state, ro repo state
 ### opam list --no-switch
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+GSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 FORMAT                          File errors in ${BASEDIR}/OPAM/repo/repos-config, ignored fields: At ${BASEDIR}/OPAM/repo/repos-config:2:0-2:8::
 Invalid field neant
-RSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 RSTATE                          Cache found
 # No matches found
 ### # ro global state, rw repo state
 ### opam repo add root-config ./root-config --set-default
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+GSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 [ERROR] Refusing write access to ${BASEDIR}/OPAM, which is more recent than this version of opam (2.2 > 2.1), aborting.
 # Return code 15 #
@@ -270,33 +269,33 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 ### # ro global state, ro repo state
 ### opam list --no-switch
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+GSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
-RSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 RSTATE                          Cache found
 # No matches found
 ### # ro global state, rw repo state
 ### opam repo add root-config ./root-config --set-default
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+GSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 [ERROR] Refusing write access to ${BASEDIR}/OPAM, which is more recent than this version of opam (2.2 > 2.1), aborting.
 # Return code 15 #
-### cp config.2.1~rc $OPAMROOT/config
+### cp config.2.1 $OPAMROOT/config
 ### cp config-w-swfoo.2.2 $OPAMROOT/config
 ### :III:3:a: Bad switch config file :
 ### cp switch-config.err $OPAMROOT/foo/.opam-switch/switch-config
 ### # ro global state, ro repo state, ro switch state
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+GSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
-RSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ foo
 FORMAT                          File errors in ${BASEDIR}/OPAM/foo/.opam-switch/switch-config, ignored fields: At ${BASEDIR}/OPAM/foo/.opam-switch/switch-config:3:0-3:8::
 Invalid field neant
-STATE                           root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+STATE                           root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 STATE                           Inferred invariant: from base packages {}, (roots {}) => []
 STATE                           Switch state loaded in 0.000s
 # Packages matching: installed
@@ -304,9 +303,9 @@ STATE                           Switch state loaded in 0.000s
 ### # ro global state, ro repo state, rw switch state
 ### opam install bar
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+GSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
-RSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ foo
 [ERROR] Refusing write access to ${BASEDIR}/OPAM, which is more recent than this version of opam (2.2 > 2.1), aborting.
@@ -316,12 +315,12 @@ STATE                           LOAD-SWITCH-STATE @ foo
 ### # ro global state, ro repo state, ro switch state
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+GSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
-RSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ foo
-STATE                           root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+STATE                           root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 STATE                           Inferred invariant: from base packages {}, (roots {}) => []
 STATE                           Switch state loaded in 0.000s
 # Packages matching: installed
@@ -329,9 +328,9 @@ STATE                           Switch state loaded in 0.000s
 ### # ro global state, ro repo state, rw switch state
 ### opam install bar
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-GSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+GSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
-RSTATE                          root version (2.2) is greater than running binary's (2.1~rc); load with best-effort (read-only)
+RSTATE                          root version (2.2) is greater than running binary's (2.1); load with best-effort (read-only)
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ foo
 [ERROR] Refusing write access to ${BASEDIR}/OPAM, which is more recent than this version of opam (2.2 > 2.1), aborting.
@@ -405,7 +404,7 @@ Fatal error:
 In ${BASEDIR}/OPAM/config:
 unsupported or missing file format version; should be 2.0 or older
 # Return code 99 #
-### cp config.2.1~rc $OPAMROOT/config
+### cp config.2.1 $OPAMROOT/config
 ### #opam switch create foo --empty --debug-level=0
 ### cp config-w-swfoo.2.3 $OPAMROOT/config
 ### :IV:3:a: Bad switch config file :
@@ -529,6 +528,7 @@ let invariant_default = {|invariant: ["i-am-sys-compiler" | "i-am-compiler"]|}
 let invariant_sw_comp = {|invariant: ["i-am-compiler"]|}
 let invariant_sw_sys_comp = {|invariant: ["i-am-sys-compiler"]|}
 let root_version =  {|opam-root-version: "2.1~rc"|}
+let root_version_21 =  {|opam-root-version: "2.1"|}
 let synopsis = Printf.sprintf "synopsis: %S"
 let opam_20 =
 [ "config", [ opam_version_2_0; repo; installed_switches; eval; default_compiler ];
@@ -566,6 +566,15 @@ let opam_21rc =
   "switch-config.sw-sys-comp", [ opam_version_2_0; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
   "switch-state.sw-sys-comp", [ opam_version_2_0; sw_state_sw_sys_comp ]
 ]
+let opam_21 =
+[ "config", [ opam_version_2_0; root_version_21; repo; installed_switches; eval; default_compiler; default_invariant; depext ];
+  "switch-config.default", [ opam_version_2_0; synopsis "default switch"; invariant_default ];
+  "switch-state.default", [ opam_version_2_0; sw_state_default ];
+  "switch-config.sw-comp", [ opam_version_2_0; synopsis "switch with compiler"; invariant_sw_comp ];
+  "switch-state.sw-comp", [ opam_version_2_0; sw_state_sw_comp ];
+  "switch-config.sw-sys-comp", [ opam_version_2_0; synopsis "switch with system compiler"; invariant_sw_sys_comp ];
+  "switch-state.sw-sys-comp", [ opam_version_2_0; sw_state_sw_sys_comp ]
+]
 let _ =
   let append v (f,c) = f^"."^v, c in
   List.iter (fun (name, content) ->
@@ -575,7 +584,8 @@ let _ =
     (List.map (append "2.0") opam_20
      @ List.map (append "2.1~alpha") opam_21alpha
      @ List.map (append "2.1~alpha2") opam_21alpha2
-     @ List.map (append "2.1~rc") opam_21rc)
+     @ List.map (append "2.1~rc") opam_21rc
+     @ List.map (append "2.1") opam_21)
 ### ocaml generate.ml
 ### <switch-root.sh>
 version=$1
@@ -599,12 +609,12 @@ No configuration file found, using built-in defaults.
 ### # ro global state
 ### opam option jobs
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-FMT_UPG                         On-the-fly config upgrade, from 2.0 to 2.1~rc
+FMT_UPG                         On-the-fly config upgrade, from 2.0 to 2.1
 FMT_UPG                         Format upgrade done
 ### # ro global state, ro repo state, ro switch state
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-FMT_UPG                         On-the-fly config upgrade, from 2.0 to 2.1~rc
+FMT_UPG                         On-the-fly config upgrade, from 2.0 to 2.1
 FMT_UPG                         Format upgrade done
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -619,7 +629,7 @@ i-am-sys-compiler    1           One-line description
 ### # ro global state, ro repo state, rw switch state
 ### opam install i-am-another-package --switch sw-comp
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-FMT_UPG                         On-the-fly config upgrade, from 2.0 to 2.1~rc
+FMT_UPG                         On-the-fly config upgrade, from 2.0 to 2.1
 FMT_UPG                         Format upgrade done
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -639,8 +649,8 @@ Done.
 ### opam switch sw-comp
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
-FMT_UPG                         Light config upgrade, from 2.0 to 2.1~rc
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.0 to version 2.1~rc, which can't be reverted.
+FMT_UPG                         Light config upgrade, from 2.0 to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.0 to version 2.1, which can't be reverted.
 You may want to back it up before going further.
 
 Continue? [Y/n] y
@@ -651,7 +661,7 @@ STATE                           LOAD-SWITCH-STATE @ sw-comp
 STATE                           Switch state loaded in 0.000s
 ### cat $OPAMROOT/config
 opam-version: "2.0"
-opam-root-version: "2.1~rc"
+opam-root-version: "2.1"
 repositories: "default"
 installed-switches: ["sw-sys-comp" "sw-comp" "default"]
 switch: "sw-comp"
@@ -687,8 +697,8 @@ installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
-FMT_UPG                         Hard config upgrade, from 2.1~alpha to 2.1~rc
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~alpha to version 2.1~rc, which can't be reverted.
+FMT_UPG                         Hard config upgrade, from 2.1~alpha to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~alpha to version 2.1, which can't be reverted.
 You may want to back it up before going further.
 
 Perform the update and continue? [Y/n] y
@@ -738,7 +748,7 @@ STATE                           LOAD-SWITCH-STATE @ sw-comp
 STATE                           Switch state loaded in 0.000s
 ### cat $OPAMROOT/config
 opam-version: "2.0"
-opam-root-version: "2.1~rc"
+opam-root-version: "2.1"
 repositories: "default"
 installed-switches: ["sw-sys-comp" "sw-comp" "default"]
 switch: "sw-comp"
@@ -778,8 +788,8 @@ GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         Intermediate opam root detected, launch hard upgrade
 FMT_UPG                         Downgrade config opam-version to fix up
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
-FMT_UPG                         Hard config upgrade, from 2.1~alpha2 to 2.1~rc
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~alpha2 to version 2.1~rc, which can't be reverted.
+FMT_UPG                         Hard config upgrade, from 2.1~alpha2 to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~alpha2 to version 2.1, which can't be reverted.
 You may want to back it up before going further.
 
 Perform the update and continue? [Y/n] y
@@ -829,7 +839,7 @@ STATE                           LOAD-SWITCH-STATE @ sw-comp
 STATE                           Switch state loaded in 0.000s
 ### cat $OPAMROOT/config
 opam-version: "2.0"
-opam-root-version: "2.1~rc"
+opam-root-version: "2.1"
 repositories: "default"
 installed-switches: ["sw-sys-comp" "sw-comp" "default"]
 switch: "sw-comp"
@@ -866,6 +876,80 @@ installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### # ro global state
 ### opam option jobs
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.1~rc to 2.1
+FMT_UPG                         Format upgrade done
+### # ro global state, ro repo state, ro switch state
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.1~rc to 2.1
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name               # Installed # Synopsis
+i-am-another-package 2           One-line description
+i-am-package         2           One-line description
+i-am-sys-compiler    1           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-another-package --switch sw-comp
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.1~rc to 2.1
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+  - install i-am-another-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-another-package.2
+Done.
+### opam option jobs=4
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Light config upgrade, from 2.1~rc to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~rc to version 2.1, which can't be reverted.
+You may want to back it up before going further.
+
+Continue? [Y/n] y
+Format upgrade done.
+Set to '4' the field jobs in global configuration
+### cat $OPAMROOT/config
+opam-version: "2.0"
+opam-root-version: "2.1"
+repositories: "default"
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+switch: "sw-sys-comp"
+jobs: 4
+download-jobs: 1
+eval-variables: [
+  sys-comp-version
+  ["sh" "-c" "echo $OPAMSYSCOMP"]
+  "comp version"
+]
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+depext: true
+depext-run-installs: true
+depext-cannot-install: false
+### cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+opam-version: "2.0"
+synopsis: "switch with compiler"
+invariant: ["i-am-compiler"]
+### cat $OPAMROOT/sw-comp/.opam-switch/switch-state
+opam-version: "2.0"
+compiler: ["i-am-compiler.2"]
+roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+### :V:5: From 2.1 root
+### sh switch-root.sh 2.1
+### # ro global state
+### opam option jobs
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 ### # ro global state, ro repo state, ro switch state
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
@@ -894,7 +978,7 @@ The following actions will be performed:
 Done.
 ### cat $OPAMROOT/config
 opam-version: "2.0"
-opam-root-version: "2.1~rc"
+opam-root-version: "2.1"
 repositories: "default"
 
 installed-switches: ["sw-sys-comp" "sw-comp" "default" "${BASEDIR}/why-did-you-delete-me" "this-internal-error"]

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -487,13 +487,49 @@ let run_test ?(vars=[]) ~opam t =
         | Cat files ->
           let print_opamfile header file =
             let content =
-              OpamPrinter.FullPos.Normalise.opamfile
-                (OpamParser.FullPos.file file)
+              let open OpamParserTypes.FullPos in
+              let original = OpamParser.FullPos.file file in
+              let rec mangle item =
+                match item.pelem with
+                | Section s ->
+                  {item with pelem = Section {s with section_name = OpamStd.Option.map (fun v -> {v with pelem = mangle_string v.pelem}) s.section_name;
+                                                     section_items = {s.section_items with pelem = List.map mangle s.section_items.pelem}}}
+                | Variable(name, value) ->
+                  {item with pelem = Variable(name, mangle_value value)}
+              and mangle_value item =
+                match item.pelem with
+                | String s ->
+                  {item with pelem = String(mangle_string s)}
+                | Relop(op, l, r) ->
+                  {item with pelem = Relop(op, mangle_value l, mangle_value r)}
+                | Prefix_relop(relop, v) ->
+                  {item with pelem = Prefix_relop(relop, mangle_value v)}
+                | Logop(op, l, r) ->
+                  {item with pelem = Logop(op, mangle_value l, mangle_value r)}
+                | Pfxop(op, v) ->
+                  {item with pelem = Pfxop(op, mangle_value v)}
+                | List l ->
+                  {item with pelem = List{l with pelem = List.map mangle_value l.pelem}}
+                | Group l ->
+                  {item with pelem = Group{l with pelem = List.map mangle_value l.pelem}}
+                | Option(v, l) ->
+                  {item with pelem = Option(mangle_value v, {l with pelem = List.map mangle_value l.pelem})}
+                | Env_binding(name, op, v) ->
+                  {item with pelem = Env_binding(name, op, mangle_value v)}
+                | Bool _
+                | Int _
+                | Ident _ -> item
+              and mangle_string = String.map (function '\\' -> '/' | c -> c)
+              in
+              let mangled =
+                {original with file_contents = List.map mangle original.file_contents}
+              in
+              OpamPrinter.FullPos.Normalise.opamfile mangled
             in
             let str = if header then Printf.sprintf "=> %s <=\n" file else "" in
             let str = Printf.sprintf "%s%s" str content in
             let str =
-              str_replace_path ~escape:true OpamSystem.back_to_forward
+              str_replace_path OpamSystem.back_to_forward
                 (common_filters dir) str
             in
             print_string str


### PR DESCRIPTION
* Fix format upgrade when there is missing local switches in the config file
* Fix not recorded local switch handling, with format upgrade
* Set opam root version to 2.1
* Update tests with 2.1, local switch (recorded and not)
fix #4713