### PR TITLE
[2.1 backport] Speed up and fix AppVeyor runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,4 +267,4 @@ cold-%:
 
 .PHONY: run-appveyor-test
 run-appveyor-test:
-	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" ./appveyor_test.sh
+	env -u OCAMLLIB -u CAML_LD_LIBRARY_PATH PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" ./appveyor_test.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
   global:
     CYG_ROOT: cygwin64
     CYG_ARCH: x86_64
+    CYGWIN: winsymlinks:native
     OCAML_PORT:
     CYG_CACHE: C:/cygwin/var/cache/setup
     CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ environment:
     CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
     DEP_MODE: lib-ext
     # This should be identical to the value in .travis.yml
+    OPAM_REPO: https://github.com/ocaml/opam-repository.git
     OPAM_REPO_SHA: 38e8f54c584fa3cfe779890f7a56fe88ee38be78
     OPAM_TEST_REPO_SHA: 38e8f54c584fa3cfe779890f7a56fe88ee38be78
   matrix:

--- a/appveyor_test.sh
+++ b/appveyor_test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-opam init -y -a --compiler=ocaml.4.12.0 git+https://github.com/ocaml/opam-repository#$OPAM_TEST_REPO_SHA
+COLD_OCAML="$(sed -ne 's/URL_ocaml = .*ocaml-.*ocaml-\(.*\)\.tar\.gz/ocaml.\1/p' src_ext/Makefile)"
+# This is supposed to be able to select ocaml-system using the bootstrap compiler
+opam init -y -a --compiler=$COLD_OCAML git+$OPAM_REPO#$OPAM_TEST_REPO_SHA
 eval $(opam config env)
 opam install -y -v ocamlfind


### PR DESCRIPTION
This fixes issues with the Cygwin run when the bootstrap ocaml compiler does not match the compiler being tested in appveyor.
It also brings faster CI runs.

Backports to 2.1 as mentioned in https://github.com/ocaml/opam/pull/4961#issuecomment-1007509058