### PR TITLE
opam lint: Warn if the license field is not present

### DIFF
--- a/.github/scripts/solvers.sh
+++ b/.github/scripts/solvers.sh
@@ -3,6 +3,7 @@
 . .github/scripts/preamble.sh
 
 export OPAMYES=1
+export OPAMCONFIRMLEVEL=unsafe-yes
 export OCAMLRUNPARAM=b
 
 # All environment variable are overwritten in job description
@@ -23,6 +24,7 @@ case "$SOLVER" in
     ;;
 esac
 
+opam update --depexts
 opam switch create $SOLVER ocaml-system || true
 opam install $PKGS
 opam install . --deps

--- a/master_changes.md
+++ b/master_changes.md
@@ -46,7 +46,7 @@ Prefixes used to help generate release notes, changes, and blog posts:
   *
 
 ## Lint
-  *
+  * W68: add warning for missing license field [#4766 @kit-ty-kate - partial fix #4598]
 
 ## Lock
   *

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -869,6 +869,9 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
        | Some urlf ->
          (OpamFile.URL.checksum urlf <> [])
          && url_is_archive <> Some true);
+    cond 68 `Warning
+      "Missing field 'license'"
+      (t.license = []);
   ]
   in
   format_errors @

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -204,6 +204,23 @@
    (run ./run.exe %{bin:opam} %{dep:legacy-local.test} %{read-lines:testing-env}))))
 
 (alias
+ (name reftest-lint)
+ (action
+  (diff lint.test lint.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-lint)))
+
+(rule
+ (targets lint.out)
+ (deps root-N0REP0)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:lint.test} %{read-lines:testing-env}))))
+
+(alias
  (name reftest-opamroot-versions)
  (action
   (diff opamroot-versions.test opamroot-versions.out)))

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -1,0 +1,29 @@
+N0REP0
+### <lint.opam>
+opam-version: "2.0"
+name: "lint"
+version: "1.0"
+synopsis: "A word"
+description: "Two words."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [ "Z" "A" "R" ]
+homepage: "x"
+bug-reports: "x"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "base-unix"
+  "base-bigarray"
+  "ocamlgraph"
+  "re" {>= "1.5.0"}
+  "dune" {>= "1.2.1"}
+  "cppo" {build}
+]
+conflicts: ["extlib-compat"]
+build: [
+  [ "./configure" ]
+  [ make ]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Warnings.
+           warning 68: Missing field 'license'

--- a/tests/reftests/show.test
+++ b/tests/reftests/show.test
@@ -126,6 +126,7 @@ synopsis: "A word"
 description: "Two words."
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [ "Z" "A" "R" ]
+license: "ISC"
 homepage: "x"
 bug-reports: "x"
 depends: [
@@ -151,6 +152,7 @@ synopsis: "A word"
 description: "Two words."
 maintainer: "opam-devel@lists.ocaml.org"
 authors: ["A" "R" "Z"]
+license: "ISC"
 homepage: "x"
 bug-reports: "x"
 depends: [
@@ -182,6 +184,7 @@ bug-reports "x"
 dev-repo    "git+https://github.com/ocaml/opam.git"
 authors     "A" "R" "Z"
 maintainer  "opam-devel@lists.ocaml.org"
+license     "ISC"
 depends     "base-bigarray"
             "base-unix"
             "ocamlgraph"
@@ -200,6 +203,7 @@ synopsis: "A word"
 description: "Two words."
 maintainer: "opam-devel@lists.ocaml.org"
 authors: ["A" "R" "Z"]
+license: "ISC"
 homepage: "x"
 bug-reports: "x"
 depends: [
@@ -233,6 +237,7 @@ synopsis: "A word"
 description: "Two words."
 maintainer: "opam-devel@lists.ocaml.org"
 authors: ["Z" "A" "R"]
+license: "ISC"
 homepage: "x"
 bug-reports: "x"
 depends: [
@@ -265,6 +270,7 @@ bug-reports "x"
 dev-repo    "git+https://github.com/ocaml/opam.git"
 authors     "Z" "A" "R"
 maintainer  "opam-devel@lists.ocaml.org"
+license     "ISC"
 depends     "ocaml" {>= "4.02.3"}
             "base-unix"
             "base-bigarray"

--- a/tests/reftests/upgrade-format.test
+++ b/tests/reftests/upgrade-format.test
@@ -2,6 +2,7 @@
 ### <opam-core.opam>
 opam-version: "1.2"
 version: "2.0.7"
+license: "ISC"
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"
@@ -51,6 +52,7 @@ authors: [
   "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
   "Frederic Tuong <tuong@users.gforge.inria.fr>"
 ]
+license: "ISC"
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [


### PR DESCRIPTION
Partially fixes https://github.com/ocaml/opam/issues/4598