### PR TITLE
Ignore new `opam-version` field in .changes files

### DIFF
--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3138,6 +3138,7 @@ module ChangesSyntax = struct
                   Pp.of_pair "digest" (digest_of_string, string_of_digest))))
 
   let fields = [
+    "opam-version", Pp.ppacc_ignore;
     "added", field
       (function Some dg -> Added dg
               | None -> Pp.bad_format "Missing digest")
@@ -3161,6 +3162,7 @@ module ChangesSyntax = struct
   ]
 
   let pp_contents =
+    Pp.I.check_opam_version ~optional:true () -|
     Pp.I.fields ~name:internal ~empty fields -|
     Pp.I.show_errors ~name:internal ()
 


### PR DESCRIPTION
Possibly change for 2.0.9 - the .changes files in 2.1 now have `opam-version: "2.0"` at the top, which causes a lot of warnings to displayed unconditionally when reading those files from a plugin compiled with opam-format.2.0.9

I haven't checked for other file formats affected by this.