### PR TITLE
OpamSystem.real_path: Remove the double chdir trick on OCaml >= 4.13.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,10 +41,10 @@ env:
   OPAM12CACHE: ~/.cache/opam1.2/cache
   # These should be identical to the values in appveyor.yml and the other workflows
   OPAM_REPO: https://github.com/ocaml/opam-repository.git
-  OPAM_TEST_REPO_SHA: ec07d6d5f363d1c5b9ed3b927d0df1d58dad333c
-  OPAM_REPO_SHA: ec07d6d5f363d1c5b9ed3b927d0df1d58dad333c
+  OPAM_TEST_REPO_SHA: fd4405c83bcd23f91373978b45479694079a8c79
+  OPAM_REPO_SHA: fd4405c83bcd23f91373978b45479694079a8c79
   # Default ocaml version for some jobs
-  OCAML_VERSION: 4.12.0
+  OCAML_VERSION: 4.13.1
   ## variables for cache paths
   GH_OCAML_CACHE: ~/.cache/ocaml-local/**
   SOLVER:
@@ -109,10 +109,10 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        ocamlv: [ 4.08.1, 4.09.1, 4.10.2, 4.11.2, 4.12.0 ]
+        ocamlv: [ 4.08.1, 4.09.1, 4.10.2, 4.11.2, 4.12.1, 4.13.1 ]
         include:
           - os: macos-latest
-            ocamlv: 4.12.0
+            ocamlv: 4.13.1
       # Intentionally fail fast, no need to run all build if there is a
       # problem in a given version; usually it is functions not defined in lower
       # versions of OCaml
@@ -181,7 +181,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        ocamlv: [ 4.12.0 ]
+        ocamlv: [ 4.13.1 ]
       fail-fast: false
     env:
       OPAM_TEST: 1
@@ -233,7 +233,7 @@ jobs:
       matrix:
 #        os: [ ubuntu-latest, macos-latest ]
         os: [ ubuntu-latest ]
-        ocamlv: [ 4.12.0 ]
+        ocamlv: [ 4.13.1 ]
       fail-fast: false
     steps:
     - name: install deps
@@ -263,7 +263,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        ocamlv: [ 4.12.0 ]
+        ocamlv: [ 4.13.1 ]
         solver: [ z3, 0install ]
       fail-fast: false
     env:
@@ -312,7 +312,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        ocamlv: [ 4.12.0 ]
+        ocamlv: [ 4.13.1 ]
       fail-fast: false
     steps:
     - name: install deps

--- a/Makefile
+++ b/Makefile
@@ -268,4 +268,4 @@ cold-%:
 
 .PHONY: run-appveyor-test
 run-appveyor-test:
-	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" ./appveyor_test.sh
+	env -u OCAMLLIB -u CAML_LD_LIBRARY_PATH PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" ./appveyor_test.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ environment:
     DEP_MODE: lib-ext
     # These should be identical to the values in .github/workflows/*.yml
     OPAM_REPO: https://github.com/ocaml/opam-repository.git
-    OPAM_REPO_SHA: ec07d6d5f363d1c5b9ed3b927d0df1d58dad333c
-    OPAM_TEST_REPO_SHA: ec07d6d5f363d1c5b9ed3b927d0df1d58dad333c
+    OPAM_REPO_SHA: fd4405c83bcd23f91373978b45479694079a8c79
+    OPAM_TEST_REPO_SHA: fd4405c83bcd23f91373978b45479694079a8c79
   matrix:
     - CYG_ROOT: cygwin
       CYG_ARCH: x86

--- a/appveyor_test.sh
+++ b/appveyor_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-opam init -y -a --compiler=ocaml.4.12.0 git+$OPAM_REPO#$OPAM_TEST_REPO_SHA
+opam init -y -a --compiler=ocaml.4.13.1 git+$OPAM_REPO#$OPAM_TEST_REPO_SHA
 eval $(opam config env)
 opam install -y -v ocamlfind

--- a/appveyor_test.sh
+++ b/appveyor_test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-opam init -y -a --compiler=ocaml.4.13.1 git+$OPAM_REPO#$OPAM_TEST_REPO_SHA
+COLD_OCAML="$(sed -ne 's/URL_ocaml = .*ocaml-.*ocaml-\(.*\)\.tar\.gz/ocaml.\1/p' src_ext/Makefile)"
+# This is supposed to be able to select ocaml-system using the bootstrap compiler
+opam init -y -a --compiler=$COLD_OCAML git+$OPAM_REPO#$OPAM_TEST_REPO_SHA
 eval $(opam config env)
 opam install -y -v ocamlfind

--- a/master_changes.md
+++ b/master_changes.md
@@ -234,3 +234,4 @@ users)
   * `OpamStd.ABSTRACT`: add `compare` and `equal`, that added those functions to `OpamFilename`, `OpamHash`, `OpamStd`, `OpamStd`, `OpamUrl`, and `OpamVersion` [#4918 @rjbou]
   * `OpamHash`: add `sort` from strongest to weakest kind
 
+  * OpamSystem.real_path: Remove the double chdir trick on OCaml >= 4.13.0 [#4961 @kit-ty-kate]

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -7,15 +7,15 @@ RUN apk add gcc g++ make coreutils openssl
 
 RUN addgroup -S opam && adduser -S opam -G opam -s /bin/sh
 
-ADD https://caml.inria.fr/pub/distrib/ocaml-4.12/ocaml-4.12.0.tar.gz /root/
+ADD https://caml.inria.fr/pub/distrib/ocaml-4.13/ocaml-4.13.1.tar.gz /root/
 
 WORKDIR /root
-RUN tar xzf ocaml-4.12.0.tar.gz
-WORKDIR ocaml-4.12.0
+RUN tar xzf ocaml-4.13.1.tar.gz
+WORKDIR ocaml-4.13.1
 RUN sed -i 's/gnueabi/*eabi/' configure
 RUN sed -i 's/musl/musl*/' configure
 RUN ./configure %CONF% -prefix /usr/local
-RUN make world opt.opt && make install && rm -rf /root/ocaml-4.12.0 /root/ocaml-4.12.0.tar.gz
+RUN make world opt.opt && make install && rm -rf /root/ocaml-4.13.1 /root/ocaml-4.13.1.tar.gz
 
 RUN apk add patch
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -7,7 +7,7 @@ FULL_ARCHIVE_URL = https://github.com/ocaml/opam/releases/download/$(VERSION)/op
 
 TARGETS = x86_64-linux i686-linux armhf-linux arm64-linux
 
-OCAMLV = 4.12.0
+OCAMLV = 4.13.1
 # currently hardcoded in Dockerfile.in
 OCAML_URL = https://caml.inria.fr/pub/distrib/ocaml-$(basename $(OCAMLV))/ocaml-$(OCAMLV).tar.gz
 

--- a/src/core/dune
+++ b/src/core/dune
@@ -14,7 +14,7 @@
                (:include ../ocaml-flags-configure.sexp)
                (:include ../ocaml-context-flags.sexp)))
   (preprocess  (per_module
-                  ((action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})) opamCompat)
+                  ((action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})) opamCompat opamSystem)
                   ((action (run %{bin:cppo} %{read-lines:developer} %{input-file})) opamCoreConfig)
                   ((action (run %{bin:cppo} -D "VERSION %{read-lines:version}" %{input-file})) opamVersion)))
   (wrapped     false))

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -317,6 +317,9 @@ let remove file =
   else
     remove_file file
 
+#if OCAML_VERSION >= (4, 13, 0)
+let normalize = Unix.realpath
+#else
 (* Sets path to s and returns the old path *)
 let getchdir s =
   let p =
@@ -330,6 +333,7 @@ let getchdir s =
 
 let normalize s =
   try getchdir (getchdir s) with File_not_found _ -> s
+#endif
 
 let real_path p =
   (* if Filename.is_relative p then *)


### PR DESCRIPTION
Partially fixes #4793