### PR TITLE
Handle empty environment variable updates

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -110,7 +110,7 @@ users)
   *
 
 ## State
-  *
+  * Handle empty environment variable updates - missed cherry-pick from 2.0 [#4840 @dra27]
 
 ## Opam file format
   *

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -303,7 +303,12 @@ module LinesBase = struct
       aux acc (i-1) in
     aux ([],0) (len - 1)
 
-  let escape_spaces str =
+  let escape_spaces = function
+  | "" ->
+      "@"
+  | "@" ->
+      "\\@"
+  | str ->
     let len = String.length str in
     match find_escapes str len with
     | [], _ -> str


### PR DESCRIPTION
In 2.0.8 (#4326), but not cherry-pick back to master so missing in 2.1