### PR TITLE
Switch the default version when undefined from ~dev to dev

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -41,7 +41,7 @@ users)
   * [BUG] Fix `set-invariant: default repos were loaded instead of switch repos [#4866 @rjbou]
 
 ## Pin
-  *
+  * Switch the default version when undefined from ~dev to dev [#4949 @kit-ty-kate]
 
 ## List
   * Some optimisations to 'opam list --installable' queries combined with other filters [@altgr]
@@ -202,6 +202,7 @@ users)
 ## opam-solver
 ## opam-format
   * `OpamStd.ABSTRACT`: add `compare` and `equal`, that added those functions to `OpamSysPkg` and `OpamVariable` [#4918 @rjbou]
+  * Add OpamPackage.Version.default returning the version number used when no version is given for a package [#4949 @kit-ty-kate]
 ## opam-core
   * OpamSystem: avoid calling Unix.environment at top level [#4789 @hannesm]
   * `OpamStd.ABSTRACT`: add `compare` and `equal`, that added those functions to `OpamFilename`, `OpamHash`, `OpamStd`, `OpamStd`, `OpamUrl`, and `OpamVersion` [#4918 @rjbou]

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -364,7 +364,7 @@ exception Nothing_to_do
 
 let default_version st name =
   try OpamPackage.version (OpamSwitchState.get_package st name)
-  with Not_found -> OpamPackage.Version.of_string "~dev"
+  with Not_found -> OpamPackage.Version.default
 
 let fetch_all_pins st ?working_dir pins =
   let root = st.switch_global.root in

--- a/src/format/opamPackage.ml
+++ b/src/format/opamPackage.ml
@@ -32,6 +32,7 @@ module Version = struct
       x;
     x
 
+  let default = "~dev"
 
   let compare = OpamVersionCompare.compare
 

--- a/src/format/opamPackage.ml
+++ b/src/format/opamPackage.ml
@@ -32,7 +32,7 @@ module Version = struct
       x;
     x
 
-  let default = "~dev"
+  let default = "dev"
 
   let compare = OpamVersionCompare.compare
 

--- a/src/format/opamPackage.mli
+++ b/src/format/opamPackage.mli
@@ -24,6 +24,9 @@ module Version: sig
 
   (** Are two package versions equal? *)
   val equal: t -> t -> bool
+
+  (** Default version used when no version is given *)
+  val default : t
 end
 
 (** Names *)

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -285,7 +285,7 @@ let pinned_package st ?version ?(working_dir=false) name =
              Some ((OpamFile.OPAM.version_opt o)
                    +! (OpamSwitchState.get_package st name |> OpamPackage.version))
            with Not_found -> None)
-          +! (OpamPackage.Version.of_string "~dev")
+          +! OpamPackage.Version.default
         in
         o |> OpamFile.OPAM.with_url_opt None
         |> OpamFile.OPAM.with_version v


### PR DESCRIPTION
Makes it easier to mix pin packages and packages from the repository without having to set the version again when encountering an issue.

When you take the development version of something you expect more often to be ahead of the latest release rather than the opposite.

Issue encountered by @bikallem 