### PR TITLE
Reftests: some updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ on:
     - 'Makefile*'
     - 'configure*'
     - '.github/**'
+    - 'tests/**'
 #    paths-ignore:
 #    - 'release/**'
 #    - 'shell/**'

--- a/master_changes.md
+++ b/master_changes.md
@@ -160,10 +160,12 @@ users)
   * Update crowbar with compare functions [#4918 @rjbou]
 
 ## Reftests
+### Tests
   * Add switch-invariant test [#4866 @rjbou]
   * opam root version: add local switch cases [#4763 @rjbou] [2.1.0~rc2 #4715]
   * opam root version: add reinit test casess [#4763 @rjbou] [2.1.0~rc2 #4750]
   * Add & update env tests [#4861 #4841 @rjbou @dra27]
+### Engine
   * Add `opam-cat` to normalise opam file printing [#4763 @rjbou @dra27] [2.1.0~rc2 #4715]
   * Fix meld reftest: open only with failing ones [#4913 @rjbou]
   * Add `BASEDIR` to environement [#4913 @rjbou]
@@ -174,6 +176,11 @@ users)
   * Hackish way to have several replacement in a single line [#4913 @rjbou]
   * Substitution in regexp pattern (for environment variables) [#4913 @rjbou]
   * Substitution for opam-cat content [#4913 @rjbou]
+  * Allow one char package name on repo [#4966 @AltGr]
+  * Remove opam output beginning with `###` [#4966 @AltGr]
+  * Add `<pin:path>` header to specify incomplete opam files to pin, it is updated from a template in reftest run (no lint errors) [#4966 @rjbou]
+  * Unescape output [#4966 @rjbou]
+  * Clean outputs from opam error reporting block [#4966 @rjbou]
 
 
 ## Github Actions
@@ -187,6 +194,7 @@ users)
   * Update ocaml version frm 4.11.2 to  4.12.0 (because of macos failure) [#4865 @rjbou]
   * Add a depext checkup, launched only is `OpamSysInteract` is changed [#4788 @rjbou]
   * Arrange scripts directory [#4922 @rjbou]
+  * Run ci on tests changes [#4966 @rjbou]
 
 ## Shell
   * fish: fix deprecated redirection syntax `^` [#4736 @vzaliva]

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -640,6 +640,7 @@ let _ =
     List.iter (write (Sys.getcwd ())) local
   | _ -> ()
 ### rm -rf $OPAMROOT
+### OPAMSYSCOMP=2
 ### opam init -na default ./default --bare --bypass-checks --no-opamrc --debug-level=0
 No configuration file found, using built-in defaults.
 

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -136,7 +136,14 @@ type filt_sort =
   | Grep
   | GrepV
 
-let str_replace_path ?(escape=false) whichway filters s =
+let str_replace_path ?escape whichway filters s =
+  let unescape = escape = Some false in
+  let escape = escape = Some true in
+  let s =
+    if unescape then
+      Re.(replace_string (compile @@ str "\\\\") ~by:"\\" s)
+    else s
+  in
   let escape =
     if escape then Re.(replace_string (compile @@ char '\\') ~by:"\\\\")
     else fun s -> s
@@ -203,7 +210,7 @@ let command
   let rec filter_output ?(first=true) ic =
     match input_line ic with
     | s ->
-      let s = str_replace_path OpamSystem.back_to_forward filter s in
+      let s = str_replace_path ~escape:false OpamSystem.back_to_forward filter s in
       if s = "\\c" then filter_output ~first ic
       else
         (if not first then Buffer.add_char out_buf '\n';

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -440,20 +440,30 @@ let parse_command = Parse.command
 let common_filters ?opam dir =
    let tmpdir = Filename.get_temp_dir_name () in
    let open Re in
-    [
-      seq [bol; str cmd_prompt],
-      Sed "##% ";
-      alt [str dir; str (OpamSystem.back_to_forward dir)],
-      Sed "${BASEDIR}";
-      seq [opt (str "/private");
-           alt [str tmpdir;
-                str (OpamSystem.back_to_forward tmpdir)];
-           rep (set "/\\");
-           str "opam-";
-           rep1 (alt [xdigit; char '-'])],
-      Sed "${OPAMTMP}";
-    ] @
-    (match opam with
+   [
+     seq [ bol;
+           alt [ str "#=== ERROR";
+                 seq [ str "# "; alt @@ List.map str
+                         [ "context";
+                           "path";
+                           "command";
+                           "exit-code";
+                           "env-file";
+                           "output-file"]]]],
+     GrepV;
+     seq [bol; str cmd_prompt],
+     Sed "##% ";
+     alt [str dir; str (OpamSystem.back_to_forward dir)],
+     Sed "${BASEDIR}";
+     seq [opt (str "/private");
+          alt [str tmpdir;
+               str (OpamSystem.back_to_forward tmpdir)];
+          rep (set "/\\");
+          str "opam-";
+          rep1 (alt [xdigit; char '-'])],
+     Sed "${OPAMTMP}";
+   ] @
+   (match opam with
     | None -> []
     | Some opam -> [ str opam, Sed "${OPAMBIN}" ])
 

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -64,7 +64,7 @@ let is_prefix pfx s =
   String.sub s 0 (String.length pfx) = pfx
 
 let rem_prefix pfx s =
-  if not (is_prefix pfx s) then invalid_arg "rem_prefix"
+  if not (is_prefix pfx s) || s = pfx then invalid_arg "rem_prefix"
   else String.sub s (String.length pfx) (String.length s - String.length pfx)
 
 (* Test file format: {v


### PR DESCRIPTION
on reftests engine:
* Allow one char package name on repo
* Remove opam output beginning with `###`
* Add `<pin:path>` header to specify incomplete opam files to pin, it is updated from a template in reftest run (no lint errors)

~On tests, adds orphans and imported opam-rt tests (reinstall, big-upgrade, dep-cycles).~
/cc @AltGr 