### PR TITLE
build: fix cudf download url

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -104,6 +104,7 @@ users)
   * Fix vendored build on mingw-w64 with g++ 11.2 [#4835 @dra27]
   * Switch to vendored build if spdx_licenses is missing [#4842 @dra27]
   * Check versions of findlib packages in configure [#4842 @dra27]
+  * Fix dose3 download url since gforge is gone [#4870 @avsm]
 
 ## Infrastructure
   *

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -28,7 +28,7 @@ MD5_ocamlgraph = 2d07fcf3501e1d4997c03fa94cea22f0
 
 $(call PKG_SAME,ocamlgraph)
 
-URL_cudf = https://gforge.inria.fr/frs/download.php/36602/cudf-0.9.tar.gz
+URL_cudf = https://github.com/ocaml/opam-source-archives/raw/main/cudf-0.9.tar.gz
 MD5_cudf = a4c0e652e56e74c7b388a43f9258d119
 
 $(call PKG_SAME,cudf)


### PR DESCRIPTION
gforge has been deprecated, so archive is now on a repository
under ocaml/opam-source-archives (with the same checksum).

This unbreaks the opam (and hence opam.ocaml.org) build

Please update `master_changes.md` file with your changes.
