### PR TITLE
opamSystem: avoid calling Unix.environment at top level

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -141,3 +141,4 @@ users)
 ## opam-solver
 ## opam-format
 ## opam-core
+  * OpamSystem: avoid calling Unix.environment at top level [#4789 @hannesm]


### PR DESCRIPTION
this is #4731 rebased onto master.