### PR TITLE
Set the priority of user-set archive-mirrors higher than the repositories'

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -88,6 +88,8 @@ users)
 
 ## Repository
   * Don't display global message when `this-switch` is given [#4899 @rjbou - fix #4889]
+  * Set the priority of user-set archive-mirrors higher than the repositories'.
+    This allows opam-repository to use the default opam.ocaml.org cache and be more resilient to changed/force-pushed or unavailable archives. [#4830 @kit-ty-kate - fixes #4411]
 
 ## VCS
   * Pass --depth=1 to git-fetch in the Git repo backend [#4442 @dra27]

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -498,7 +498,7 @@ let active_caches st nv =
           else Some OpamUrl.Op.(root_url / rel))
         (OpamFile.Repo.dl_cache repo_def)
   in
-  repo_cache @ global_cache
+  global_cache @ repo_cache
 
 let cleanup_source st old_opam_opt new_opam =
   let open OpamStd.Option.Op in


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/4411

I can't find any good reason someone would have a custom cache but want the repository one (even a custom local one) to be taken first.

The one annoying issue with this is that this changes behaviour based on the version of opam used by the user, however we can always announce it before the release (or rather before the change in opam-repository), so it should be ok.