### PR TITLE
Set DEBIAN_FRONTEND=noninteractive for unsafe-yes

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -55,7 +55,7 @@ Prefixes used to help generate release notes, changes, and blog posts:
   *
 
 ## External dependencies
-  *
+  * Set DEBIAN_FRONTEND=noninteractive for unsafe-yes confirmation level [#4735 @dra27 - partially fix #4731]
 
 ## Sandbox
   *

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -586,8 +586,9 @@ let packages_status packages =
 (* Install *)
 
 let install_packages_commands_t sys_packages =
+  let unsafe_yes = OpamCoreConfig.answer_is `unsafe_yes in
   let yes ?(no=[]) yes r =
-    if OpamCoreConfig.answer_is `unsafe_yes then
+    if unsafe_yes then
       yes @ r else no @ r
   in
   let packages =
@@ -613,7 +614,8 @@ let install_packages_commands_t sys_packages =
                  |> OpamStd.String.Set.remove epel_release
                  |> OpamStd.String.Set.elements);
        "rpm", "-q"::"--whatprovides"::packages], None
-  | Debian -> ["apt-get", "install"::yes ["-qq"; "-yy"] packages], None
+  | Debian -> ["apt-get", "install"::yes ["-qq"; "-yy"] packages],
+      (if unsafe_yes then Some ["DEBIAN_FRONTEND", "noninteractive"] else None)
   | Freebsd -> ["pkg", "install"::yes ["-y"] packages], None
   | Gentoo -> ["emerge", yes ~no:["-a"] [] packages], None
   | Homebrew ->


### PR DESCRIPTION
`--confirm-level=unsafe-yes` and "closing stdin" are opam's two non-interactive mechanisms. The latter works correctly with depext (since the package manager will never be invoked) but the former breaks for `apt` if a package has a prompt.

This PR adds `DEBIAN_FRONTEND=noninteractive` to calls to `apt-get install`.