### PR TITLE
Fix working dir checkout

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -82,6 +82,7 @@ users)
   * [BUG] Fix repin of locked pins when there is no change in lock file [#5079 @rjbou - fix #4313]
   * [BUG] Fix `opam install ./file.opam` lock pinning [#5148 @rjbou - fix #4313]
   * [BUG] Fix origin opam file retrieval when opam originate from locked file [#5079 @rjbou - fix #4936]
+  * [BUG] When reinstalling a package that has a dirty source, if uncommitted changes are the same than the ones stored in opam's cache, opam consider that it is up to date and nothing is updated [4879 @rjbou]
 
 ## List
   * Some optimisations to 'opam list --installable' queries combined with other filters [#4882 @altgr - fix #4311]
@@ -409,6 +410,8 @@ users)
   * Add `?subpath` to `OpamRepository.fetch_dev_packages`, `OpamVCS.is_up_to_date` and vcs specific functions in `OpamDarcs`, `OpamHG`, and `OpamGit` [#4876 @rjbou]
   * `OpamRepositoryConfig.E`: add `curl_t` and `fetch_t` to get their respective environement vairbales value dynamically, without lazyness. It is used in `opamClient.InitDefaults`, that can be called at topelevel [#5111 @rjbou]
   * `OpamRepository.update`: Return a change state result of the repo update [#5043 @Armael]
+  * `OpamVCS.VCS`: add a `clean` function to the interface clearing all the uncommited files [#4879 @rjbou]
+  * `OpamVCS.pull_url`: clean repository before fetching [#4879 @rjbou]
 
 ## opam-state
   * `OpamSwitchState.universe`: `requested` argument moved from `name_package_set` to `package_set`, to precise installed packages with `--best-effort` [#4796 @LasseBlaauwbroek]

--- a/src/repository/opamDarcs.ml
+++ b/src/repository/opamDarcs.ml
@@ -81,10 +81,14 @@ module VCS = struct
     OpamSystem.raise_on_process_error r;
     Done ()
 
-  let reset_tree repo_root _repo_url =
+  let clean repo_root =
     darcs repo_root [ "obliterate"; "--all"; "-t"; opam_local_tag ]
     @@> fun r ->
     OpamSystem.raise_on_process_error r;
+    Done ()
+
+  let reset_tree repo_root _repo_url =
+    clean repo_root @@+ fun () ->
     darcs repo_root [ "obliterate"; "--all"; "-p"; opam_reverse_commit ]
     @@> fun r ->
     (* returns 0 even if patch doesn't exist *)

--- a/src/repository/opamHg.ml
+++ b/src/repository/opamHg.ml
@@ -56,6 +56,12 @@ module VCS = struct
       if String.length full > 8 then Done (Some (String.sub full 0 8))
       else Done (Some full)
 
+  let clean repo_root =
+    hg repo_root ["revert"; "--all"; "--no-backup"]
+    @@> fun r ->
+    OpamSystem.raise_on_process_error r;
+    Done ()
+
   let reset_tree repo_root repo_url =
     let mark = mark_from_url repo_url in
     hg repo_root [ "update"; "--clean"; "--rev"; mark ] @@> fun r ->

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -86,6 +86,7 @@ module Make (VCS: VCS) = struct
          Done (Not_available (None, OpamUrl.to_string url)))
     @@ fun () ->
     if VCS.exists dirname then
+      VCS.clean dirname @@+ fun () ->
       VCS.fetch ?cache_dir ?subpath dirname url @@+ fun () ->
       VCS.is_up_to_date ?subpath dirname url @@+ function
       | true -> Done (Up_to_date None)

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -31,6 +31,7 @@ module type VCS = sig
   val is_dirty: ?subpath:subpath -> dirname -> bool OpamProcess.job
   val modified_files: dirname -> string list OpamProcess.job
   val get_remote_url: ?hash:string -> dirname -> url option OpamProcess.job
+  val clean: dirname -> unit OpamProcess.job
 end
 
 let convert_path =

--- a/src/repository/opamVCS.mli
+++ b/src/repository/opamVCS.mli
@@ -70,10 +70,14 @@ module type VCS = sig
   val is_dirty: ?subpath:subpath -> dirname -> bool OpamProcess.job
 
   (** Returns the list of files under version control, modified in the working
-      tree but not comitted *)
+      tree but not committed *)
   val modified_files: dirname -> string list OpamProcess.job
 
+  (* Returns associated remote url, if found *)
   val get_remote_url: ?hash:string -> dirname -> url option OpamProcess.job
+
+  (* Remove uncommitted changes *)
+  val clean: dirname -> unit OpamProcess.job
 end
 
 (** Create a backend from a [VCS] implementation. *)

--- a/tests/reftests/working-dir.test
+++ b/tests/reftests/working-dir.test
@@ -89,7 +89,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> removed   ongoing.dev
 Done.
-### opam install ongoing -v | grep -v "^#" | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*(/|\\|")cat(\.exe)?"? "' -> 'cat "'
+### opam install ongoing -v | grep -v "^#" | '.*(/|\\|")test(\.exe)?"? "' -> 'test "'
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1:
@@ -106,25 +106,23 @@ Processing  1/3: [ongoing.dev: git]
 -> retrieved ongoing.dev  (no changes)
 Processing  2/3: [ongoing: test newfile.txt]
 test "-f" "newfile.txt" (CWD=${BASEDIR}/OPAM/working-dir/.opam-switch/build/ongoing.dev)
-Processing  2/3: [ongoing: cat newfile.txt]
-cat "newfile.txt" (CWD=${BASEDIR}/OPAM/working-dir/.opam-switch/build/ongoing.dev)
-- new!
--> compiled  ongoing.dev
--> installed ongoing.dev
-Done.
-### opam remove ongoing
-The following actions will be performed:
-=== remove 1 package
-  - remove ongoing dev (pinned)
+[ERROR] The compilation of ongoing.dev failed at "test -f newfile.txt".
 
-<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> removed   ongoing.dev
-Done.
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - build ongoing dev
++- 
+- No changes have been performed
+'${OPAM} install ongoing -v' failed.
+# Return code 31 #
 ### opam install ongoing --working-dir -v | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*(/|\\|")cat(\.exe)?"? "' -> 'cat "'
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [ongoing.dev: git]
-[ongoing.dev] synchronised (no changes)
+[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)
 
 The following actions will be performed:
 === install 1 package


### PR DESCRIPTION
Splitted on several PRs #5081 #5082  #5083
Keep in this PR the inital purpose : working dir checkout corner case: when reinstalling a package that has a dirty source, if uncommitted changes are the same than remotely committed, opam consider that it is up to date and nothing is updated.


#### old comment
> Add a ~sandbox and~ working dir test plus a fix on working dir checkout corner case: when reinstalling a package that has a dirty source, if uncommitted changes are the same than remotely committed, opam consider that it is up to date and nothing is updated.
>~And some update on reftests: replace opam bin path and add a `grep -v` command~
>
>edit: integrate also a 
>* fix for working-dir & non pinned package, that should be a no-op (fix # 5060)
>* notification when packages are skipped with assume built
>* add test for inplace, assume-built & their mix