### PR TITLE
Support LOCALAPPDATA as HOME fallback for Windows

### DIFF
--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -68,7 +68,11 @@ type t = {
 
 let default = {
   root_dir = OpamFilename.(
-      concat_and_resolve (Dir.of_string (OpamStd.Sys.home ())) ".opam"
+      if Sys.win32 then
+        (* CSIDL_LOCAL_APPDATA = 0x1c *)
+        concat_and_resolve (Dir.of_string (OpamStubs.(shGetFolderPath 0x1c SHGFP_TYPE_CURRENT))) "opam"
+      else
+        concat_and_resolve (Dir.of_string (OpamStd.Sys.home ())) ".opam"
     );
   current_switch = None;
   switch_from = `Default;


### PR DESCRIPTION
Splitting up https://github.com/ocaml/opam/pull/4813

> For a24d269 ("Support USERPROFILE as HOME fallback for Windows"), there's prior art in dra27@ed44880. The choice of directory (user documents) in that one is bad - in fact, my current intention is to address this "properly" as part of Support ~/.config/opam (per XDG base dir spec) #3766 in opam 2.2. My issue with falling back to %USERPROFILE% is that it's not a directory which we should be writing in (my enterprise setup, for example, uses both redirected folders and roaming profiles).

For continuity this initial PR is as-is from the original PR, but I'll make a change to address the valid enterprise concern.
