### PR TITLE
Make yes the default answer to opam init's setup in interactive mode

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -22,6 +22,8 @@ users)
 
 ## Init
   * Run the sandbox check in the temporary directory [#4787 @dra27 - fix #4783]
+  * Make "yes" the default answer to opam init's setup in interactive mode [#4877 @kit-ty-kate]
+  * Make the interactive mode of opam init's setup ask the user again when the answer isn't recognized instead of using the default value [#4877 @kit-ty-kate]
 
 ## Config report
   *

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -748,12 +748,14 @@ let setup
         OpamConsole.warning "Shell not updated in non-interactive mode: use --shell-setup";
         None
       end else
+      let rec ask_loop () =
         match
           OpamConsole.read
-            "Do you want opam to modify %s? [N/y/f]\n\
-             (default is 'no', use 'f' to choose a different file)"
+            "Do you want opam to modify %s? [Y/n/f]\n\
+             (default is 'yes', use 'f' to choose a different file)"
             (OpamFilename.prettify dot_profile)
         with
+        | None (* Default is "yes" *)
         | Some ("y" | "Y" | "yes"  | "YES" ) -> Some dot_profile
         | Some ("f" | "F" | "file" | "FILE") ->
           begin
@@ -765,7 +767,12 @@ let setup
               None
             | Some f -> Some (OpamFilename.of_string f)
           end
-        | _ -> None
+        | Some ("n" | "N" | "no" | "NO") -> None
+        | Some answer ->
+          OpamConsole.error "Could not understand '%s'" answer;
+          ask_loop ()
+      in
+      ask_loop ()
   in
   let env_hook = match env_hook, interactive with
     | Some b, _ -> Some b


### PR DESCRIPTION
Beginner hitting the issue in: https://discuss.ocaml.org/t/beginner-issue-ocamlc-not-found-in-tree-or-in-path/8701/3

I'm not sure why the default answer to this critical experience of opam is "no" by default.
Changing it to "yes" by default would be more inviting for beginners and would not change anything for other people (given this would only change the default in the interactive mode)

I've also made it loop on itself if the answer could not be parsed so the behaviour is less surprising (e.g. people writing "yes" in their own language but no error message is shown by opam)