### PR TITLE
Remove memoization from `OpamSolverConfig.best_effort`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -174,6 +174,7 @@ users)
   * [BUG] handle converted variables correctly when no_undef_expand is true [#4811 @timbertson]
   * [BUG] check Unix.has_symlink before using Unix.symlink [#4962 @jonahbeckford]
   * OpamCudf: provide machine-readable information on conflicts caused by cycles [#4039 @gasche]
+  * Remove memoization from `best_effort ()` to allow for multiple different settings during the same session (useful for libaray users) [#4805 @LasseBlaauwbroek]
 
 ## Test
   * Update crowbar with compare functions [#4918 @rjbou]

--- a/src/solver/opamSolverConfig.ml
+++ b/src/solver/opamSolverConfig.ml
@@ -211,7 +211,8 @@ let initk k =
 let init ?noop:_ = initk (fun () -> ())
 
 let best_effort =
-  let r = lazy (
+  let already_warned = ref false in
+  fun () ->
     !r.best_effort &&
     let crit = match Lazy.force !r.solver_preferences_default with
       | Some c -> c
@@ -220,14 +221,15 @@ let best_effort =
     let pfx = Lazy.force !r.solver_preferences_best_effort_prefix in
     pfx <> None ||
     OpamStd.String.contains ~sub:"opam-query" crit ||
-    (OpamConsole.warning
-       "Your solver configuration does not support --best-effort, the option \
-        was ignored (you need to specify variable OPAMBESTEFFORTCRITERIA, or \
-        set your criteria to maximise the count for cudf attribute \
-        'opam-query')";
+    (if not !already_warned then begin
+       already_warned := true;
+       OpamConsole.warning
+         "Your solver configuration does not support --best-effort, the option \
+          was ignored (you need to specify variable OPAMBESTEFFORTCRITERIA, or \
+          set your criteria to maximise the count for cudf attribute \
+          'opam-query')"
+     end;
      false)
-  ) in
-  fun () -> Lazy.force r
 
 let criteria kind =
   let crit = match kind with


### PR DESCRIPTION
Because this function is memoized, it becomes impossible to change the
best-effort setting after the function has been called. The ability to change it
is important for library users that want to make multiple solver calls with
different settings.

The performance implications of this should be minimal, because normally this
function is only called once, and if best_effort is disabled, the `check ()`
function will be short-circuited.