### PR TITLE
depexts: Disable the detection of available packages on RHEL-based distributions

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -63,6 +63,10 @@ users)
   * Set DEBIAN_FRONTEND=noninteractive for unsafe-yes confirmation level [#4735 @dra27 - partially fix #4731] [2.1.0~rc2 #4739]
   * Fix depext alpine tagged repositories handling [#4763 @rjbou] [2.1.0~rc2 #4758]
   * Homebrew: Add support for casks and full-names [#4801 @kit-ty-kate]
+  * Disable the detection of available packages on RHEL-based distributions.
+    This fixes an issue on RHEL-based distributions where yum list used to detect available
+    and installed packages would wait for user input without showing any output and/or fail
+    in some cases [#4791 @kit-ty-kate - fixes #4790]
 
 ## Format upgrade
   * Fix format upgrade when there is missing local switches in the config file [#4763 @rjbou - fix #4713] [2.1.0~rc2 #4715]


### PR DESCRIPTION
#4790 shows that `yum list` is an unreliable command to use and no options seems to be available to make it so.
#4759 also shows that RHEL-based distributions have virtual packages that opam is not taking into account.

For these two reasons I propose we simply remove the use of `yum list` in favour of `rpm -qa` which seems way more reliable and leaps faster (~0.1s vs. ~2s!!).

Sadly we incidently disable the detection of available packages and thus revert to the behaviour of the opam-depext plugin.
IMO this is not a big deal as only a few distributions that we support actually have it disabled as well due to the method to acquire the data being either incomplete or too tedious/unreliable. This is the case currently (in 2.1.0) for FreeBSD, Gentoo, Homebrew, NetBSD and OpenBSD