### PR TITLE
Sync the behaviour of the macOS sandbox script with Linux's

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -66,7 +66,7 @@ Prefixes used to help generate release notes, changes, and blog posts:
   * Fix bypass-check handling on reinit [#4750 @rjbou] [#4763 @rjbou] [2.1.0~rc2 #4750 #4756]
 
 ## Sandbox
-  *
+  * Sync the behaviour of the macOS sandbox script with Linux's: /tmp is now ready-only [#4719 @kit-ty-kate]
 
 ## Repository management
   *

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -15,9 +15,6 @@ add_mounts() {
     fi
 }
 
-# Even if TMPDIR is set, some applications uses /tmp directly
-add_mounts rw /tmp
-
 if [ -z ${TMPDIR+x} ]; then
   # Others applications obtain the per-user temporary
   # directory differently; the latter should be made readable/writable


### PR DESCRIPTION
I'm not sure what was the reason behind having /tmp rw on macos but read-only on linux.
In opam 2.0 it seem to have been the invert at first (rw on linux and ro on macos) however it was synchronized to rw in both in 2.0.8 in see https://github.com/ocaml/opam/pull/3742.
In opam 2.1~rc a linux-only change was done which made it ro: https://github.com/ocaml/opam/pull/4589, but it was never ported to macos.
