### PR TITLE
Use --no-depexts in CLI 2.0 mode

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -16,6 +16,7 @@ users)
 ## Global CLI
   * Fix typo in error message for opam var [#4786 @kit-ty-kate - fix #4785]
   * Add cli 2.2 handling [#4853 @rjbou]
+  * --assume-depext is the default in CLI 2.0 mode [#4908 @dra27]
 
 ## Plugins
   *

--- a/master_changes.md
+++ b/master_changes.md
@@ -16,7 +16,7 @@ users)
 ## Global CLI
   * Fix typo in error message for opam var [#4786 @kit-ty-kate - fix #4785]
   * Add cli 2.2 handling [#4853 @rjbou]
-  * --assume-depext is the default in CLI 2.0 mode [#4908 @dra27]
+  * --no-depexts is the default in CLI 2.0 mode [#4908 @dra27]
 
 ## Plugins
   *

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -600,7 +600,7 @@ let create_build_options
     assume_depexts; no_depexts;
   }
 
-let apply_build_options b =
+let apply_build_options cli b =
   let open OpamStd.Option.Op in
   let flag f = if f then Some true else None in
   OpamRepositoryConfig.update
@@ -633,7 +633,7 @@ let apply_build_options b =
     ?show:(flag b.show)
     ?fake:(flag b.fake)
     ?skip_dev_update:(flag b.skip_update)
-    ?assume_depexts:(flag (b.assume_depexts || b.no_depexts))
+    ?assume_depexts:(flag (b.assume_depexts || b.no_depexts || OpamCLIVersion.Op.(cli @= cli2_0)))
     ~scrubbed_environment_variables
     ()
 

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -624,7 +624,7 @@ let apply_build_options cli b =
        OpamPackage.Name.Set.of_list)
     ?unlock_base:(flag b.unlock_base)
     ?locked:(if b.locked then Some (Some b.lock_suffix) else None)
-    ?no_depexts:(flag b.no_depexts)
+    ?no_depexts:(flag b.no_depexts || OpamCLIVersion.Op.(cli @= cli2_0))
     ();
   OpamClientConfig.update
     ?keep_build_dir:(flag b.keep_build_dir)
@@ -633,7 +633,7 @@ let apply_build_options cli b =
     ?show:(flag b.show)
     ?fake:(flag b.fake)
     ?skip_dev_update:(flag b.skip_update)
-    ?assume_depexts:(flag (b.assume_depexts || b.no_depexts || OpamCLIVersion.Op.(cli @= cli2_0)))
+    ?assume_depexts:(flag (b.assume_depexts || b.no_depexts))
     ~scrubbed_environment_variables
     ()
 

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -624,7 +624,7 @@ let apply_build_options cli b =
        OpamPackage.Name.Set.of_list)
     ?unlock_base:(flag b.unlock_base)
     ?locked:(if b.locked then Some (Some b.lock_suffix) else None)
-    ?no_depexts:(flag b.no_depexts || OpamCLIVersion.Op.(cli @= cli2_0))
+    ?no_depexts:(flag (b.no_depexts || OpamCLIVersion.Op.(cli @= cli2_0)))
     ();
   OpamClientConfig.update
     ?keep_build_dir:(flag b.keep_build_dir)

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -192,7 +192,7 @@ val recurse: OpamCLIVersion.Sourced.t -> bool Term.t
 val subpath: OpamCLIVersion.Sourced.t -> string option Term.t
 
 (** Applly build options *)
-val apply_build_options: build_options -> unit
+val apply_build_options: OpamCLIVersion.Sourced.t -> build_options -> unit
 
 (** Lock options *)
 val locked: ?section:string -> OpamCLIVersion.Sourced.t -> bool Term.t

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -310,7 +310,7 @@ let init cli =
       show_opamrc bypass_checks
       () =
     apply_global_options cli global_options;
-    apply_build_options build_options;
+    apply_build_options cli build_options;
     (* If show option is set, dump opamrc and exit *)
     if show_opamrc then
       (OpamFile.InitConfig.write_to_channel stdout @@
@@ -1614,7 +1614,7 @@ let install cli =
       restore destdir assume_built check recurse subpath depext_only
       download_only atoms_or_locals () =
     apply_global_options cli global_options;
-    apply_build_options build_options;
+    apply_build_options cli build_options;
     if atoms_or_locals = [] && not restore then
       `Error (true, "required argument PACKAGES is missing")
     else
@@ -1730,7 +1730,7 @@ let remove cli =
   let remove global_options build_options autoremove force destdir recurse
       subpath atom_locs () =
     apply_global_options cli global_options;
-    apply_build_options build_options;
+    apply_build_options cli build_options;
     OpamGlobalState.with_ `Lock_none @@ fun gt ->
     match destdir with
     | Some d ->
@@ -1803,7 +1803,7 @@ let reinstall cli =
   let reinstall global_options build_options assume_built recurse subpath
       atoms_locs cmd () =
     apply_global_options cli global_options;
-    apply_build_options build_options;
+    apply_build_options cli build_options;
     let open OpamPackage.Set.Op in
     OpamGlobalState.with_ `Lock_none @@ fun gt ->
     match cmd, atoms_locs with
@@ -1974,7 +1974,7 @@ let upgrade cli =
   let upgrade global_options build_options fixup check only_installed all
       recurse subpath atom_locs () =
     apply_global_options cli global_options;
-    apply_build_options build_options;
+    apply_build_options cli build_options;
     let all = all || atom_locs = [] in
     OpamGlobalState.with_ `Lock_none @@ fun gt ->
     if fixup then
@@ -2553,7 +2553,7 @@ let switch cli =
       OpamConsole.warning "Option %s is deprecated, ignoring it."
         (OpamConsole.colorise `bold "--no-autoinstall");
     apply_global_options cli global_options;
-    apply_build_options build_options;
+    apply_build_options cli build_options;
     let invariant_arg ?repos rt args =
       match args, packages, formula, empty with
       | [], None, None, false -> None
@@ -3107,7 +3107,7 @@ let pin ?(unpin_only=false) cli =
       with_version
       command params () =
     apply_global_options cli global_options;
-    apply_build_options build_options;
+    apply_build_options cli build_options;
     let locked = OpamStateConfig.(!r.locked) <> None in
     let action = not no_act in
     let get_command = function


### PR DESCRIPTION
As we continue the puzzle for allowing CI workflows to work properly with CLI versioning, we hit another slight tweak. In opam-depext 1.2 we focused on ensuring that `opam depext` worked in a compatible way. However, there is a slightly subtle interaction with CLI versioning and built-in depext:

```
OPAMCLI=2.0 opam install conf-npm
```
requires, on Ubuntu, the `npm` package but the package may succeed if the user has installed npm manually (or via another mechanism than apt). opam's built-in depext is now a nuisance, as it forces interaction, cf. [this ocaml-cohttp workflow](https://github.com/dra27/ocaml-cohttp/runs/4190685413?check_suite_focus=true#step:7:211):

```
===== ∗ 163 =====

The following system packages will first need to be installed:
    npm

<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><><><>
Let opam run your package manager to install the required system packages?
(answer 'n' for other options) [Y/n] n
This command should get the requirements installed:

    apt-get install npm

You can retry with '--assume-depexts' to skip this check, or run 'opam option depext=false' to permanently disable handling of system packages altogether.
```

In CLI 2.0 mode, `--assume-depexts` of course isn't available, neither - correctly - is `--confirm-level=unsafe-yes`. This PR changes the default mode of depext to be `--assume-depext` in CLI 2.0 mode. We could select `--no-depexts` as the default, but I think the resulting messages, e.g. from [this adapted workflow](https://github.com/dra27/ocaml-cohttp/runs/4190938818?check_suite_focus=true#step:7:208) provides better output if the depexts are _actually_ missing:

```
===== ∗ 163 =====

The following system packages will first need to be installed:
    npm

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
```

so I think it's worth the cost of the extra depext check, as a failure later on (if `conf-npm` didn't install) would have a visible remedy further up.