### PR TITLE
Support MSYS2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ _build/
 _obuild/
 _opam/
 _olint/
+.vscode/
 bootstrap/
 tests/tmp/
 tests/.merlin

--- a/master_changes.md
+++ b/master_changes.md
@@ -111,6 +111,7 @@ users)
 ## Internal
   * Add license and lowerbounds to opam files [#4714 @kit-ty-kate]
   * Bump version to 2.2.0~alpha~dev [#4725 @dra27]
+  * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]
 
 ## Test
 

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1004,7 +1004,11 @@ module OpamSys = struct
         let rec f a =
           match input_line c with
           | x ->
-              if OpamString.ends_with ~suffix:"cygwin1.dll" (String.trim x) then
+              (* Treat MSYS2's variant of `cygwin1.dll` called `msys-2.0.dll` equivalently.
+                 Confer https://www.msys2.org/wiki/How-does-MSYS2-differ-from-Cygwin/ *)
+              let tx = String.trim x in
+              if (OpamString.ends_with ~suffix:"cygwin1.dll" tx ||
+                  OpamString.ends_with ~suffix:"msys-2.0.dll" tx) then
                 if OpamString.starts_with ~prefix:"  " x then
                   f `Cygwin
                 else if a <> `Cygwin then


### PR DESCRIPTION
This is a follow-up to the announcement made at https://discuss.ocaml.org/t/ann-windows-friendly-ocaml-4-12-distribution-diskuv-ocaml-0-1-0/8358


Key Changes:

* Use USERPROFILE environment variable on Windows if HOME is not defined
* For the most part treat MSYS2 and Cygwin as equivalent. MSYS2 executables can be detected as `msys-2.0.dll`.
* Symlinks are not portably supported on Windows. Solutions like requiring the developer mode of Windows or Administrator access for NTFS symlinks will always limit the audience on Windows; I don't want to limit the audience. For Opam packages with symlinks the MSYS2 environment will simply default to copying rather than symlinking, but copying has edge cases:
  1. When rsync-ing the symlink referent must exist _before_ the symlink (ie. copy) is made. In this PR I've dealt with that by doing a two-pass rsync on MSYS2; the first pass syncs all the files except the symlink, while the second pass does the symlinks.
  2. `tar.exe` may fail on these same source packages; I can't use the two-pass trick. There isn't a problem if the `.tar` is packaged in topological order (referents come before the symlinks) but that presumes a lot. For now I'm just creating branches of the problematic source packages (ex. https://github.com/diskuv/ocp-indent/commits/windows-support), but I suspect a real solution may require a patch to tar.exe on Windows to add an option to skip symlinks.
* There is a PowerShell replacement for `eval $(opam env)` that I've included in this PR

Extra guidance needed:

- [ ] I think that `os.distribution` should be defined as `msys2` or even `diskuvocaml` so that OCaml package maintainers can use Opam filters. For example I've seen <https://github.com/ocamllabs/ocaml-ctypes/blob/261fe071fad17ab323d8d2b82df2aec593e64e3f/ctypes-foreign.opam#L13> use `["libffi"] {os = "win32" & os-distribution = "cygwinports"}`. Do you think it is a good idea to change `os.distribution`, or perhaps another variable?

---

> Please update `master_changes.md` file with your changes.

*I'm not sure which section to put these changes.*