### PR TITLE
Release scripts update

### DIFF
--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -1,20 +1,23 @@
-FROM multiarch/debian-debootstrap:%TARGET_TAG%
+FROM multiarch/alpine:%TARGET_TAG%
 # May need configuration on the host:
 #    docker run --rm --privileged multiarch/qemu-user-static:register --reset
 LABEL Description="opam release builds" Vendor="OCamlPro" Version="1.0"
 
-RUN apt-get update && apt-get install bzip2 g++ make patch wget libltdl-dev --yes && apt-get clean --yes
-RUN useradd -U --create-home opam
+RUN apk add gcc g++ make coreutils openssl
 
-ADD https://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.1.tar.gz /root/
+RUN addgroup -S opam && adduser -S opam -G opam -s /bin/sh
+
+ADD https://caml.inria.fr/pub/distrib/ocaml-4.12/ocaml-4.12.0.tar.gz /root/
 
 WORKDIR /root
-RUN tar xzf ocaml-4.07.1.tar.gz
-WORKDIR ocaml-4.07.1
+RUN tar xzf ocaml-4.12.0.tar.gz
+WORKDIR ocaml-4.12.0
+RUN sed -i 's/gnueabi/*eabi/' configure
+RUN sed -i 's/musl/musl*/' configure
 RUN ./configure %CONF% -prefix /usr/local
-RUN make world opt.opt
-RUN make install
-RUN rm -rf /root/ocaml-4.07.1 /root/ocaml-4.07.1.tar.gz
+RUN make world opt.opt && make install && rm -rf /root/ocaml-4.12.0 /root/ocaml-4.12.0.tar.gz
+
+RUN apk add patch
 
 ENV PATH /usr/local/bin:/usr/bin:/bin
 USER opam

--- a/release/Makefile
+++ b/release/Makefile
@@ -6,9 +6,8 @@ GIT_URL = ..
 FULL_ARCHIVE_URL = https://github.com/ocaml/opam/releases/download/$(VERSION)/opam-full-$(VERSION).tar.gz
 
 TARGETS = x86_64-linux i686-linux armhf-linux arm64-linux
-# todo: x86_64-darwin
 
-OCAMLV = 4.10.2
+OCAMLV = 4.12.0
 # currently hardcoded in Dockerfile.in
 OCAML_URL = https://caml.inria.fr/pub/distrib/ocaml-$(basename $(OCAMLV))/ocaml-$(OCAMLV).tar.gz
 
@@ -31,26 +30,29 @@ out/opam-full-$(VERSION).tar.gz:
 	}
 
 build/Dockerfile.x86_64-linux: Dockerfile.in
-	mkdir -p build && sed 's/%TARGET_TAG%/amd64-jessie/g' $^ | sed 's/%CONF%//g' >$@
+	mkdir -p build && sed 's/%TARGET_TAG%/x86_64-v3.13/g' $^ | sed 's/%CONF%//g' >$@
 build/Dockerfile.i686-linux: Dockerfile.in
-	mkdir -p build && sed 's/%TARGET_TAG%/i386-jessie/g' $^ | sed 's/%CONF%/-host i686-linux/g' >$@
+	mkdir -p build && sed 's/%TARGET_TAG%/x86-v3.13/g' $^ | sed 's/%CONF%/-build i586-alpine-linux-musl/g' >$@
+
+# Need to lie about gnueabihf instead of musleabihf, because of a ./configure bug
 build/Dockerfile.armhf-linux: Dockerfile.in
-	mkdir -p build && sed 's/%TARGET_TAG%/armhf-jessie/g' $^ | sed 's/%CONF%//g' >$@
+	mkdir -p build && sed 's/%TARGET_TAG%/armv7-v3.13/g' $^ | sed 's/%CONF%//g' >$@
 build/Dockerfile.arm64-linux: Dockerfile.in
-	mkdir -p build && sed 's/%TARGET_TAG%/arm64-stretch/g' $^ | sed 's/%CONF%//g' >$@
+	mkdir -p build && sed 's/%TARGET_TAG%/arm64-v3.13/g' $^ | sed 's/%CONF%//g' >$@
 
 
 build/%.image: build/Dockerfile.%
 	docker build -t opam-build-$* -f $^ build
 	touch $@
 
-# Actually, this is for debian 8 jessie, and varies wildly
+# Actually, this is for alpine 3.13, and varies
 CLINKING_linux = \
 -Wl,-Bstatic \
 -lunix -lmccs_stubs -lmccs_glpk_stubs \
 -lstdc++ \
--Wl,-Bdynamic \
--static-libgcc
+-static-libgcc \
+-static
+# -Wl,-Bdynamic 
 
 CLINKING_macos = \
 -lunix -lmccs_stubs -lmccs_glpk_stubs \
@@ -96,8 +98,9 @@ host: out/opam-full-$(VERSION).tar.gz build/$(HOST).env
 	  cd build/opam-full-$(VERSION) && \
 	  ./configure && \
 	  echo "$(call LINKING,$(HOST_OS))" >src/client/linking.sexp && \
-	  $(MAKE) lib-ext DUNE_ARGS="--root=`pwd`"; \
-	  $(MAKE) opam DUNE_ARGS="--root=`pwd`"; \
+	  $(MAKE) lib-ext && \
+	  sed -i 's/ -Wno-stringop-overflow//' src_ext/mccs/src/glpk/context_flags.ml && \
+	  $(MAKE) opam; \
 	)
 	cp build/opam-full-$(VERSION)/opam out/opam-$(VERSION)-$(HOST)
 	strip out/opam-$(VERSION)-$(HOST)


### PR DESCRIPTION
* Use Alpine and build really static binaries with Musl
* Add hepers to do the artifacts signatures
* This was used already for the 2.1.0~rc2 binaries (and some of the rc1)
* Temporary fixes using last-minute patches:
 - Fix for arm32+musl (see https://github.com/ocaml/ocaml/pull/10471)
 - Remove -Wno-stringop-overflow from glpk as it breaks with some (older)
compilers