### PR TITLE
Make the SAT preemptive check optional, by-solver

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -127,6 +127,7 @@ users)
 
 ## Solver
   * [BUG] Remove z3 debug output [#4723 @rjbou - fix #4717] [2.1.0~rc2 #4720]
+  * Fix and improve the Z3 solver backend [#4880 @altgr]
 
 ## Client
   *

--- a/src/solver/opamBuiltin0install.dummy.ml
+++ b/src/solver/opamBuiltin0install.dummy.ml
@@ -18,6 +18,8 @@ let ext = ref None
 
 let command_name = None
 
+let preemptive_check = false
+
 let default_criteria = {
   crit_default = "";
   crit_upgrade = "";

--- a/src/solver/opamBuiltin0install.real.ml
+++ b/src/solver/opamBuiltin0install.real.ml
@@ -20,6 +20,8 @@ let is_present () = true
 
 let command_name = None
 
+let preemptive_check = false
+
 let default_criteria = {
   crit_default = "";
   crit_upgrade = "";

--- a/src/solver/opamBuiltinMccs.dummy.ml
+++ b/src/solver/opamBuiltinMccs.dummy.ml
@@ -17,6 +17,8 @@ module S = struct
 
   let ext = ref None
 
+  let preemptive_check = false
+
   let command_name = None
 
   let default_criteria = {

--- a/src/solver/opamBuiltinMccs.real.ml
+++ b/src/solver/opamBuiltinMccs.real.ml
@@ -58,6 +58,7 @@ let of_backend backend : (module OpamCudfSolverSig.S) =
       | _ -> true
     let command_name = None
     let default_criteria = default_criteria
+    let preemptive_check = true
     let call = call backend !ext
   end)
 

--- a/src/solver/opamBuiltinZ3.dummy.ml
+++ b/src/solver/opamBuiltinZ3.dummy.ml
@@ -18,6 +18,8 @@ let ext = ref None
 
 let command_name = None
 
+let preemptive_check = false
+
 let default_criteria = {
   crit_default = "";
   crit_upgrade = "";

--- a/src/solver/opamBuiltinZ3.real.ml
+++ b/src/solver/opamBuiltinZ3.real.ml
@@ -20,6 +20,8 @@ let is_present () = true
 
 let command_name = None
 
+let preemptive_check = false
+
 let default_criteria = {
   crit_default = "-removed,\
                   -count[avoid-version,changed],\

--- a/src/solver/opamCudfSolver.ml
+++ b/src/solver/opamCudfSolver.ml
@@ -86,6 +86,8 @@ module External (E: ExternalArg) : S = struct
 
   let command_name = Some E.command_name
 
+  let preemptive_check = true
+
   let default_criteria = E.default_criteria
 
   let call =

--- a/src/solver/opamCudfSolverSig.ml
+++ b/src/solver/opamCudfSolverSig.ml
@@ -32,6 +32,11 @@ module type S = sig
 
   val default_criteria: criteria_def
 
+  val preemptive_check: bool
+  (** Should be true for solvers that may take a long time to detect that there
+      is no solution: in this case, dose's check is run beforehand ; otherwise
+      it's only run if the solver returns unsat, to extract the explanations. *)
+
   val call:
     criteria:string -> ?timeout:float -> Cudf.cudf ->
     Cudf.preamble option * Cudf.universe


### PR DESCRIPTION
Closes #4658, see the discussion there.

It'd probably be worth it to check the Dose3 check times though; they
may be due to the increased complexity of the repo, but also maybe to
the new dose3 version ?

Also I didn't re-check the response times of the different solvers in
case of complex, unsat cases : the worrying case here was mccs stalling
for tenths of seconds, even sometimes timing out, while dose3 (which we
would call anyway) would detect the conflict in a fraction of a second.