### PR TITLE
Depexts: Stop zypper from upgrading packages on updates on OpenSUSE

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -82,6 +82,7 @@ users)
     in some cases [#4791 @kit-ty-kate - fixes #4790]
   * Archlinux: handle virtual package detection [#4831 @rjbou - partial fix #4759]
   * Fallback on dnf if yum does not exist on RHEL-based systems [#4825 @kit-ty-kate]
+  * Stop zypper from upgrading packages on updates on OpenSUSE [#4978 @kit-ty-kate]
 
 ## Format upgrade
   * Fix format upgrade when there is missing local switches in the config file [#4763 @rjbou - fix #4713] [2.1.0~rc2 #4715]

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -714,7 +714,7 @@ let update () =
     | Gentoo -> Some ("emerge", ["--sync"])
     | Homebrew -> Some ("brew", ["update"])
     | Macports -> Some ("port", ["sync"])
-    | Suse -> Some ("zypper", ["--non-interactive"; "update"])
+    | Suse -> Some ("zypper", ["--non-interactive"; "refresh"])
     | Freebsd | Netbsd | Openbsd ->
       None
   in


### PR DESCRIPTION
Mirrors https://github.com/ocaml-opam/opam-depext/commit/bfb81de27552ce854925a6e9b5d8fadd36785e7b for yum/dnf