### PR TITLE
Windows: remove double printing on commands and their output

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -148,6 +148,7 @@ users)
   * Bump version to 2.2.0~alpha~dev [#4725 @dra27]
   * Add specific comparison function on several module (that includes `OpamStd.ABSTRACT`) [#4918 @rjbou]
   * Homogeneise is_archive tar & zip: if file exists check magic number, otherwise check extension [#4964 @rjbou]
+  * [BUG] Remove windows double printing on commands and their output [#4940 @rjbou]
 
 ## Internal: Windows
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -639,8 +639,8 @@ let exit_status p return =
   if isset_verbose_f () then
     stop_verbose_f ()
   else if p.p_verbose then
-    (verbose_print_cmd p;
-     List.iter verbose_print_out stdout;
+    (List.iter verbose_print_out stdout;
+     if p.p_stdout <> p.p_stderr then
      List.iter verbose_print_out stderr;
      flush OpamCompat.Stdlib.stdout);
   let info =


### PR DESCRIPTION
A specific behavior is set for non windows devices to handle verbose printing of commands and their output. This makes windows workflow go into the fallback one, and have the double printing.