### PR TITLE
Add some debug log to OpamCudf.extract_explanations to help debug #4373

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -194,6 +194,7 @@ users)
   * Optimised reverse dependencies calculation [#5005 @AltGr]
   * Enable cudf preprocessing for (co)insallability calculation, resulting in a x20 speedup [@AltGr]
   * Make sure that `--best-effort` only installs root package versions that where requested [#4796 @LasseBlaauwbroek]
+  * Ask users to report errors when no explanations are given to them [#4981 @kit-ty-kate]
 
 ## Client
   * Check whether the repository might need updating more often [#4935 @kit-ty-kate]
@@ -208,6 +209,7 @@ users)
   * [BUG] Remove windows double printing on commands and their output [#4940 @rjbou]
   * OpamParallel, MakeGraph(_).to_json: fix incorrect use of List.assoc [#5038 @Armael]
   * [BUG] Fix display of command when parallelised [#5091 @rjbou]
+  * Add some debug log to OpamCudf.extract_explanations to help debug #4373 [#4981 @kit-ty-kate]
 
 ## Internal: Windows
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -750,7 +750,7 @@ type explanation =
                   OpamFormula.formula
   ]
 
-module Opam_dose_debug = struct
+module Pp_dose_diagnostic = struct
   let pp_package fmt pkg =
     let name = pkg.Cudf.package in
     let version =
@@ -809,7 +809,7 @@ let extract_explanations packages cudfnv2opam reasons : explanation list =
   let open Set.Op in
   let module CS = ChainSet in
   (* Definitions and printers *)
-  log ~level:3 "Reasons: %a" (Opam_dose_debug.pp_reasonlist cudfnv2opam) reasons;
+  log ~level:3 "Reasons: %a" (Pp_dose_diagnostic.pp_reasonlist cudfnv2opam) reasons;
   let all_opam =
     let add p set =
       if is_artefact p then set

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -1042,6 +1042,9 @@ let extract_explanations packages cudfnv2opam reasons : explanation list =
         | _ -> false)
   in
   match explanations with
+  | [] ->
+    OpamConsole.error_and_exit `Internal_error
+      "Internal error while computing conflict explanations: sorry, please report."
   | `Missing (_, sdeps, fdeps) :: rest when same_depexts sdeps fdeps rest ->
     [`Missing (None, sdeps, fdeps)]
   | _ -> explanations

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -1071,7 +1071,9 @@ let extract_explanations packages cudfnv2opam reasons : explanation list =
   match explanations with
   | [] ->
     OpamConsole.error_and_exit `Internal_error
-      "Internal error while computing conflict explanations: sorry, please report."
+      "Internal error while computing conflict explanations:\n\
+       sorry about that. Please report how you got here in \
+       https://github.com/ocaml/opam/discussions/5130 if possible."
   | `Missing (_, sdeps, fdeps) :: rest when same_depexts sdeps fdeps rest ->
     [`Missing (None, sdeps, fdeps)]
   | _ -> explanations


### PR DESCRIPTION
The following dockerfile (derived from https://github.com/ocaml/opam/issues/4373#issuecomment-992725743):
```
FROM ocaml/opam:debian-11-ocaml-4.12@sha256:40813dc1391636b4a428afbf0e678d2c81b80d9eade8a5214d8ee271fae155f3
RUN git clone https://github.com/kit-ty-kate/opam.git -b extract_explanations-debug
WORKDIR opam
RUN opam exec -- ./configure --with-vendored-deps
RUN opam exec -- make
RUN sudo ln -f _build/default/src/client/opamMain.exe /usr/bin/opam
RUN opam init --reinit -ni
RUN opam remote set-url default git+https://github.com/ocaml/opam-repository.git#a5d7cdc0c91452b0aef4fa71c331ee5237f6dddd
RUN opam pin add --debug --debug-level=3 --with-version 0.6.1 git+https://github.com/bikallem/resto.git#e725f56dd2d5ca0148272d754a0f29ffe76f94e8
```
now reports:
```
00:10.228  CLIENT                          conflict!
[ERROR] Package conflict!
00:10.228  CUDF                            Conflict reporting
00:10.228  CUDF                            Reasons: [
  Dependency (dose-dummy-request.???, [resto-cohttp-server], [resto-cohttp-server.0.6.1]);
  Dependency (resto-cohttp-server.0.6.1, [cohttp-lwt-unix>=4.0.0], [cohttp-lwt-unix.4.0.0]);
  Dependency (resto-cohttp-server.0.6.1, [conduit-lwt-unix>=5.0.0], [conduit-lwt-unix.5.0.0]);
  Conflict (conduit-lwt-unix.1.0.3, conduit-lwt-unix.5.0.0, conduit-lwt-unix);
  Conflict (conduit-lwt-unix.1.4.0, conduit-lwt-unix.5.0.0, conduit-lwt-unix);
  Conflict (conduit-lwt-unix.4.0.1, conduit-lwt-unix.5.0.0, conduit-lwt-unix);
  Conflict (conduit-lwt-unix.1.5.0, conduit-lwt-unix.5.0.0, conduit-lwt-unix);
  Conflict (conduit-lwt-unix.1.2.0, conduit-lwt-unix.5.0.0, conduit-lwt-unix);
  Conflict (conduit-lwt-unix.2.0.1, conduit-lwt-unix.5.0.0, conduit-lwt-unix);
  Conflict (conduit-lwt-unix.1.0.2, conduit-lwt-unix.5.0.0, conduit-lwt-unix);
  Conflict (conduit-lwt-unix.5.0.0, conduit-lwt-unix.2.3.0, conduit-lwt-unix);
  Conflict (conduit-lwt-unix.5.0.0, conduit-lwt-unix.4.0.2, conduit-lwt-unix);
  Conflict (conduit-lwt-unix.5.0.0, conduit-lwt-unix.2.2.2, conduit-lwt-unix);
  Conflict (conduit-lwt-unix.5.0.0, conduit-lwt-unix.4.0.0, conduit-lwt-unix);
  Conflict (conduit-lwt-unix.5.0.0, conduit-lwt-unix.2.0.2, conduit-lwt-unix);
  Conflict (conduit-lwt-unix.5.0.0, conduit-lwt-unix.2.0.0, conduit-lwt-unix);
  Conflict (conduit-lwt-unix.5.0.0, conduit-lwt-unix.1.1.0, conduit-lwt-unix);
  Conflict (conduit-lwt-unix.5.0.0, conduit-lwt-unix.1.3.0, conduit-lwt-unix);
  Dependency (cohttp-lwt-unix.4.0.0, [conduit-lwt-unix<5.0.0], [conduit-lwt-unix.1.2.0, conduit-lwt-unix.1.0.2, conduit-lwt-unix.2.0.1, conduit-lwt-unix.4.0.0, conduit-lwt-unix.4.0.2, conduit-lwt-unix.2.2.2, conduit-lwt-unix.2.3.0, conduit-lwt-unix.1.4.0, conduit-lwt-unix.1.0.3, conduit-lwt-unix.1.5.0, conduit-lwt-unix.1.3.0, conduit-lwt-unix.2.0.2, conduit-lwt-unix.4.0.1, conduit-lwt-unix.1.1.0, conduit-lwt-unix.2.1.0, conduit-lwt-unix.2.0.0]);
  Conflict (conduit-lwt-unix.5.0.0, conduit-lwt-unix.2.1.0, conduit-lwt-unix);
]
[ERROR] Internal error while computing conflict explanations: sorry, please report.
[NOTE] Pinning command successful, but your installed packages may be out of sync.
```