### PR TITLE
Use simplified version comparison function

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -144,7 +144,8 @@ users)
   * Actually allow multiple state caches to co-exist [#4934 @dra27 - fix #4554 properly this time]
 
 ## Opam file format
-  *
+  * ✘ Version comparison is now strictly as specified in the docs, and doesn't
+    handle Debian-like "epoch" prefixes or "revision" suffixes [@AltGr - fix #4272]
 
 ## Solver
   * [BUG] Remove z3 debug output [#4723 @rjbou - fix #4717] [2.1.0~rc2 #4720]

--- a/src/core/opamVersionCompare.ml
+++ b/src/core/opamVersionCompare.ml
@@ -27,32 +27,6 @@ let skip_while_from i f w m =
   in loop i
 ;;
 
-(* splits a version into (epoch,rest), without the separating ':'. The
- * epoch is delimited by the leftmost occurrence of ':' in x, and is ""
- * in case there is no ':' in x.  *)
-let extract_epoch x =
-  try
-    let ci = String.index x ':' in
-    let epoch = String.sub x 0 ci
-    and rest = String.sub x (ci + 1) (String.length x - ci - 1)
-    in (epoch,rest)
-  with
-    | Not_found -> ("",x)
-;;
-
-(* splits a version into (prefix,revision). The revision starts on the
- * right-most occurrence of '-', or is empty in case the version does
- * not contain '-'.  *)
-let extract_revision x =
-  try
-    let di = String.rindex x '-' in
-    let before = String.sub x 0 di in
-    let after = String.sub x (di+1) (String.length x - di -1) in
-    (before,after)
-  with
-    | Not_found -> (x,"")
-;;
-
 (* character comparison uses a modified character ordering: '~' first,
    then letters, then anything else *)
 let compare_chars c1 c2 = match c1 with
@@ -146,6 +120,37 @@ let compare_chunks x y =
   in loop_lexical 0 0
 ;;
 
+let compare = compare_chunks
+
+(* -- Original code from Dose, full debian-compatible version comparison
+      including epoch and revisions -- *)
+(*
+(* splits a version into (epoch,rest), without the separating ':'. The
+ * epoch is delimited by the leftmost occurrence of ':' in x, and is ""
+ * in case there is no ':' in x.  *)
+let extract_epoch x =
+  try
+    let ci = String.index x ':' in
+    let epoch = String.sub x 0 ci
+    and rest = String.sub x (ci + 1) (String.length x - ci - 1)
+    in (epoch,rest)
+  with
+    | Not_found -> ("",x)
+;;
+
+(* splits a version into (prefix,revision). The revision starts on the
+ * right-most occurrence of '-', or is empty in case the version does
+ * not contain '-'.  *)
+let extract_revision x =
+  try
+    let di = String.rindex x '-' in
+    let before = String.sub x 0 di in
+    let after = String.sub x (di+1) (String.length x - di -1) in
+    (before,after)
+  with
+    | Not_found -> (x,"")
+;;
+
 let compare (x : string) (y : string) =
   let normalize_comp_result x = if x=0 then 0 else if x < 0 then -1 else 1
   in
@@ -162,6 +167,7 @@ let compare (x : string) (y : string) =
       if u_comp <> 0 then normalize_comp_result u_comp
       else normalize_comp_result (compare_chunks r1 r2)
 ;;
+*)
 
 let equal (x : string) (y : string) =
   if x = y then true else (compare x y) = 0


### PR DESCRIPTION
As specified in the docs, and not as handled in Debian: we used to run the 
Debian comparison from Dose, which handled epoch prefixes and revision
suffixes in an undocumented way (undocumented in opam, not blaming Dose
here!).

Closes #4272