### PR TITLE
Fallback on dnf if yum does not exist on RHEL-based systems

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -73,6 +73,7 @@ users)
     and installed packages would wait for user input without showing any output and/or fail
     in some cases [#4791 @kit-ty-kate - fixes #4790]
   * Archlinux: handle virtual package detection [#4831 @rjbou - partial fix #4759]
+  * Fallback on dnf if yum does not exist on RHEL-based systems [#4825 @kit-ty-kate]
 
 ## Format upgrade
   * Fix format upgrade when there is missing local switches in the config file [#4763 @rjbou - fix #4713] [2.1.0~rc2 #4715]

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -136,7 +136,7 @@ let yum_cmd = lazy begin
   else if OpamSystem.resolve_command "dnf" <> None then
     "dnf"
   else
-    failwith "Could not find either yum or dnf to install external dependencies"
+    raise (OpamSystem.Command_not_found "yum or dnf")
 end
 
 let packages_status packages =

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -130,6 +130,14 @@ let family =
   ) in
   fun () -> Lazy.force family
 
+let yum_cmd = lazy begin
+  if OpamSystem.resolve_command "yum" <> None then
+    "yum"
+  else if OpamSystem.resolve_command "dnf" <> None then
+    "dnf"
+  else
+    failwith "Could not find either yum or dnf to install external dependencies"
+end
 
 let packages_status packages =
   let (+++) pkg set = OpamSysPkg.Set.add (OpamSysPkg.of_string pkg) set in
@@ -632,11 +640,11 @@ let install_packages_commands_t sys_packages =
     let epel_release = "epel-release" in
     let install_epel rest =
       if List.mem epel_release packages then
-        ["yum", "install"::yes ["-y"] [epel_release]] @ rest
+        [Lazy.force yum_cmd, "install"::yes ["-y"] [epel_release]] @ rest
       else rest
     in
     install_epel
-      ["yum", "install"::yes ["-y"]
+      [Lazy.force yum_cmd, "install"::yes ["-y"]
                 (OpamStd.String.Set.of_list packages
                  |> OpamStd.String.Set.remove epel_release
                  |> OpamStd.String.Set.elements);
@@ -701,7 +709,7 @@ let update () =
     match family () with
     | Alpine -> Some ("apk", ["update"])
     | Arch -> Some ("pacman", ["-Sy"])
-    | Centos -> Some ("yum", ["makecache"])
+    | Centos -> Some (Lazy.force yum_cmd, ["makecache"])
     | Debian -> Some ("apt-get", ["update"])
     | Gentoo -> Some ("emerge", ["--sync"])
     | Homebrew -> Some ("brew", ["update"])


### PR DESCRIPTION
On some settings, some RHEL-based systems do not come with `yum` installed by default.
Encountered by @vsiles on CentOS (Stream) and minimal docker images for Oraclelinux 8 https://github.com/avsm/ocaml-dockerfile/pull/35