### PR TITLE
Actually permit multiple state caches to co-exist

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -124,6 +124,7 @@ users)
   * Handle empty environment variable updates - missed cherry-pick from 2.0 [#4840 @dra27]
   * Repository state: stop scanning directory once opam file is found [#4847 @rgrinberg]
   * Fix reverting environment additions to PATH-like variables when several dirs added at once [#4861 @dra27]
+  * Actually allow multiple state caches to co-exist [#4934 @dra27 - fix #4554 properly this time]
 
 ## Opam file format
   *

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -36,8 +36,7 @@ module Cache = struct
     in
     List.iter remove_cache_file (OpamFilename.files cache_dir)
 
-  let save rt =
-    let file = OpamPath.state_cache rt.repos_global.root in
+  let marshall rt =
     (* Repository without remote are not cached, they are intended to be
        manually edited *)
     let filter_out_nourl repos_map =
@@ -49,7 +48,6 @@ module Cache = struct
            with Not_found -> false)
         repos_map
     in
-    let t =
       { cached_repofiles =
           OpamRepositoryName.Map.bindings
             (filter_out_nourl rt.repos_definitions);
@@ -57,9 +55,16 @@ module Cache = struct
           OpamRepositoryName.Map.bindings
             (filter_out_nourl rt.repo_opams);
       }
-    in
+
+  let file rt =
+    OpamPath.state_cache rt.repos_global.root
+
+  let save rt =
     remove ();
-    C.save file t
+    C.save (file rt) (marshall rt)
+
+  let save_new rt =
+    C.save (file rt) (marshall rt)
 
   let load root =
     let file = OpamPath.state_cache root in
@@ -231,7 +236,7 @@ let load lock_kind gt =
         repos_map (OpamRepositoryName.Map.empty, OpamRepositoryName.Map.empty)
     in
     let rt = make_rt repofiles opams in
-    Cache.save rt;
+    Cache.save_new rt;
     rt
 
 let find_package_opt rt repo_list nv =


### PR DESCRIPTION
Apropos this morning's dev meeting, it turns out that #4642 is as correct as @AltGr's assertion in https://github.com/ocaml/opam/issues/4930#issuecomment-979931192 😀

`OpamRepositoryState.Cache.save` clears all the other caches away, which
is correct _except_ when initialising the cache for the first time, which rather defeats the point. This PR ensures that when the cache is written for the first time, it doesn't erase other caches. All the other (external) paths to the repo cache go via the normal `save` method, and will correctly clear any other caches out of the way.

The behaviour can be seen with this repro for #4554 between opam 2.1.1 and opam-state 2.1.0:

```
FROM ocaml/opam
RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && opam init --reinit -a
RUN cd ~/opam-repository/packages/opam-0install/opam-0install.0.4.2 ; echo 'flags: plugin' >> opam ; git add -u ; git commit -m 'flags' ; opam update
RUN opam install opam-0install opam-state.2.1.0
RUN ls -l ~/.opam/repo
RUN opam 0install dune > /dev/null
RUN ls -l ~/.opam/repo
RUN opam info dune > /dev/null
RUN ls -l ~/.opam/repo
```

The three ls calls will show:
1. `state-028890EA.cache` (opam 2.1.1 state cache)
2. `state-392B1E43.cache` (opam-state 2.1.0 state cache, the other one is deleted)
3. `state-028890EA.cache` (opam 2.1.1 state cache; again the other one is deleted)

Switch in opam 2.1 + this PR, you get:
1. `state-18227757.cache` (opam 2.1.2* state cache)
2. `state-392B1E43.cache` (opam-state 2.1.0 state cache, the 2.1.2 cache is incorrectly deleted by opam-state 2.1.0)
3. `state-18227757.cache` **and** `state-392B1E43.cache` (opam 2.1.2* regenerates its state cache and now correctly leaves the other one alone)

Then pin opam-state to this PR, and you get the complete correct outcome:
1. `state-18227757.cache` (opam 2.1.2* state cache)
2. `state-3F983742.cache` **and** `state-18227757.cache` (opam-state 2.1.2* correctly _adds_ its cache)
3. `state-3F983742.cache` **and** `state-18227757.cache` (no change)