### PR TITLE
Patch ocaml-mccs for C++17 on Windows

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -91,6 +91,7 @@ users)
   * Add `--without-dune` to configure to force compiling vendored Dune [#4776 @dra27]
   * Use `--without-dune` in `make cold` to avoid picking up external Dune [#4776 @dra27 - fix #3987]
   * Add `--with-vendored-deps` to replace `make lib-ext` instruction [#4776 @dra27 - fix #4772]
+  * Fix vendored build on mingw-w64 with g++ 11.2 [#4835 @dra27]
 
 ## Infrastructure
   *

--- a/src_ext/patches/mccs.common/0001-Always-include-std-headers-first.patch
+++ b/src_ext/patches/mccs.common/0001-Always-include-std-headers-first.patch
@@ -1,0 +1,20 @@
+diff -Naur a/src/lp_solver.cpp b/src/lp_solver.cpp
+--- a/src/lp_solver.cpp	2021-04-16 13:58:45.000000000 +0000
++++ b/src/lp_solver.cpp	2021-09-10 13:05:45.624884900 +0000
+@@ -5,7 +5,6 @@
+ /*******************************************************/
+ 
+ 
+-#include <lp_solver.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <sys/types.h>
+@@ -15,6 +14,8 @@
+ #include <unistd.h>
+ #endif
+ 
++#include <lp_solver.h>
++
+ #define CLEAN_FILES 1
+ #ifdef _WIN32
+ #define TMP_FILES_PATH temp_files_path


### PR DESCRIPTION
The rpcndr.h header includes a typedef for byte which gets messed up when combined with using namespace std and C++17's byte type.

Should fix AppVeyor. We should get https://github.com/AltGr/ocaml-mccs/pull/35 merged and released prior to 2.1.1 (and then switch to the `+14` release of ocaml-mccs and nuke this patch).