### PR TITLE
Fallback when OCaml says symlinks not supported

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -150,6 +150,7 @@ users)
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]
   * Process control: close stdin by default for Windows subprocesses and on all platforms for the download command [#4615 @dra27]
   * [BUG] handle converted variables correctly when no_undef_expand is true [#4811 @timbertson]
+  * [BUG] check Unix.has_symlink before using Unix.symlink [#4962 @jonahbeckford]
 
 ## Test
   * Update crowbar with compare functions [#4918 @rjbou]

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -1012,7 +1012,8 @@ let link src dst =
   in
   mkdir (Filename.dirname dst);
   if file_or_symlink_exists dst then (
-    if Sys.win32 then Unix.chmod dst 0o640 else ();
+    (* TODO: move this into remove_file *)
+    if Sys.win32 then Unix.chmod dst 0o640;
     remove_file dst
   );
   if Unix.has_symlink () then

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -999,13 +999,7 @@ let extract_in ~dir file =
   | None -> ()
 
 let link src dst =
-  mkdir (Filename.dirname dst);
-  if file_or_symlink_exists dst then
-    remove_file dst;
-  try
-    log "ln -s %s %s" src dst;
-    Unix.symlink src dst
-  with Unix.Unix_error (Unix.EXDEV, _, _) ->
+  let fallback () =
     (* Fall back to copy if symlinks are not supported *)
     let src =
       if Filename.is_relative src then Filename.dirname dst / src
@@ -1015,6 +1009,22 @@ let link src dst =
       copy_dir src dst
     else
       copy_file src dst
+  in
+  mkdir (Filename.dirname dst);
+  if file_or_symlink_exists dst then (
+    if Sys.win32 then Unix.chmod dst 0o640 else ();
+    remove_file dst
+  );
+  if Unix.has_symlink () then
+    try
+      log "ln -s %s %s" src dst;
+      Unix.symlink src dst
+    with Unix.Unix_error (Unix.EXDEV, _, _) ->
+      fallback ()
+  else (
+    log "copy %s -> %s" src dst;
+    fallback ()
+  )
 
 type actual_lock_flag = [ `Lock_read | `Lock_write ]
 type lock_flag = [ `Lock_none | actual_lock_flag ]


### PR DESCRIPTION
- [X] Please update `master_changes.md` file with your changes.

Without this PR, as a Windows user without "Run as Administrator" permission:

```powershell
opam install `
  --root C:\Users\beckf\AppData\Local\opam `
  --switch C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\0\host-tools `
  Z:\source\diskuv-communicator-kernel\vendor\diskuv-ocaml\opam-dkml.opam `
  --yes --verbose --debug-level 2
```
```text
...
00:19.866  SYSTEM                          install C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\0\host-tools\_opam\.opam-switch\build\opam-dkml.~dev\_build\install\default\doc\opam-dkml\README.md -> C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\0\host-tools\_opam\doc\opam-dkml\README.md (644)
00:19.866  SYSTEM                          rm C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\0\host-tools\_opam\doc\opam-dkml\README.md
00:19.868  TRACK                           after install: 7 elements, 0 added, scanned in 0.000s
00:19.868  FILE(changes)                   Wrote C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\0\host-tools\_opam\.opam-switch\install\opam-dkml.changes in 0.000s
-> installed opam-dkml.~dev
00:19.869  SYSTEM                          ln -s C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\0\host-tools\_opam\bin\opam-dkml.exe C:\Users\beckf\AppData\Local\opam\plugins\bin\opam-dkml.exe
00:19.869  PARALLEL                        Exception while computing job 788192587: install opam-dkml.~dev

#=== ERROR while installing opam-dkml.~dev ====================================#
C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\0\bin\opam.exe: "symlink" failed on C:\Users\beckf\AppData\Local\opam\plugins\bin\opam-dkml.exe: Operation not permitted
```

Now it succeeds:

```text
...
00:14.605  SYSTEM                          install C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\2\host-tools\_opam\.opam-switch\build\opam-dkml.~dev\_build\install\default\doc\opam-dkml\README.md -> C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\2\host-tools\_opam\doc\opam-dkml\README.md (644)                                              ]
00:14.606  TRACK                           after install: 9 elements, 9 added, scanned in 0.001s                                ]
00:14.606  FILE(changes)                   Wrote C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\2\host-tools\_opam\.opam-switch\install\opam-dkml.changes in 0.000s
-> installed opam-dkml.~dev                                                                                                     ]
00:14.607  SYSTEM                          copy C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\2\host-tools\_opam\bin\opam-dkml.exe -> C:\Users\beckf\AppData\Local\opam\plugins\bin\opam-dkml.exe
00:14.608  SYSTEM                          copy C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\2\host-tools\_opam\bin\opam-dkml.exe -> C:\Users\beckf\AppData\Local\opam\plugins\bin\opam-dkml.exe
00:14.621  FILE(switch-state)              Wrote C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\2\host-tools\_opam\.opam-switch\switch-state in 0.010s
```

---

One loose end is that the `if Sys.win32 then Unix.chmod dst 0o640 else ();` code before the symlink is deleted (`remove_file dst`) was not lifted into `remove_file`. I wanted this PR to focus just one issue (a functioning symlink creation function).