### PR TITLE
deprecated syntax removed

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -104,7 +104,7 @@ Prefixes used to help generate release notes, changes, and blog posts:
   * Fix ocaml link (http -> https) [#4729 @rjbou]
 
 ## Shell
-  *
+  * fish: fix deprecated redirection syntax `^` [#4736 @vzaliva]
 
 ## Doc
   *

--- a/src/state/shellscripts/env_hook.fish
+++ b/src/state/shellscripts/env_hook.fish
@@ -1,3 +1,3 @@
 function __opam_env_export_eval --on-event fish_prompt;
-    eval (opam env --shell=fish --readonly ^ /dev/null);
+    eval (opam env --shell=fish --readonly 2> /dev/null);
 end


### PR DESCRIPTION
According to https://fishshell.com/docs/current/index.html#id4 
"Previous versions of fish also allowed specifying this as ^DESTINATION, but that made another character special so it was deprecated and will be removed in the future."

fish version 3.3.0 by default gives an error on old syntax

