### PR TITLE
Make opam show --list-files <pkg> fail when <pkg> is not installed

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -48,6 +48,7 @@ users)
 
 ## Show
   * Add `depexts` to default printer [#4898 @rjbou]
+  * Make `opam show --list-files <pkg>` fail with not found when `<pkg>` is not installed [#4956 @kit-ty-kate - fix #4930]
 
 ## Var
   *

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -598,7 +598,10 @@ let detail_printer ?prettify ?normalise ?(sort=false) st nv =
       OpamPath.Switch.changes st.switch_global.root st.switch nv.name
     in
     (match OpamFile.Changes.read_opt changes_f with
-     | None -> ""
+     | None ->
+       OpamConsole.error_and_exit `Not_found
+         "Cannot list installed files: %s is not installed"
+         (OpamPackage.Name.to_string nv.name)
      | Some c ->
        OpamStd.Format.itemize ~bullet:""
          (fun (file, status) ->


### PR DESCRIPTION
Fixes #4930
