### PR TITLE
Fix behaviour when stdout gets closed

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -17,6 +17,7 @@ users)
   * Fix typo in error message for opam var [#4786 @kit-ty-kate - fix #4785]
   * Add cli 2.2 handling [#4853 @rjbou]
   * --no-depexts is the default in CLI 2.0 mode [#4908 @dra27]
+  * [BUG] Fix behaviour on closed stdout/stderr [#4901 @altgr - fix #4216]
 
 ## Plugins
   *

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -358,7 +358,8 @@ let rec main_catch_all f =
          "Update done, please now retry your command.\n";
        exit (OpamStd.Sys.get_exit_code `Aborted))
   | e ->
-    Sys.set_signal Sys.sigpipe Sys.Signal_default;
+    (try Sys.set_signal Sys.sigpipe Sys.Signal_default
+     with Invalid_argument _ -> ());
     flush_all_noerror ();
     if (OpamConsole.verbose ()) then
       OpamConsole.errmsg "'%s' failed.\n"

--- a/tests/reftests/list.unix.test
+++ b/tests/reftests/list.unix.test
@@ -1,4 +1,3 @@
 f372039d
 ### sh -c "opam list --depends-on dune -s --all-versions | head -n1"
 0install.2.14
-Fatal error: exception Sys_error("Broken pipe")


### PR DESCRIPTION
Restore the sigpipe handler before exiting, to prevent the finaliser
from crashing on flushes.

Closes #4216: the behaviour on that example is now to exit with code
141, and without an error message.