### PR TITLE
Fix deps-only with depopts

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -27,7 +27,7 @@ users)
   *
 
 ## Install
-  *
+  * When installing with deps-only, depopts are removed because on reinstall actions are explosed [#4914 @rjbou - fix #4911]
 
 ## Remove
   *

--- a/tests/reftests/deps-only.test
+++ b/tests/reftests/deps-only.test
@@ -25,5 +25,4 @@ The following actions will be performed:
 Done.
 ### opam install bar --deps-only --show
 The following actions would be performed:
-  - remove baz 1
-
+  - recompile baz 1

--- a/tests/reftests/deps-only.test
+++ b/tests/reftests/deps-only.test
@@ -1,0 +1,29 @@
+N0REP0
+### <pkg:foo.1>
+opam-version: "2.0"
+### <pkg:bar.1>
+opam-version: "2.0"
+depends: "foo"
+### <pkg:baz.1>
+opam-version: "2.0"
+depopts: "bar"
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### opam switch create deps-only --empty
+### opam install foo baz | unordered
+The following actions will be performed:
+  - install foo 1
+  - install baz 1
+===== 2 to install =====
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed baz.1
+-> installed foo.1
+Done.
+### opam install bar --deps-only --show
+The following actions would be performed:
+  - remove baz 1
+

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -119,6 +119,23 @@
    (run ./run.exe %{bin:opam} %{dep:cudf-preprocess.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-deps-only)
+ (action
+  (diff deps-only.test deps-only.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-deps-only)))
+
+(rule
+ (targets deps-only.out)
+ (deps root-N0REP0)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:deps-only.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-dot-install)
  (action
   (diff dot-install.test dot-install.out)))


### PR DESCRIPTION
Packages to reinstall/recompile were removed. Fix #4911 
There is no more removal of depopts, but remains some unneeded recompiling (trigered by the main package).