### PR TITLE
Fix error 67 in presence of an archive without extention

### DIFF
--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -296,7 +296,7 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
     t.url >>| OpamFile.URL.url >>| (fun u ->
         match u.OpamUrl.backend with
         | #OpamUrl.version_control -> false
-        | _ -> OpamSystem.is_archive (OpamUrl.base_url u))
+        | `http | `rsync -> true)
   in
   let check_upstream =
     check_upstream &&


### PR DESCRIPTION
Archives without exentions exist in the wild and giving an error just because the extention isn't explicit doesn't feel right (especially an error)
With this change, we assume that any `http` or `rsync` source is an archive.

Examples:
```
Error in wget.0.1.0:
              error 67: Checksum specified with a non archive url: "https://github.com/samoht/ocaml-wget/tarball/0.1.0 - md5=d1e2f51b61b8d8791ccd7bc2a18d98dc"
```
```
Error in patoline.0.1:
              error 67: Checksum specified with a non archive url: "https://opam.ocaml.org/cache/md5/2f/2f7fe33ef6dff305e9a2407696c7a799 - md5=2f7fe33ef6dff305e9a2407696c7a799"
```