### PR TITLE
Switch minimum OCaml version to 4.08

### DIFF
--- a/.github/scripts/legacy.sh
+++ b/.github/scripts/legacy.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -xue
+
+. .github/scripts/preamble.sh
+
+export OPAMYES=1
+export OCAMLRUNPARAM=b
+
+opam init default git+$OPAM_REPO#$OPAM_REPO_SHA
+eval $(opam env)
+OPAMCLI=2.0 opam reinstall ocaml-system --unlock-base
+opam upgrade
+for package in core format installer ; do
+  opam pin add -yn opam-$package .
+done
+opam install opam-core opam-format opam-installer --deps-only
+dune build --profile=dev --only-packages opam-core,opam-format,opam-installer @install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,14 +108,14 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        ocamlv: [ 4.03.0, 4.04.2, 4.05.0, 4.06.1, 4.07.1, 4.08.1, 4.09.1, 4.10.2, 4.11.2, 4.12.0 ]
+        ocamlv: [ 4.08.1, 4.09.1, 4.10.2, 4.11.2, 4.12.0 ]
         include:
           - os: macos-latest
             ocamlv: 4.12.0
-      # Intentionnaly fail fast, no need to run all build if there is a
+      # Intentionally fail fast, no need to run all build if there is a
       # problem in a given version; usually it is functions not defined in lower
-      # versions of caml
-      # fail-fast: false
+      # versions of OCaml
+      fail-fast: true
     steps:
     - name: install deps
       if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -136,6 +136,39 @@ jobs:
       env:
         OCAML_VERSION: ${{ matrix.ocamlv }}
       run: bash -exu .github/scripts/main.sh
+
+####
+# Legacy
+####
+  legacy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ Linux ]
+        ocamlv: [ 4.03.0, 4.04.2, 4.05.0, 4.06.1, 4.07.1 ]
+      # Intentionally fail fast, no need to run all build if there is a
+      # problem in a given version; usually it is functions not defined in lower
+      # versions of OCaml
+      fail-fast: true
+    steps:
+    - name: install deps
+      run: sudo apt install opam
+    - uses: actions/checkout@v2
+    - name: ocaml ${{ matrix.ocamlv }} cache
+      id: ocaml-cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.GH_OCAML_CACHE }}
+        key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ hashFiles ('.github/scripts/ocaml-cache.sh', '.github/scripts/preamble.sh') }}
+    - name: Building ocaml ${{ matrix.ocamlv }} cache
+      if: steps.ocaml-cache.outputs.cache-hit != 'true'
+      env:
+        OCAML_VERSION: ${{ matrix.ocamlv }}
+      run: bash -exu .github/scripts/ocaml-cache.sh ocaml
+    - name: Build
+      env:
+        OCAML_VERSION: ${{ matrix.ocamlv }}
+      run: bash -exu .github/scripts/legacy.sh
 
 ####
 # Opam tests

--- a/configure
+++ b/configure
@@ -4788,13 +4788,8 @@ fi
 
 fi
 
-CONF_OCAMLFLAGS="-w -67"
+CONF_OCAMLFLAGS=''
 
-if test "x${CI}" != "x"; then :
-
-  CONF_OCAMLFLAGS="${CONF_OCAMLFLAGS} -w -67"
-
-fi
 if test "x${CI}" != "x" -o "x${enable_developer_mode}" = "xyes"; then :
 
   if test "x${CCOMP_TYPE}" = "xmsvc"; then :

--- a/configure
+++ b/configure
@@ -2184,8 +2184,7 @@ if  test -x bootstrap/ocaml/bin/ocamlc -o -x bootstrap/ocaml/bin/ocamlopt ; then
 
 fi
 
-# XXX This isn't strictly correct for Windows
-MIN_OCAML_VERSION=4.03.0
+MIN_OCAML_VERSION=4.08.0
 
   # checking for ocamlc
   if test -n "$ac_tool_prefix"; then
@@ -3504,8 +3503,6 @@ CPATH=$CPATH
 LIBRARY_PATH=$LIBRARY_PATH
 
 
-# Check that OCaml version is greater or equal to 4.03.0
-# Native Windows builds require at least 4.06.0 for the Unicode runtime.
 for ac_prog in gawk mawk nawk awk
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
@@ -3550,9 +3547,6 @@ done
 
 if test "x${enable_version_check}" != "xno"; then :
 
-  if  test ${WIN32} -eq 1 ; then :
-  MIN_OCAML_VERSION=4.06.0
-fi
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -164,11 +164,8 @@ AS_IF([test "x${with_libacl}" = "xyes"],[
   ])
 ])
 
-CONF_OCAMLFLAGS="-w -67"
+CONF_OCAMLFLAGS=''
 
-AS_IF([test "x${CI}" != "x"], [
-  CONF_OCAMLFLAGS="${CONF_OCAMLFLAGS} -w -67"
-],[])
 AS_IF([test "x${CI}" != "x" -o "x${enable_developer_mode}" = "xyes"],[
   AS_IF([test "x${CCOMP_TYPE}" = "xmsvc"],[
     CONF_CFLAGS="\"/WX\""

--- a/configure.ac
+++ b/configure.ac
@@ -14,8 +14,7 @@ AS_IF([ test -x bootstrap/ocaml/bin/ocamlc -o -x bootstrap/ocaml/bin/ocamlopt ],
   export PATH="$PATH_PREPEND$PATH"
 ])
 
-# XXX This isn't strictly correct for Windows
-MIN_OCAML_VERSION=4.03.0
+MIN_OCAML_VERSION=4.08.0
 
 AC_PROG_OCAML
 if test "x$OCAMLC" = "xno"; then
@@ -86,10 +85,7 @@ AC_SUBST(LIB_PREFIX,$LIB_PREFIX)
 AC_SUBST(CPATH,$CPATH)
 AC_SUBST(LIBRARY_PATH,$LIBRARY_PATH)
 
-# Check that OCaml version is greater or equal to 4.03.0
-# Native Windows builds require at least 4.06.0 for the Unicode runtime.
 AS_IF([test "x${enable_version_check}" != "xno"], [
-  AS_IF([ test ${WIN32} -eq 1 ],[MIN_OCAML_VERSION=4.06.0])
   AX_COMPARE_VERSION(
     [$OCAMLVERSION], [lt], [$MIN_OCAML_VERSION],
     AC_MSG_ERROR([Your version of OCaml ($OCAMLVERSION) is not supported]))

--- a/master_changes.md
+++ b/master_changes.md
@@ -76,7 +76,7 @@ users)
   *
 
 ## VCS
-  *
+  * Use 4.08's unnamed functor arguments to silence warning 67 [#4775 @dra27]
 
 ## Build
   * Bump src_exts and fix build compat with Dune 2.9.0 [#4752 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -83,6 +83,7 @@ users)
   * Upgrade to dose3 >= 6.1 and vendor dose3 7.0.0 [#4760 @kit-ty-kate]
   * Change minimum required OCaml to 4.03.0 [#4770 @dra27]
   * Change minimum required Dune to 2.0 [#4770 @dra27]
+  * Change minimum required OCaml to 4.08.0 for everything except opam-core, opam-format and opam-installer [#4775 @dra27]
 
 ## Infrastructure
   *

--- a/opam-client.opam
+++ b/opam-client.opam
@@ -26,7 +26,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "opam-state" {= version}
   "opam-solver" {= version}
   "base64" {>= "3.1.0"}

--- a/opam-core.opam
+++ b/opam-core.opam
@@ -26,7 +26,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {(>= "4.03.0" & os != "win32") | >= "4.06.0"}
   "base-unix"
   "base-bigarray"
   "ocamlgraph"

--- a/opam-devel.opam
+++ b/opam-devel.opam
@@ -26,7 +26,7 @@ build: [
   [make "%{name}%.install"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "opam-client" {= version}
   "cmdliner" {>= "0.9.8"}
   "dune" {>= "2.0.0"}

--- a/opam-format.opam
+++ b/opam-format.opam
@@ -26,7 +26,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {(>= "4.03.0" & os != "win32") | >= "4.06.0"}
   "opam-core" {= version}
   "opam-file-format" {>= "2.1.3"}
   "re" {>= "1.9.0"}

--- a/opam-installer.opam
+++ b/opam-installer.opam
@@ -28,7 +28,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {(>= "4.03.0" & os != "win32") | >= "4.06.0"}
   "opam-format" {= version}
   "cmdliner" {>= "0.9.8"}
   "dune" {>= "2.0.0"}

--- a/opam-repository.opam
+++ b/opam-repository.opam
@@ -26,7 +26,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
   "dune" {>= "2.0.0"}
 ]

--- a/opam-solver.opam
+++ b/opam-solver.opam
@@ -26,7 +26,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
   "mccs" {>= "1.1+9"}
   "dose3" {>= "6.1"}

--- a/opam-state.opam
+++ b/opam-state.opam
@@ -26,7 +26,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
   "dune" {>= "2.0.0"}

--- a/src/client/opamCLIVersion.ml
+++ b/src/client/opamCLIVersion.ml
@@ -39,9 +39,9 @@ let of_json = function
   | `String x -> of_string_opt x
   | _ -> None
 
-let ( >= ) = OpamCompat.Stdlib.( >= )
-let ( < ) = OpamCompat.Stdlib.( < )
-let compare = OpamCompat.Stdlib.compare
+let ( >= ) = Stdlib.( >= )
+let ( < ) = Stdlib.( < )
+let compare = Stdlib.compare
 
 let previous cli =
   let f previous version =
@@ -64,9 +64,9 @@ module Sourced = struct
 end
 
 module Op = struct
-  let ( @>= ) (c,_) = OpamCompat.Stdlib.( >= ) c
-  let ( @< ) (c,_) = OpamCompat.Stdlib.( < ) c
-  let ( @= ) (c,_) = OpamCompat.Stdlib.( = ) c
+  let ( @>= ) (c,_) = Stdlib.( >= ) c
+  let ( @< ) (c,_) = Stdlib.( < ) c
+  let ( @= ) (c,_) = Stdlib.( = ) c
 end
 
 module O = struct

--- a/src/repository/opamVCS.mli
+++ b/src/repository/opamVCS.mli
@@ -75,4 +75,4 @@ module type VCS = sig
 end
 
 (** Create a backend from a [VCS] implementation. *)
-module Make(VCS : VCS) : OpamRepositoryBackend.S
+module Make(_ : VCS) : OpamRepositoryBackend.S


### PR DESCRIPTION
Continues from #4770. opam-core, opam-format and opam-installer are now tested separately where only the libraries are built.

CI is still quite painful because the ocaml-secondary-compiler, however, I have an overhaul PR ready to go which sorts out the caching for that.