### PR TITLE
Make the release script setup-less using QEMU, Docker and Rosetta 2

### DIFF
--- a/dune
+++ b/dune
@@ -1,1 +1,1 @@
-(dirs :standard \ bootstrap)
+(dirs :standard \ bootstrap release)

--- a/master_changes.md
+++ b/master_changes.md
@@ -214,6 +214,9 @@ users)
   * Adapt Windows CI to new safe.directory setting [#5119 @dra27]
   * Bid a fond farewell to AppVeyor, with thanks for 5100+ CI builds [#5134 @dra27]
 
+## Release scripts
+  * Make the release script setup-less using QEMU, Docker and Rosetta 2 [#4947 @kit-ty-kate]
+
 ## Admin
   * ✘ `opam admin cache` now ignores all already present cache files. Option
     `--check-all` restores the previous behaviour of validating all checksums.

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -7,15 +7,15 @@ RUN apk add gcc g++ make coreutils openssl
 
 RUN addgroup -S opam && adduser -S opam -G opam -s /bin/sh
 
-ADD https://caml.inria.fr/pub/distrib/ocaml-4.13/ocaml-4.13.1.tar.gz /root/
+ADD https://github.com/ocaml/ocaml/archive/refs/tags/%OCAMLV%.tar.gz /root/
 
 WORKDIR /root
-RUN tar xzf ocaml-4.13.1.tar.gz
-WORKDIR ocaml-4.13.1
+RUN tar xzf %OCAMLV%.tar.gz
+WORKDIR ocaml-%OCAMLV%
 RUN sed -i 's/gnueabi/*eabi/' configure
 RUN sed -i 's/musl/musl*/' configure
 RUN ./configure %CONF% -prefix /usr/local
-RUN make world opt.opt && make install && rm -rf /root/ocaml-4.13.1 /root/ocaml-4.13.1.tar.gz
+RUN make world opt.opt && make install && rm -rf /root/ocaml-%OCAMLV% /root/ocaml-%OCAMLV%.tar.gz
 
 RUN apk add patch
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -35,15 +35,15 @@ $(OUTDIR)/opam-full-$(VERSION).tar.gz:
 	}
 
 build/Dockerfile.x86_64-linux: Dockerfile.in
-	mkdir -p build && sed 's/%TARGET_TAG%/x86_64-v3.13/g' $^ | sed 's/%CONF%//g' >$@
+	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/x86_64-v3.13/g' -e 's/%CONF%//g' $^ >$@
 build/Dockerfile.i686-linux: Dockerfile.in
-	mkdir -p build && sed 's/%TARGET_TAG%/x86-v3.13/g' $^ | sed 's/%CONF%/-build i586-alpine-linux-musl/g' >$@
+	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/x86-v3.13/g' -e 's/%CONF%/-build i586-alpine-linux-musl/g' $^ >$@
 
 # Need to lie about gnueabihf instead of musleabihf, because of a ./configure bug
 build/Dockerfile.armhf-linux: Dockerfile.in
-	mkdir -p build && sed 's/%TARGET_TAG%/armv7-v3.13/g' $^ | sed 's/%CONF%//g' >$@
+	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/armv7-v3.13/g' -e 's/%CONF%//g' $^ >$@
 build/Dockerfile.arm64-linux: Dockerfile.in
-	mkdir -p build && sed 's/%TARGET_TAG%/arm64-v3.13/g' $^ | sed 's/%CONF%//g' >$@
+	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/arm64-v3.13/g' -e 's/%CONF%//g' $^ >$@
 
 
 build/%.image: build/Dockerfile.%

--- a/release/Makefile
+++ b/release/Makefile
@@ -141,3 +141,10 @@ qemu: $(OUTDIR)/opam-full-$(VERSION).tar.gz
 	scp -P "$(QEMU_PORT)" "$^" "root@localhost:$(REMOTE_DIR)/$^"
 	ssh -p "$(QEMU_PORT)" root@localhost 'sh -c "cd $(REMOTE_DIR) && ulimit -s 8192 && $(REMOTE_MAKE) host TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV)"'
 	scp -P "$(QEMU_PORT)" "root@localhost:$(REMOTE_DIR)/$(OUTDIR)/opam-$(VERSION)*" "$(OUTDIR)/"
+
+macos-local: $(OUTDIR)/opam-full-$(VERSION).tar.gz
+	dir=$(mktemp -d) && \
+          mkdir -p "${dir}/${OUTDIR}" && \
+          cp Makefile "$^" "${dir}" && \
+          cd "${dir}" && ulimit -s 8192 && arch -arch $(ARCH) make host TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV) && \
+          cp "${dir}/$(OUTDIR)/opam-$(VERSION)*" "$(OUTDIR)/"

--- a/release/Makefile
+++ b/release/Makefile
@@ -134,19 +134,21 @@ distclean: clean
 
 REMOTE_DIR = /tmp/opam-release
 REMOTE_MAKE = make
+SSH = ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+SCP = scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
 remote: $(OUTDIR)/opam-full-$(VERSION).tar.gz
-	ssh "$(REMOTE)" "mkdir -p $(REMOTE_DIR)/${OUTDIR}"
-	scp Makefile "$(REMOTE):$(REMOTE_DIR)/"
-	scp "$^" "$(REMOTE):$(REMOTE_DIR)/$^"
-	ssh "$(REMOTE)" 'sh -c "cd $(REMOTE_DIR) && ulimit -s 8192 && $(REMOTE_MAKE) -j$(JOBS) host TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV)"'
-	scp "$(REMOTE):$(REMOTE_DIR)/$(OUTDIR)/opam-$(VERSION)*" "$(OUTDIR)/"
+	$(SSH) "$(REMOTE)" "mkdir -p $(REMOTE_DIR)/${OUTDIR}"
+	$(SCP) Makefile "$(REMOTE):$(REMOTE_DIR)/"
+	$(SCP) "$^" "$(REMOTE):$(REMOTE_DIR)/$^"
+	$(SSH) "$(REMOTE)" 'sh -c "cd $(REMOTE_DIR) && ulimit -s 8192 && $(REMOTE_MAKE) host TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV)"'
+	$(SCP) "$(REMOTE):$(REMOTE_DIR)/$(OUTDIR)/opam-$(VERSION)*" "$(OUTDIR)/"
 
 qemu: $(OUTDIR)/opam-full-$(VERSION).tar.gz
-	ssh -p "$(QEMU_PORT)" root@localhost "mkdir -p $(REMOTE_DIR)/${OUTDIR}"
-	scp -P "$(QEMU_PORT)" Makefile "root@localhost:$(REMOTE_DIR)/"
-	scp -P "$(QEMU_PORT)" "$^" "root@localhost:$(REMOTE_DIR)/$^"
-	ssh -p "$(QEMU_PORT)" root@localhost 'sh -c "cd $(REMOTE_DIR) && ulimit -s 8192 && $(REMOTE_MAKE) host TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV)"'
-	scp -P "$(QEMU_PORT)" "root@localhost:$(REMOTE_DIR)/$(OUTDIR)/opam-$(VERSION)*" "$(OUTDIR)/"
+	$(SSH) -p "$(QEMU_PORT)" root@localhost "mkdir -p $(REMOTE_DIR)/${OUTDIR}"
+	$(SCP) -P "$(QEMU_PORT)" Makefile "root@localhost:$(REMOTE_DIR)/"
+	$(SCP) -P "$(QEMU_PORT)" "$^" "root@localhost:$(REMOTE_DIR)/$^"
+	$(SSH) -p "$(QEMU_PORT)" root@localhost 'sh -c "cd $(REMOTE_DIR) && ulimit -s 8192 && $(REMOTE_MAKE) host JOBS=$(JOBS) TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV)"'
+	$(SCP) -P "$(QEMU_PORT)" "root@localhost:$(REMOTE_DIR)/$(OUTDIR)/opam-$(VERSION)*" "$(OUTDIR)/"
 
 macos-local: $(OUTDIR)/opam-full-$(VERSION).tar.gz
 	LOCAL_RELEASE_DIR=$(shell mktemp -d); \

--- a/release/Makefile
+++ b/release/Makefile
@@ -15,6 +15,9 @@ HOST_OS = $(shell uname -s | tr A-Z a-z | sed 's/darwin/macos/')
 HOST = $(shell uname -m | sed 's/amd64/x86_64/')-$(HOST_OS)
 OUTDIR = out/$(TAG)
 
+# The equivalent of "which <cmd>". Taken from the GNU Make documentation
+pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
+
 all: $(patsubst %,$(OUTDIR)/opam-$(VERSION)-%,$(TARGETS))
 
 $(OUTDIR)/opam-full-$(VERSION).tar.gz:
@@ -25,8 +28,8 @@ $(OUTDIR)/opam-full-$(VERSION).tar.gz:
 	    opam-full-$(VERSION)/configure.ac.tmp; \
 	  mv opam-full-$(VERSION)/configure.ac.tmp \
 	    opam-full-$(VERSION)/configure.ac; \
-	  $(MAKE) -C opam-full-$(VERSION) configure download-ext; \
-	  tar cz --exclude-vcs opam-full-$(VERSION) -f $(notdir $@); \
+	  $(MAKE) -C opam-full-$(VERSION) OCAML=$(call pathsearch,ocaml) configure download-ext; \
+	  tar cz -f $(notdir $@) --exclude-vcs opam-full-$(VERSION); \
 	  rm -rf opam-full-$(VERSION); \
 	}
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -122,7 +122,7 @@ $(OUTDIR)/opam-$(VERSION)-%-linux: $(OUTDIR)/opam-full-$(VERSION).tar.gz build/%
 	docker run --rm -i \
 	  -e "VERSION=$(VERSION)" \
 	  -e "TARGET=$*-linux" \
-	  -e "LINKING=$(call LINKING,$(HOST_OS))" \
+	  -e "LINKING=$(call LINKING,linux)" \
 	  opam-build-$*-linux \
 	  <$< >$@
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -133,3 +133,10 @@ remote: $(OUTDIR)/opam-full-$(VERSION).tar.gz
 	scp "$^" "$(REMOTE):$(REMOTE_DIR)/$^"
 	ssh "$(REMOTE)" 'sh -c "cd $(REMOTE_DIR) && ulimit -s 8192 && $(REMOTE_MAKE) host TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV)"'
 	scp "$(REMOTE):$(REMOTE_DIR)/$(OUTDIR)/opam-$(VERSION)*" "$(OUTDIR)/"
+
+qemu: $(OUTDIR)/opam-full-$(VERSION).tar.gz
+	ssh -p "$(QEMU_PORT)" root@localhost "mkdir -p $(REMOTE_DIR)/${OUTDIR}"
+	scp -P "$(QEMU_PORT)" Makefile "root@localhost:$(REMOTE_DIR)/"
+	scp -P "$(QEMU_PORT)" "$^" "root@localhost:$(REMOTE_DIR)/$^"
+	ssh -p "$(QEMU_PORT)" root@localhost 'sh -c "cd $(REMOTE_DIR) && ulimit -s 8192 && $(REMOTE_MAKE) host TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV)"'
+	scp -P "$(QEMU_PORT)" "root@localhost:$(REMOTE_DIR)/$(OUTDIR)/opam-$(VERSION)*" "$(OUTDIR)/"

--- a/release/Makefile
+++ b/release/Makefile
@@ -66,10 +66,15 @@ CLINKING_macos = \
 -lstdc++
 
 CLINKING_openbsd = $(CLINKING_macos)
+CLINKING_freebsd = $(CLINKING_macos)
 
 LINKING = (-noautolink $(patsubst %,-cclib %,$(CLINKING_$(1))))
 
 EXPORTS_openbsd = \
+CPATH=/usr/local/include: \
+LIBRARY_PATH=/usr/local/lib: \
+
+EXPORTS_freebsd = \
 CPATH=/usr/local/include: \
 LIBRARY_PATH=/usr/local/lib: \
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -32,7 +32,7 @@ $(OUTDIR)/opam-full-$(VERSION).tar.gz:
 	  mv opam-full-$(VERSION)/configure.ac.tmp \
 	    opam-full-$(VERSION)/configure.ac; \
 	  $(MAKE) -C opam-full-$(VERSION) OCAML=$(call pathsearch,ocaml) configure download-ext; \
-	  tar cz -f $(notdir $@) --exclude-vcs opam-full-$(VERSION); \
+	  tar cz -f $(notdir $@) --exclude .git/ opam-full-$(VERSION); \
 	  rm -rf opam-full-$(VERSION); \
 	}
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -6,8 +6,6 @@ GIT_URL = ..
 
 FULL_ARCHIVE_URL = https://github.com/$(GH_USER)/opam/releases/download/$(VERSION)/opam-full-$(VERSION).tar.gz
 
-TARGETS = x86_64-linux i686-linux armhf-linux arm64-linux
-
 OCAMLV = 4.13.1
 # currently hardcoded in Dockerfile.in
 OCAML_URL = https://caml.inria.fr/pub/distrib/ocaml-$(basename $(OCAMLV))/ocaml-$(OCAMLV).tar.gz
@@ -19,7 +17,10 @@ OUTDIR = out/$(TAG)
 # The equivalent of "which <cmd>". Taken from the GNU Make documentation
 pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
 
-all: $(patsubst %,$(OUTDIR)/opam-$(VERSION)-%,$(TARGETS))
+x86_64-linux: $(OUTDIR)/opam-$(VERSION)-$@
+i686-linux: $(OUTDIR)/opam-$(VERSION)-$@
+armhf-linux: $(OUTDIR)/opam-$(VERSION)-$@
+arm64-linux: $(OUTDIR)/opam-$(VERSION)-$@
 
 $(OUTDIR)/opam-full-$(VERSION).tar.gz:
 	mkdir -p "$(OUTDIR)"

--- a/release/Makefile
+++ b/release/Makefile
@@ -140,7 +140,7 @@ qemu: $(OUTDIR)/opam-full-$(VERSION).tar.gz
 	ssh -p "$(QEMU_PORT)" root@localhost "mkdir -p $(REMOTE_DIR)/${OUTDIR}"
 	scp -P "$(QEMU_PORT)" Makefile "root@localhost:$(REMOTE_DIR)/"
 	scp -P "$(QEMU_PORT)" "$^" "root@localhost:$(REMOTE_DIR)/$^"
-	ssh -p "$(QEMU_PORT)" root@localhost 'sh -c "cd $(REMOTE_DIR) && ulimit -s 8192 && $(REMOTE_MAKE) -j$(JOBS) host TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV)"'
+	ssh -p "$(QEMU_PORT)" root@localhost 'sh -c "cd $(REMOTE_DIR) && ulimit -s 8192 && $(REMOTE_MAKE) host TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV)"'
 	scp -P "$(QEMU_PORT)" "root@localhost:$(REMOTE_DIR)/$(OUTDIR)/opam-$(VERSION)*" "$(OUTDIR)/"
 
 macos-local: $(OUTDIR)/opam-full-$(VERSION).tar.gz

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,9 +1,10 @@
+GH_USER = ocaml
 TAG = master
 VERSION = $(shell git describe $(TAG))
 OPAM_VERSION = $(subst -,~,$(VERSION))
 GIT_URL = ..
 
-FULL_ARCHIVE_URL = https://github.com/ocaml/opam/releases/download/$(VERSION)/opam-full-$(VERSION).tar.gz
+FULL_ARCHIVE_URL = https://github.com/$(GH_USER)/opam/releases/download/$(VERSION)/opam-full-$(VERSION).tar.gz
 
 TARGETS = x86_64-linux i686-linux armhf-linux arm64-linux
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -4,6 +4,7 @@ VERSION = $(shell git describe $(TAG))
 OPAM_VERSION = $(subst -,~,$(VERSION))
 GIT_URL = ..
 
+# TODO: For some reason Draft Releases do not have the $(VERSION) after download/ and instead have something like "untagged-<git-commit>"
 FULL_ARCHIVE_URL = https://github.com/$(GH_USER)/opam/releases/download/$(VERSION)/opam-full-$(VERSION).tar.gz
 
 OCAMLV = 4.13.1
@@ -17,10 +18,10 @@ OUTDIR = out/$(TAG)
 # The equivalent of "which <cmd>". Taken from the GNU Make documentation
 pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
 
-x86_64-linux: $(OUTDIR)/opam-$(VERSION)-$@
-i686-linux: $(OUTDIR)/opam-$(VERSION)-$@
-armhf-linux: $(OUTDIR)/opam-$(VERSION)-$@
-arm64-linux: $(OUTDIR)/opam-$(VERSION)-$@
+x86_64-linux: $(OUTDIR)/opam-$(VERSION)-x86_64-linux
+i686-linux: $(OUTDIR)/opam-$(VERSION)-i686-linux
+armhf-linux: $(OUTDIR)/opam-$(VERSION)-armhf-linux
+arm64-linux: $(OUTDIR)/opam-$(VERSION)-arm64-linux
 
 $(OUTDIR)/opam-full-$(VERSION).tar.gz:
 	mkdir -p "$(OUTDIR)"
@@ -86,8 +87,8 @@ build/$(HOST).env:
 	cd build/$(HOST) && curl -OL $(OCAML_URL)
 	cd build/$(HOST) && tar xzf ocaml-$(OCAMLV).tar.gz
 	cd build/$(HOST)/ocaml-$(OCAMLV) && \
-	  ./configure -prefix $(shell pwd)/build/$(HOST) && \
-	  $(MAKE) world opt.opt && \
+	  ./configure --prefix "$(shell pwd)/build/$(HOST)" && \
+	  $(MAKE) -j$(MACOS_JOBS) && \
 	  $(MAKE) install
 	rm -rf build/$(HOST)/ocaml-$(OCAMLV) build/$(HOST)/ocaml-$(OCAMLV).tar.gz
 	touch $@
@@ -132,19 +133,19 @@ remote: $(OUTDIR)/opam-full-$(VERSION).tar.gz
 	ssh "$(REMOTE)" "mkdir -p $(REMOTE_DIR)/${OUTDIR}"
 	scp Makefile "$(REMOTE):$(REMOTE_DIR)/"
 	scp "$^" "$(REMOTE):$(REMOTE_DIR)/$^"
-	ssh "$(REMOTE)" 'sh -c "cd $(REMOTE_DIR) && ulimit -s 8192 && $(REMOTE_MAKE) host TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV)"'
+	ssh "$(REMOTE)" 'sh -c "cd $(REMOTE_DIR) && ulimit -s 8192 && $(REMOTE_MAKE) -j$(JOBS) host TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV)"'
 	scp "$(REMOTE):$(REMOTE_DIR)/$(OUTDIR)/opam-$(VERSION)*" "$(OUTDIR)/"
 
 qemu: $(OUTDIR)/opam-full-$(VERSION).tar.gz
 	ssh -p "$(QEMU_PORT)" root@localhost "mkdir -p $(REMOTE_DIR)/${OUTDIR}"
 	scp -P "$(QEMU_PORT)" Makefile "root@localhost:$(REMOTE_DIR)/"
 	scp -P "$(QEMU_PORT)" "$^" "root@localhost:$(REMOTE_DIR)/$^"
-	ssh -p "$(QEMU_PORT)" root@localhost 'sh -c "cd $(REMOTE_DIR) && ulimit -s 8192 && $(REMOTE_MAKE) host TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV)"'
+	ssh -p "$(QEMU_PORT)" root@localhost 'sh -c "cd $(REMOTE_DIR) && ulimit -s 8192 && $(REMOTE_MAKE) -j$(JOBS) host TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV)"'
 	scp -P "$(QEMU_PORT)" "root@localhost:$(REMOTE_DIR)/$(OUTDIR)/opam-$(VERSION)*" "$(OUTDIR)/"
 
 macos-local: $(OUTDIR)/opam-full-$(VERSION).tar.gz
-	dir=$(mktemp -d) && \
-          mkdir -p "${dir}/${OUTDIR}" && \
-          cp Makefile "$^" "${dir}" && \
-          cd "${dir}" && ulimit -s 8192 && arch -arch $(ARCH) make host TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV) && \
-          cp "${dir}/$(OUTDIR)/opam-$(VERSION)*" "$(OUTDIR)/"
+	LOCAL_RELEASE_DIR=$(shell mktemp -d); \
+          mkdir -p "$${LOCAL_RELEASE_DIR}/${OUTDIR}" && \
+          cp Makefile "$^" "$${LOCAL_RELEASE_DIR}" && \
+          cd "$${LOCAL_RELEASE_DIR}" && ulimit -s 8192 && arch -arch $(MACOS_ARCH) make host MACOS_JOBS=$(JOBS) TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV) && \
+          cp $${LOCAL_RELEASE_DIR}/$(OUTDIR)/opam-$(VERSION)* "$(GIT_URL)/release/$(OUTDIR)/"

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,11 +1,7 @@
-GH_USER = ocaml
 TAG = master
 VERSION = $(shell git describe $(TAG))
 OPAM_VERSION = $(subst -,~,$(VERSION))
 GIT_URL = ..
-
-# TODO: For some reason Draft Releases do not have the $(VERSION) after download/ and instead have something like "untagged-<git-commit>"
-FULL_ARCHIVE_URL = https://github.com/$(GH_USER)/opam/releases/download/$(VERSION)/opam-full-$(VERSION).tar.gz
 
 OCAMLV = 4.13.1
 # currently hardcoded in Dockerfile.in
@@ -25,16 +21,14 @@ arm64-linux: $(OUTDIR)/opam-$(VERSION)-arm64-linux
 
 $(OUTDIR)/opam-full-$(VERSION).tar.gz:
 	mkdir -p "$(OUTDIR)"
-	cd "$(OUTDIR)" && curl -OfL $(FULL_ARCHIVE_URL) || { \
-	  git clone $(GIT_URL) -b $(TAG) --depth 1 opam-full-$(VERSION); \
-	  sed 's/^AC_INIT(opam,.*)/AC_INIT(opam,$(OPAM_VERSION))/' opam-full-$(VERSION)/configure.ac > \
-	    opam-full-$(VERSION)/configure.ac.tmp; \
-	  mv opam-full-$(VERSION)/configure.ac.tmp \
-	    opam-full-$(VERSION)/configure.ac; \
-	  $(MAKE) -C opam-full-$(VERSION) OCAML=$(call pathsearch,ocaml) configure download-ext; \
-	  tar cz -f $(notdir $@) --exclude .git/ opam-full-$(VERSION); \
-	  rm -rf opam-full-$(VERSION); \
-	}
+	git clone $(GIT_URL) -b $(TAG) "$(OUTDIR)/opam-full-$(VERSION)"
+	sed 's/^AC_INIT(opam,.*)/AC_INIT(opam,$(OPAM_VERSION))/' "$(OUTDIR)/opam-full-$(VERSION)/configure.ac" > \
+	  "$(OUTDIR)/opam-full-$(VERSION)/configure.ac.tmp"
+	mv "$(OUTDIR)/opam-full-$(VERSION)/configure.ac.tmp" \
+	  "$(OUTDIR)/opam-full-$(VERSION)/configure.ac"
+	$(MAKE) -C "$(OUTDIR)/opam-full-$(VERSION)" OCAML=$(call pathsearch,ocaml) configure download-ext
+	cd "$(OUTDIR)" && tar cz -f $(notdir $@) --exclude .git/ opam-full-$(VERSION)
+	rm -rf "$(OUTDIR)/opam-full-$(VERSION)"
 
 build/Dockerfile.x86_64-linux: Dockerfile.in
 	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/x86_64-v3.13/g' -e 's/%CONF%//g' $^ >$@
@@ -93,7 +87,7 @@ build/$(HOST).env:
 	cd build/$(HOST) && tar xzf ocaml-$(OCAMLV).tar.gz
 	cd build/$(HOST)/ocaml-$(OCAMLV) && \
 	  ./configure --prefix "$(shell pwd)/build/$(HOST)" && \
-	  $(MAKE) -j$(MACOS_JOBS) && \
+	  $(MAKE) -j$(JOBS) && \
 	  $(MAKE) install
 	rm -rf build/$(HOST)/ocaml-$(OCAMLV) build/$(HOST)/ocaml-$(OCAMLV).tar.gz
 	touch $@
@@ -154,5 +148,5 @@ macos-local: $(OUTDIR)/opam-full-$(VERSION).tar.gz
 	LOCAL_RELEASE_DIR=$(shell mktemp -d); \
           mkdir -p "$${LOCAL_RELEASE_DIR}/${OUTDIR}" && \
           cp Makefile "$^" "$${LOCAL_RELEASE_DIR}" && \
-          cd "$${LOCAL_RELEASE_DIR}" && ulimit -s 8192 && arch -arch $(MACOS_ARCH) make host MACOS_JOBS=$(JOBS) TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV) && \
+          cd "$${LOCAL_RELEASE_DIR}" && ulimit -s 8192 && arch -arch $(MACOS_ARCH) make host JOBS=$(JOBS) TAG=$(TAG) VERSION=$(VERSION) OCAMLV=$(OCAMLV) && \
           cp $${LOCAL_RELEASE_DIR}/$(OUTDIR)/opam-$(VERSION)* "$(GIT_URL)/release/$(OUTDIR)/"

--- a/release/readme.md
+++ b/release/readme.md
@@ -18,7 +18,7 @@
 * Create a new file at ~/.github/jar/infra with: {"scopes":[],"token":"ghp_XXX","app":{"name":"infra","url":"https://developer.github.com/v3/oauth_authorizations/"},"url":"https://api.github.com/authorizations/YYY","id":"YYY","note":"infra"}
   * Replace XXX by the token
   * Replace YYY by its ID
-* generate opam artifacts, using `release/release.sh`, it requires to have Docker install with several remotes, the different arches
+* generate opam artifacts, using `release/release.sh` from a macOS/arm64 machine, it requires to have Docker and QEMU installed
 * add releases notes (content of `master_changes.md`) in the release
 * upload signature of artefacts
 * finalise the release (publish)

--- a/release/readme.md
+++ b/release/readme.md
@@ -5,21 +5,31 @@
 * run `make configure` to regenerate `./configure` [checked by github actions]
 * update copyright headers
 * run `make tests`, `opam-rt` [checked by github actions]
-* update the CHANGE file: take `master_changes.md` content to fil it
+* update the CHANGE file: take `master_changes.md` content to fill it
 
 ## Github release
 
 [ once bump version & changes PRs merged ]
-* tag the release (git tag -a 2.2.0; git push origin 2.2.0)
+* tag the release (git tag -am 2.2.0 2.2.0; git push origin 2.2.0)
 * /!\ Once the tag pushed, it can be updated [different commit] only in case of severe issue
 * create a release (or prerelease if intermediate release) draft on github based on your tag (https://github.com/ocaml/opam/releases/new)
 * Install the github-unix package from opam (needed to get git-upload-release)
-* Create a new token at https://github.com/settings/tokens with the following rights: read:user, repo, user:email, write:packages
-* Create a new file at ~/.github/jar/infra with: {"scopes":[],"token":"ghp_XXX","app":{"name":"infra","url":"https://developer.github.com/v3/oauth_authorizations/"},"url":"https://api.github.com/authorizations/YYY","id":"YYY","note":"infra"}
+* Create a new token at https://github.com/settings/tokens with the following rights: repo, write:packages, read:user, user:email
+* Create a new file at ~/.github/jar/infra with:
+```
+{
+  "scopes":[],
+  "token":"ghp_XXX",
+  "app":{"name":"infra","url":"https://developer.github.com/v3/oauth_authorizations/"},
+  "url":"https://api.github.com/authorizations/YYY",
+  "id":"YYY",
+  "note":"infra"
+}
+```
   * Replace XXX by the token
-  * Replace YYY by its ID
-* generate opam artifacts, using `release/release.sh` from a macOS/arm64 machine, it requires to have Docker and QEMU installed
-* add releases notes (content of `master_changes.md`) in the release
+  * Replace YYY by its ID (you can find it in the url of the token page)
+* generate opam artifacts, using `release/release.sh <tag>` from a macOS/arm64 machine, it requires to have Docker and QEMU installed
+* add releases notes (content of `master_changes.md`) in the release draft
 * upload signature of artefacts
 * finalise the release (publish)
 

--- a/release/readme.md
+++ b/release/readme.md
@@ -28,7 +28,8 @@
 ```
   * Replace XXX by the token
   * Replace YYY by its ID (you can find it in the url of the token page)
-* generate opam artifacts, using `release/release.sh <tag>` from a macOS/arm64 machine, it requires to have Docker and QEMU installed
+* fetch locally the tag
+* generate opam artifacts, using `release/release.sh <tag>` from a macOS/arm64 machine, it requires to have Docker and QEMU installed (see below device requirements)
 * add releases notes (content of `master_changes.md`) in the release draft
 * upload signature of artefacts
 * finalise the release (publish)
@@ -53,3 +54,12 @@
 ### On a release candidate
 * create a branch to a `x.y` for rc's and the final release
 * remove `shell/install.sh`
+
+---
+
+## Device requirements
+* Mac M1
+* installed: git, gpg
+* opam repo with the tag fetched
+* Have the secret key available, or comment signing function in release.sh
+* Launch docker `sudo launchctl start dockerd`

--- a/release/readme.md
+++ b/release/readme.md
@@ -14,7 +14,7 @@
 * /!\ Once the tag pushed, it can be updated [different commit] only in case of severe issue
 * create a release (or prerelease if intermediate release) draft on github based on your tag (https://github.com/ocaml/opam/releases/new)
 * Install the github-unix package from opam (needed to get git-upload-release)
-* Create a new token at https://github.com/settings/tokens
+* Create a new token at https://github.com/settings/tokens with the following rights: read:user, repo, user:email, write:packages
 * Create a new file at ~/.github/jar/infra with: {"scopes":[],"token":"ghp_XXX","app":{"name":"infra","url":"https://developer.github.com/v3/oauth_authorizations/"},"url":"https://api.github.com/authorizations/YYY","id":"YYY","note":"infra"}
   * Replace XXX by the token
   * Replace YYY by its ID

--- a/release/readme.md
+++ b/release/readme.md
@@ -48,6 +48,7 @@
 
 * Bump the version with a `~dev` at the end (e.g. `2.2.0~alpha~dev`)
 * Check if reftests needs an update
+* Bring the changes to the changelog (CHANGES) from the branch of the release to the `master` branch
 
 ### On a release candidate
 * create a branch to a `x.y` for rc's and the final release

--- a/release/readme.md
+++ b/release/readme.md
@@ -13,25 +13,10 @@
 * tag the release (git tag -am 2.2.0 2.2.0; git push origin 2.2.0)
 * /!\ Once the tag pushed, it can be updated [different commit] only in case of severe issue
 * create a release (or prerelease if intermediate release) draft on github based on your tag (https://github.com/ocaml/opam/releases/new)
-* Install the github-unix package from opam (needed to get git-upload-release)
-* Create a new token at https://github.com/settings/tokens with the following rights: repo, write:packages, read:user, user:email
-* Create a new file at ~/.github/jar/infra with:
-```
-{
-  "scopes":[],
-  "token":"ghp_XXX",
-  "app":{"name":"infra","url":"https://developer.github.com/v3/oauth_authorizations/"},
-  "url":"https://api.github.com/authorizations/YYY",
-  "id":"YYY",
-  "note":"infra"
-}
-```
-  * Replace XXX by the token
-  * Replace YYY by its ID (you can find it in the url of the token page)
 * fetch locally the tag
 * generate opam artifacts, using `release/release.sh <tag>` from a macOS/arm64 machine, it requires to have Docker and QEMU installed (see below device requirements)
 * add releases notes (content of `master_changes.md`) in the release draft
-* upload signature of artefacts
+* upload everything from `release/out/<tag>`
 * finalise the release (publish)
 
 ## Publish the release
@@ -61,5 +46,5 @@
 * Mac M1
 * installed: git, gpg
 * opam repo with the tag fetched
-* Have the secret key available, or comment signing function in release.sh
-* Launch docker `sudo launchctl start dockerd`
+* Have the secret key available
+* Launch docker using the Docker GUI macOS app

--- a/release/readme.md
+++ b/release/readme.md
@@ -15,6 +15,7 @@
 * create a release (or prerelease if intermediate release) draft on github based on your tag (https://github.com/ocaml/opam/releases/new)
 * fetch locally the tag
 * generate opam artifacts, using `release/release.sh <tag>` from a macOS/arm64 machine, it requires to have Docker and QEMU installed (see below device requirements)
+* generate the signatures using `release/sign.sh <tag>`
 * add releases notes (content of `master_changes.md`) in the release draft
 * upload everything from `release/out/<tag>`
 * finalise the release (publish)

--- a/release/readme.md
+++ b/release/readme.md
@@ -13,7 +13,12 @@
 * tag the release (git tag -a 2.2.0; git push origin 2.2.0)
 * /!\ Once the tag pushed, it can be updated [different commit] only in case of severe issue
 * create a release (or prerelease if intermediate release) draft on github based on your tag (https://github.com/ocaml/opam/releases/new)
-* generate opam artifacts, using `shell/release.sh`, it requires to have Docker install with several remotes, the different arches
+* Install the github-unix package from opam (needed to get git-upload-release)
+* Create a new token at https://github.com/settings/tokens
+* Create a new file at ~/.github/jar/infra with: {"scopes":[],"token":"ghp_XXX","app":{"name":"infra","url":"https://developer.github.com/v3/oauth_authorizations/"},"url":"https://api.github.com/authorizations/YYY","id":"YYY","note":"infra"}
+  * Replace XXX by the token
+  * Replace YYY by its ID
+* generate opam artifacts, using `release/release.sh`, it requires to have Docker install with several remotes, the different arches
 * add releases notes (content of `master_changes.md`) in the release
 * upload signature of artefacts
 * finalise the release (publish)

--- a/release/release.sh
+++ b/release/release.sh
@@ -50,7 +50,8 @@ if [[ $# -eq 0 || " $* " =~ " builds " ]]; then
   [ -f ${OUTDIR}/opam-$TAG-x86_64-macos ] || make GH_USER="${GH_USER}" TAG="$TAG" macos-local ARCH=x86_64 REMOTE_DIR=opam-release-$TAG &
   [ -f ${OUTDIR}/opam-$TAG-arm64-macos ] || make GH_USER="${GH_USER}" TAG="$TAG" macos-local ARCH=arm64 REMOTE_DIR=opam-release-$TAG &
   [ -f ${OUTDIR}/opam-$TAG-x86_64-openbsd ] || \
-    ( ([ -f ./qemu-base-images ] || (git clone https://github.com/kit-ty-kate/qemu-base-images.git && qemu-img convert -O raw ./qemu-base-images/OpenBSD-7.0-amd64.qcow2 ./qemu-base-images/OpenBSD-7.0-amd64.raw)) &&
+    ( ([ -d ./qemu-base-images ] || (git clone https://github.com/kit-ty-kate/qemu-base-images.git)) &&
+      qemu-img convert -O raw ./qemu-base-images/OpenBSD-7.0-amd64.qcow2 ./qemu-base-images/OpenBSD-7.0-amd64.raw &&
       (ssh -p 9999 root@localhost true || (qemu-system-x86_64 -drive "file=./qemu-base-images/OpenBSD-7.0-amd64.raw,format=raw" -nic "user,hostfwd=tcp::9999-:22" -m 1G & sleep 60)) &&
       ssh -p 9999 root@localhost "pkg_add gmake curl bzip2" &&
       make GH_USER="${GH_USER}" TAG="$TAG" qemu QEMU_PORT=9999 REMOTE_MAKE=gmake REMOTE_DIR=opam-release-$TAG &&

--- a/release/release.sh
+++ b/release/release.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -uex
 
-# Change this to your github user if you only want to test the script
-GH_USER=ocaml
-
 usage() {
     echo "Usage: $0 TAG"
     exit 1
@@ -27,6 +24,7 @@ cd "$DIR"
 LC_ALL=C
 CWD=$(pwd)
 JOBS=$(sysctl -n hw.ncpu)
+JOBS=$(echo "${JOBS} / 1.5" | bc)
 SSH="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 
 OUTDIR="out/$TAG"
@@ -41,21 +39,23 @@ qemu_build() {
 
   if ! ${SSH} -p "${port}" root@localhost true; then
       qemu-img convert -O raw "./qemu-base-images/${image}.qcow2" "./qemu-base-images/${image}.raw"
-      "qemu-system-${arch}" -drive "file=./qemu-base-images/${image}.raw,format=raw" -nic "user,hostfwd=tcp::${port}-:22" -m 2G -smp "${JOBS}" &
+      "qemu-system-${arch}" -drive "file=./qemu-base-images/${image}.raw,format=raw" -nic "user,hostfwd=tcp::${port}-:22" -m 2G &
       sleep 60
   fi
   ${SSH} -p "${port}" root@localhost "${install}"
-  make GH_USER="${GH_USER}" TAG="$TAG" JOBS="${JOBS}" qemu QEMU_PORT="${port}" REMOTE_MAKE="${make}" REMOTE_DIR=opam-release-$TAG
+  # NOTE: JOBS=1 because qemu does not support proper multithreading from arm64 to x86_64 yet because of memory model differences.
+  # See https://wiki.qemu.org/Features/tcg-multithread
+  make TAG="$TAG" JOBS=1 qemu QEMU_PORT="${port}" REMOTE_MAKE="${make}" REMOTE_DIR=opam-release-$TAG
   ${SSH} -p "${port}" root@localhost "shutdown -p now"
 }
 
-make GH_USER="${GH_USER}" TAG="$TAG" GIT_URL="https://github.com/${GH_USER}/opam.git" "${OUTDIR}/opam-full-$TAG.tar.gz"
-make "-j${JOBS}" GH_USER="${GH_USER}" TAG="$TAG" x86_64-linux
-make "-j${JOBS}" GH_USER="${GH_USER}" TAG="$TAG" i686-linux
-make "-j${JOBS}" GH_USER="${GH_USER}" TAG="$TAG" armhf-linux
-make "-j${JOBS}" GH_USER="${GH_USER}" TAG="$TAG" arm64-linux
-[ -f "${OUTDIR}/opam-$TAG-x86_64-macos" ] || make GH_USER="${GH_USER}" TAG="$TAG" JOBS="${JOBS}" macos-local MACOS_ARCH=x86_64 REMOTE_DIR=opam-release-$TAG GIT_URL="$CWD/.."
-[ -f "${OUTDIR}/opam-$TAG-arm64-macos" ] || make GH_USER="${GH_USER}" TAG="$TAG" JOBS="${JOBS}" macos-local MACOS_ARCH=arm64 REMOTE_DIR=opam-release-$TAG GIT_URL="$CWD/.."
+make JOBS="${JOBS}" TAG="$TAG" "${OUTDIR}/opam-full-$TAG.tar.gz"
+make JOBS="${JOBS}" TAG="$TAG" x86_64-linux
+make JOBS="${JOBS}" TAG="$TAG" i686-linux
+make JOBS="${JOBS}" TAG="$TAG" armhf-linux
+make JOBS="${JOBS}" TAG="$TAG" arm64-linux
+[ -f "${OUTDIR}/opam-$TAG-x86_64-macos" ] || make TAG="$TAG" JOBS="${JOBS}" macos-local MACOS_ARCH=x86_64 REMOTE_DIR=opam-release-$TAG GIT_URL="$CWD/.."
+[ -f "${OUTDIR}/opam-$TAG-arm64-macos" ] || make TAG="$TAG" JOBS="${JOBS}" macos-local MACOS_ARCH=arm64 REMOTE_DIR=opam-release-$TAG GIT_URL="$CWD/.."
 [ -d ./qemu-base-images ] || git clone https://gitlab.com/kit-ty-kate/qemu-base-images.git
 [ -f "${OUTDIR}/opam-$TAG-x86_64-openbsd" ] || qemu_build 9999 OpenBSD-7.0-amd64 "pkg_add gmake curl bzip2" gmake x86_64 &
 [ -f "${OUTDIR}/opam-$TAG-x86_64-freebsd" ] || qemu_build 9998 FreeBSD-13.0-RELEASE-amd64 "pkg install -y gmake curl bzip2" gmake x86_64 &

--- a/release/release.sh
+++ b/release/release.sh
@@ -56,7 +56,7 @@ if [[ $# -eq 0 || " $* " =~ " builds " ]]; then
         sleep 60)) &&
       ssh -p 9999 root@localhost "pkg_add gmake curl bzip2" &&
       make GH_USER="${GH_USER}" TAG="$TAG" JOBS=$(JOBS) qemu QEMU_PORT=9999 REMOTE_MAKE=gmake REMOTE_DIR=opam-release-$TAG &&
-      ssh -p 9999 root@localhost "shutdown -p now" )
+      ssh -p 9999 root@localhost "shutdown -p now" ) &
   [ -f ${OUTDIR}/opam-$TAG-x86_64-freebsd ] || \
     ( (ssh -p 9998 root@localhost true ||
        (qemu-img convert -O raw ./qemu-base-images/FreeBSD-13.0-RELEASE-amd64.qcow2 ./qemu-base-images/FreeBSD-13.0-RELEASE-amd64.raw &&
@@ -64,7 +64,8 @@ if [[ $# -eq 0 || " $* " =~ " builds " ]]; then
         sleep 60)) &&
       ssh -p 9998 root@localhost "pkg install -y gmake curl bzip2" &&
       make GH_USER="${GH_USER}" TAG="$TAG" JOBS=$(JOBS) qemu QEMU_PORT=9998 REMOTE_MAKE=gmake REMOTE_DIR=opam-release-$TAG &&
-      ssh -p 9998 root@localhost "shutdown -p now" )
+      ssh -p 9998 root@localhost "shutdown -p now" ) &
+  wait
   upload_failed=
   cd ${OUTDIR} && for f in opam-$TAG-*; do
       if [ "${f%.sig}" != "$f" ]; then continue; fi

--- a/release/release.sh
+++ b/release/release.sh
@@ -1,18 +1,9 @@
 #!/usr/bin/env bash
 set -uex
 
-# This script is expected to run on Linux with docker available, and to have
-# three remotes "some-osx-x86", "some-osx-arm" and "some-openbsd", with the
-# corresponding OSes, ocaml deps installed
-
 # Change this to your github user if you only want to test the script
 GH_USER=ocaml
 
-LC_ALL=C
-CWD=$(pwd)
-JOBS=$(sysctl -n hw.ncpu)
-DIR=$(dirname $0)
-cd "$DIR"
 if [[ $# -eq 0 || "x$1" =~ "x-" ]]; then
     echo "Usage: $0 TAG [archive|builds]"
     exit 1
@@ -22,6 +13,12 @@ if test "$(uname -s)" != Darwin -o "$(uname -m)" != arm64; then
   echo "This script is required to be run on macOS/arm64"
   exit 1
 fi
+
+LC_ALL=C
+CWD=$(pwd)
+JOBS=$(sysctl -n hw.ncpu)
+DIR=$(dirname $0)
+cd "$DIR"
 
 TAG="$1"; shift
 OUTDIR="out/$TAG"

--- a/release/release.sh
+++ b/release/release.sh
@@ -21,12 +21,12 @@ if test "$(uname -s)" != Darwin -o "$(uname -m)" != arm64; then
   exit 1
 fi
 
+DIR=$(dirname $0)
+cd "$DIR"
+
 LC_ALL=C
 CWD=$(pwd)
 JOBS=$(sysctl -n hw.ncpu)
-
-DIR=$(dirname $0)
-cd "$DIR"
 SSH="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 
 OUTDIR="out/$TAG"

--- a/release/release.sh
+++ b/release/release.sh
@@ -38,7 +38,10 @@ if [[ $# -eq 0 || " $* " =~ " archive " ]]; then
 fi
 
 if [[ $# -eq 0 || " $* " =~ " builds " ]]; then
-  make GH_USER="${GH_USER}" TAG="$TAG" all &
+  make GH_USER="${GH_USER}" TAG="$TAG" x86_64-linux &
+  make GH_USER="${GH_USER}" TAG="$TAG" i686-linux &
+  make GH_USER="${GH_USER}" TAG="$TAG" armhf-linux &
+  make GH_USER="${GH_USER}" TAG="$TAG" arm64-linux &
   [ -f ${OUTDIR}/opam-$TAG-x86_64-macos ] || make GH_USER="${GH_USER}" TAG="$TAG" remote REMOTE=some-osx-x86 REMOTE_DIR=opam-release-$TAG &
   [ -f ${OUTDIR}/opam-$TAG-arm64-macos ] || make GH_USER="${GH_USER}" TAG="$TAG" remote REMOTE=some-osx-arm REMOTE_DIR=opam-release-$TAG &
   [ -f ${OUTDIR}/opam-$TAG-x86_64-openbsd ] || \

--- a/release/release.sh
+++ b/release/release.sh
@@ -48,7 +48,7 @@ if [[ $# -eq 0 || " $* " =~ " builds " ]]; then
   make "-j${JOBS}" GH_USER="${GH_USER}" TAG="$TAG" arm64-linux
   [ -f ${OUTDIR}/opam-$TAG-x86_64-macos ] || make GH_USER="${GH_USER}" TAG="$TAG" JOBS=$(JOBS) macos-local MACOS_ARCH=x86_64 REMOTE_DIR=opam-release-$TAG GIT_URL="$CWD/.."
   [ -f ${OUTDIR}/opam-$TAG-arm64-macos ] || make GH_USER="${GH_USER}" TAG="$TAG" JOBS=$(JOBS) macos-local MACOS_ARCH=arm64 REMOTE_DIR=opam-release-$TAG GIT_URL="$CWD/.."
-  [ -d ./qemu-base-images ] || git clone https://github.com/kit-ty-kate/qemu-base-images.git
+  [ -d ./qemu-base-images ] || git clone https://gitlab.com/kit-ty-kate/qemu-base-images.git
   [ -f ${OUTDIR}/opam-$TAG-x86_64-openbsd ] || \
     ( (ssh -p 9999 root@localhost true ||
        (qemu-img convert -O raw ./qemu-base-images/OpenBSD-7.0-amd64.qcow2 ./qemu-base-images/OpenBSD-7.0-amd64.raw &&

--- a/release/release.sh
+++ b/release/release.sh
@@ -16,6 +16,11 @@ if [[ $# -eq 0 || "x$1" =~ "x-" ]]; then
     exit 1
 fi
 
+if test "$(uname -s)" != Darwin -o "$(uname -m)" != arm64; then
+  echo "This script is required to be run on macOS/arm64"
+  exit 1
+fi
+
 TAG="$1"; shift
 OUTDIR="out/$TAG"
 
@@ -42,8 +47,8 @@ if [[ $# -eq 0 || " $* " =~ " builds " ]]; then
   make GH_USER="${GH_USER}" TAG="$TAG" i686-linux &
   make GH_USER="${GH_USER}" TAG="$TAG" armhf-linux &
   make GH_USER="${GH_USER}" TAG="$TAG" arm64-linux &
-  [ -f ${OUTDIR}/opam-$TAG-x86_64-macos ] || make GH_USER="${GH_USER}" TAG="$TAG" remote REMOTE=some-osx-x86 REMOTE_DIR=opam-release-$TAG &
-  [ -f ${OUTDIR}/opam-$TAG-arm64-macos ] || make GH_USER="${GH_USER}" TAG="$TAG" remote REMOTE=some-osx-arm REMOTE_DIR=opam-release-$TAG &
+  [ -f ${OUTDIR}/opam-$TAG-x86_64-macos ] || make GH_USER="${GH_USER}" TAG="$TAG" macos-local ARCH=x86_64 REMOTE_DIR=opam-release-$TAG &
+  [ -f ${OUTDIR}/opam-$TAG-arm64-macos ] || make GH_USER="${GH_USER}" TAG="$TAG" macos-local ARCH=arm64 REMOTE_DIR=opam-release-$TAG &
   [ -f ${OUTDIR}/opam-$TAG-x86_64-openbsd ] || \
     ( ([ -f ./qemu-base-images ] || (git clone https://github.com/kit-ty-kate/qemu-base-images.git && qemu-img convert -O raw ./qemu-base-images/OpenBSD-7.0-amd64.qcow2 ./qemu-base-images/OpenBSD-7.0-amd64.raw)) &&
       (ssh -p 9999 root@localhost true || (qemu-system-x86_64 -drive "file=./qemu-base-images/OpenBSD-7.0-amd64.raw,format=raw" -nic "user,hostfwd=tcp::9999-:22" -m 1G & sleep 60)) &&

--- a/release/release.sh
+++ b/release/release.sh
@@ -37,7 +37,7 @@ if [[ $# -eq 0 || " $* " =~ " archive " ]]; then
     make GH_USER="${GH_USER}" TAG="$TAG" GIT_URL="https://github.com/${GH_USER}/opam.git" "${OUTDIR}/opam-full-$TAG.tar.gz"
     ( cd ${OUTDIR} &&
           sign "opam-full-$TAG.tar.gz" &&
-          git-upload-release "${GH_USER}" opam "$TAG" "opam-full-$TAG.tar.gz.sig" &&
+          if [ -f "opam-full-$TAG.tar.gz.sig" ]; then git-upload-release "${GH_USER}" opam "$TAG" "opam-full-$TAG.tar.gz.sig"; fi &&
           git-upload-release "${GH_USER}" opam "$TAG" "opam-full-$TAG.tar.gz"; )
 fi
 

--- a/release/release.sh
+++ b/release/release.sh
@@ -5,30 +5,15 @@ set -uex
 GH_USER=ocaml
 
 usage() {
-    echo "Usage: $0 TAG [archive|builds] [--without-signatures]"
+    echo "Usage: $0 TAG"
     exit 1
 }
 
-if [[ $# -lt 1 || $# -gt 3 || "x$1" =~ "x-" ]]; then
+if [[ $# -lt 1 || $# -gt 1 || "x$1" =~ "x-" ]]; then
   usage
 fi
 
 TAG="$1"
-shift
-
-case "$1" in
-"archive") ACTION_ARCHIVE=true; ACTION_BUILDS=false;;
-"builds") ACTION_ARCHIVE=false; ACTION_BUILDS=true;;
-"") ACTION_ARCHIVE=true; ACTION_BUILDS=true;;
-*) usage;;
-esac
-shift
-
-case "$1" in
-"--without-signatures") WITH_SIGS=false;;
-"") WITH_SIGS=true;;
-*) usage;;
-esac
 shift
 
 if test "$(uname -s)" != Darwin -o "$(uname -m)" != arm64; then
@@ -39,30 +24,12 @@ fi
 LC_ALL=C
 CWD=$(pwd)
 JOBS=$(sysctl -n hw.ncpu)
+
 DIR=$(dirname $0)
 cd "$DIR"
 
 OUTDIR="out/$TAG"
-
-OPAM_DEV_KEY='92C526AE50DF39470EB2911BED4CF1CA67CBAA92'
-
-sign() {
-    if ! [ -f "$1.sig" ] || ! gpg -u "$OPAM_DEV_KEY" --verify "$1.sig" "$1"; then
-        gpg -u "$OPAM_DEV_KEY" --detach-sign "$1"
-    fi
-}
-
 mkdir -p "$OUTDIR"
-
-if test "$ACTION_ARCHIVE" = true; then
-    make GH_USER="${GH_USER}" TAG="$TAG" GIT_URL="https://github.com/${GH_USER}/opam.git" "${OUTDIR}/opam-full-$TAG.tar.gz"
-    cd "${OUTDIR}"
-    if test "$WITH_SIGS" = true; then
-        sign "opam-full-$TAG.tar.gz"
-        git-upload-release "${GH_USER}" opam "$TAG" "opam-full-$TAG.tar.gz.sig"
-    fi
-    git-upload-release "${GH_USER}" opam "$TAG" "opam-full-$TAG.tar.gz"
-fi
 
 qemu_build() {
   local port=$1
@@ -73,37 +40,22 @@ qemu_build() {
 
   if ! ssh -p "${port}" root@localhost true; then
       qemu-img convert -O raw "./qemu-base-images/${image}.qcow2" "./qemu-base-images/${image}.raw"
-      "qemu-system-${arch}" -drive "file=./qemu-base-images/${image}.raw,format=raw" -nic "user,hostfwd=tcp::${port}-:22" -m 2G &
+      "qemu-system-${arch}" -drive "file=./qemu-base-images/${image}.raw,format=raw" -nic "user,hostfwd=tcp::${port}-:22" -m 2G -smp "${JOBS}" &
       sleep 60
   fi
   ssh -p "${port}" root@localhost "${install}"
-  make GH_USER="${GH_USER}" TAG="$TAG" JOBS=$(JOBS) qemu QEMU_PORT="${port}" REMOTE_MAKE="${make}" REMOTE_DIR=opam-release-$TAG
+  make GH_USER="${GH_USER}" TAG="$TAG" JOBS="${JOBS}" qemu QEMU_PORT="${port}" REMOTE_MAKE="${make}" REMOTE_DIR=opam-release-$TAG
   ssh -p "${port}" root@localhost "shutdown -p now"
 }
 
-if test "$ACTION_BUILDS" = true; then
-  make "-j${JOBS}" GH_USER="${GH_USER}" TAG="$TAG" x86_64-linux
-  make "-j${JOBS}" GH_USER="${GH_USER}" TAG="$TAG" i686-linux
-  make "-j${JOBS}" GH_USER="${GH_USER}" TAG="$TAG" armhf-linux
-  make "-j${JOBS}" GH_USER="${GH_USER}" TAG="$TAG" arm64-linux
-  [ -f ${OUTDIR}/opam-$TAG-x86_64-macos ] || make GH_USER="${GH_USER}" TAG="$TAG" JOBS=$(JOBS) macos-local MACOS_ARCH=x86_64 REMOTE_DIR=opam-release-$TAG GIT_URL="$CWD/.."
-  [ -f ${OUTDIR}/opam-$TAG-arm64-macos ] || make GH_USER="${GH_USER}" TAG="$TAG" JOBS=$(JOBS) macos-local MACOS_ARCH=arm64 REMOTE_DIR=opam-release-$TAG GIT_URL="$CWD/.."
-  [ -d ./qemu-base-images ] || git clone https://gitlab.com/kit-ty-kate/qemu-base-images.git
-  [ -f ${OUTDIR}/opam-$TAG-x86_64-openbsd ] || qemu_build 9999 OpenBSD-7.0-amd64 "pkg_add gmake curl bzip" gmake x86_64 &
-  [ -f ${OUTDIR}/opam-$TAG-x86_64-freebsd ] || qemu_build 9998 FreeBSD-13.0-RELEASE-amd64 "pkg install -y gmake curl bzip2" gmake x86_64 &
-  wait
-  upload_failed=
-  cd "${OUTDIR}"
-  for f in opam-$TAG-*; do
-      if [ "${f%.sig}" != "$f" ]; then continue; fi
-      if test "$WITH_SIGS" = true; then
-        sign "$f"
-        git-upload-release "${GH_USER}" opam "$TAG" "$f.sig" || upload_failed="$upload_failed $f.sig"
-      fi
-      git-upload-release "${GH_USER}" opam "$TAG" "$f" || upload_failed="$upload_failed $f"
-  done
-fi
-if [ -n "$upload_failed" ]; then
-    echo "Failed uploads: $upload_failed"
-    exit 10
-fi
+make GH_USER="${GH_USER}" TAG="$TAG" GIT_URL="https://github.com/${GH_USER}/opam.git" "${OUTDIR}/opam-full-$TAG.tar.gz"
+make "-j${JOBS}" GH_USER="${GH_USER}" TAG="$TAG" x86_64-linux
+make "-j${JOBS}" GH_USER="${GH_USER}" TAG="$TAG" i686-linux
+make "-j${JOBS}" GH_USER="${GH_USER}" TAG="$TAG" armhf-linux
+make "-j${JOBS}" GH_USER="${GH_USER}" TAG="$TAG" arm64-linux
+[ -f "${OUTDIR}/opam-$TAG-x86_64-macos" ] || make GH_USER="${GH_USER}" TAG="$TAG" JOBS="${JOBS}" macos-local MACOS_ARCH=x86_64 REMOTE_DIR=opam-release-$TAG GIT_URL="$CWD/.."
+[ -f "${OUTDIR}/opam-$TAG-arm64-macos" ] || make GH_USER="${GH_USER}" TAG="$TAG" JOBS="${JOBS}" macos-local MACOS_ARCH=arm64 REMOTE_DIR=opam-release-$TAG GIT_URL="$CWD/.."
+[ -d ./qemu-base-images ] || git clone https://gitlab.com/kit-ty-kate/qemu-base-images.git
+[ -f "${OUTDIR}/opam-$TAG-x86_64-openbsd" ] || qemu_build 9999 OpenBSD-7.0-amd64 "pkg_add gmake curl bzip2" gmake x86_64 &
+[ -f "${OUTDIR}/opam-$TAG-x86_64-freebsd" ] || qemu_build 9998 FreeBSD-13.0-RELEASE-amd64 "pkg install -y gmake curl bzip2" gmake x86_64 &
+wait

--- a/release/release.sh
+++ b/release/release.sh
@@ -27,6 +27,7 @@ JOBS=$(sysctl -n hw.ncpu)
 
 DIR=$(dirname $0)
 cd "$DIR"
+SSH="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 
 OUTDIR="out/$TAG"
 mkdir -p "$OUTDIR"
@@ -38,14 +39,14 @@ qemu_build() {
   local make=$4
   local arch=$5
 
-  if ! ssh -p "${port}" root@localhost true; then
+  if ! ${SSH} -p "${port}" root@localhost true; then
       qemu-img convert -O raw "./qemu-base-images/${image}.qcow2" "./qemu-base-images/${image}.raw"
       "qemu-system-${arch}" -drive "file=./qemu-base-images/${image}.raw,format=raw" -nic "user,hostfwd=tcp::${port}-:22" -m 2G -smp "${JOBS}" &
       sleep 60
   fi
-  ssh -p "${port}" root@localhost "${install}"
+  ${SSH} -p "${port}" root@localhost "${install}"
   make GH_USER="${GH_USER}" TAG="$TAG" JOBS="${JOBS}" qemu QEMU_PORT="${port}" REMOTE_MAKE="${make}" REMOTE_DIR=opam-release-$TAG
-  ssh -p "${port}" root@localhost "shutdown -p now"
+  ${SSH} -p "${port}" root@localhost "shutdown -p now"
 }
 
 make GH_USER="${GH_USER}" TAG="$TAG" GIT_URL="https://github.com/${GH_USER}/opam.git" "${OUTDIR}/opam-full-$TAG.tar.gz"

--- a/release/release.sh
+++ b/release/release.sh
@@ -42,7 +42,8 @@ if [[ $# -eq 0 || " $* " =~ " builds " ]]; then
   [ -f ${OUTDIR}/opam-$TAG-x86_64-macos ] || make GH_USER="${GH_USER}" TAG="$TAG" remote REMOTE=some-osx-x86 REMOTE_DIR=opam-release-$TAG &
   [ -f ${OUTDIR}/opam-$TAG-arm64-macos ] || make GH_USER="${GH_USER}" TAG="$TAG" remote REMOTE=some-osx-arm REMOTE_DIR=opam-release-$TAG &
   [ -f ${OUTDIR}/opam-$TAG-x86_64-openbsd ] || \
-    ( (ssh -p 9999 root@localhost true || (qemu-system-x86_64 -drive "file=./qemu-base-images/OpenBSD-7.0-amd64.qcow2,format=qcow2" -nic "user,hostfwd=tcp::9999-:22" -m 1G & sleep 60)) &&
+    ( ([ -f ./qemu-base-images ] || (git clone https://github.com/kit-ty-kate/qemu-base-images.git && qemu-img convert -O raw ./qemu-base-images/OpenBSD-7.0-amd64.qcow2 ./qemu-base-images/OpenBSD-7.0-amd64.raw)) &&
+      (ssh -p 9999 root@localhost true || (qemu-system-x86_64 -drive "file=./qemu-base-images/OpenBSD-7.0-amd64.raw,format=raw" -nic "user,hostfwd=tcp::9999-:22" -m 1G & sleep 60)) &&
       ssh -p 9999 root@localhost "pkg_add gmake curl bzip2" &&
       make GH_USER="${GH_USER}" TAG="$TAG" qemu QEMU_PORT=9999 REMOTE_MAKE=gmake REMOTE_DIR=opam-release-$TAG &&
       ssh -p 9999 root@localhost "shutdown -p now" ) &

--- a/release/sign.sh
+++ b/release/sign.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -uex
+
+usage() {
+    echo "Usage: $0 TAG"
+    exit 1
+}
+
+if [[ $# -lt 1 || $# -gt 1 || "x$1" =~ "x-" ]]; then
+  usage
+fi
+
+TAG="$1"
+shift
+
+OPAM_DEV_KEY='92C526AE50DF39470EB2911BED4CF1CA67CBAA92'
+
+sign() {
+    if ! [ -f "$1.sig" ] || ! gpg -u "$OPAM_DEV_KEY" --verify "$1.sig" "$1"; then
+        gpg -u "$OPAM_DEV_KEY" --detach-sign "$1"
+    fi
+}
+
+DIR=$(dirname $0)
+cd "$DIR"
+
+OUTDIR="out/$TAG"
+cd "${OUTDIR}"
+
+for f in opam-$TAG-*; do
+    sign "$f"
+done


### PR DESCRIPTION
One button press to release. So far the QEMU setup is by far the slowest bit (~3/4 hours) but at least it does not require any supervision or setup.

PR on top of #4946 