### PR TITLE
Fix `OPAMZ3DEBUG` cyclic dependency

### DIFF
--- a/.github/scripts/ocaml-cache.sh
+++ b/.github/scripts/ocaml-cache.sh
@@ -8,12 +8,21 @@ tar -xzf "ocaml-$OCAML_VERSION.tar.gz"
 cd "ocaml-$OCAML_VERSION"
 if [[ $OPAM_TEST -ne 1 ]] ; then
   if [[ -e configure.ac ]]; then
-    CONFIGURE_SWITCHES="--disable-debugger --disable-debug-runtime --disable-ocamldoc"
+    CONFIGURE_SWITCHES="--disable-debugger --disable-debug-runtime"
+    if [ "$SOLVER" != "z3" ]; then
+      CONFIGURE_SWITCHES="$CONFIGURE_SWITCHES --disable-ocamldoc"
+    fi
     if [[ ${OCAML_VERSION%.*} = '4.08' ]]; then
       CONFIGURE_SWITCHES="$CONFIGURE_SWITCHES --disable-graph-lib"
     fi
   else
-    CONFIGURE_SWITCHES="-no-graph -no-debugger -no-ocamldoc"
+    CONFIGURE_SWITCHES="-no-graph -no-debugger"
+    if [ "$SOLVER" != "z3" ]; then
+      CONFIGURE_SWITCHES="$CONFIGURE_SWITCHES -no-ocamldoc"
+    fi
+    if [[ ${OCAML_VERSION%.*} = '4.08' ]]; then
+      CONFIGURE_SWITCHES="$CONFIGURE_SWITCHES --disable-graph-lib"
+    fi
     if [[ "$OCAML_VERSION" != "4.02.3" ]] ; then
       CONFIGURE_SWITCHES="$CONFIGURE_SWITCHES -no-ocamlbuild"
     fi

--- a/.github/scripts/preamble.sh
+++ b/.github/scripts/preamble.sh
@@ -34,7 +34,7 @@ git config --global gc.autoDetach false
 
 # used only for TEST jobs
 init-bootstrap () {
-  if [ "$OPAM_TEST" = "1" ]; then
+  if [ "$OPAM_TEST" = "1" ] || [ -n "$SOLVER" ]; then
     set -e
     export OPAMROOT=$OPAMBSROOT
     # The system compiler will be picked up

--- a/.github/scripts/solvers.sh
+++ b/.github/scripts/solvers.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -xue
+
+. .github/scripts/preamble.sh
+
+export OPAMYES=1
+export OCAMLRUNPARAM=b
+
+# All environment variable are overwritten in job description
+# One cache per solver, $CACHE/opam.<solver>.cached
+export OPAMROOT=$OPAMBSROOT
+echo $OPAMROOT
+
+case "$SOLVER" in
+  z3)
+    PKGS=$SOLVER
+    ;;
+  0install)
+    PKGS="$SOLVER opam-0install-cudf"
+    ;;
+  *)
+    echo -e "\e[31mSolver $SOLVER not handled\e[0m";
+    exit 3
+    ;;
+esac
+
+opam switch create $SOLVER ocaml-system || true
+opam install $PKGS
+opam install . --deps
+opam clean --logs --switch-cleanup
+eval $(opam env)
+./configure
+make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
   OCAML_VERSION: 4.11.2
   ## variables for cache paths
   GH_OCAML_CACHE: ~/.cache/ocaml-local/**
+  SOLVER:
 
 defaults:
   run:
@@ -154,6 +155,9 @@ jobs:
         OCAML_VERSION: ${{ matrix.ocamlv }}
       run: bash -exu .github/scripts/main.sh
 
+####
+# Opam cold
+####
   cold:
     needs: [ build, archives-cache ]
     runs-on: ${{ matrix.os }}
@@ -182,6 +186,59 @@ jobs:
         make lib-pkg
         bash -exu .github/scripts/main.sh
 
+####
+# Compile solver backends
+####
+  solvers:
+    needs: [ build ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        ocamlv: [ 4.11.2 ]
+        solver: [ z3, 0install ]
+      fail-fast: false
+    env:
+      SOLVER: ${{ matrix.solver }}
+      OPAM_REPO_SHA: 02ead5a557
+      OPAMBSROOT: ~/.cache/opam.${{ matrix.solver }}.cached
+    steps:
+    - uses: actions/checkout@v2
+    - name: install deps
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: sudo apt install bubblewrap
+    - name: ocaml ${{ matrix.ocamlv }} cache - test
+      id: ocaml-cache-test
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.GH_OCAML_CACHE }}
+        key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ matrix.solver }}-${{ hashFiles ('.github/scripts/ocaml-cache.sh', '.github/scripts/preamble.sh') }}-test
+    - name: Building ocaml ${{ env.OCAML_VERSION }} cache - test
+      if: steps.ocaml-cache-test.outputs.cache-hit != 'true'
+      env:
+        OCAML_VERSION: ${{ matrix.ocamlv }}
+      run: bash -exu .github/scripts/ocaml-cache.sh ocaml
+    - name: opam bootstrap cache
+      id: opam-bootstrap
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/opam.${{ matrix.solver }}.cached
+          ~/.cache/opam-local/bin/**
+        key: opam-${{ matrix.solver }}-${{ runner.os }}-${{ env.OPAMBSVERSION }}-${{ matrix.ocamlv }}-${{ hashFiles ('.github/scripts/opam-bs-cache.sh', '.github/scripts/preamble.sh') }}
+    - name: opam root cache
+      env:
+        OPAMBSROOT: ~/.cache/opam.${{ matrix.solver }}.cached
+      if: steps.opam-bootstrap.outputs.cache-hit != 'true'
+      run: bash -exu .github/scripts/opam-bs-cache.sh
+    - name: Compile
+      env:
+        OCAML_VERSION: ${{ matrix.ocamlv }}
+      run: bash -exu .github/scripts/solvers.sh
+
+####
+# Upgrade from 1.2 to current
+####
   upgrade:
     needs: [ build ]
     runs-on: ${{ matrix.os }}

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,9 @@ repositories (changes that are automatically handled by the format upgrade tools
 are not marked). Those prefixed with "(+)" are new command/option (since
 2.1.0~alpha2).
 
+2.1.0~rc2:
+  * Remove OPAMZ3DEBUG evironment variable [#4720 @rjbou - fix #4718]
+
 2.1.0~rc:
 * (*) Environment variables initialised only at opam client launch, no more via
   libraries [#4606 #4703 @rjbou]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -196,8 +196,6 @@ let environment_variables =
       "see option `--use-internal-solver'.";
       "VERSIONLAGPOWER", cli_original, (fun v -> VERSIONLAGPOWER (env_int v)),
       "do not use.";
-      "Z3DEBUG", cli_from cli2_1, (fun v -> Z3DEBUG (env_string v)),
-      "Enable debug for Z3 backend";
     ] in
   let repository =
     let open OpamRepositoryConfig.E in [

--- a/src/solver/opamBuiltinZ3.ml.real
+++ b/src/solver/opamBuiltinZ3.ml.real
@@ -413,12 +413,6 @@ let call ~criteria ?timeout (preamble, universe, _ as cudf) =
     def_criteria ctx opt cudf psym (Syntax.criteria_of_string criteria)
   in
   log "Resolving...";
-  (match OpamStd.Env.getopt "Z3DEBUG" with
-   | None -> ()
-   | Some f ->
-     let debug = open_out (f^".smt2") in
-     output_string debug (Z3.Optimize.to_string opt);
-     close_out debug);
   match Z3.Optimize.check opt with
   | UNSATISFIABLE ->
     log "UNSAT";

--- a/src/solver/opamBuiltinZ3.ml.real
+++ b/src/solver/opamBuiltinZ3.ml.real
@@ -413,7 +413,7 @@ let call ~criteria ?timeout (preamble, universe, _ as cudf) =
     def_criteria ctx opt cudf psym (Syntax.criteria_of_string criteria)
   in
   log "Resolving...";
-  (match OpamSolverConfig.E.z3debug () with
+  (match OpamStd.Env.getopt "Z3DEBUG" with
    | None -> ()
    | Some f ->
      let debug = open_out (f^".smt2") in

--- a/src/solver/opamSolverConfig.ml
+++ b/src/solver/opamSolverConfig.ml
@@ -26,7 +26,6 @@ module E = struct
     | UPGRADECRITERIA of string option
     | USEINTERNALSOLVER of bool option
     | VERSIONLAGPOWER of int option
-    | Z3DEBUG of string option
 
   open OpamStd.Config.E
   let besteffort = value (function BESTEFFORT b -> b | _ -> None)
@@ -46,7 +45,6 @@ module E = struct
   let useinternalsolver = value (function USEINTERNALSOLVER b -> b | _ -> None)
   let upgradecriteria = value (function UPGRADECRITERIA s -> s | _ -> None)
   let versionlagpower = value (function VERSIONLAGPOWER i -> i | _ -> None)
-  let z3debug = value (function Z3DEBUG s -> s | _ -> None)
 
 end
 

--- a/src/solver/opamSolverConfig.mli
+++ b/src/solver/opamSolverConfig.mli
@@ -28,10 +28,7 @@ module E : sig
     | UPGRADECRITERIA of string option
     | USEINTERNALSOLVER of bool option
     | VERSIONLAGPOWER of int option
-    | Z3DEBUG of string option
-
-  val externalsolver: unit -> string option
-  val z3debug: unit -> string option
+    val externalsolver: unit -> string option
 end
 
 type t = private {


### PR DESCRIPTION
This environment variable is no more needed, so remove it.
fix #4717
