### PR TITLE
OpamFilter: handle converted variables correctly when no_undef_expand is true

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -121,6 +121,7 @@ users)
 ## Internal: Windows
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]
   * Process control: close stdin by default for Windows subprocesses and on all platforms for the download command [#4615 @dra27]
+  * [BUG] handle converted variables correctly when no_undef_expand is true [#4811 @timbertson]
 
 ## Test
 

--- a/src/format/opamFilter.ml
+++ b/src/format/opamFilter.ml
@@ -203,13 +203,15 @@ let resolve_ident_raw ?(no_undef_expand=false) env fident =
       (Some true) names
     >>| fun b -> B b
   in
-  match converter, no_undef_expand with
-  | Some (iftrue, iffalse), false ->
+  match converter with
+  | Some (iftrue, iffalse) ->
     (match value_opt >>= bool_of_value with
      | Some true -> Some (S iftrue)
      | Some false -> Some (S iffalse)
-     | None -> Some (S iffalse))
-  | _ -> value_opt
+     | None ->
+         if no_undef_expand then value_opt else Some (S iffalse)
+    )
+  | None -> value_opt
 
 (* Resolves [FIdent] to string or bool, using its package and converter
    specification *)


### PR DESCRIPTION
Currently it returns the unconverted value when `no_undef_expand` is true, which means that `lwt:enable` gets rendered as "true"/"false", not "enable" / "disable". This PR applies conversions if there is some value which can be cast to a boolean.

I don't think this affects end users at all, I discovered this behaviour by using `OpamFilter.expand_string ~partial:true` directly.