### PR TITLE
Cygpath the PATH from opam env

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -230,6 +230,7 @@ users)
   * [BUG] Catch `EACCES` in lock function [#4948 @oandrieu - fix #4944]
   * Permissions: chmod+unlink before copy [#4827 @jonahbeckford @dra27]
   * Support MSYS2: two-phase rsync on MSYS2 to allow MSYS2's behavior of copying rather than symlinking [#4817 @jonahbeckford]
+  * Environment: translate PATH from Windows to Unix during opam env. [#4844 @jonahbeckford]
 
 ## Test
   * Update crowbar with compare functions [#4918 @rjbou]

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -506,7 +506,7 @@ let get_cygpath_function =
 let apply_cygpath_path_transform path =
   let r =
     OpamProcess.run
-      (OpamProcess.command ~name:(temp_file "command") ~verbose:false "cygpath" ["--path"; path])
+      (OpamProcess.command ~name:(temp_file "command") ~verbose:false "cygpath" ["--path"; "--"; path])
   in
   OpamProcess.cleanup ~force:true r;
   if OpamProcess.is_success r then

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -503,6 +503,28 @@ let get_cygpath_function =
     let f = Lazy.from_val (fun x -> x) in
     fun ~command:_ -> f
 
+let apply_cygpath_path_transform path =
+  let r =
+    OpamProcess.run
+      (OpamProcess.command ~name:(temp_file "command") ~verbose:false "cygpath" ["--path"; path])
+  in
+  OpamProcess.cleanup ~force:true r;
+  if OpamProcess.is_success r then
+    List.hd r.OpamProcess.r_stdout
+  else
+    OpamConsole.error_and_exit `Internal_error "Could not apply cygpath --path to %s" path
+
+let get_cygpath_path_transform =
+  (* We are running in a functioning Cygwin or MSYS2 environment if and only
+     if `cygpath` is in the PATH. *)
+  if Sys.win32 then
+    lazy (
+      match resolve_command "cygpath" with
+      | Some _ -> apply_cygpath_path_transform
+      | None -> fun x -> x)
+  else
+    Lazy.from_val (fun x -> x)
+
 let runs = ref []
 let print_stats () =
   match !runs with

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -190,6 +190,12 @@ val resolve_command: ?env:string array -> ?dir:string -> string -> string option
     the identity function otherwise. *)
 val get_cygpath_function: command:string -> (string -> string) lazy_t
 
+(** Returns a function which should be applied to a PATH environment variable
+    if in a functioning Cygwin or MSYS2 environment, translating the Windows or a
+    Unix PATH variable into a Unix PATH variable. Returns the identity function
+    otherwise. *)
+val get_cygpath_path_transform: (string -> string) lazy_t
+
 (** [command cmd] executes the command [cmd] in the correct OPAM
     environment. *)
 val command: ?verbose:bool -> ?env:string array -> ?name:string ->


### PR DESCRIPTION
When using a native Windows opam.exe the PATH from `opam env` is in Windows format.

PowerShell output from `opam env`: `$env:PATH = 'Z:\source\opam\_opam\bin;...'`
CMD.exe output from `opam env`: `SET PATH=Z:\source\opam\_opam\bin;...`

With this change both MSYS2 and Cygwin will Unix-ize the PATH with essentially `cygpath --path $PATH`.

Cygwin output from `opam env`: `PATH='/cygdrive/c/Users/beckf/AppData/Local/opam/diskuv-boot-DO-NOT-DELETE/bin:...'`
MSYS2 output from `opam env`: `PATH='/z/source/opam/_opam/bin:...'`

`cygpath --path` on an already Unix PATH is idempotent, so a Cygwin opam.exe will still work after this change. That is, the following says "MATCHES" on both Cygwin and MSYS2:
```sh
if [[ "$(cygpath --path '$PATH')" = $(cygpath --path "$(cygpath --path '$PATH')") ]]; then echo MATCHES; fi
```

---

This PR gets `eval $(opam env)` working from a native Windows opam.exe into a MSYS2 shell. However the same command in a Cygwin shell chokes with `-bash: $'\r': command not found` because native Windows opam.exe prints carriage returns (which MSYS2 eval can handle, but not Cygwin). I don't actually know a clean fix for that, and I suspect removing carriage returns when in MSYS2/Cygwin probably belongs in another PR.