### PR TITLE
Allow opam source to run without a switch, add a `--no-switch' option

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -83,6 +83,8 @@ users)
 
 ## Source
   * [BUG] Fix directory display in dev mode [#5102 @rjbou]
+  * Download source even if no switch is set [#4850 @rjbou @zapashcanon - fix #4809]
+  * [NEW] Add `--no-switch` option [#4850 @rjbou - fix #4858]
 
 ## Lint
   * W68: add warning for missing license field [#4766 @kit-ty-kate - partial fix #4598]
@@ -322,6 +324,7 @@ users)
 
   * `OpamConfigCommand`: `set_opt_switch`, `set_var_switch`, `options_list_switch`, and `var_list_switch` now raise configuration error exception (50) if no switch is found [#5027 @rjbou]
   * `OpamArgs`, `OpamArgTools`: add `experimental` optional argument to `cli_from` and replace `default` by `option:['experimental | 'ëefault]` for `cli_between`, to handle experimental features [#5099 @rjbou]
+  * OpamAction: `prepare_package_source` can now take any switch state (previously required `rw`) [#4850 @rjbou]
 ## opam-repository
   * `OpamRepositoryConfig`: add in config record `repo_tarring` field and as an argument to config functions, and a new constructor `REPOSITORYTARRING` in `E` environment module and its access function [#5015 @rjbou]
   * New download functions for shared source, old ones kept [#4893 @rjbou]

--- a/src/client/opamAction.mli
+++ b/src/client/opamAction.mli
@@ -34,7 +34,7 @@ val download_shared_source:
     extra downloads, overlays and patches from the package's metadata
     applied. *)
 val prepare_package_source:
-  rw switch_state -> package -> dirname -> exn option OpamProcess.job
+  'a switch_state -> package -> dirname -> exn option OpamProcess.job
 
 (** [prepare_package_build env opam pkg dir] is a lower level version
     of `prepare_package_source`, without requiring a switch and

--- a/tests/reftests/source.test
+++ b/tests/reftests/source.test
@@ -93,8 +93,19 @@ pandore.3/src/src.ml
 ### opam pin
 pandore.3  (uninstalled)  rsync  file://${BASEDIR}/pandore.3
 ### rm -rf pandore.3
+### OPAMDEBUGSECTIONS="RSTATE GSTATE STATE" opam source pandore --no-switch --debug-level=-1
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+Successfully extracted to ${BASEDIR}/pandore.3
+### find pandore.3 | unordered
+pandore.3
+pandore.3/opam
+pandore.3/root.ml
+pandore.3/src
+pandore.3/src/src.ml
+### rm -rf pandore.3
 ### opam switch remove phantom -y
 Switch phantom and all its packages will be wiped. Are you sure? [y/n] y
 ### opam source pandore
-[ERROR] No switch is currently set. Please use 'opam switch' to set or install a switch
-# Return code 50 #
+Successfully extracted to ${BASEDIR}/pandore.3


### PR DESCRIPTION
**@rjbou Update**:
* Added a `--no-switch` option fix #4858
* Run on a non switch mode if there is the option or if switch list is empty
---
Here's a draft to fix #4809 as asked by @dra27.

It doesn't typecheck:

```shell-session
$ make
dune build --profile=release --root .  --promote-install-files -- opam-installer.install opam.install
File "src/client/opamCommands.ml", line 3358, characters 44-45:
3358 |           OpamAction.prepare_package_source t nv dir @@| function
                                                   ^
Error: This expression has type
         OpamStateTypes.unlocked OpamStateTypes.switch_state
       but an expression was expected of type
         OpamStateTypes.rw OpamStateTypes.switch_state
       Type
         OpamStateTypes.unlocked = [ `Lock_none | `Lock_read | `Lock_write ]
       is not compatible with type OpamStateTypes.rw = [ `Lock_write ]
       The second variant type does not allow tag(s) `Lock_none, `Lock_read
```

But currently, there's no simple way to get a lock for the virtual state so I don't know how to fix this...

cc @AltGr @rjbou 
