### PR TITLE
Tweak bootstrap & CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
   global:
     CYG_ROOT: cygwin64
     CYG_ARCH: x86_64
+    CYGWIN: winsymlinks:native
     OCAML_PORT:
     CYG_CACHE: C:/cygwin/var/cache/setup
     CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/

--- a/master_changes.md
+++ b/master_changes.md
@@ -123,7 +123,8 @@ users)
   * Switch to vendored build if spdx_licenses is missing [#4842 @dra27]
   * Check versions of findlib packages in configure [#4842 @dra27]
   * Fix dose3 download url since gforge is gone [#4870 @avsm]
-  * Update bootstap ocaml to 4.12.1 to integrate mingw fix [#4927 @rjbou]
+  * Update bootstrap ocaml to 4.12.1 to integrate mingw fix [#4927 @rjbou]
+  * Update bootstrap to use `-j` for Unix (Windows already does) [#4988 @dra27]
 
 ## Infrastructure
   * Fix caching of Cygwin compiler on AppVeyor [#4988 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -126,7 +126,7 @@ users)
   * Update bootstap ocaml to 4.12.1 to integrate mingw fix [#4927 @rjbou]
 
 ## Infrastructure
-  *
+  * Fix caching of Cygwin compiler on AppVeyor [#4988 @dra27]
 
 ## Admin
   * ✘ `opam admin cache` now ignores all already present cache files. Option

--- a/shell/bootstrap-ocaml.sh
+++ b/shell/bootstrap-ocaml.sh
@@ -157,8 +157,8 @@ else
   PREFIX=`cd .. ; pwd`/ocaml
   if [ ${GEN_CONFIG_ONLY} -eq 0 ] ; then
     ./configure --prefix "${PREFIX}" $BOOTSTRAP_EXTRA_OPTS --disable-stdlib-manpages
-    ${MAKE:-make} world
-    ${MAKE:-make} $BOOTSTRAP_OPT_TARGET
+    ${MAKE:-make} -j world
+    ${MAKE:-make} -j $BOOTSTRAP_OPT_TARGET
     ${MAKE:-make} install
   fi
   OCAMLLIB=${PREFIX}/lib/ocaml


### PR DESCRIPTION
Two changes, related inasmuch as they improve the time Cygwin takes on AppVeyor:

- `make cold` build the compiler sequentially on Unix (Windows has always had `-j`). This is historical - the script dates from a time when `make -j` didn't reliably work. This slows down our CI when the cache is invalid or the bootstrap moves forward and it unnecessarily slows down the base image builder.
- Recent versions of Cygwin use WSL symlinks which appear not to work with AppVeyor's caching mechanism. Switch to native Windows symlinks which means the bootstrap compiler is cached again.

I'm very paranoid about changing the bootstrap script, so the AppVeyor fix should go to 2.1 and 2.0, but the parallel build change should not.