### PR TITLE
Depext: fix alpine tagged repositories handling

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ are not marked). Those prefixed with "(+)" are new command/option (since
 * Fix bypass-check handling on reinit [#4750 @rjbou]
 * fish: fix deprecated redirection syntax `^` [#4736 @vzaliva]
 * Bump src_exts and fix build compat with Dune 2.9.0 [#4754 @dra27]
+* Fix depext alpine tagged repositories handling [#4758 @rjbou]
 
 2.1.0~rc2:
 * Remove OPAMZ3DEBUG evironment variable [#4720 @rjbou - fix #4717]


### PR DESCRIPTION
Some examples of the new behavior
```
libx11-dev policy:
 1.7.1-r0:
   lib/apk/db/installed
   https://dl-cdn.alpinelinux.org/alpine/v3.13/main
 1.7.2-r0:
   @edge https://dl-cdn.alpinelinux.org/alpine/edge/main
```
* `libx11` as installed
* `libx11@edge` as available
```
bubblewrap policy:
 0.4.1-r2:
   lib/apk/db/installed
   https://dl-cdn.alpinelinux.org/alpine/v3.13/main
   @edge https://dl-cdn.alpinelinux.org/alpine/v3.13/main
   https://dl-cdn.alpinelinux.org/alpine/edge/main
   @edge https://dl-cdn.alpinelinux.org/alpine/edge/main
```
* `bubblewrap` and `bubblewrap@edge` as installed
```
capnproto policy:
  0.8.0-r1:
    @edgecommunity https://dl-cdn.alpinelinux.org/alpine/edge/community
```
* `capnproto-dev@edgecommunity` as available
