### PR TITLE
Print user-friendly error messages when a command is not found, before calling the sandbox

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -88,6 +88,7 @@ users)
   * Sync the behaviour of the macOS sandbox script with Linux's: /tmp is now ready-only [#4719 @kit-ty-kate]
   * Always mount every directories under / on Linux [#4795 @kit-ty-kate]
   * Get rid of OPAM_USER_PATH_RO (never used on macOS and no longer needed on Linux) [#4795 @kit-ty-kate]
+  * Print error message if command doesn't exist [#4971 @kit-ty-kat - fix #4112]
 
 ## Repository
   * Don't display global message when `this-switch` is given [#4899 @rjbou - fix #4889]

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -125,6 +125,11 @@ case "$COMMAND" in
         exit 2
 esac
 
+if ! command -v "$1" >/dev/null; then
+    echo "[ERROR] Command not found: $1" >&2
+    exit 10
+fi
+
 # Note: we assume $1 can be trusted, see https://github.com/projectatomic/bubblewrap/issues/259
 # As of now we are compatible up to 0.1.8, '--' can be added here when we require >= 0.3.0
 exec bwrap "${ARGS[@]}" "$@"

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -81,4 +81,9 @@ case "$COMMAND" in
         exit 2
 esac
 
+if ! command -v "$1" >/dev/null; then
+    echo "[ERROR] Command not found: $1" >&2
+    exit 10
+fi
+
 exec sandbox-exec -p "$POL" "$@"


### PR DESCRIPTION
bwrap for instance will exit with the confusing "bwrap: execvp <cmd>: No such file or directory"

Example of such confused user can be found here: https://github.com/ocaml/opam/issues/4112#issuecomment-996208463