### PR TITLE
Improve performance of opam show by 300% when the package to show is given explicitly or unique

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -50,6 +50,7 @@ users)
 ## Show
   * Add `depexts` to default printer [#4898 @rjbou]
   * Make `opam show --list-files <pkg>` fail with not found when `<pkg>` is not installed [#4956 @kit-ty-kate - fix #4930]
+  * Improve performance of opam show by 300% when the package to show is given explicitly or unique [#4998 @kit-ty-kate - fix #4997 and partially #4172]
 
 ## Var
   *

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -820,7 +820,7 @@ let info st ~fields ~raw ~where ?normalise ?(show_empty=false)
   List.iter (fun (name,_) ->
       (* Like OpamSwitchState.get_package, but restricted to [packages] *)
       let nvs = OpamPackage.packages_of_name packages name in
-      if all_versions then
+      if OpamPackage.Set.is_singleton nvs || all_versions then
         (header (OpamPackage.Set.max_elt nvs);
          OpamPackage.Set.iter output_package nvs)
       else


### PR DESCRIPTION
Fixes #4997 and partially https://github.com/ocaml/opam/issues/4172

Before:
```
opam show --raw dune.2.9.0  0.94s user 0.32s system 97% cpu 1.286 total
```
After:
```
./opam show --raw dune.2.9.0  0.37s user 0.05s system 97% cpu 0.433 total
```