### PR TITLE
Environments for PowerShell and Windows command line

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -300,6 +300,8 @@ users)
 
 ## Shell
   * fish: fix deprecated redirection syntax `^` [#4736 @vzaliva]
+  * pwsh,powershell: use $env: for opam env [#4816 @jonahbeckford]
+  * command prompt: use SET for opam env [#4816 @jonahbeckford]
 
 ## Doc
   * Standardise `macOS` use [#4782 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -300,6 +300,7 @@ users)
 
 ## Shell
   * fish: fix deprecated redirection syntax `^` [#4736 @vzaliva]
+  * dash: recognize dash as a POSIX shell for opam env [#4816 @jonahbeckford]
   * pwsh,powershell: use $env: for opam env [#4816 @jonahbeckford]
   * command prompt: use SET for opam env [#4816 @jonahbeckford]
 

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1026,12 +1026,15 @@ let print_short_flag cli validity =
 
 let shell_opt cli validity =
   let enum = [
-    "bash",SH_bash;
-    "sh",SH_sh;
-    "csh",SH_csh;
-    "zsh",SH_zsh;
-    "fish",SH_fish;
-  ] |> List.map (fun (s,v) -> cli_original, s, v)
+    None,"bash",SH_bash;
+    None,"sh",SH_sh;
+    None,"csh",SH_csh;
+    None,"zsh",SH_zsh;
+    None,"fish",SH_fish;
+    Some cli2_2,"pwsh",SH_pwsh;
+    Some cli2_2,"cmd",SH_win_cmd;
+    Some cli2_2,"powershell",SH_win_powershell
+  ] |> List.map (fun (c,s,v) -> OpamStd.Option.map_default cli_from cli_original c, s, v)
   in
   mk_enum_opt ~cli validity ["shell"] "SHELL" enum
     (Printf.sprintf

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1224,7 +1224,10 @@ let config cli =
        | Some sw ->
          `Ok (OpamConfigCommand.env gt sw
                 ~set_opamroot ~set_opamswitch
-                ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish) ~inplace_path))
+                ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
+                ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
+                ~cmd:(shell=SH_win_cmd)
+                ~inplace_path))
     | Some `revert_env, [] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
       (match OpamStateConfig.get_switch_opt () with
@@ -1233,6 +1236,8 @@ let config cli =
          `Ok (OpamConfigCommand.ensure_env gt sw;
               OpamConfigCommand.print_eval_env
                 ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
+                ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
+                ~cmd:(shell=SH_win_cmd)
                 (OpamEnv.add [] [])))
     | Some `list, [] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -1529,10 +1534,15 @@ let env cli =
        | Some sw ->
          OpamConfigCommand.env gt sw
            ~set_opamroot ~set_opamswitch
-           ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish) ~inplace_path);
+           ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
+           ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
+           ~cmd:(shell=SH_win_cmd)
+           ~inplace_path);
     | true ->
       OpamConfigCommand.print_eval_env
         ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
+        ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
+        ~cmd:(shell=SH_win_cmd)
         (OpamEnv.add [] [])
   in
   let open Common_config_flags in

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -105,9 +105,16 @@ let print_cmd_env env =
       if OpamConsole.verbose () then
         OpamStd.Option.iter (OpamConsole.msg ": %s;\n") comment;
       if not (List.exists (fun (k1, _, _) -> k = k1) r) || OpamConsole.verbose ()
-      then
-        OpamConsole.msg "SET %s=%s\n"
-          k (OpamStd.Env.escape_windows_command_line v);
+      then begin
+        let is_special = function
+        | '(' | ')' | '!' | '^' | '%' | '"' | '<' | '>' | '|' -> true
+        | _ -> false
+        in
+        if OpamCompat.String.(exists is_special v || exists is_special k) then
+          OpamConsole.msg "SET \"%s=%s\"\n" k v
+        else
+          OpamConsole.msg "SET %s=%s\n" k v
+      end;
       aux r
   in
   aux env

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -23,8 +23,8 @@ open OpamStateTypes
 val env:
   'a global_state -> switch ->
   ?set_opamroot:bool -> ?set_opamswitch:bool ->
-  csh:bool -> sexp:bool -> fish:bool -> inplace_path:bool ->
-  unit
+  csh:bool -> sexp:bool -> fish:bool -> pwsh:bool -> cmd:bool ->
+  inplace_path:bool -> unit
 
 (** Ensures that the environment file exists in the given switch, regenerating
     it, if necessary. *)
@@ -32,7 +32,7 @@ val ensure_env: 'a global_state -> switch -> unit
 
 (** Like [env] but allows one to specify the precise env to print rather than
     compute it from a switch state *)
-val print_eval_env: csh:bool -> sexp:bool -> fish:bool -> env -> unit
+val print_eval_env: csh:bool -> sexp:bool -> fish:bool -> pwsh:bool -> cmd:bool -> env -> unit
 
 (** Display the content of all available packages variables *)
 val list: 'a switch_state -> name list -> unit

--- a/src/core/opamCompat.ml
+++ b/src/core/opamCompat.ml
@@ -8,7 +8,22 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module String = String
+module String =
+#if OCAML_VERSION >= (4, 13, 0)
+  String
+#else
+struct
+  include String
+
+  let exists p s =
+    let n = length s in
+    let rec loop i =
+      if i = n then false
+      else if p (unsafe_get s i) then true
+      else loop (succ i) in
+    loop 0
+end
+#endif
 
 module Char = Char
 

--- a/src/core/opamCompat.mli
+++ b/src/core/opamCompat.mli
@@ -8,7 +8,17 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module String = String
+module String
+#if OCAML_VERSION >= (4, 13, 0)
+= String
+#else
+: sig
+  include module type of struct include String end
+
+  val exists: (char -> bool) -> string -> bool
+end
+#endif
+
 
 module Char = Char
 

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -957,19 +957,14 @@ module OpamSys = struct
       with Failure _ -> []
     )
 
-  type shell_choice = Reject | Accept of shell
+  type shell_choice = Accept of shell
 
   let windows_get_shell =
     let categorize_process = function
       | "powershell.exe" | "powershell_ise.exe" -> Some (Accept SH_win_powershell)
       | "pwsh.exe" -> Some (Accept SH_pwsh)
       | "cmd.exe" -> Some (Accept SH_win_cmd)
-      | "env.exe" ->
-        (* If the nearest ancestor is env.exe it may be `env bash` or
-           even `env cmd.exe`. On Windows we can't see whether bash,
-           cmd or something else was chosen by `env ...`. So kick
-           out of categorization immediately. *)
-        Some Reject
+      | "env.exe" -> Some (Accept SH_sh)
       | name ->
         Option.map
           (fun shell -> Accept shell)
@@ -980,7 +975,6 @@ module OpamSys = struct
       match (List.map String.lowercase_ascii ancestors |>
               OpamList.filter_map categorize_process) with
       | [] -> None
-      | Reject :: _ -> None
       | Accept most_relevant_shell :: _ -> Some most_relevant_shell
     )
 

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -923,6 +923,7 @@ module OpamSys = struct
     | "bash" -> Some SH_bash
     | "fish" -> Some SH_fish
     | "pwsh" -> Some SH_pwsh
+    | "dash"
     | "sh"   -> Some SH_sh
     | _      -> None
 

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -733,12 +733,6 @@ module Env = struct
     (* escape single quotes with two single quotes.
        https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.1 *)
     Re.(replace_string (compile (char '\'')) ~by:"''")
-
-  let escape_windows_command_line s =
-    (* escape all Windows command line metacharacters with a caret (^) *)
-    List.fold_left
-      (fun acc ch -> Re.(replace_string (compile (char ch)) ~by:("^" ^ String.make 1 ch) acc))
-      s ['^'; '"'; '&'; '|'; '<'; '>']
 end
 
 

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -389,6 +389,12 @@ module Env : sig
       [using_backslashes] to escape both quotes and backslashes using
       backslashes *)
   val escape_single_quotes: ?using_backslashes:bool -> string -> string
+
+  (** Utility function for PowerShell strings. *)
+  val escape_powershell: string -> string
+
+  (** Utility function for Windows command line (cmd.exe) strings. *)
+  val escape_windows_command_line: string -> string
 end
 
 (** {2 System query and exit handling} *)
@@ -436,7 +442,8 @@ module Sys : sig
   val executable_name : string -> string
 
   (** The different families of shells we know about *)
-  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish
+  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh
+    | SH_win_cmd | SH_win_powershell
 
   (** Guess the shell compat-mode *)
   val guess_shell_compat: unit -> shell

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -392,9 +392,6 @@ module Env : sig
 
   (** Utility function for PowerShell strings. *)
   val escape_powershell: string -> string
-
-  (** Utility function for Windows command line (cmd.exe) strings. *)
-  val escape_windows_command_line: string -> string
 end
 
 (** {2 System query and exit handling} *)

--- a/src/core/opamStubs.dummy.ml
+++ b/src/core/opamStubs.dummy.ml
@@ -34,5 +34,6 @@ let process_putenv _ = that's_a_no_no
 let shGetFolderPath _ = that's_a_no_no
 let sendMessageTimeout _ _ _ _ _ = that's_a_no_no
 let getParentProcessID = that's_a_no_no
+let getProcessName = that's_a_no_no
 let getConsoleAlias _ = that's_a_no_no
 let win_create_process _ _ _ _ _ = that's_a_no_no

--- a/src/core/opamStubs.mli
+++ b/src/core/opamStubs.mli
@@ -69,7 +69,7 @@ val writeRegistry :
   (** Windows only. [writeRegistry root key name value_type value] sets the
       value [name] of type [value_type] in registry key [key] of [root] to
       [value].
- 
+
       @raise Failure If the value could not be set.
       @raise Not_found If [key] does not exist. *)
 
@@ -123,6 +123,11 @@ val getParentProcessID : int32 -> int32
     of [pid].
 
     @raise Failure If walking the process tree fails to find the process. *)
+
+val getProcessName : int32 -> string
+(** Windows only. [getProcessName pid] returns the executable name of [pid].
+
+    @raise Failure If the process does not exist. *)
 
 val getConsoleAlias : string -> string -> string
 (** Windows only. [getConsoleAlias alias exeName] retrieves the value for a

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -317,7 +317,8 @@ type pin_kind = [ `version | OpamUrl.backend ]
 
 (** Shell compatibility modes *)
 type shell = OpamStd.Sys.shell =
-    SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish
+    SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh
+    | SH_win_cmd | SH_win_powershell
 
 (** {2 Generic command-line definitions with filters} *)
 

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -48,6 +48,9 @@ let string_of_shell = function
   | SH_zsh  -> "zsh"
   | SH_sh   -> "sh"
   | SH_bash -> "bash"
+  | SH_pwsh -> "pwsh"
+  | SH_win_cmd -> "cmd"
+  | SH_win_powershell -> "powershell"
 
 let file_null = ""
 let pos_file filename =

--- a/src/stubs/win32/opamWin32Stubs.ml
+++ b/src/stubs/win32/opamWin32Stubs.ml
@@ -33,4 +33,5 @@ external process_putenv : int32 -> string -> string -> bool = "OPAMW_process_put
 external shGetFolderPath : int -> 'a -> string = "OPAMW_SHGetFolderPath"
 external sendMessageTimeout : nativeint -> int -> int -> 'a -> 'b -> 'c -> int * 'd = "OPAMW_SendMessageTimeout_byte" "OPAMW_SendMessageTimeout"
 external getParentProcessID : int32 -> int32 = "OPAMW_GetParentProcessID"
+external getProcessName : int32 -> string = "OPAMW_GetProcessName"
 external getConsoleAlias : string -> string -> string = "OPAMW_GetConsoleAlias"

--- a/src/stubs/win32/opamWindows.c
+++ b/src/stubs/win32/opamWindows.c
@@ -726,6 +726,23 @@ CAMLprim value OPAMW_GetParentProcessID(value processId)
   OPAMreturn(caml_copy_int32(entry.th32ParentProcessID));
 }
 
+CAMLprim value OPAMW_GetProcessName(value processId)
+{
+  CAMLparam1(processId);
+
+  PROCESSENTRY32 entry;
+  DWORD parent_pid;
+  char* msg;
+  HANDLE hProcessSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+
+  if ((msg = getProcessInfo(hProcessSnapshot, Int32_val(processId), &entry)))
+    caml_failwith(msg);
+
+  CloseHandle(hProcessSnapshot);
+
+  CAMLreturn(caml_copy_string(entry.szExeFile));
+}
+
 CAMLprim value OPAMW_GetConsoleAlias(value alias, value exeName)
 {
   CAMLparam2(alias, exeName);


### PR DESCRIPTION
Splitting up https://github.com/ocaml/opam/pull/4813:

> For 0f0bd98 ("Show eval expression for PowerShell on native Windows"), opam 2.2 should finally see the activation of parent_putenv (and the opam-putenv auxiliary)... on Windows, there's no need to output shell instructions - on Windows, opam env can actually update the environment variables of the shell (see dra27@2934dc4#diff-e21e37a0339dbaafa95fd0b6d57221f656f18d0771c06f6f837bb98c3a71b91aR193). However, that doesn't necessarily preclude merging this first!

For continuity this initial PR is as-is from the original PR.