### PR TITLE
opamSpdxList: add LGPL-3.0 linking exception

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -46,7 +46,7 @@ Prefixes used to help generate release notes, changes, and blog posts:
   *
 
 ## Lint
-  *
+  * Added support for LGPL-3 linking exception
 
 ## Lock
   *

--- a/master_changes.md
+++ b/master_changes.md
@@ -46,7 +46,7 @@ Prefixes used to help generate release notes, changes, and blog posts:
   *
 
 ## Lint
-  * Added support for LGPL-3 linking exception
+  * Add support for LGPL-3 linking exception [#4747 @mseri]
 
 ## Lock
   *

--- a/src/state/opamSpdxList.ml
+++ b/src/state/opamSpdxList.ml
@@ -436,4 +436,5 @@ let exceptions = OpamStd.String.Set.of_list @@ List.map String.lowercase_ascii @
   "GCC-exception-2.0";
   "mif-exception";
   "OCaml-LGPL-linking-exception";
+  "LGPL-3.0-linking-exception";
 ]


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/19010

- [x] Update `master_changes.md` file with your changes.
