### PR TITLE
add a way to skip the certificate check

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -61,7 +61,7 @@ Prefixes used to help generate release notes, changes, and blog posts:
   *
 
 ## Repository management
-  *
+  * [NEW] Add OPAMSKIPCERTIFICATECHECK for skipping SSL certificate checking [#4733 @mt-caret] [2.1.0~rc2 #4720]
 
 ## VCS
   *

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -218,6 +218,9 @@ let environment_variables =
       "VALIDATIONHOOK", cli_original, (fun v -> VALIDATIONHOOK (env_string v)),
       "if set, uses the `%{hook%}' command to validate \
        an opam repository update.";
+      "SKIPCERTIFICATECHECK", cli_original,
+      (fun v -> SKIPCERTIFICATECHECK (env_bool v)),
+      "skip checking of certificates (not recommended).";
     ] in
   let state =
     let open OpamStateConfig.E in [

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -149,6 +149,7 @@ val opam_init:
   ?validation_hook:OpamTypes.arg list option ->
   ?retries:int ->
   ?force_checksums:bool option ->
+  ?skip_certificate_check:bool ->
   ?debug_level:int ->
   ?debug_sections:OpamStd.Config.sections ->
   ?verbose_level:OpamStd.Config.level ->

--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -68,11 +68,7 @@ let ftp_args = [
 
 let download_args ~url ~out ~retry ?checksum ~compress () =
   let cmd, _ = Lazy.force OpamRepositoryConfig.(!r.download_tool) in
-  let skip_certificate_check =
-    match OpamRepositoryConfig.(!r.skip_certificate_check) with
-    | None -> false
-    | Some skip_certificate_check -> skip_certificate_check
-  in
+  let skip_certificate_check = OpamRepositoryConfig.(!r.skip_certificate_check) in
   let cmd =
     match cmd with
     | [(CIdent "wget"), _] -> cmd @ wget_args ~skip_certificate_check

--- a/src/repository/opamRepositoryConfig.ml
+++ b/src/repository/opamRepositoryConfig.ml
@@ -39,7 +39,7 @@ type t = {
   validation_hook: arg list option;
   retries: int;
   force_checksums: bool option;
-  skip_certificate_check: bool option;
+  skip_certificate_check: bool;
 }
 
 type 'a options_fun =
@@ -47,7 +47,7 @@ type 'a options_fun =
   ?validation_hook:arg list option ->
   ?retries:int ->
   ?force_checksums:bool option ->
-  ?skip_certificate_check:bool option ->
+  ?skip_certificate_check:bool ->
   'a
 
 let default = {
@@ -79,7 +79,7 @@ let default = {
   validation_hook = None;
   retries = 3;
   force_checksums = None;
-  skip_certificate_check = None;
+  skip_certificate_check = false;
 }
 
 let setk k t

--- a/src/repository/opamRepositoryConfig.ml
+++ b/src/repository/opamRepositoryConfig.ml
@@ -19,6 +19,7 @@ module E = struct
     | REQUIRECHECKSUMS of bool option
     | RETRIES of int option
     | VALIDATIONHOOK of string option
+    | SKIPCERTIFICATECHECK of bool option
 
   open OpamStd.Config.E
   let curl = value (function CURL s -> s | _ -> None)
@@ -27,6 +28,7 @@ module E = struct
   let requirechecksums = value (function REQUIRECHECKSUMS b -> b | _ -> None)
   let retries = value (function RETRIES i -> i | _ -> None)
   let validationhook = value (function VALIDATIONHOOK s -> s | _ -> None)
+  let skipcertificatecheck = value (function SKIPCERTIFICATECHECK b -> b | _ -> None)
 
 end
 
@@ -37,6 +39,7 @@ type t = {
   validation_hook: arg list option;
   retries: int;
   force_checksums: bool option;
+  skip_certificate_check: bool option;
 }
 
 type 'a options_fun =
@@ -44,6 +47,7 @@ type 'a options_fun =
   ?validation_hook:arg list option ->
   ?retries:int ->
   ?force_checksums:bool option ->
+  ?skip_certificate_check:bool option ->
   'a
 
 let default = {
@@ -75,6 +79,7 @@ let default = {
   validation_hook = None;
   retries = 3;
   force_checksums = None;
+  skip_certificate_check = None;
 }
 
 let setk k t
@@ -82,6 +87,7 @@ let setk k t
     ?validation_hook
     ?retries
     ?force_checksums
+    ?skip_certificate_check
   =
   let (+) x opt = match opt with Some x -> x | None -> x in
   k {
@@ -89,6 +95,7 @@ let setk k t
     validation_hook = t.validation_hook + validation_hook;
     retries = t.retries + retries;
     force_checksums = t.force_checksums + force_checksums;
+    skip_certificate_check = t.skip_certificate_check + skip_certificate_check;
   }
 
 let set t = setk (fun x () -> x) t
@@ -139,5 +146,6 @@ let initk k =
     ?validation_hook
     ?retries:(E.retries ())
     ?force_checksums
+    ?skip_certificate_check:(E.skipcertificatecheck ())
 
 let init ?noop:_ = initk (fun () -> ())

--- a/src/repository/opamRepositoryConfig.mli
+++ b/src/repository/opamRepositoryConfig.mli
@@ -19,6 +19,7 @@ module E : sig
     | REQUIRECHECKSUMS of bool option
     | RETRIES of int option
     | VALIDATIONHOOK of string option
+    | SKIPCERTIFICATECHECK of bool option
 
   val curl: unit -> string option
   val fetch: unit -> string option
@@ -33,6 +34,7 @@ type t = {
   validation_hook: OpamTypes.arg list option;
   retries: int;
   force_checksums: bool option;
+  skip_certificate_check: bool option;
 }
 
 type 'a options_fun =
@@ -40,6 +42,7 @@ type 'a options_fun =
   ?validation_hook:OpamTypes.arg list option ->
   ?retries:int ->
   ?force_checksums:bool option ->
+  ?skip_certificate_check:bool option ->
   'a
 
 include OpamStd.Config.Sig

--- a/src/repository/opamRepositoryConfig.mli
+++ b/src/repository/opamRepositoryConfig.mli
@@ -34,7 +34,7 @@ type t = {
   validation_hook: OpamTypes.arg list option;
   retries: int;
   force_checksums: bool option;
-  skip_certificate_check: bool option;
+  skip_certificate_check: bool;
 }
 
 type 'a options_fun =
@@ -42,7 +42,7 @@ type 'a options_fun =
   ?validation_hook:OpamTypes.arg list option ->
   ?retries:int ->
   ?force_checksums:bool option ->
-  ?skip_certificate_check:bool option ->
+  ?skip_certificate_check:bool ->
   'a
 
 include OpamStd.Config.Sig


### PR DESCRIPTION
Currently, there is no easy way to skip the default certificate check to circumvent issues with the certificate for opam servers (like https://github.com/ocaml/opam/issues/4732). This PR makes it possible to add an environment variable to fix this.