### PR TITLE
[WIP] Enable the fragile-match warning to avoid potential bugs when adding new cases

### DIFF
--- a/shell/context_flags.ml
+++ b/shell/context_flags.ml
@@ -7,7 +7,7 @@ let p = succ p in
 let _ocaml_minor = String.sub Sys.ocaml_version p (String.index_from Sys.ocaml_version p '.' - p) |> int_of_string in
 match Sys.argv.(1) with
 | "flags" ->
-    print_string "()"
+    print_string "(-w +4)"
 | "mingw-arch" ->
     if Config.system = "mingw64" then
       print_string "x86_64"

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2272,7 +2272,7 @@ let repository cli =
         if scope = [] ||
            List.exists (function
                | `This_switch | `Current_switch | `Switch _ -> true
-               | _ -> false)
+               | `All | `Default | `No_selection -> false)
              scope
         then switches
         else []

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1252,7 +1252,7 @@ let apply ?ask t ~requested ?add_roots ?(assume_built=false)
           ~requested ?add_roots ~assume_built ~download_only ?force_remove
           action_graph
       in
-      let success = match r with | OK _ -> true | _ -> false in
+      let success = match r with | OK _ -> true | Nothing_to_do | Aborted | Partial_error _ -> false in
       let post_session =
         let open OpamPackage.Set.Op in
         let local = [


### PR DESCRIPTION
Adding new cases to a variant type can cause bugs pretty easily when matching on it with a default case. Warning 4 (fragile-match) tries to remedy to this by alerting when such pattern is used.

Suggested in https://github.com/ocaml/opam/pull/4899#discussion_r745575772

*This is currently WIP as this requires to go in almost all source files and add the missing cases (or eventually remove the warning by hand) and I don’t have the time at the minute, so to not forget this I’m opening a draft PR*