### PR TITLE
Make sure that recursive dependencies are not reflexive

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -38,7 +38,7 @@ users)
   *
 
 ## List
-  *
+  * Do not list the package itself when running `--depends-on` and `--required-by` with `--required` [#4804 @LasseBlaauwbroek]
 
 ## Show
   *

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -226,10 +226,11 @@ let apply_selector ~base st = function
       | Depends_on _ -> OpamSolver.reverse_dependencies
       | _ -> assert false
     in
-    deps_fun ~depopts:tog.depopts ~build:tog.build ~post:tog.post
+    let packages = packages_of_atoms st atoms in
+    let deps = deps_fun ~depopts:tog.depopts ~build:tog.build ~post:tog.post
       ~installed:false ~unavailable:true
-      (get_universe st tog)
-      (packages_of_atoms st atoms)
+      (get_universe st tog) packages in
+    OpamPackage.Set.diff deps packages
   | Required_by (tog, atoms) ->
     atom_dependencies st tog atoms |>
     OpamFormula.packages base


### PR DESCRIPTION
`opam list --recursive --recursive --required-by=package` is reflexive (it shows the package itself). This does not seem correct, since a package does not require itself. Note that without `--recursive`, the command is not reflexive.