### PR TITLE
Add a warning if an external executable is not in `PATH`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -53,6 +53,7 @@ users)
   * Ensure setenv can use package variables defined during the build [#4841 @dra27]
   * [BUG] Fix `set-invariant: default repos were loaded instead of switch repos [#4866 @rjbou]
   * Add support for `opam switch -` (go to previous non-local switch) [#4910 @kit-ty-kate - fix 4866]
+  * On loading, check for executable external files if they are in `PATH`, and warn if not the case [#4932 @rjbou - fix #4923]
 
 ## Pin
   * Switch the default version when undefined from ~dev to dev [#4949 @kit-ty-kate]
@@ -348,3 +349,4 @@ users)
   * `OpamSystem.real_path`: Remove the double chdir trick on OCaml >= 4.13.0 [#4961 @kit-ty-kate]
   * `OpamProcess.wait_one`: display command in verbose mode for finished found process [#5091 @rjbou]
   * `OpamStd.Config.E`: add a `REMOVED` variant to allow removing completely an environment variable handling [#5112 @rjbou]
+  * `OpamHash`: add `is_null`

--- a/src/core/opamHash.ml
+++ b/src/core/opamHash.ml
@@ -64,6 +64,12 @@ let len = function
 
 let valid kind = is_hex_str (len kind)
 
+let is_null h =
+  let count_not_zero c =
+    function '0' -> c | _ -> succ c
+  in
+  OpamStd.String.fold_left count_not_zero 0 (contents h) <> 0
+
 let make kind s =
   if valid kind s then kind, String.lowercase_ascii s
   else invalid_arg ("OpamHash.make_"^string_of_kind kind)

--- a/src/core/opamHash.mli
+++ b/src/core/opamHash.mli
@@ -28,6 +28,9 @@ include OpamStd.ABSTRACT with type t := t
 
 val of_string_opt: string -> t option
 
+(** Check if [hash] contains only 0 *)
+val is_null: t -> bool
+
 (** returns a sub-path specific to this hash, e.g.
     "md5/d4/d41d8cd98f00b204e9800998ecf8427e", as a list *)
 val to_path: t -> string list


### PR DESCRIPTION
fix #4923