### PR TITLE
Factorise fetching of shared archive source packages

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -30,6 +30,9 @@ users)
 ## Config report
   *
 
+## Actions
+  *  Add a `'Fetch` action with several packages: one node to download once and prepare source once for packages that share same archive [#4893 @rjbou - fix #3741]
+
 ## Install
   * Make the status of pinned packages more explicit during installation [#4987 @kit-ty-kate - fix #4925]
   * Better recognize depexts on Gentoo, NetBSD, OpenBSD [#5065 @mndrix]
@@ -272,6 +275,8 @@ users)
   * Add `OpamSwitchCommand.previous_switch` [#4910 @kit-ty-kate]
 ## opam-repository
   * `OpamRepositoryConfig`: add in config record `repo_tarring` field and as an argument to config functions, and a new constructor `REPOSITORYTARRING` in `E` environment module and its access function [#5015 @rjbou]
+  * New download functions for shared source, old ones kept [#4893 @rjbou]
+
 ## opam-state
 ## opam-solver
   * `OpamCudf`: Change type of `conflict_case.Conflict_cycle` (`string list list` to `Cudf.package action list list`) and `cycle_conflict`, `string_of_explanations`, `conflict_explanations_raw` types accordingly [#4039 @gasche]
@@ -281,11 +286,14 @@ users)
   * `OpamSolver.load_cudf_universe`: change staging of `add_invariant` [#5024 @AltGr]
   * `OpamSolver.coinstallable_subset`: add `add_invariant` optional argument [#5024 @AltGr]
   * `OpamSolver.installable`: use `installable_subset` that uses `coinstallable_subset` [#5024 @kit_ty_kate]
+  * `OpamSolver.explicit`: when adding fetch nodes, add shared source ones. Change of `sources_needed` argument type [#4893 @rjbou]
 ## opam-format
   * `OpamStd.ABSTRACT`: add `compare` and `equal`, that added those functions to `OpamSysPkg` and `OpamVariable` [#4918 @rjbou]
   * Add OpamPackage.Version.default returning the version number used when no version is given for a package [#4949 @kit-ty-kate]
   * Add `OpamPath.Switch.man_dirs` [#4915 @rjbou]
   * `OpamFile.Config`: order list of installed switches according their last use, update `with_switch` accordingly, and add `previous_switch` [#4910 @AltGr]
+  * Change ``Fetch` action to take several packages, in order to handle shared fetching of packages [#4893 @rjbou]
+
 ## opam-core
   * OpamSystem: avoid calling Unix.environment at top level [#4789 @hannesm]
   * `OpamStd.ABSTRACT`: add `compare` and `equal`, that added those functions to `OpamFilename`, `OpamHash`, `OpamStd`, `OpamStd`, `OpamUrl`, and `OpamVersion` [#4918 @rjbou]

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -237,33 +237,55 @@ let preprocess_dot_install st nv build_dir =
   in
   files, really_process_dot_install, config
 
-let download_package st nv =
-  log "download_package: %a" (slog OpamPackage.to_string) nv;
+let download_shared_source st url nvs =
+  let labelise pkg_str = OpamStd.List.concat_map ", " pkg_str nvs in
+  log "download_package: %a%a"
+    (slog (fun _ -> labelise OpamPackage.to_string)) ()
+    (slog (fun url -> match url, nvs with
+         | None, _ | _, [_] -> ""
+         | Some url, _ -> " " ^ OpamUrl.to_string (OpamFile.URL.url url))) url;
   if OpamStateConfig.(!r.dryrun) || OpamClientConfig.(!r.fake)
-  then Done None
+  then Done None else
+  let nvs =
+    (* filter out version-pinned packages since we already have their source *)
+    List.filter (fun nv ->
+        let dir = OpamSwitchState.source_dir st nv in
+        not (OpamPackage.Set.mem nv st.pinned &&
+             OpamFilename.exists_dir dir &&
+             OpamStd.Option.Op.(
+               OpamPinned.find_opam_file_in_source nv.name dir >>|
+               OpamFile.OPAM.safe_read >>=
+               OpamFile.OPAM.version_opt) = Some nv.version))
+      nvs
+  in
+  if nvs = [] then Done None
   else
-  let dir = OpamSwitchState.source_dir st nv in
-  if OpamPackage.Set.mem nv st.pinned &&
-     OpamFilename.exists_dir dir &&
-     OpamStd.Option.Op.(
-       OpamPinned.find_opam_file_in_source nv.name dir >>|
-       OpamFile.OPAM.safe_read >>=
-       OpamFile.OPAM.version_opt)
-     = Some nv.version
-  then Done None
-  else
-  let print_action msg =
-    OpamConsole.msg "%s retrieved %s.%s  (%s)\n"
+  let print_action =
+    OpamConsole.msg "%s retrieved %s  (%s)\n"
       (if not (OpamConsole.utf8 ()) then "->"
        else OpamActionGraph.
               (action_color (`Fetch []) (action_strings (`Fetch []))))
-      (OpamConsole.colorise `bold (OpamPackage.name_to_string nv))
-      (OpamPackage.version_to_string nv)
-      msg;
   in
-  OpamUpdate.cleanup_source st
-    (OpamPackage.Map.find_opt nv st.installed_opams)
-    (OpamSwitchState.opam st nv);
+  let print_single_actions msgs =
+    List.iter (fun (nv, msg) ->
+        print_action
+          (OpamConsole.colorise `bold (OpamPackage.name_to_string nv)
+           ^ "." ^ (OpamPackage.version_to_string nv))
+          msg)
+      msgs
+  in
+  let print_full_action msg =
+    print_action
+      (labelise @@ fun nv ->
+       (OpamConsole.colorise `bold (OpamPackage.name_to_string nv))
+       ^ "." ^ (OpamPackage.version_to_string nv))
+      msg
+  in
+  List.iter (fun nv ->
+      OpamUpdate.cleanup_source st
+        (OpamPackage.Map.find_opt nv st.installed_opams)
+        (OpamSwitchState.opam st nv))
+    nvs;
   OpamProcess.Job.catch (fun e ->
       let na =
         match e with
@@ -272,30 +294,48 @@ let download_package st nv =
       in
       Done (Some na))
   @@ fun () ->
-  OpamUpdate.download_package_source st nv dir @@| function
+  OpamUpdate.download_shared_package_source st url nvs @@| function
   | Some (Not_available (s, l)), _ ->
-    let msg = match s with None -> l | Some s -> s in
-    OpamConsole.error "Failed to get sources of %s: %s"
-      (OpamPackage.to_string nv) msg;
+    let msg = OpamStd.Option.default l s in
+    OpamConsole.error "Failed to get sources of %s%s: %s"
+      (labelise OpamPackage.to_string)
+      (match url, nvs with
+       | None, _ | _, [_] -> ""
+       | Some url, _ ->
+         Printf.sprintf " (%s)" (OpamUrl.to_string (OpamFile.URL.url url)))
+      msg;
     Some (s, l)
-  | _, ((name, Not_available (s, l)) :: _) ->
+  | _, ((nv, name, Not_available (s, l)) :: _) ->
     let msg = match s with None -> l | Some s -> s in
     OpamConsole.error "Failed to get extra source \"%s\" of %s: %s"
       name (OpamPackage.to_string nv) msg;
     Some (s, l)
   | Some (Result msg), _ ->
-    print_action msg; None
+    print_full_action msg; None
   | Some (Up_to_date msg), _ ->
-    print_action msg; None
+    print_full_action msg; None
   | None, [] -> None
   | None, (e :: es as extras) ->
-    if List.for_all (function _, Up_to_date _ -> true | _ -> false) extras then
-      print_action "cached"
-    else begin match e, es with
-      | (_, Result msg), [] -> print_action msg
-      | _, _ -> print_action (Printf.sprintf "%d extra sources" (List.length extras))
-    end;
+    if List.for_all (function _, _, Up_to_date _ -> true | _ -> false) extras then
+      print_full_action "cached"
+    else
+      (match e, es with
+       | (_, _, Result msg), [] -> print_full_action msg
+       | _, _ ->
+         print_single_actions
+           (List.map (fun (nv, _, _) ->
+                nv,
+                (Printf.sprintf "%d extra sources"
+                   (List.length
+                      (List.filter (fun (nv',_,_) ->
+                           OpamPackage.compare nv nv' = 0)
+                          extras))))
+               extras));
     None
+
+let download_package st nv =
+  download_shared_source st
+    (OpamFile.OPAM.url (OpamSwitchState.opam st nv)) [nv]
 
 (* Prepare the package build:
    * apply the patches

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -256,7 +256,7 @@ let download_package st nv =
     OpamConsole.msg "%s retrieved %s.%s  (%s)\n"
       (if not (OpamConsole.utf8 ()) then "->"
        else OpamActionGraph.
-              (action_color (`Fetch ()) (action_strings (`Fetch ()))))
+              (action_color (`Fetch []) (action_strings (`Fetch []))))
       (OpamConsole.colorise `bold (OpamPackage.name_to_string nv))
       (OpamPackage.version_to_string nv)
       msg;

--- a/src/client/opamAction.mli
+++ b/src/client/opamAction.mli
@@ -14,14 +14,21 @@
 open OpamTypes
 open OpamStateTypes
 
-(** [download t pkg] downloads the source of the package [pkg] into its locally
-    cached source dir. Returns [Some (short_errmsg option, long_errmsg)] on error,
-    [None] on success. See {!OpamTypes.Not_available}.
+(** [download_package t pkg] downloads the source of the package [pkg] into its
+    locally cached source dir. Returns [Some (short_errmsg option,
+    long_errmsg)] on error, [None] on success. See {!OpamTypes.Not_available}.
 
     This doesn't update dev packages that already have a locally cached
     source. *)
 val download_package:
   rw switch_state -> package -> (string option * string) option OpamProcess.job
+
+(** [download_same_source_package t url packages]
+    As [download_package], download upstream shared source [url] between
+    [packages]. *)
+val download_shared_source:
+  rw switch_state -> OpamFile.URL.t option -> package list ->
+  (string option * string) option OpamProcess.job
 
 (** [prepare_package_source t pkg dir] updates the given source [dir] with the
     extra downloads, overlays and patches from the package's metadata

--- a/src/client/opamAction.mli
+++ b/src/client/opamAction.mli
@@ -51,7 +51,7 @@ val build_package:
   exn option OpamProcess.job
 
 (** [install_package t pkg] installs an already built package. Returns
-    [None] on success, [Some exn] on error. Do not update OPAM's
+    [None] on success, [Some exn] on error. Do not update opam's
     metadata. See {!build_package} to build the package. *)
 val install_package:
   rw switch_state -> ?test:bool -> ?doc:bool -> ?build_dir:dirname -> package ->

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -24,7 +24,8 @@ exception Fetch_fail of string
 
 let post_message ?(failed=false) st action =
   match action, failed with
-  | `Remove _, _ | `Reinstall _, _ | `Build _, false | `Fetch _, _ -> ()
+  | `Remove _, _ | `Reinstall _, _ | `Build _, false
+  | `Fetch _, _ -> ()
   | `Build pkg, true | `Install pkg, _ | `Change (_,_,pkg), _ ->
     let opam = OpamSwitchState.opam st pkg in
     let messages = OpamFile.OPAM.post_messages opam in
@@ -211,9 +212,11 @@ let sanitize_atom_list ?(permissive=false) ?(installed=false) t atoms =
 
 (* Pretty-print errors *)
 let display_error (n, error) =
-  let f action nv =
+  let f action nvs =
     let disp =
-      OpamConsole.header_error "while %s %s" action (OpamPackage.to_string nv) in
+      OpamConsole.header_error "while %s %s" action
+        (OpamStd.Format.pretty_list (List.map OpamPackage.to_string nvs))
+    in
     match error with
     | Sys.Break | OpamParallel.Aborted -> ()
     | Failure s -> disp "%s" s
@@ -224,13 +227,13 @@ let display_error (n, error) =
         OpamConsole.errmsg "%s" (OpamStd.Exn.pretty_backtrace e)
   in
   match n with
-  | `Change (`Up, _, nv)   -> f "upgrading to" nv
-  | `Change (`Down, _, nv) -> f "downgrading to" nv
-  | `Install nv        -> f "installing" nv
-  | `Reinstall nv      -> f "recompiling" nv
-  | `Remove nv         -> f "removing" nv
-  | `Build nv          -> f "compiling" nv
-  | `Fetch nv          -> f "fetching sources for" nv
+  | `Change (`Up, _, nv)   -> f "upgrading to" [nv]
+  | `Change (`Down, _, nv) -> f "downgrading to" [nv]
+  | `Install nv        -> f "installing" [nv]
+  | `Reinstall nv      -> f "recompiling" [nv]
+  | `Remove nv         -> f "removing" [nv]
+  | `Build nv          -> f "compiling" [nv]
+  | `Fetch nvs         -> f "fetching sources for" nvs
 
 module Json = struct
   let output_request request user_action =
@@ -458,7 +461,7 @@ let parallel_apply t
       OpamAction.noop_remove_package t nv in
     PackageActionGraph.explicit
       ~noop_remove
-      ~sources_needed:(fun p -> OpamPackage.Set.mem p sources_needed)
+      ~sources_needed:(fun p -> if OpamPackage.Set.mem p sources_needed then [p] else [])
       action_graph
   in
   let action_graph =
@@ -535,9 +538,8 @@ let parallel_apply t
             (fun name _ -> OpamPackage.Set.exists (fun pkg -> OpamPackage.Name.equal name pkg.name) visible_installed)
             !t_ref.conf_files; }
     in
-    let nv = action_contents action in
-    let opam = OpamSwitchState.opam t nv in
-    let source_dir =
+    let source_dir nv =
+      let opam = OpamSwitchState.opam t nv in
       let raw = OpamSwitchState.source_dir t nv in
       match OpamFile.OPAM.url opam with
       | None -> raw
@@ -556,16 +558,17 @@ let parallel_apply t
       | `Remove nv ->
         remove_from_install nv;
         Done (`Successful (installed, OpamPackage.Set.add nv removed))
-      | _ -> assert false
+      | `Change _ | `Reinstall _ -> assert false
     else
     match action with
-    | `Fetch nv ->
+    | `Fetch [nv] ->
       log "Fetching sources for %s" (OpamPackage.to_string nv);
       (OpamAction.download_package t nv @@+ function
         | None ->
           store_time (); Done (`Successful (installed, removed))
         | Some (_short_error, long_error) ->
           Done (`Exception (Fetch_fail long_error)))
+    | `Fetch _ -> assert false
 
     | `Build nv ->
       if assume_built && OpamPackage.Set.mem nv requested then
@@ -590,6 +593,7 @@ let parallel_apply t
       let doc =
         OpamStateConfig.(!r.build_doc) && OpamPackage.Set.mem nv requested
       in
+      let source_dir = source_dir nv in
       (if OpamFilename.exists_dir source_dir
        then (if not is_inplace then
                OpamFilename.copy_dir ~src:source_dir ~dst:build_dir)
@@ -620,6 +624,7 @@ let parallel_apply t
       (if OpamAction.removal_needs_download t nv then
          let d = OpamPath.Switch.remove t.switch_global.root t.switch nv in
          OpamFilename.rmdir d;
+         let source_dir = source_dir nv in
          if OpamFilename.exists_dir source_dir
          then OpamFilename.copy_dir ~src:source_dir ~dst:d
          else OpamFilename.mkdir d;
@@ -632,7 +637,7 @@ let parallel_apply t
         nv;
       store_time ();
       `Successful (installed, OpamPackage.Set.add nv removed)
-    | _ -> assert false
+    | `Change _ | `Reinstall _ -> assert false
   in
 
   let action_results =
@@ -681,7 +686,7 @@ let parallel_apply t
         (* Report download failures *)
         let failed_downloads = List.fold_left (fun failed (a, err) ->
             match (a, err) with
-            | `Fetch pkg, `Exception (Fetch_fail long_error) ->
+            | `Fetch [pkg], `Exception (Fetch_fail long_error) ->
               OpamPackage.Map.add pkg long_error failed
             | _ ->
               failed
@@ -772,7 +777,7 @@ let parallel_apply t
           if not OpamClientConfig.(!r.keep_build_dir) then
             OpamFilename.rmdir build_dir
         | `Remove _ | `Install _ | `Build _ | `Fetch _ -> ()
-        | _ -> assert false)
+        | `Change _ | `Reinstall _  -> assert false)
       graph
   in
   let t =
@@ -834,9 +839,11 @@ let parallel_apply t
       (* Cleanup build/install actions when one of them failed, it's verbose and
          doesn't add information *)
       let successful =
+        let was_successful p = not @@ List.mem (`Install p) failed in
         List.filter (function
-            | `Fetch p | `Build p when List.mem (`Install p) failed -> false
-            | _ -> true)
+            | `Fetch ps -> List.for_all was_successful ps
+            | `Build p -> was_successful p
+            | `Change _ | `Install _ | `Reinstall _ | `Remove _ -> true)
           successful
       in
       let remaining =
@@ -844,18 +851,24 @@ let parallel_apply t
             | `Remove p | `Install p
               when List.mem (`Build p) failed -> false
             | `Remove p | `Install p | `Build p
-              when List.mem (`Fetch p) failed -> false
-            | _ -> true)
+              when List.exists (function
+                  | `Fetch ps -> List.mem p ps
+                  | _ -> false) failed
+              -> false
+            | `Build _ | `Change _ | `Fetch _ | `Install _
+            | `Reinstall _ | `Remove _ -> true)
           remaining
       in
       let removes_missing_source =
         List.filter (function
             | `Remove p as rem ->
-              let fetch = `Fetch p in
-              List.mem fetch failed &&
-              PackageActionGraph.mem_edge action_graph fetch rem
-            | _ -> false
-          )
+              let is_fetch = function `Fetch ps -> List.mem p ps | _ -> false in
+              List.exists is_fetch failed
+              && PackageActionGraph.fold_edges (fun v v' mem ->
+                  mem || (is_fetch v && PackageAction.equal v' rem))
+                action_graph false
+            | `Build _ | `Change _ | `Fetch _ | `Install _
+            | `Reinstall _ -> false)
           successful
       in
       let failed =
@@ -866,7 +879,8 @@ let parallel_apply t
               let succ = PackageActionGraph.succ action_graph a in
               not (List.for_all (fun a -> List.mem a removes_missing_source)
                      succ)
-            | _ -> true)
+            | `Build _ | `Change _ | `Install _ | `Reinstall _
+            | `Remove _ -> true)
           failed
       in
       let filter_graph l =
@@ -921,9 +935,9 @@ let parallel_apply t
          OpamConsole.warning
                  "The sources of the following couldn't be obtained, they may be \
                   uncleanly removed:\n%s"
-                 (OpamStd.Format.itemize
-                    (fun rm -> OpamPackage.to_string (action_contents rm))
-                    removes_missing_source));
+                 (OpamStd.Format.itemize OpamPackage.to_string
+                    (List.flatten
+                       (List.map action_contents removes_missing_source))));
       OpamConsole.msg "\n";
       OpamConsole.header_msg "Error report";
       if OpamConsole.debug () || OpamConsole.verbose () then
@@ -942,7 +956,7 @@ let parallel_apply t
         ~empty:"No changes have been performed"
         successful;
       t, err
-    | _ -> assert false
+    | Nothing_to_do | OK _  -> assert false
 
 let simulate_new_state state t =
   let installed =
@@ -969,7 +983,9 @@ let confirmation ?ask requested solution =
     let open PackageActionGraph in
     let solution_packages =
       fold_vertex (fun v acc ->
-          OpamPackage.Name.Set.add (OpamPackage.name (action_contents v)) acc)
+          List.map OpamPackage.name (action_contents v)
+          |> OpamPackage.Name.Set.of_list
+          |> OpamPackage.Name.Set.union acc)
         solution
         OpamPackage.Name.Set.empty in
     OpamPackage.Name.Set.equal requested solution_packages

--- a/src/core/opamProcess.mli
+++ b/src/core/opamProcess.mli
@@ -199,7 +199,7 @@ module Job: sig
   val of_fun_list: ?keep_going:bool -> (unit -> command) list ->
     (command * result) option Op.job
 
-  (** Returns the job made of the the given homogeneous jobs run sequentially *)
+  (** Returns the job made of the given homogeneous jobs run sequentially *)
   val seq: ('a -> 'a Op.job) list -> 'a -> 'a Op.job
 
   (** Sequentially maps jobs on a list *)

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -237,7 +237,7 @@ type 'a inst_action = [
 type 'a concrete_action = [
   | 'a atomic_action
   | `Build of 'a
-  | `Fetch of 'a
+  | `Fetch of 'a list
 ]
 
 type 'a action = [

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -170,12 +170,13 @@ let pkg_flag_of_string = function
   | s -> Pkgflag_Unknown s
 
 let action_contents = function
-  | `Remove p | `Install p | `Reinstall p | `Build p | `Fetch p -> p
-  | `Change (_,_,p) -> p
+  | `Remove p | `Install p | `Reinstall p | `Build p
+  | `Change (_,_,p) -> [p]
+  | `Fetch pl -> pl
 
 let full_action_contents = function
-  | `Remove p | `Install p | `Reinstall p | `Build p | `Fetch p -> [p]
   | `Change (_,p1,p2) -> [p1; p2]
+  | a -> action_contents a
 
 let map_atomic_action f = function
   | `Remove p -> `Remove (f p)
@@ -189,7 +190,7 @@ let map_highlevel_action f = function
 let map_concrete_action f = function
   | #atomic_action as a -> map_atomic_action f a
   | `Build p -> `Build (f p)
-  | `Fetch p -> `Fetch (f p)
+  | `Fetch pl -> `Fetch (List.map f pl)
 
 let map_action f = function
   | #highlevel_action as a -> map_highlevel_action f a

--- a/src/format/opamTypesBase.mli
+++ b/src/format/opamTypesBase.mli
@@ -24,7 +24,7 @@ val std_path_of_string: string -> std_path
 val all_std_paths: std_path list
 
 (** Extract a package from a package action. *)
-val action_contents: [< 'a action ] -> 'a
+val action_contents: [< 'a action ] -> 'a list
 
 val map_atomic_action: ('a -> 'b) -> 'a atomic_action -> 'b atomic_action
 val map_highlevel_action: ('a -> 'b) -> 'a highlevel_action -> 'b highlevel_action

--- a/src/repository/opamRepository.mli
+++ b/src/repository/opamRepository.mli
@@ -26,11 +26,22 @@ val packages_with_prefixes: dirname -> string option package_map
     achieved. *)
 val update: repository -> dirname -> unit OpamProcess.job
 
-(** Fetch an URL and put the resulting tree into the supplied directory. The URL
-    must either point to a tree (VCS, rsync) or to a known archive type. In case
-    of an archive, the cache is used and supplied the hashes verified, then the
-    archive uncompressed. In case of a version-controlled URL, it's checked out,
-    or synchronised directly if local and [working_dir] was set. *)
+(** [pull_shared_tree ?cache_dir ?cache_url labels_dirnames checksums urls]
+    Fetch an URL and put the resulting tree into the supplied directories
+    specified in [labels_dirnames]. The string in [labels_dirnames] are text
+    labels of this given dirname for display. [urls] must either point to a
+    tree (VCS, rsync) or to a known archive type. In case of an archive, the
+    [cache_dir] is used and supplied the hashes verified, then the archive
+    uncompressed. In case of a version-controlled URL, it's checked out, or
+    synchronised directly if local and [working_dir] was set.  [cache_urls] is
+    used to retrieve from repository caches. *)
+val pull_shared_tree:
+  ?cache_dir:dirname ->
+  ?cache_urls:OpamUrl.t list ->
+  (string * OpamFilename.Dir.t) list -> OpamHash.t list -> url list ->
+  string download OpamProcess.job
+
+(* Same as [pull_shared_tree], but for a unique label/dirname. *)
 val pull_tree:
   string -> ?cache_dir:dirname -> ?cache_urls:url list -> ?working_dir:bool ->
   ?subpath:string -> dirname -> OpamHash.t list -> url list ->

--- a/src/solver/opamActionGraph.mli
+++ b/src/solver/opamActionGraph.mli
@@ -43,12 +43,14 @@ module type SIG = sig
       The argument [noop_remove] is a function that should return `true`
       for package where the `remove` action is known not to modify the
       filesystem (such as `conf-*` package).
-      The argument [sources_needed] is a function that should return `true`
-      for packages that require fetching sources (packages that do not
-      require it are typically up-to-date pins or "in-place" builds). *)
+      The argument [sources_needed p] is a function that should return packages
+      list that require fetching same shared source (singleton when no source
+      is shared), and an empty list if no fetching is required for that package
+      (packages that do not require it are typically up-to-date pins or
+      "in-place" builds). *)
   val explicit:
     ?noop_remove:(package -> bool) ->
-    sources_needed:(package -> bool) ->
+    sources_needed:(package -> package list) ->
     t -> t
 
   (** Folds on all recursive successors of the given action, including itself,

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -416,6 +416,12 @@ let string_of_action = Action.to_string
 let string_of_actions l =
   OpamStd.List.to_string (fun a -> " - " ^ string_of_action a) l
 
+let action_contents = function
+  | `Remove p | `Install p | `Reinstall p | `Change (_,_,p) -> p
+  | `Build _ | `Fetch _ ->
+    OpamConsole.error_and_exit `Internal_error
+      "Shouldn't have a multi package action on printing solution"
+
 exception Solver_failure of string
 exception Cyclic_actions of Action.t list list
 

--- a/src/solver/opamCudf.mli
+++ b/src/solver/opamCudf.mli
@@ -285,6 +285,9 @@ val packages: Cudf.universe -> Cudf.package list
 val to_cudf: Cudf.universe -> Cudf_types.vpkg request
   -> Cudf.preamble * Cudf.universe * Cudf.request
 
+(** Like [OpamTypesBase.action_contents] but return the single package of
+    remove, install, reinstal, and change action *)
+val action_contents: 'a action -> 'a
 
 module Json: sig
   open Cudf_types

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -762,7 +762,7 @@ let print_solution ~messages ~append ~requested ~reinstall ~available t =
   let actions, details =
     OpamCudf.ActionGraph.Topological.fold (fun a (actions,details) ->
         let cause =
-          try OpamCudf.Map.find (action_contents a) causes
+          try OpamCudf.Map.find (OpamCudf.action_contents a) causes
           with Not_found -> Unknown in
         let action = map_action OpamCudf.cudf2opam a in
         let cudf_name p = OpamPackage.name_to_string (OpamCudf.cudf2opam p) in

--- a/src/state/opamUpdate.mli
+++ b/src/state/opamUpdate.mli
@@ -82,6 +82,14 @@ val download_package_source:
   'a switch_state -> package -> dirname ->
   (string download option * (string * string download) list) OpamProcess.job
 
+(** As [download_package_source] but for several packages sharing the same
+    source. If [url] is None, do nothing. Downloads and synchronise upstream
+    source in their respective source directories. *)
+val download_shared_package_source:
+  'a switch_state -> OpamFile.URL.t option -> package list ->
+  (string download option * (package * string * string download) list)
+    OpamProcess.job
+
 (** [cleanup_source old_opam_option new_opam] checks if the remote URL has
     changed between [old_opam_option] and [new_opam], and, depending on that,
     cleans up the source directory of the package ([OpamPath.Switch.sources]) if

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -479,6 +479,23 @@
    (run ./run.exe %{bin:opam} %{dep:repository.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-shared-fetch)
+ (action
+  (diff shared-fetch.test shared-fetch.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-shared-fetch)))
+
+(rule
+ (targets shared-fetch.out)
+ (deps root-N0REP0)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:shared-fetch.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-show)
  (action
   (diff show.test show.out)))

--- a/tests/reftests/shared-fetch.test
+++ b/tests/reftests/shared-fetch.test
@@ -1,0 +1,292 @@
+N0REP0
+### <shared.ml>
+print_endline "I am a shared code"
+### <non-shared.ml>
+print_endline "I am a non shared code"
+### tar czf shared.tgz shared.ml
+### tar czf non-shared.tgz non-shared.ml
+### <pkg:no-extra.3>
+opam-version: "2.0"
+build: [ "ocaml" "shared.ml" ]
+### <pkg:extra.3>
+opam-version: "2.0"
+build: [
+  [ "ocaml" "shared.ml" ]
+  [ "ocaml" "extra_uniq.ml" ]
+]
+#patches: ["shared.patch"]
+### <pkg:extra.3:extra_uniq.ml>
+print_endline "I am a non shared code"
+### <pkg:non-shared.4>
+opam-version: "2.0"
+build: [ "ocaml" "non-shared.ml" ]
+### <mkurl.sh>
+arch=$1
+shift
+for p in $@; do
+  file="REPO/packages/${p%.*}/$p/opam"
+  echo "url {" >> $file
+  echo "src: \"$arch.tgz\"" >> $file
+  MD5=$(openssl md5 $arch.tgz | cut -d' ' -f2)
+  echo "checksum: \"md5=$MD5\"" >> $file
+  echo "}" >> $file
+done
+### sh mkurl.sh shared no-extra.3 extra.3
+### sh mkurl.sh non-shared non-shared.4
+### OPAMJOBS=1 OPAMDOWNLOADJOBS=1 OPAMYES=1
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### opam switch create shared --empty
+### opam install no-extra extra non-shared | unordered
+The following actions will be performed:
+  - install extra      3
+  - install non-shared 4
+  - install no-extra   3
+===== 3 to install =====
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved extra.3  (file://${BASEDIR}/shared.tgz)
+-> retrieved no-extra.3  (cached)
+-> retrieved non-shared.4  (file://${BASEDIR}/non-shared.tgz)
+-> installed extra.3
+-> installed no-extra.3
+-> installed non-shared.4
+Done.
+### : From archive with top directory and extra sources :
+### <shared/shared.ml>
+print_endline "I am a shared code"
+### <non-shared/non-shared.ml>
+print_endline "I am a non shared code"
+### tar czf shared.tgz shared
+### tar czf non-shared.tgz non-shared
+### <pkg:no-extra.3>
+opam-version: "2.0"
+build: [
+  [ "ocaml" "shared.ml" ]
+  [ "ocaml" "extra_source.ml" ]
+]
+### <pkg:extra.3>
+opam-version: "2.0"
+build: [
+  [ "ocaml" "shared.ml" ]
+  [ "ocaml" "extra_uniq.ml" ]
+  [ "ocaml" "extra_source.ml" ]
+]
+### <extra/extra_source.ml>
+print_endline "I am an extra sourced code!"
+### <pkg:non-shared.4>
+opam-version: "2.0"
+build: [ "ocaml" "non-shared.ml" ]
+### sh mkurl.sh shared no-extra.3 extra.3
+### sh mkurl.sh non-shared non-shared.4
+### <mkextrasource.sh>
+src=$1
+shift
+for p in $@; do
+  file="REPO/packages/${p%.*}/$p/opam"
+  echo "extra-source \"$src\" {" >> $file
+  echo "src: \"extra/$src\"" >> $file
+  MD5=$(openssl md5 extra/$src | cut -d' ' -f2)
+  echo "checksum: \"md5=$MD5\"" >> $file
+  echo "}" >> $file
+done
+### sh mkextrasource.sh extra_source.ml extra.3 no-extra.3
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### opam install no-extra extra non-shared --cudf dotty | unordered
+The following actions will be performed:
+  - recompile no-extra   3
+  - recompile extra      3
+  - recompile non-shared 4
+===== 3 to recompile =====
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved extra.3  (file://${BASEDIR}/shared.tgz)
+-> retrieved no-extra.3  (cached)
+-> retrieved non-shared.4  (file://${BASEDIR}/non-shared.tgz)
+-> removed   extra.3
+-> installed extra.3
+-> removed   no-extra.3
+-> installed no-extra.3
+-> removed   non-shared.4
+-> installed non-shared.4
+Done.
+### cat dotty-actions-explicit.dot
+digraph G {
+  "install no-extra.3";
+  "install non-shared.4";
+  "fetch extra.3";
+  "build non-shared.4";
+  "build no-extra.3";
+  "install extra.3";
+  "build extra.3";
+  "remove extra.3";
+  "fetch no-extra.3";
+  "remove non-shared.4";
+  "remove no-extra.3";
+  "fetch non-shared.4";
+  
+  
+  "fetch extra.3" -> "remove extra.3";
+  "fetch extra.3" -> "build extra.3";
+  "build non-shared.4" -> "remove non-shared.4";
+  "build non-shared.4" -> "install non-shared.4";
+  "build no-extra.3" -> "remove no-extra.3";
+  "build no-extra.3" -> "install no-extra.3";
+  "build extra.3" -> "remove extra.3";
+  "build extra.3" -> "install extra.3";
+  "remove extra.3" -> "install extra.3";
+  "fetch no-extra.3" -> "remove no-extra.3";
+  "fetch no-extra.3" -> "build no-extra.3";
+  "remove non-shared.4" -> "install non-shared.4";
+  "remove no-extra.3" -> "install no-extra.3";
+  "fetch non-shared.4" -> "remove non-shared.4";
+  "fetch non-shared.4" -> "build non-shared.4";
+  
+  }
+### : several hashes handling
+### <pkg:no-extra.3>
+opam-version: "2.0"
+build: [ "ocaml" "shared.ml" ]
+### <pkg:extra.3>
+opam-version: "2.0"
+build: [ "ocaml" "shared.ml" ]
+depends: [ "no-extra" ]
+### <pkg:intra.3>
+opam-version: "2.0"
+build: [ "ocaml" "shared.ml" ]
+depends: [ "extra" ]
+### <pkg:in.3>
+opam-version: "2.0"
+### <pkg:out.3>
+opam-version: "2.0"
+build: [ "ocaml" "shared.ml" ]
+depends: [ "intra" "in" ]
+### <mkurl.sh>
+arch=shared
+pkg=$1
+shift
+file="REPO/packages/${pkg%.*}/$pkg/opam"
+echo "url {" >> $file
+echo "src: \"$arch.tgz\"" >> $file
+echo "checksum: [" >> $file
+for h in $@; do
+  HASH=$(openssl $h $arch.tgz | cut -d' ' -f2)
+  echo "\"$h=$HASH\"" >> $file
+done
+echo "  ]" >> $file
+echo "}" >> $file
+### sh mkurl.sh extra.3 md5 sha512
+### sh mkurl.sh no-extra.3 sha256 sha512
+### sh mkurl.sh intra.3 sha512
+### sh mkurl.sh out.3 md5
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### opam remove no-extra
+The following actions will be performed:
+  - remove extra    3 [uses no-extra]
+  - remove no-extra 3
+===== 2 to remove =====
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   extra.3
+-> removed   no-extra.3
+Done.
+### opam install out
+The following actions will be performed:
+  - install in       3 [required by out]
+  - install no-extra 3 [required by extra]
+  - install extra    3 [required by intra]
+  - install intra    3 [required by out]
+  - install out      3
+===== 5 to install =====
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved extra.3  (cached)
+-> installed in.3
+-> retrieved intra.3  (file://${BASEDIR}/shared.tgz)
+-> retrieved no-extra.3  (cached)
+-> retrieved out.3  (cached)
+-> installed no-extra.3
+-> installed extra.3
+-> installed intra.3
+-> installed out.3
+Done.
+### opam remove no-extra in
+The following actions will be performed:
+  - remove out      3 [uses in]
+  - remove intra    3 [uses extra]
+  - remove in       3
+  - remove extra    3 [uses no-extra]
+  - remove no-extra 3
+===== 5 to remove =====
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   out.3
+-> removed   in.3
+-> removed   intra.3
+-> removed   extra.3
+-> removed   no-extra.3
+Done.
+### <pkg:extra.3>
+opam-version: "2.0"
+build: [ "ocaml" "shared.ml" ]
+depends: [ "no-extra" ]
+### <mkurl.sh>
+p=extra.3
+arch=shared
+file="REPO/packages/${p%.*}/$p/opam"
+echo "url {" >> $file
+echo "src: \"$arch.tgz\"" >> $file
+MD5="01234567890123456789012345678901"
+echo "checksum: \"md5=$MD5\"" >> $file
+echo "}" >> $file
+### sh mkurl.sh
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### opam install out | '[0-9a-f]{32,}' -> "a-given-hash" | grep -v "switch import"
+The following actions will be performed:
+  - install in       3 [required by out]
+  - install no-extra 3 [required by extra]
+  - install extra    3 [required by intra]
+  - install intra    3 [required by out]
+  - install out      3
+===== 5 to install =====
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[ERROR] extra.3: Checksum mismatch for file://${BASEDIR}/shared.tgz:
+          expected md5=a-given-hash
+          got      md5=a-given-hash
+[ERROR] Failed to get sources of extra.3: Checksum mismatch
+-> installed in.3
+-> retrieved intra.3  (cached)
+-> retrieved no-extra.3  (cached)
+-> retrieved out.3  (cached)
+-> installed no-extra.3
+
+OpamSolution.Fetch_fail("Checksum mismatch")
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - fetch extra 3
++- 
++- The following changes have been performed (the rest was aborted)
+| - install in       3
+| - install no-extra 3
++- 
+
+The former state can be restored with:
+# Return code 40 #

--- a/tests/reftests/shared-fetch.test
+++ b/tests/reftests/shared-fetch.test
@@ -14,7 +14,6 @@ build: [
   [ "ocaml" "shared.ml" ]
   [ "ocaml" "extra_uniq.ml" ]
 ]
-#patches: ["shared.patch"]
 ### <pkg:extra.3:extra_uniq.ml>
 print_endline "I am a non shared code"
 ### <pkg:non-shared.4>
@@ -48,8 +47,7 @@ The following actions will be performed:
 ===== 3 to install =====
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved extra.3  (file://${BASEDIR}/shared.tgz)
--> retrieved no-extra.3  (cached)
+-> retrieved extra.3, no-extra.3  (file://${BASEDIR}/shared.tgz)
 -> retrieved non-shared.4  (file://${BASEDIR}/non-shared.tgz)
 -> installed extra.3
 -> installed no-extra.3
@@ -107,8 +105,7 @@ The following actions will be performed:
 ===== 3 to recompile =====
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved extra.3  (file://${BASEDIR}/shared.tgz)
--> retrieved no-extra.3  (cached)
+-> retrieved extra.3, no-extra.3  (file://${BASEDIR}/shared.tgz)
 -> retrieved non-shared.4  (file://${BASEDIR}/non-shared.tgz)
 -> removed   extra.3
 -> installed extra.3
@@ -119,22 +116,25 @@ The following actions will be performed:
 Done.
 ### cat dotty-actions-explicit.dot
 digraph G {
+  "fetch extra.3, no-extra.3";
   "install no-extra.3";
   "install non-shared.4";
-  "fetch extra.3";
+  "fetch non-shared.4";
   "build non-shared.4";
   "build no-extra.3";
   "install extra.3";
   "build extra.3";
   "remove extra.3";
-  "fetch no-extra.3";
   "remove non-shared.4";
   "remove no-extra.3";
-  "fetch non-shared.4";
   
   
-  "fetch extra.3" -> "remove extra.3";
-  "fetch extra.3" -> "build extra.3";
+  "fetch extra.3, no-extra.3" -> "remove extra.3";
+  "fetch extra.3, no-extra.3" -> "remove no-extra.3";
+  "fetch extra.3, no-extra.3" -> "build extra.3";
+  "fetch extra.3, no-extra.3" -> "build no-extra.3";
+  "fetch non-shared.4" -> "remove non-shared.4";
+  "fetch non-shared.4" -> "build non-shared.4";
   "build non-shared.4" -> "remove non-shared.4";
   "build non-shared.4" -> "install non-shared.4";
   "build no-extra.3" -> "remove no-extra.3";
@@ -142,12 +142,8 @@ digraph G {
   "build extra.3" -> "remove extra.3";
   "build extra.3" -> "install extra.3";
   "remove extra.3" -> "install extra.3";
-  "fetch no-extra.3" -> "remove no-extra.3";
-  "fetch no-extra.3" -> "build no-extra.3";
   "remove non-shared.4" -> "install non-shared.4";
   "remove no-extra.3" -> "install no-extra.3";
-  "fetch non-shared.4" -> "remove non-shared.4";
-  "fetch non-shared.4" -> "build non-shared.4";
   
   }
 ### : several hashes handling
@@ -211,11 +207,8 @@ The following actions will be performed:
 ===== 5 to install =====
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved extra.3  (cached)
+-> retrieved extra.3, intra.3, no-extra.3, out.3  (cached)
 -> installed in.3
--> retrieved intra.3  (file://${BASEDIR}/shared.tgz)
--> retrieved no-extra.3  (cached)
--> retrieved out.3  (cached)
 -> installed no-extra.3
 -> installed extra.3
 -> installed intra.3
@@ -266,26 +259,27 @@ The following actions will be performed:
 ===== 5 to install =====
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-[ERROR] extra.3: Checksum mismatch for file://${BASEDIR}/shared.tgz:
+[ERROR] Conflicting file hashes, or broken or compromised cache!
+          - md5=a-given-hash (MISMATCH)
+          - md5=a-given-hash (match)
+          - sha256=a-given-hash (match)
+          - sha512=a-given-hash (match)
+
+[ERROR] extra.3, intra.3, no-extra.3, out.3: Checksum mismatch for file://${BASEDIR}/shared.tgz:
           expected md5=a-given-hash
           got      md5=a-given-hash
-[ERROR] Failed to get sources of extra.3: Checksum mismatch
+[ERROR] Failed to get sources of extra.3, intra.3, no-extra.3, out.3 (file://${BASEDIR}/shared.tgz): Checksum mismatch
 -> installed in.3
--> retrieved intra.3  (cached)
--> retrieved no-extra.3  (cached)
--> retrieved out.3  (cached)
--> installed no-extra.3
 
 OpamSolution.Fetch_fail("Checksum mismatch")
 
 
 <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 +- The following actions failed
-| - fetch extra 3
+| - fetch extra.3, intra.3, no-extra.3, out.3 
 +- 
-+- The following changes have been performed (the rest was aborted)
-| - install in       3
-| - install no-extra 3
++- The following changes have been performed
+| - install in 3
 +- 
 
 The former state can be restored with:


### PR DESCRIPTION
Regroup same (shared) archive source packages for fetching. They are regrouped in a single action `'Fetch` node, that now takes several packages. Download functions are also updated to handle fetching an archive once and copy to sources directories.