### PR TITLE
Make sure OpamListCommand.filter Depends_on recursive only returns a subset of base

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -110,6 +110,7 @@ users)
 ## Internal
   * Add license and lowerbounds to opam files [#4714 @kit-ty-kate]
   * Bump version to 2.2.0~alpha~dev [#4725 @dra27]
+  - Make sure `OpamListCommand.filter` only returns a subset of the given base [#4803]
 
 ## Test
 

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -226,10 +226,11 @@ let apply_selector ~base st = function
       | Depends_on _ -> OpamSolver.reverse_dependencies
       | _ -> assert false
     in
-    deps_fun ~depopts:tog.depopts ~build:tog.build ~post:tog.post
+    let deps = deps_fun ~depopts:tog.depopts ~build:tog.build ~post:tog.post
       ~installed:false ~unavailable:true
       (get_universe st tog)
-      (packages_of_atoms st atoms)
+      (packages_of_atoms st atoms) in
+    OpamPackage.Set.inter base deps
   | Required_by (tog, atoms) ->
     atom_dependencies st tog atoms |>
     OpamFormula.packages base


### PR DESCRIPTION
It seems that `OpamListCommand.filter ~base:packages` is supposed to only return a subset of the supplied packages. For recursive dependency search, this does not happen, however. As far as I can tell, this is not visible from the command line, because supplied patterns are filtered separately. However, for people who use Opam as a library, this is still unexpected behavior.