### PR TITLE
Make opam partially compilable on stock macOS/FreeBSD

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -76,6 +76,7 @@ Prefixes used to help generate release notes, changes, and blog posts:
 
 ## Build
   * Bump src_exts and fix build compat with Dune 2.9.0 [#4752 @dra27]
+  * Make opam partially compilable on stock macOS/FreeBSD [#4761 @kit-ty-kate]
 
 ## Infrastructure
   *

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -25,6 +25,12 @@ ifndef FETCH
   endif
 endif
 
+ifneq ($(shell command -v md5sum 2>/dev/null),)
+  MD5SUM = md5sum
+else
+  MD5SUM = md5 -q
+endif
+
 # Shorthand for designating that lib-ext and lib-pkg use the same version of a library
 PKG_SAME = $(eval $(call PKG_SAME_DEFS,$(1)))
 define PKG_SAME_DEFS
@@ -61,7 +67,7 @@ ifdef OCAML
 MD5CHECK = $(OCAML) ../shell/md5check.ml $(1) $(2)
 else
 MD5CHECK = { \
-  sum=`md5sum $(1) | sed -e 's/^[^a-f0-9]*\([a-f0-9]*\).*/\1/'`; \
+  sum=`$(MD5SUM) $(1) | sed -e 's/^[^a-f0-9]*\([a-f0-9]*\).*/\1/'`; \
   { test "$$sum" = "$(2)" && echo '$(1) has the expected MD5.'; } || \
   { rm -f $(1); \
     echo 'MD5 for $(1) differs:'; \


### PR DESCRIPTION
FreeBSD and macOS do not have md5sum by default but `./configure && make lib-ext && make` works fine with this patch at least on macOS