### PR TITLE
Fix intermediate format upgrade with reinit

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,8 @@ are not marked). Those prefixed with "(+)" are new command/option (since
 2.1.0:
 * Set DEBIAN_FRONTEND=noninteractive for unsafe-yes confirmation level
   [#4735 @dra27 - partially fix #4731]
+* Fix 2.1~alpha2 to 2.1 format upgrade with reinit [#4750 @rjbou - fix #4748]
+* Fix bypass-check handling on reinit [#4750 @rjbou]
 
 2.1.0~rc2:
 * Remove OPAMZ3DEBUG evironment variable [#4720 @rjbou - fix #4717]

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -380,7 +380,7 @@ let init cli =
           | None -> OpamFile.Config.empty
         in
         OpamClient.reinit ~init_config ~interactive ~dot_profile
-          ?update_config ?env_hook ?completion ~inplace
+          ?update_config ?env_hook ?completion ~inplace ~bypass_checks
           ~check_sandbox:(not no_sandboxing)
           config shell
       else

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -232,9 +232,13 @@ let load_config_root ?lock_kind readf opamroot =
     (OpamFile.Config.raw_root_version f)
     readf f
 
+let safe read read' default =
+  let safe r f = OpamStd.Option.default default @@ r f in
+  safe read, safe read'
+
 let safe_load ?lock_kind opamroot =
   load_config_root ?lock_kind
-    OpamFile.Config.(safe_read, BestEffort.safe_read) opamroot
+    OpamFile.Config.(safe read_opt BestEffort.read_opt empty) opamroot
 
 let load ?lock_kind opamroot =
   load_config_root ?lock_kind
@@ -250,7 +254,7 @@ module Switch = struct
   let safe_load_t ?lock_kind root switch =
     let config = safe_load ~lock_kind:`Lock_read root in
     load_raw ?lock_kind root config
-      OpamFile.Switch_config.(safe_read, BestEffort.safe_read)
+      OpamFile.Switch_config.(safe read_opt BestEffort.read_opt empty)
       switch
 
   let load ?lock_kind gt readf switch =
@@ -258,7 +262,7 @@ module Switch = struct
 
   let safe_load ?lock_kind gt switch =
     load ?lock_kind gt
-      OpamFile.Switch_config.(safe_read, BestEffort.safe_read)
+      OpamFile.Switch_config.(safe read_opt BestEffort.read_opt empty)
       switch
 
   let read_opt ?lock_kind gt switch =
@@ -268,7 +272,7 @@ module Switch = struct
 
   let safe_read_selections ?lock_kind gt switch =
     load_if_possible ?lock_kind gt
-      OpamFile.SwitchSelections.(safe_read, BestEffort.safe_read)
+      OpamFile.SwitchSelections.(safe read_opt BestEffort.read_opt empty)
       (OpamPath.Switch.selections gt.root switch)
 
 end
@@ -277,7 +281,7 @@ end
 module Repos = struct
   let safe_read ?lock_kind gt =
     load_if_possible ?lock_kind gt
-      OpamFile.Repos_config.(safe_read, BestEffort.safe_read)
+      OpamFile.Repos_config.(safe read_opt BestEffort.read_opt empty)
       (OpamPath.repos_config gt.root)
 end
 

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -933,6 +933,60 @@ compiler: ["i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+### :V:1:e: reinit from 2.0
+### ocaml generate.ml 2.0
+### opam init --reinit --bypass-checks --no-setup
+No configuration file found, using built-in defaults.
+Checking for available remotes: rsync and local, git, mercurial, darcs. Perfect!
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Light config upgrade, from 2.0 to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.0 to version 2.1, which can't be reverted.
+You may want to back it up before going further.
+
+Continue? [Y/n] y
+Format upgrade done.
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[default] no changes from file://${BASEDIR}/default
+### opam switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+#   switch                                     compiler             description
+->  ${BASEDIR}  i-am-sys-compiler.2  local switch
+    default                                                         default switch
+    sw-comp                                    i-am-compiler.2      switch with compiler
+    sw-sys-comp                                                     switch with system compiler
+
+[NOTE] Current switch has been selected based on the current directory.
+       The current global system switch is sw-sys-comp.
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-package      2           One-line description
+i-am-sys-compiler 2           One-line description
+### opam-cat $OPAMROOT/config
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["ocaml" {>= "4.05.0"}]
+depext: true
+depext-cannot-install: false
+depext-run-installs: true
+download-jobs: 3
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
 ### rm -rf _opam
 ### :V:2:a: From 2.1~alpha root, global
 ### ocaml generate.ml 2.1~alpha
@@ -1215,6 +1269,65 @@ compiler: ["i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+### :V:2:e: reinit from 2.1~alpha
+### ocaml generate.ml 2.1~alpha
+### opam init --reinit --bypass-checks --no-setup
+No configuration file found, using built-in defaults.
+Checking for available remotes: rsync and local, git, mercurial, darcs. Perfect!
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Hard config upgrade, from 2.1~alpha to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~alpha to version 2.1, which can't be reverted.
+You may want to back it up before going further.
+
+Perform the update and continue? [Y/n] y
+Format upgrade done.
+
+<><> Rerunning init and update ><><><><><><><><><><><><><><><><><><><><><><><><>
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[default] no changes from file://${BASEDIR}/default
+Update done, please now retry your command.
+# Return code 10 #
+### opam switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+#   switch                                     compiler             description
+->  ${BASEDIR}  i-am-sys-compiler.2  local switch
+    default                                                         default switch
+    sw-comp                                    i-am-compiler.2      switch with compiler
+    sw-sys-comp                                                     switch with system compiler
+
+[NOTE] Current switch has been selected based on the current directory.
+       The current global system switch is sw-sys-comp.
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-package      2           One-line description
+i-am-sys-compiler 2           One-line description
+### opam-cat $OPAMROOT/config
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["ocaml" {>= "4.05.0"}]
+depext: true
+depext-cannot-install: false
+depext-run-installs: true
+download-jobs: 3
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
 ### rm -rf _opam
 ### :V:3:a: From 2.1~alpha2 root, global
 ### ocaml generate.ml 2.1~alpha2
@@ -1504,6 +1617,65 @@ compiler: ["i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+### :V:3:e: reinit from 2.1~alpha2
+### ocaml generate.ml 2.1~alpha2
+### opam init --reinit --bypass-checks --no-setup
+No configuration file found, using built-in defaults.
+FMT_UPG                         Intermediate opam root detected, launch hard upgrade
+FMT_UPG                         Downgrade config opam-version to fix up
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Hard config upgrade, from 2.1~alpha2 to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~alpha2 to version 2.1, which can't be reverted.
+You may want to back it up before going further.
+
+Perform the update and continue? [Y/n] y
+Format upgrade done.
+
+<><> Rerunning init and update ><><><><><><><><><><><><><><><><><><><><><><><><>
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[default] no changes from file://${BASEDIR}/default
+Update done, please now retry your command.
+# Return code 10 #
+### opam switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+#   switch                                     compiler             description
+->  ${BASEDIR}  i-am-sys-compiler.2  local switch
+    default                                                         default switch
+    sw-comp                                    i-am-compiler.2      switch with compiler
+    sw-sys-comp                                                     switch with system compiler
+
+[NOTE] Current switch has been selected based on the current directory.
+       The current global system switch is sw-sys-comp.
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-package      2           One-line description
+i-am-sys-compiler 2           One-line description
+### opam-cat $OPAMROOT/config
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["ocaml" {>= "4.05.0"}]
+depext: true
+depext-cannot-install: false
+depext-run-installs: true
+download-jobs: 3
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
 ### rm -rf _opam
 ### :V:4:a: From 2.1~rc root, global
 ### ocaml generate.ml 2.1~rc
@@ -1755,6 +1927,60 @@ compiler: ["i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+### :V:4:e: reinit from 2.1~rc
+### ocaml generate.ml 2.1~rc
+### opam init --reinit --bypass-checks --no-setup
+No configuration file found, using built-in defaults.
+Checking for available remotes: rsync and local, git, mercurial, darcs. Perfect!
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Light config upgrade, from 2.1~rc to 2.1
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1~rc to version 2.1, which can't be reverted.
+You may want to back it up before going further.
+
+Continue? [Y/n] y
+Format upgrade done.
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[default] no changes from file://${BASEDIR}/default
+### opam switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+#   switch                                     compiler             description
+->  ${BASEDIR}  i-am-sys-compiler.2  local switch
+    default                                                         default switch
+    sw-comp                                    i-am-compiler.2      switch with compiler
+    sw-sys-comp                                                     switch with system compiler
+
+[NOTE] Current switch has been selected based on the current directory.
+       The current global system switch is sw-sys-comp.
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-package      2           One-line description
+i-am-sys-compiler 2           One-line description
+### opam-cat $OPAMROOT/config
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+depext: true
+depext-cannot-install: false
+depext-run-installs: true
+download-jobs: 3
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
 ### rm -rf _opam
 ### :V:5:a: From 2.1 root, global
 ### ocaml generate.ml 2.1
@@ -1954,3 +2180,51 @@ compiler: ["i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+### :V:5:e: reinit from 2.1
+### ocaml generate.ml 2.1
+### opam init --reinit --bypass-checks --no-setup
+No configuration file found, using built-in defaults.
+Checking for available remotes: rsync and local, git, mercurial, darcs. Perfect!
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[default] no changes from file://${BASEDIR}/default
+### opam-cat $OPAMROOT/config
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+depext: true
+depext-cannot-install: false
+depext-run-installs: true
+download-jobs: 3
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "${BASEDIR}/why-did-you-delete-me" "this-internal-error"]
+opam-root-version: "2.1"
+opam-version: "2.0"
+repositories: "default"
+switch: "sw-sys-comp"
+wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
+### opam switch
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+#   switch                                     compiler             description
+->  ${BASEDIR}  i-am-sys-compiler.2  local switch
+    default                                                         default switch
+    sw-comp                                    i-am-compiler.2      switch with compiler
+    sw-sys-comp                                                     switch with system compiler
+    this-internal-error                                             Missing config file
+
+[NOTE] Current switch has been selected based on the current directory.
+       The current global system switch is sw-sys-comp.
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-package      2           One-line description
+i-am-sys-compiler 2           One-line description

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -937,7 +937,6 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### ocaml generate.ml 2.0
 ### opam init --reinit --bypass-checks --no-setup
 No configuration file found, using built-in defaults.
-Checking for available remotes: rsync and local, git, mercurial, darcs. Perfect!
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Light config upgrade, from 2.0 to 2.1
@@ -1273,7 +1272,6 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### ocaml generate.ml 2.1~alpha
 ### opam init --reinit --bypass-checks --no-setup
 No configuration file found, using built-in defaults.
-Checking for available remotes: rsync and local, git, mercurial, darcs. Perfect!
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Hard config upgrade, from 2.1~alpha to 2.1
@@ -1931,7 +1929,6 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### ocaml generate.ml 2.1~rc
 ### opam init --reinit --bypass-checks --no-setup
 No configuration file found, using built-in defaults.
-Checking for available remotes: rsync and local, git, mercurial, darcs. Perfect!
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Light config upgrade, from 2.1~rc to 2.1
@@ -2184,7 +2181,6 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### ocaml generate.ml 2.1
 ### opam init --reinit --bypass-checks --no-setup
 No configuration file found, using built-in defaults.
-Checking for available remotes: rsync and local, git, mercurial, darcs. Perfect!
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -950,16 +950,12 @@ RSTATE                          Cache found
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
-### opam switch
+### opam switch --short
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-#   switch                                     compiler             description
-->  ${BASEDIR}  i-am-sys-compiler.2  local switch
-    default                                                         default switch
-    sw-comp                                    i-am-compiler.2      switch with compiler
-    sw-sys-comp                                                     switch with system compiler
-
-[NOTE] Current switch has been selected based on the current directory.
-       The current global system switch is sw-sys-comp.
+${BASEDIR}
+default
+sw-comp
+sw-sys-comp
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
@@ -1290,16 +1286,12 @@ RSTATE                          Cache found
 [default] no changes from file://${BASEDIR}/default
 Update done, please now retry your command.
 # Return code 10 #
-### opam switch
+### opam switch --short
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-#   switch                                     compiler             description
-->  ${BASEDIR}  i-am-sys-compiler.2  local switch
-    default                                                         default switch
-    sw-comp                                    i-am-compiler.2      switch with compiler
-    sw-sys-comp                                                     switch with system compiler
-
-[NOTE] Current switch has been selected based on the current directory.
-       The current global system switch is sw-sys-comp.
+${BASEDIR}
+default
+sw-comp
+sw-sys-comp
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
@@ -1638,16 +1630,12 @@ RSTATE                          Cache found
 [default] no changes from file://${BASEDIR}/default
 Update done, please now retry your command.
 # Return code 10 #
-### opam switch
+### opam switch --short
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-#   switch                                     compiler             description
-->  ${BASEDIR}  i-am-sys-compiler.2  local switch
-    default                                                         default switch
-    sw-comp                                    i-am-compiler.2      switch with compiler
-    sw-sys-comp                                                     switch with system compiler
-
-[NOTE] Current switch has been selected based on the current directory.
-       The current global system switch is sw-sys-comp.
+${BASEDIR}
+default
+sw-comp
+sw-sys-comp
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
@@ -1942,16 +1930,12 @@ RSTATE                          Cache found
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
-### opam switch
+### opam switch --short
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-#   switch                                     compiler             description
-->  ${BASEDIR}  i-am-sys-compiler.2  local switch
-    default                                                         default switch
-    sw-comp                                    i-am-compiler.2      switch with compiler
-    sw-sys-comp                                                     switch with system compiler
-
-[NOTE] Current switch has been selected based on the current directory.
-       The current global system switch is sw-sys-comp.
+${BASEDIR}
+default
+sw-comp
+sw-sys-comp
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
@@ -2203,17 +2187,13 @@ switch: "sw-sys-comp"
 wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
 wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
 wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
-### opam switch
+### opam switch --short
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-#   switch                                     compiler             description
-->  ${BASEDIR}  i-am-sys-compiler.2  local switch
-    default                                                         default switch
-    sw-comp                                    i-am-compiler.2      switch with compiler
-    sw-sys-comp                                                     switch with system compiler
-    this-internal-error                                             Missing config file
-
-[NOTE] Current switch has been selected based on the current directory.
-       The current global system switch is sw-sys-comp.
+${BASEDIR}
+default
+sw-comp
+sw-sys-comp
+this-internal-error
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM


### PR DESCRIPTION
Fix `safe_load` behavior to permit to catch format upgrade triggers.
Fix #4748