### PR TITLE
remove -C option from yum

### DIFF
--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -287,7 +287,7 @@ let packages_status packages =
     compute_sets sys_installed ~sys_available
   | Centos ->
     (* XXX /!\ only checked on centos XXX *)
-    let lines = run_query_command "yum" ["-q"; "-C"; "list"] in
+    let lines = run_query_command "yum" ["-q"; "list"] in
     (* -C to retrieve from cache, no update but still quite long, 1,5 sec *)
     (* Return a list of installed packages then available ones:
        >Installed Packages


### PR DESCRIPTION
opam 2.1 issuing `yum -q -C list` in red hat linux 8.4 seems to be problematic. Consider the following
```
$ opam upgrade -vvv 
...
... 
+ /bin/yum "-q" "-C" "list"
- 2021-08-07 21:51:36,409 [ERROR] yum:21580:MainThread @logutil.py:194 - [Errno 13] Permission denied: '/var/log/rhsm/rhsm.log' - Further logging output will be written to stderr
- 2021-08-07 21:51:36,410 [ERROR] yum:21580:MainThread @identity.py:156 - Reload of consumer identity cert /etc/pki/consumer/cert.pem raised an exception with msg: [Errno 13] Permission denied: '/etc/pki/consumer/key.pem'
- Importing GPG key 0x442DF0F8:
-  Userid     : "PostgreSQL RPM Building Project <pgsql-pkg-yum@postgresql.org>"
-  Fingerprint: 68C9 E2B9 1A37 D136 FE74 D176 1F16 D2E1 442D F0F8
-  From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
- Is this ok [y/N]:
```
We continue with `y` and `yum -q -C list` fails due to some cache issue (`- Error: Cache-only enabled but no cache for 'pgdg-common'`) and `opam upgrade` fails.
```y
- Error: Cache-only enabled but no cache for 'pgdg-common'
[WARNING] Opam packages conf-diffutils.1, conf-libev.4-12, conf-pkg-config.2 and
          conf-postgresql.1 depend on the following system packages that are no longer installed:
          diffutils libev-devel pkgconf-pkg-config postgresql-devel
  - conf-diffutils.1: depends on diffutils
  - conf-libev.4-12: depends on libev-devel
  - conf-pkg-config.2: depends on pkgconf-pkg-config
  - conf-postgresql.1: depends on postgresql-devel
[WARNING] Upgrade is not possible because of conflicts or packages that are no longer available:
    - Missing dependency:
    - angstrom >= 0.15.0


You may run "opam upgrade --fixup" to let opam fix the current state.
'opam upgrade -vvv' failed.

```
The UX experience is even worse if one only issues `opam upgrade`. In the latter case the command never completes because it is waiting for user input.

This PR fixes this use case by removing `-C` option from `yum -q list` and this seems to handle this error case correctly. 