### PR TITLE
Fix the cold target in presence of an older OCaml compiler version on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ src_ext/dune-local/dune.exe: src_ext/dune-local.stamp $(DUNE_SECONDARY)
 ifeq ($(DUNE_SECONDARY),)
 	cd src_ext/dune-local && ocaml bootstrap.ml
 else
-	cd src_ext/dune-local && ( unset OCAMLLIB ; PATH="$(dir $(realpath $(DUNE_SECONDARY))):$$PATH" ../../$(DUNE_SECONDARY) bootstrap.ml )
+	cd src_ext/dune-local && ( unset OCAMLLIB ; unset CAML_LD_LIBRARY_PATH ; PATH="$(dir $(realpath $(DUNE_SECONDARY))):$$PATH" ../../$(DUNE_SECONDARY) bootstrap.ml )
 endif
 
 src_ext/dune-local.stamp:
@@ -250,12 +250,12 @@ src_ext/secondary/ocaml/bin/ocaml:
 	env MAKE=$(MAKE) BOOTSTRAP_EXTRA_OPTS="--disable-ocamldoc --disable-debug-runtime --disable-debugger" BOOTSTRAP_OPT_TARGET=opt BOOTSTRAP_ROOT=../.. BOOTSTRAP_DIR=src_ext/secondary ./shell/bootstrap-ocaml.sh $(OCAML_PORT)
 
 cold: compiler
-	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" ./configure --enable-cold-check $(CONFIGURE_ARGS)
-	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" $(MAKE) lib-ext
-	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" $(MAKE)
+	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" CAML_LD_LIBRARY_PATH= ./configure --enable-cold-check $(CONFIGURE_ARGS)
+	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" CAML_LD_LIBRARY_PATH= $(MAKE) lib-ext
+	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" CAML_LD_LIBRARY_PATH= $(MAKE)
 
 cold-%:
-	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" $(MAKE) $*
+	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" CAML_LD_LIBRARY_PATH= $(MAKE) $*
 
 .PHONY: run-appveyor-test
 run-appveyor-test:

--- a/master_changes.md
+++ b/master_changes.md
@@ -86,6 +86,7 @@ users)
   * Change minimum required OCaml to 4.03.0 [#4770 @dra27]
   * Change minimum required Dune to 2.0 [#4770 @dra27]
   * Change minimum required OCaml to 4.08.0 for everything except opam-core, opam-format and opam-installer [#4775 @dra27]
+  * Fix the cold target in presence of an older OCaml compiler version on macOS [#4802 @kit-ty-kate - fix #4801]
 
 ## Infrastructure
   *


### PR DESCRIPTION
Issue encountered in #4801 

The fix isn't too great. Ideally I wish I knew a way to scrub the environment of anything non-standard or something like that but it's complicated. Using `su -l $USER -c -- ...` works for this but is rather tricky. If someone knows a way please do propose.