### PR TITLE
Run sandbox checker in temp directory

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -20,7 +20,7 @@ users)
   *
 
 ## Init
-  *
+  * Run the sandbox check in the temporary directory [#4787 @dra27 - fix #4783]
 
 ## Config report
   *

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -515,7 +515,9 @@ let check_and_revert_sandboxing root config =
         Array.append [| "OPAM_SWITCH_PREFIX=/dev/null" |] (Unix.environment ())
       in
       try
-        OpamSystem.read_command_output ~env ~allow_stdin:false (cmd @ test_cmd)
+        (* Don't assume that we can mount the CWD *)
+        OpamSystem.in_tmp_dir @@ fun () ->
+          OpamSystem.read_command_output ~env ~allow_stdin:false (cmd @ test_cmd)
         = ["SUCCESS"]
       with e ->
         (OpamConsole.error "Sandboxing is not working on your platform%s:\n%s"

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -503,12 +503,8 @@ let check_and_revert_sandboxing root config =
   match OpamFilter.commands env sdbx_wrappers with
   | [] -> config
   | cmd::_ ->
-    (* All the provided sandboxing scripts are expected to define [TMPDIR] *)
-    let test_file = "$TMPDIR/opam-sandbox-check-out" in
     let test_cmd =
-      [ "sh"; "-c";
-        Printf.sprintf "echo SUCCESS >%s && cat %s; rm -f %s"
-          test_file test_file test_file ]
+      [ "sh"; "-c"; "echo SUCCESS | tee check-write" ]
     in
     let working_or_noop =
       let env =

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -302,6 +302,10 @@ let with_tmp_dir fn =
     OpamStd.Exn.finalise e @@ fun () ->
     remove_dir dir
 
+let in_tmp_dir fn =
+  with_tmp_dir @@ fun dir ->
+    in_dir dir fn
+
 let with_tmp_dir_job fjob =
   let dir = mk_temp_dir () in
   mkdir dir;

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -31,8 +31,12 @@ exception Internal_error of string
 (** Raise [Internal_error] *)
 val internal_error: ('a, unit, string, 'b) format4 -> 'a
 
-(** [with_tmp_dir fn] executes [fn] in a tempory directory *)
+(** [with_tmp_dir fn] executes [fn] creates a temporary directory and
+    passes its name to [fn]. The directory is alwasy removed on completion. *)
 val with_tmp_dir: (string -> 'a) -> 'a
+
+(** [in_tmp_dir fn] executes [fn] in a temporary directory. *)
+val in_tmp_dir: (unit -> 'a) -> 'a
 
 (** Runs a job with a temp dir that is cleaned up afterwards *)
 val with_tmp_dir_job: (string -> 'a OpamProcess.job) -> 'a OpamProcess.job


### PR DESCRIPTION
The sandbox will attempt to mount the current working directory which may fail (and which we don't necessarily have any business doing).