### PR TITLE
shell/install.sh: Add the ability to specify the version of opam you want

### DIFF
--- a/shell/install.sh
+++ b/shell/install.sh
@@ -116,6 +116,7 @@ usage() {
     echo "                           is from the 2.0 branch already)"
     echo "    --fresh                Create the opam $VERSION root from scratch"
     echo "    --restore   VERSION    Restore a backed up opam binary and root"
+    echo "    --version   VERSION    Install this specific version instead of $VERSION"
     echo
     echo "The default is to backup if the current version of opam is 1.*, or when"
     echo "using '--fresh' or '--dev'"
@@ -135,6 +136,10 @@ while [ $# -gt 0 ]; do
             if [ $# -lt 2 ]; then echo "Option $1 requires an argument"; exit 2; fi
             shift;
             RESTORE=$1;;
+        --version)
+            if [ $# -lt 2 ]; then echo "Option $1 requires an argument"; exit 2; fi
+            shift;
+            VERSION=$1;;
         --no-backup)
             NOBACKUP=1;;
         --backup)


### PR DESCRIPTION
In https://github.com/ocaml/opam/wiki/How-to-test-an-opam-feature, the following thing is said:
```
To test a release other than the latest, change master to the tag name.
```
I think this is extremely brittle and dangerous. e.g. the script might be buggy and need to be fixed, the checksums of some of the binaries might need to change for some reason, an update to the install script might have been forgotten in the tag, …

The later happened in 2.1.0~rc2 so the following fails:
```
sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/2.1.0-rc2/shell/install.sh) --dev --backup         
## Downloading opam 2.1.0~rc2 for macos on x86_64...
Checksum mismatch, a problem occurred during download.
```
Issue found by @patricoferris

If/Once this is accepted and merged we need to also change the wiki page.