### PR TITLE
opam admin cache: only fill missing by default

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -115,7 +115,8 @@ users)
   *
 
 ## Admin
-  *
+  * ✘ `opam admin cache` now ignores all already present cache files. Option
+    `--check-all` restores the previous behaviour of validating all checksums.
 
 ## Opam installer
   *


### PR DESCRIPTION
and add a `--check-all` option for the previous behaviour

Please update `master_changes.md` file with your changes.
