### PR TITLE
Check whether the repository might need updating more often

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -134,7 +134,7 @@ users)
   * Refactored, fixed, improved and optimised the z3 solver backend [#4878 @altgr]
 
 ## Client
-  *
+  * Check whether the repository might need updating more often [#4935 @kit-ty-kate]
 
 ## Internal
   * Add license and lowerbounds to opam files [#4714 @kit-ty-kate]

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -133,7 +133,6 @@ let get_installed_atoms t atoms =
 (* Check atoms for pinned packages, and update them. Returns the state that
    may have been reloaded if there were changes *)
 let update_dev_packages_t ?(only_installed=false) atoms t =
-  OpamRepositoryState.check_last_update ();
   if OpamClientConfig.(!r.skip_dev_update) then t else
   let working_dir = OpamClientConfig.(!r.working_dir || !r.inplace_build) in
   let to_update =

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1279,6 +1279,7 @@ let resolve t action ~orphans ?reinstall ~requested request =
       (`A (List.map (fun s -> `String s) (Array.to_list Sys.argv)));
     OpamJson.append "switch" (OpamSwitch.to_json t.switch)
   );
+  OpamRepositoryState.check_last_update ();
   let universe =
     OpamSwitchState.universe t ~requested ?reinstall action
   in

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -204,7 +204,6 @@ let install_compiler
      OpamEnv.check_and_print_env_warning t);
     t
   end else
-  let () = OpamRepositoryState.check_last_update () in
   let atoms = OpamFormula.atoms invariant in
   let names_of_atoms at = OpamPackage.Name.Set.of_list (List.map fst at) in
   let comp_roots = names_of_atoms atoms in


### PR DESCRIPTION
Currently many of the users encountering issues with opam and asking about it on the forum encounter the following problem:

- They try to install a new package
- It fails because they forgot to call opam update
- They give up or have to ask about it
- If they ask about it, the answer is 99% always the same: you forgot to opam update

This PR makes it so that the reminder to call opam update appears more often, not just on opam upgrade.