### PR TITLE
[WIP] add support for swhid reading

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -422,7 +422,7 @@ let prepare_package_source st nv dir =
         ~silent_hits:true
         (OpamPackage.to_string nv ^ "/" ^ OpamFilename.Base.to_string basename)
         (OpamFilename.create dir basename)
-        (OpamFile.URL.checksum urlf)
+        (assert false (*List.map OpamHash.to_computable (OpamFile.URL.checksum urlf)*))
         (OpamFile.URL.url urlf :: OpamFile.URL.mirrors urlf)
       @@| function
       | Result () | Up_to_date () -> None
@@ -449,7 +449,7 @@ let prepare_package_source st nv dir =
         let extra_files_dir =
           OpamPath.Switch.extra_files_dir st.switch_global.root st.switch
         in
-        OpamStd.List.filter_map (fun (base, hash) ->
+        assert false (* OpamStd.List.filter_map (fun (base, hash) ->
             let src =
               OpamFilename.create extra_files_dir
                 (OpamFilename.Base.of_string (OpamHash.contents hash))
@@ -457,14 +457,14 @@ let prepare_package_source st nv dir =
             if OpamFilename.exists src then
               Some (src, base, hash)
             else None)
-          xs
+          (xs :> (OpamFilename.Base.t * OpamHash.t) list)*)
     in
     let bad_hash =
       OpamStd.List.filter_map (fun (src, base, hash) ->
           if OpamHash.check_file (OpamFilename.to_string src) hash then
             (OpamFilename.copy ~src ~dst:(OpamFilename.create dir base); None)
           else
-            Some src) extra_files
+            Some src) (List.map (fun (f, n, k) -> f, n, assert false (*OpamHash.to_computable k*)) (extra_files :> (OpamTypes.filename * OpamTypes.basename * OpamHash.t) list))
     in
     if bad_hash = [] then None else
       Some (Failure

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -161,7 +161,7 @@ let package_files_to_cache repo_root cache_dir cache_urls ?link (nv, prefix) =
       | (first_checksum :: _) as checksums ->
         OpamRepository.pull_file_to_cache label
           ~cache_urls ~cache_dir
-          checksums
+          (assert false (* List.map OpamHash.to_computable checksums *))
           (OpamFile.URL.url urlf :: OpamFile.URL.mirrors urlf)
         @@| fun r -> match OpamRepository.report_fetch_result nv r with
         | Not_available (_,m) ->
@@ -370,10 +370,10 @@ let add_hashes_command cli =
                ~cache_dir:(OpamRepositoryPath.download_cache
                              OpamStateConfig.(!r.root_dir))
                ~cache_urls
-               f known_hashes [url]
+               f (assert false (*List.map OpamHash.to_computable known_hashes*)) [url]
              @@| function
              | Result () | Up_to_date () ->
-               OpamHash.compute ~kind (OpamFilename.to_string f)
+               OpamHash.compute ~kind:(assert false (*Obj.magic kind*)) (OpamFilename.to_string f)
                |> OpamStd.Option.some
              | Not_available _ -> None)
       in
@@ -382,12 +382,12 @@ let add_hashes_command cli =
          List.iter (fun h0 ->
              Hashtbl.replace
                (snd (Hashtbl.find hash_tables (OpamHash.kind h0, kind)))
-               h0 h
+               h0 (h :> OpamHash.t)
            ) known_hashes;
          incr additions_count;
          if !additions_count mod 20 = 0 then save_hashes ()
        | None -> ());
-      h
+      (h :> OpamHash.t option)
   in
   let cmd global_options hash_types replace packages () =
     OpamArg.apply_global_options cli global_options;

--- a/src/client/opamAdminRepoUpgrade.ml
+++ b/src/client/opamAdminRepoUpgrade.ml
@@ -186,7 +186,7 @@ let do_upgrade repo_root =
     (fun url ->
        try Done (Some (Hashtbl.find url_md5 url))
        with Not_found ->
-         OpamFilename.with_tmp_dir_job @@ fun dir ->
+         (OpamFilename.with_tmp_dir_job @@ fun dir ->
          OpamProcess.Job.ignore_errors ~default:None
            (fun () ->
                 (* Download to package.patch, rather than allowing the name to be
@@ -198,8 +198,8 @@ let do_upgrade repo_root =
               in
               OpamDownload.download_as ~overwrite:false url f @@| fun () ->
               let hash = OpamHash.compute (OpamFilename.to_string f) in
-              Hashtbl.add url_md5 url hash;
-              Some hash)),
+              Hashtbl.add url_md5 url (hash :> OpamHash.t);
+              Some hash) :> OpamHash.t option OpamProcess.Job.Op.job)),
     (fun () ->
        Hashtbl.fold
          (fun url hash l -> [OpamUrl.to_string url; OpamHash.to_string hash]::l)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -141,7 +141,7 @@ let get_init_config ~no_sandboxing ~no_default_config_file ~add_config_file =
               "Using configuration file from %s. \
                Please verify the following SHA256:\n    %s\n\
                Is this correct?"
-              (OpamUrl.to_string url) (OpamHash.contents hash)
+              (OpamUrl.to_string url) (OpamHash.contents (hash :> OpamHash.t))
           then OpamFile.make f
           else OpamStd.Sys.exit_because `Aborted
       ) add_config_file

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -401,8 +401,8 @@ let import_t ?ask importfile t =
   in
   OpamHash.Map.iter (fun hash content ->
       let value = Base64.decode_exn content in
-      let my = OpamHash.compute_from_string ~kind:(OpamHash.kind hash) value in
-      if OpamHash.contents my = OpamHash.contents hash then
+      let my = OpamHash.compute_from_string ~kind:(assert false (* Obj.magic OpamHash.kind hash*)) value in
+      if OpamHash.contents (my :> OpamHash.t) = OpamHash.contents hash then
         let dst =
           let base = OpamFilename.Base.of_string (OpamHash.contents hash) in
           OpamFilename.create xfiles_dir base
@@ -607,7 +607,7 @@ let export rt ?(freeze=false) ?(full=false)
                   if OpamFilename.exists file &&
                      OpamHash.check_file (OpamFilename.to_string file) hash then
                     let value = Base64.encode_string (OpamFilename.read file) in
-                    OpamHash.Map.add hash value hmap, err
+                    OpamHash.Map.add (hash :> OpamHash.Map.key) value hmap, err
                   else hmap, base::err)
                 (hmap,[]) files
             in

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -520,11 +520,11 @@ module Attribute = struct
     let perm = match t.perm with
       | None   -> []
       | Some p -> [Printf.sprintf "0o%o" p] in
-    Base.to_string t.base :: OpamHash.to_string t.md5 :: perm
+    Base.to_string t.base :: OpamHash.to_string (t.md5 :> OpamHash.t) :: perm
 
   let of_string_list = function
     | [base; md5]      ->
-      { base=Base.of_string base; md5=OpamHash.of_string md5; perm=None }
+      { base=Base.of_string base; md5=(OpamHash.of_string md5 :> OpamHash.t); perm=None }
     | [base;md5; perm] ->
       { base=Base.of_string base;
         md5=OpamHash.of_string md5;
@@ -582,4 +582,5 @@ let to_attribute root file =
     let s = Unix.stat (to_string file) in
     s.Unix.st_perm in
   let digest = OpamHash.compute ~kind:`MD5 (to_string file) in
-  Attribute.create basename digest (Some perm)
+  let digest = assert false (* OpamHash.to_computable (digest :> OpamHash.t)*) in
+  Attribute.create basename (digest :> OpamHash.t) (Some perm)

--- a/src/core/opamHash.mli
+++ b/src/core/opamHash.mli
@@ -9,22 +9,29 @@
 (**************************************************************************)
 
 (** Stored as hexadecimal strings *)
-type kind = [ `MD5 | `SHA256 | `SHA512 ]
+type computable_kind = [ `MD5 | `SHA256 | `SHA512 ]
 
-type t
+type kind = [ computable_kind | `SWHID ]
 
-val kind: t -> kind
+type +'kind hash constraint 'kind = [< kind]
+
+type t = kind hash
+
+val kind: 'a hash -> 'a
 
 (** The value of the hash, as a string of hexadecimal characters *)
 val contents: t -> string
 
 val string_of_kind: kind -> string
 
-val md5: string -> t
-val sha256: string -> t
-val sha512: string -> t
+val md5: string -> [> `MD5] hash
+val sha256: string -> [> `SHA256] hash
+val sha512: string -> [> `SHA512] hash
+val swhid : string -> [> `SWHID] hash
 
 include OpamStd.ABSTRACT with type t := t
+
+val to_string: t -> string
 
 val of_string_opt: string -> t option
 
@@ -32,14 +39,17 @@ val of_string_opt: string -> t option
     "md5/d4/d41d8cd98f00b204e9800998ecf8427e", as a list *)
 val to_path: t -> string list
 
-val check_file: string -> t -> bool
+val check_file: string -> computable_kind hash -> bool
 
 (** Like [check_file], but returns the actual mismatching hash of the file, or
     [None] in case of match *)
-val mismatch: string -> t -> t option
+val mismatch: string -> computable_kind hash -> computable_kind hash option
 
 (** Compute hash of the given file *)
-val compute: ?kind:kind -> string -> t
+val compute: ?kind:computable_kind -> string -> computable_kind hash
 
 (** Compute the hash of the given string *)
-val compute_from_string: ?kind:kind -> string -> t
+val compute_from_string: ?kind:computable_kind -> string -> computable_kind hash
+
+(** The identity function but raises on a non computable kind, e.g. `SWHID *)
+val to_computable: t -> computable_kind hash

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -2356,7 +2356,7 @@ module OPAMSyntax = struct
     metadata_dir: (repository_name option * string) option;
 
     (* Names and hashes of the files below files/ *)
-    extra_files: (OpamFilename.Base.t * OpamHash.t) list option;
+    extra_files: (OpamFilename.Base.t * OpamHash.computable_kind OpamHash.hash) list option;
 
     (* Stores any file errors for printing them later *)
     format_errors: (string * Pp.bad_format) list;
@@ -2902,7 +2902,7 @@ module OPAMSyntax = struct
         (Pp.V.map_list ~depth:2 @@
          Pp.V.map_pair
            pp_basename
-           (Pp.V.string -| Pp.of_module "checksum" (module OpamHash)));
+           (Pp.V.string -| Pp.of_pair "checksum" (assert false (* Obj.magic OpamHash.of_string_opt, Obj.magic OpamHash.to_string*))));
 
       (* deprecated fields, here for compat *)
       "configure-style", (Pp.ppacc_ignore, Pp.ppacc_ignore);

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -304,7 +304,7 @@ module URL: sig
   include IO_FILE
 
   val create:
-    ?mirrors:url list -> ?checksum:OpamHash.t list -> ?subpath:string ->
+    ?mirrors:url list -> ?checksum:(OpamHash.t list) -> ?subpath:string ->
     url -> t
 
   (** URL address *)
@@ -313,11 +313,11 @@ module URL: sig
   val mirrors: t -> url list
 
   (** Archive checksum *)
-  val checksum: t -> OpamHash.t list
+  val checksum: t -> (OpamHash.t list)
 
   (** Constructor *)
   val with_url: url -> t -> t
-  val with_checksum: OpamHash.t list -> t -> t
+  val with_checksum: (OpamHash.t list) -> t -> t
   val with_subpath: string -> t -> t
   val with_subpath_opt: string option -> t -> t
 
@@ -389,7 +389,7 @@ module OPAM: sig
     metadata_dir: (repository_name option * string) option;
 
     (* Names and hashes of the files below files/ *)
-    extra_files: (OpamFilename.Base.t * OpamHash.t) list option;
+    extra_files: (OpamFilename.Base.t * OpamHash.computable_kind OpamHash.hash) list option;
 
     format_errors: (string * OpamPp.bad_format) list;
 
@@ -560,13 +560,13 @@ module OPAM: sig
     repos_roots:(repository_name -> dirname) -> t -> dirname option
 
   (** Names and hashes of the files below files/ *)
-  val extra_files: t -> (OpamFilename.Base.t * OpamHash.t) list option
+  val extra_files: t -> (OpamFilename.Base.t * OpamHash.computable_kind OpamHash.hash) list option
 
   (** Looks up the extra files, and returns their full paths, relative path to
       the package source, and hash. Doesn't check the hashes. *)
   val get_extra_files:
     repos_roots:(repository_name -> dirname) ->
-    t -> (filename * basename * OpamHash.t) list
+    t -> (filename * basename * OpamHash.computable_kind OpamHash.hash) list
 
   (** Returns the errors that were found when parsing the file, associated to
       their fields (that were consequently ignored) *)
@@ -680,8 +680,8 @@ module OPAM: sig
 
   val with_metadata_dir: (repository_name option * string) option -> t -> t
 
-  val with_extra_files: (OpamFilename.Base.t * OpamHash.t) list -> t -> t
-  val with_extra_files_opt: (OpamFilename.Base.t * OpamHash.t) list option -> t -> t
+  val with_extra_files: (OpamFilename.Base.t * OpamHash.computable_kind OpamHash.hash) list -> t -> t
+  val with_extra_files_opt: (OpamFilename.Base.t * OpamHash.computable_kind OpamHash.hash) list option -> t -> t
 
   val with_format_errors: (string * OpamPp.bad_format) list -> t -> t
 

--- a/src/format/opamPath.mli
+++ b/src/format/opamPath.mli
@@ -251,32 +251,32 @@ module Switch: sig
       a switch's layout in non-switch contexts *)
   module DefaultF : functor (L:LAYOUT) -> sig
     val lib: t -> L.ctx -> name -> dirname
-  
+
     val lib_dir: t -> L.ctx -> dirname
-  
+
     val stublibs: t -> L.ctx -> dirname
-  
+
     val toplevel: t -> L.ctx -> dirname
-  
+
     val doc: t -> L.ctx -> name -> dirname
-  
+
     val doc_dir: t -> L.ctx -> dirname
-  
+
     val share_dir: t -> L.ctx -> dirname
-  
+
     val share: t -> L.ctx -> name -> dirname
-  
+
     val etc_dir: t -> L.ctx -> dirname
-  
+
     val etc: t -> L.ctx -> name -> dirname
-  
+
     val man_dir: ?num:string -> t -> L.ctx -> dirname
-  
+
     val bin: t -> L.ctx -> dirname
-  
+
     val sbin: t -> L.ctx -> dirname
   end
-  
+
 
   (** Actual config handling the global-config.config indirections *)
 

--- a/src/repository/opamDownload.mli
+++ b/src/repository/opamDownload.mli
@@ -19,13 +19,13 @@ exception Download_fail of string option * string
     doesn't match*)
 val download:
   ?quiet:bool -> ?validate:bool -> overwrite:bool -> ?compress:bool ->
-  ?checksum:OpamHash.t ->
+  ?checksum:(OpamHash.computable_kind OpamHash.hash) ->
   OpamUrl.t -> OpamFilename.Dir.t ->
   OpamFilename.t OpamProcess.job
 
 (** As [download], but with a specified output filename. *)
 val download_as:
   ?quiet:bool -> ?validate:bool -> overwrite:bool -> ?compress:bool ->
-  ?checksum:OpamHash.t ->
+  ?checksum:(OpamHash.computable_kind OpamHash.hash) ->
   OpamUrl.t -> OpamFilename.t ->
   unit OpamProcess.job

--- a/src/repository/opamRepository.mli
+++ b/src/repository/opamRepository.mli
@@ -33,24 +33,24 @@ val update: repository -> dirname -> unit OpamProcess.job
     or synchronised directly if local and [working_dir] was set. *)
 val pull_tree:
   string -> ?cache_dir:dirname -> ?cache_urls:url list -> ?working_dir:bool ->
-  ?subpath:string -> dirname -> OpamHash.t list -> url list ->
+  ?subpath:string -> dirname -> OpamHash.computable_kind OpamHash.hash list -> url list ->
   string download OpamProcess.job
 
 (** Same as [pull_tree], but for fetching a single file. *)
 val pull_file:
   string -> ?cache_dir:dirname -> ?cache_urls:url list -> ?silent_hits:bool ->
-  filename -> OpamHash.t list -> url list ->
+  filename -> OpamHash.computable_kind OpamHash.hash list -> url list ->
   unit download OpamProcess.job
 
 (** Same as [pull_file], but without a destination file: just ensures the file
     is present in the cache. *)
 val pull_file_to_cache:
   string -> cache_dir:dirname -> ?cache_urls:url list ->
-  OpamHash.t list -> url list -> string download OpamProcess.job
+  OpamHash.computable_kind OpamHash.hash list -> url list -> string download OpamProcess.job
 
 (** The file where the file with the given hash is stored under cache at given
     dirname. *)
-val cache_file: dirname -> OpamHash.t -> filename
+val cache_file: dirname -> OpamHash.kind OpamHash.hash -> filename
 
 (** Get the optional revision associated to a backend (git hash, etc.). *)
 val revision: dirname -> url -> version option OpamProcess.job

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -22,7 +22,7 @@ type update =
 module type S = sig
   val name: OpamUrl.backend
   val pull_url:
-    ?cache_dir:dirname -> ?subpath:string -> dirname -> OpamHash.t option -> url ->
+    ?cache_dir:dirname -> ?subpath:string -> dirname -> OpamHash.computable_kind OpamHash.hash option -> url ->
     filename option download OpamProcess.job
   val fetch_repo_update:
     repository_name -> ?cache_dir:dirname -> dirname -> url ->
@@ -59,8 +59,8 @@ let check_digest filename = function
          \                     got      %s\n\
           Metadata might be out of date, in this case use `opam update`."
          (OpamFilename.to_string filename)
-         (OpamHash.to_string expected)
-         (OpamHash.to_string bad_hash);
+         (OpamHash.to_string (expected :> OpamHash.t))
+         (OpamHash.to_string (bad_hash :> OpamHash.t));
        false)
   | _ -> true
 

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -45,7 +45,7 @@ module type S = sig
       [checksum] can be used for retrieval but is NOT checked by this
       function. *)
   val pull_url:
-    ?cache_dir:dirname -> ?subpath:string -> dirname -> OpamHash.t option -> url ->
+    ?cache_dir:dirname -> ?subpath:string -> dirname -> OpamHash.computable_kind OpamHash.hash option -> url ->
     filename option download OpamProcess.job
 
   (** [pull_repo_update] fetches the remote update from [url] to the local
@@ -92,7 +92,7 @@ val compare: repository -> repository -> int
 
 (** [check_digest file expected] check that the [file] digest is the
     one [expected]. *)
-val check_digest: filename -> OpamHash.t option -> bool
+val check_digest: filename -> OpamHash.computable_kind OpamHash.hash option -> bool
 
 (** Adds a label to the given job, for the corresponding repository name and
     action *)

--- a/src/repository/opamRepositoryPath.ml
+++ b/src/repository/opamRepositoryPath.ml
@@ -28,8 +28,8 @@ let pin_cache u =
   pin_cache_dir () /
   String.sub
     (OpamHash.contents @@
-     OpamHash.compute_from_string ~kind:`SHA512 @@
-     OpamUrl.to_string u)
+     ((OpamHash.compute_from_string ~kind:`SHA512 @@
+     OpamUrl.to_string u) :> OpamHash.t))
     0 16
 
 let repo repo_root = repo_root // "repo" |> OpamFile.make

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -590,7 +590,7 @@ let write_custom_init_scripts root custom =
       if not (OpamFilename.exists hash_file)
       || (let same_hash =
           OpamHash.of_string_opt (OpamFilename.read hash_file) =
-          Some (OpamHash.compute ~kind (OpamFilename.to_string script_file))
+          Some (OpamHash.compute ~kind (OpamFilename.to_string script_file) :> OpamHash.t)
         in
         same_hash
         || not same_hash
@@ -599,8 +599,8 @@ let write_custom_init_scripts root custom =
              (OpamFilename.to_string script_file)) then
             (write_script hookdir (name, script);
             OpamFilename.chmod script_file 0o777;
-            write_script hookdir (hash_name, OpamHash.to_string hash))
-    ) custom
+            write_script hookdir (hash_name, OpamHash.to_string (hash :> OpamHash.t))
+            )) custom
 
 let write_dynamic_init_scripts st =
   let updates = updates ~set_opamroot:false ~set_opamswitch:false st in

--- a/src/state/opamFileTools.mli
+++ b/src/state/opamFileTools.mli
@@ -22,7 +22,7 @@ val template: package -> OpamFile.OPAM.t
    warning/error. If [check_extra_files] is unspecified or false, warning 53
    won't be checked. *)
 val lint:
-  ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
+  ?check_extra_files:(basename * (OpamHash.computable_kind OpamHash.hash -> bool)) list ->
   ?check_upstream:bool ->
   OpamFile.OPAM.t -> (int * [`Warning|`Error] * string) list
 
@@ -32,7 +32,7 @@ val lint:
    should be set when reading packages from a repository, so that package name
    and version are inferred from the filename. *)
 val lint_file:
-  ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
+  ?check_extra_files:(basename * (OpamHash.computable_kind OpamHash.hash -> bool)) list ->
   ?check_upstream:bool ->
   ?handle_dirname:bool ->
   OpamFile.OPAM.t OpamFile.typed_file ->
@@ -42,7 +42,7 @@ val lint_file:
    defaults to a function that will look for a [files/] directory besides
    [filename] *)
 val lint_channel:
-  ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
+  ?check_extra_files:(basename * (OpamHash.computable_kind OpamHash.hash -> bool)) list ->
   ?check_upstream: bool ->
   ?handle_dirname:bool ->
   OpamFile.OPAM.t OpamFile.typed_file -> in_channel ->
@@ -52,7 +52,7 @@ val lint_channel:
    [check_extra_files] defaults to a function that will look for a [files/]
    directory besides [filename] *)
 val lint_string:
-  ?check_extra_files:(basename * (OpamHash.t -> bool)) list ->
+  ?check_extra_files:(basename * (OpamHash.computable_kind OpamHash.hash -> bool)) list ->
   ?check_upstream: bool ->
   ?handle_dirname:bool ->
   OpamFile.OPAM.t OpamFile.typed_file -> string ->

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -608,7 +608,7 @@ let from_1_3_dev2_to_1_3_dev5 root conf =
                 in
                 config |>
                 OpamFile.Dot_config.with_file_depends
-                  [ocamlc, OpamHash.compute (OpamFilename.to_string ocamlc)] |>
+                  [ocamlc, (OpamHash.compute (OpamFilename.to_string ocamlc) :> OpamHash.t)] |>
                 OpamFile.Dot_config.set
                   (OpamVariable.of_string "ocaml-version")
                   (Some (S (String.concat "" vnum)))

--- a/src/state/opamPackageVar.ml
+++ b/src/state/opamPackageVar.ml
@@ -183,7 +183,7 @@ let build_id st opam =
       (* no fixed source: build-id undefined *)
       raise Exit
     | _ ->
-      let hash_map, deps_hashes =
+      let (hash_map : OpamHash.computable_kind OpamHash.hash OpamPackage.Map.t), deps_hashes =
         OpamPackage.Set.fold (fun nv (hash_map, hashes) ->
             let hash_map, hash =
               aux hash_map nv (OpamPackage.Map.find nv st.opams)
@@ -198,15 +198,15 @@ let build_id st opam =
       let hash =
         OpamHash.compute_from_string ~kind
           (OpamStd.List.concat_map " " OpamHash.contents
-             (opam_hash :: deps_hashes))
+             ((opam_hash :> OpamHash.t) :: (deps_hashes :> OpamHash.t list)))
       in
-      OpamPackage.Map.add nv hash hash_map, hash
+      ((OpamPackage.Map.add nv hash hash_map) :> OpamHash.computable_kind OpamHash.hash OpamPackage.Map.t), (hash :> OpamHash.computable_kind OpamHash.hash)
   in
   try
     let _hash_map, hash =
       aux OpamPackage.Map.empty (OpamFile.OPAM.package opam) opam
     in
-    Some (OpamHash.contents hash)
+    Some (OpamHash.contents (hash :> OpamHash.t))
   with Exit -> None
 
 (* filter handling *)

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -462,7 +462,7 @@ let load lock_kind gt rt switch =
               in
               let changed =
                 exists <> should_exist ||
-                exists && not (OpamHash.check_file (OpamFilename.to_string file) hash)
+                exists && not (OpamHash.check_file (OpamFilename.to_string file) (assert false (*Obj.magic hash*)))
               in
               if not exists && should_exist then
                 OpamConsole.warning

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -181,7 +181,7 @@ let fetch_dev_package url srcdir ?(working_dir=false) ?subpath nv =
     (slog (OpamStd.Option.map_default (fun s -> " ("^s^")") "")) subpath;
   OpamRepository.pull_tree
     ~cache_dir:(OpamRepositoryPath.download_cache OpamStateConfig.(!r.root_dir))
-    (OpamPackage.to_string nv) srcdir checksum ~working_dir ?subpath mirrors
+    (OpamPackage.to_string nv) srcdir (assert false (*List.map OpamHash.to_computable checksum*)) ~working_dir ?subpath mirrors
   @@| OpamRepository.report_fetch_result nv
 
 let pinned_package st ?version ?(working_dir=false) name =
@@ -327,9 +327,9 @@ let pinned_package st ?version ?(working_dir=false) name =
           else
             OpamConsole.warning "Ignoring file %s with invalid hash"
               (OpamFilename.to_string file))
-        (OpamFile.OPAM.get_extra_files
+        (List.map (fun (f, n, k) -> f, n, assert false (*OpamHash.to_computable k*)) ((OpamFile.OPAM.get_extra_files
            ~repos_roots:(OpamRepositoryState.get_root st.switch_repos)
-           opam);
+           opam) :> (OpamTypes.filename * OpamTypes.basename * OpamHash.t) list));
       OpamFile.OPAM.write opam_file
         (OpamFile.OPAM.with_extra_files_opt None opam);
       opam
@@ -532,7 +532,7 @@ let download_package_source st nv dirname =
       (OpamRepository.pull_tree (OpamPackage.to_string nv)
         ~cache_dir ~cache_urls ?subpath:(OpamFile.URL.subpath u)
         dirname
-        (OpamFile.URL.checksum u)
+        (List.map (fun k -> assert false (* OpamHash.to_computable k*)) (OpamFile.URL.checksum u))
         (OpamFile.URL.url u :: OpamFile.URL.mirrors u))
       @@| fun r -> Some r
   in
@@ -542,7 +542,7 @@ let download_package_source st nv dirname =
       (OpamRepository.pull_file_to_cache
          (OpamPackage.to_string nv ^"/"^ OpamFilename.Base.to_string name)
          ~cache_dir ~cache_urls
-         (OpamFile.URL.checksum u)
+         (List.map (fun k -> assert false (*OpamHash.to_computable k*)) (OpamFile.URL.checksum u))
          (OpamFile.URL.url u :: OpamFile.URL.mirrors u))
       @@| fun r -> (OpamFilename.Base.to_string name, r) :: ret
   in


### PR DESCRIPTION
Here's a draft to allow opam files to contain a new hash type named `swhid`. The goal is to be able to query the Software Heritage repository when an archive is not available anymore and is not in opam's cache.

The idea is to have to kind of hashes:

```ml
type computable_kind = [ `MD5 | `SHA256 | `SHA512 ]

type kind = [ computable_kind | `SWHID ]
```

Because a swhid hash is not easily computable and we don't want to do it inside of opam.

Unfortunately, this as an impact in a lot of places in the code. Thus, as you'll see, there's a lot of `assert false`, it's because in these places, I don't know if it makes sense to keep the swhid hash or if I should just filter it out. That's mainly because I'm not familiar at all with opam's codebase...

Help is welcome. :)

cc @AltGr  @rjbou 