### PR TITLE
Doc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # opam - A package manager for OCaml
 
-|master|2.0|
+|master|2.0|2.1|
 |--|--|
-|[![GH actions](https://github.com/ocaml/opam/workflows/Builds,%20tests%20&%20co/badge.svg)](https://github.com/ocaml/opam/actions?query=workflow%3A%22Builds%2C+tests+%26+co%22+branch%3Amaster) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/ocaml/opam?branch=master&svg=true)](https://ci.appveyor.com/project/AltGr/opam) | [![2.0 GH actions](https://github.com/ocaml/opam/workflows/Builds,%20tests%20&%20co/badge.svg?branch=2.0)](https://github.com/ocaml/opam/actions?query=workflow%3A%22Builds%2C+tests+%26+co%22+branch%3A2.0) [![AppVeyor 2.0 Build Status](https://ci.appveyor.com/api/projects/status/github/ocaml/opam?branch=2.0&svg=true)](https://ci.appveyor.com/project/AltGr/opam) |
+|[![GH actions](https://github.com/ocaml/opam/workflows/Builds,%20tests%20&%20co/badge.svg)](https://github.com/ocaml/opam/actions?query=workflow%3A%22Builds%2C+tests+%26+co%22+branch%3Amaster) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/ocaml/opam?branch=master&svg=true)](https://ci.appveyor.com/project/AltGr/opam) | [![2.0 GH actions](https://github.com/ocaml/opam/workflows/Builds,%20tests%20&%20co/badge.svg?branch=2.0)](https://github.com/ocaml/opam/actions?query=workflow%3A%22Builds%2C+tests+%26+co%22+branch%3A2.0) [![AppVeyor 2.0 Build Status](https://ci.appveyor.com/api/projects/status/github/ocaml/opam?branch=2.0&svg=true)](https://ci.appveyor.com/project/AltGr/opam) | [![2.1 GH actions](https://github.com/ocaml/opam/workflows/Builds,%20tests%20&%20co/badge.svg?branch=2.1)](https://github.com/ocaml/opam/actions?query=workflow%3A%22Builds%2C+tests+%26+co%22+branch%3A2.1) [![AppVeyor 2.1 Build Status](https://ci.appveyor.com/api/projects/status/github/ocaml/opam?branch=2.1&svg=true)](https://ci.appveyor.com/project/AltGr/opam) |
 
 Opam is a source-based package manager for OCaml. It supports multiple simultaneous
 compiler installations, flexible package constraints, and a Git-friendly development

--- a/doc/pages/Distribution.md
+++ b/doc/pages/Distribution.md
@@ -58,10 +58,10 @@ OS/distrubtion, their latest opam version and their maintainers:
   * [Package definition](https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/ocaml.scm#n428)
   * Julien Lepiller [@roptat](https://github.com/roptat)
 
-* Homebrew (MacOS X)
+* Homebrew (macOS)
  [![Homebrew package](https://repology.org/badge/version-for-repo/homebrew/opam.svg?header=)](https://formulae.brew.sh/formula/opam)
 
-* Macports (MacOS X)
+* Macports (macOS)
  [![MacPorts package](https://repology.org/badge/version-for-repo/macports/opam.svg?header=)](https://ports.macports.org/port/opam/summary)
   * [Package definition](https://github.com/macports/macports-ports/blob/master/sysutils/opam/Portfile)
   * Perry E. Metzger [@pmetzger](https://www.github.com/pmetzger)

--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -213,9 +213,9 @@ You can also download the full archives, including opam dependencies (these
 don't require any extra downloads, just the OCaml compiler -- 4.02.3 or later
 for the latest version):
 
-* [2.0.8](https://github.com/ocaml/opam/releases/download/2.0.8/opam-full-2.0.8.tar.gz)
- - MD5: 69e95d318fec8027b9eb6af6075a2a13
- - SHA384: f534860f511768f78f646be4248df58ecaf699dc55eea90e21f0d8d6e2bd23235a9ca132fcf17bf854cf3c25adfab4c8
+* [2.1.0](https://github.com/ocaml/opam/releases/download/2.1.0/opam-full-2.1.0.tar.gz)
+ - MD5: 24dbfb43515e8edc617485f6c5853802
+ - SHA384: ba4d375a1dea73937e8790c45c2fbd3d68ebbb0fddd2fd22af3e682037d50979abeda0c5cf17ffd8cc6a3951ff07242f
 
 Follow the instructions in the included
 [`README.md`](https://github.com/ocaml/opam#readme) to get opam built and

--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -24,7 +24,7 @@ Then see the [Upgrade guide](Upgrade_guide.html) to check the changes.
 The quickest way to get the latest opam up and working is to run
 [this script](https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh):
 ```
-sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)"
 ```
 
 This will simply check your architecture, download and install the proper

--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -220,8 +220,3 @@ for the latest version):
 Follow the instructions in the included
 [`README.md`](https://github.com/ocaml/opam#readme) to get opam built and
 installed from there.
-
-> Note that opam1.2.2 doesn't build from source with OCaml 4.06.0. Use this command to compile `lib_ext`
-> ```
-> OCAMLPARAM="safe-string=0,_" make lib-ext
-> ```

--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -37,7 +37,7 @@ and run `sh install.sh`)
 
 We provide pre-compiled binaries for:
 - Linux i686, amd64, arm7, arm64
-- OSX (intel 64 bits, arm64)
+- macOS (intel 64 bits, arm64)
 - We do not at present provide an official Windows distribution of opam, but please see [this separately maintained distribution](https://fdopen.github.io/opam-repository-mingw/)
 (other platforms are available using the other methods below)
 
@@ -152,7 +152,7 @@ cd /usr/ports/devel/ocaml-opam
 make install
 ```
 
-#### OSX
+#### macOS
 
 [![badge](https://repology.org/badge/version-for-repo/homebrew/opam.svg)](https://repology.org/project/opam/versions) [![badge](https://repology.org/badge/version-for-repo/macports/opam.svg)](https://repology.org/project/opam/versions)
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -5,6 +5,10 @@ Prefixes used to help generate release notes, changes, and blog posts:
 * ◈ New option/command/subcommand
 * [BUG] for bug fixes
 * [NEW] for new features (not a command itself)
+* [API] api updates 🕮
+If there is changes in the API (new non optional argument, function renamed or
+moved, etc.), please update the _API updates_ part (it helps opam library
+users)
 
 ## Version
   *
@@ -92,7 +96,7 @@ Prefixes used to help generate release notes, changes, and blog posts:
 ## State
   *
 
-# Opam file format
+## Opam file format
   *
 
 ## Solver
@@ -128,3 +132,11 @@ Prefixes used to help generate release notes, changes, and blog posts:
 
 ## Security fixes
   *
+
+# API updates
+## opam-client
+## opam-repository
+## opam-state
+## opam-solver
+## opam-format
+## opam-core

--- a/master_changes.md
+++ b/master_changes.md
@@ -128,7 +128,7 @@ users)
   * fish: fix deprecated redirection syntax `^` [#4736 @vzaliva]
 
 ## Doc
-  *
+  * Standardise `macOS` use [#4782 @kit-ty-kate]
 
 ## Security fixes
   *

--- a/release/readme.md
+++ b/release/readme.md
@@ -11,7 +11,7 @@
 
 [ once bump version & changes PRs merged ]
 * tag the release (git tag -a 2.2.0; git push origin 2.2.0)
-* /!\ Once the tag pushed, it can be updated only in case of severe issue
+* /!\ Once the tag pushed, it can be updated [different commit] only in case of severe issue
 * create a release (or prerelease if intermediate release) draft on github based on your tag (https://github.com/ocaml/opam/releases/new)
 * generate opam artifacts, using `shell/release.sh`, it requires to have Docker install with several remotes, the different arches
 * add releases notes (content of `master_changes.md`) in the release
@@ -27,3 +27,13 @@
 
 * a blog entry in opam.ocaml.org
 * a announcement in discuss.ocaml.org
+
+
+## After release
+
+* Bump the version with a `~dev` at the end (e.g. `2.2.0~alpha~dev`)
+* Check if reftests needs an update
+
+### On a release candidate
+* create a branch to a `x.y` for rc's and the final release
+* remove `shell/install.sh`

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -130,7 +130,7 @@ let environment_variables =
          (string_of_enum when_enum));
       "UTF8MSGS", cli_original, (fun v -> UTF8MSGS (env_bool v)),
       "use extended UTF8 characters (camels) in opam messages. Implies \
-       $(i,OPAMUTF8). This is set by default on OSX only.";
+       $(i,OPAMUTF8). This is set by default on macOS only.";
       "VERBOSE", cli_original, (fun v -> VERBOSE (env_level v)),
       "see option `--verbose'.";
     ] in

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -458,7 +458,7 @@ let run_test ?(vars=[]) ~opam t =
   else
     ignore @@ command "cp" ["-a"; opamroot0; opamroot];
   Sys.chdir dir;
-  let dir = Sys.getcwd () in (* because it may need to be normalised on OSX *)
+  let dir = Sys.getcwd () in (* because it may need to be normalised on macOS *)
   if t.repo_hash = no_opam_repo then
     (mkdir_p (default_repo^"/packages");
      write_file ~path:(default_repo^"/repo") ~contents:{|opam-version: "2.0"|};


### PR DESCRIPTION
The change of the advised way to call `install.sh` was proposed in https://github.com/ocaml/platform-blog/pull/77 and includes:
* `<()` is a bash syntax, so people using this command in `sh` or `csh` will see the command fail
* `curl` without `-fS` will output things in stdout when something goes wrong (404, and other network failure) and can cause random shell commands being executed. This is what https://brew.sh/ recommend for instance.