### PR TITLE
opam lint: Fix E67, check checksum only if vcs backend

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -100,6 +100,7 @@ users)
   * E57 (capital on synopsis) not trigger W47 (empty descr) [#5070 @rjbou]
   * [BUG] Fix linting packages from repository with tarred repositories, the file in temporary repository was no more avaiable when lint is done [#5068 @rjbou]
   * Update repository package filename display [#5068 @rjbou]
+  * E67: check checksums only for vcs urls [#4960 @rjbou]
 
 ## Repository
   * When several checksums are specified, instead of adding in the cache only the archive by first checksum, name by best one and link others to this archive [#4696 rjbou]


### PR DESCRIPTION
Reported in https://discuss.ocaml.org/t/opamlint-error-67-checksum-specified-with-a-non-archive-url/8998

The problem with lint-check 67 (Checksum specified with a non archive url) is that it is checked using `OpamSystem.is_archive`, which expects as parameter: a file on the disk. However currently, only the base name from the url is given (which does not exist on the disk).

This is why the `zip` check fails: the file is not present on the filesystem and thus cannot be checked and returns `false`.
It only works for `tar.*` files because `OpamSystem.Tar.is_archive` also checks the extension if the file does not exists on the system.

Should render https://github.com/ocaml/opam/pull/4834 obsolete