### PR TITLE
Improve performance of some opam list combination

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -45,7 +45,9 @@ users)
   * ◈ New option `opam pin --current` to fix a package in its current state (avoiding pending reinstallations or removals from the repository) [#4973 @AltGr - fix #4970]
 
 ## List
-  * Some optimisations to 'opam list --installable' queries combined with other filters [@altgr]
+  * Some optimisations to 'opam list --installable' queries combined with other filters [#4882 @altgr - fix #4311]
+  * Improve performance of some opam list combination (e.g. --available --installable) [#4999 @kit-ty-kate]
+  * Improve performance of opam list --conflicts-with when combined with other filters [#4999 @kit-ty-kate]
 
 ## Show
   * Add `depexts` to default printer [#4898 @rjbou]

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -243,7 +243,7 @@ let apply_selector ~base st = function
       base
   | Conflicts_with packages ->
     OpamSwitchState.conflicts_with st (OpamPackage.Set.of_list packages)
-      (Lazy.force st.available_packages)
+      base
   | Coinstallable_with (tog, packages) ->
     let universe = get_universe st tog in
     let set = OpamPackage.Set.of_list packages in

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -374,8 +374,8 @@ let rec filter ~base st = function
   | Block b -> filter ~base st b
   | And (a, b) ->
     let base = filter ~base st a in
-    base %% filter ~base st b
-  | Or (a, b) -> base %% (filter ~base st a ++ filter ~base st b)
+    filter ~base st b
+  | Or (a, b) -> filter ~base st a ++ filter ~base st b
 
 type output_format =
   | Name

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -370,12 +370,12 @@ let apply_selector ~base st = function
 
 let rec filter ~base st = function
   | Empty -> base
-  | Atom select -> apply_selector ~base st select
+  | Atom select -> base %% apply_selector ~base st select
   | Block b -> filter ~base st b
   | And (a, b) ->
     let base = filter ~base st a in
     base %% filter ~base st b
-  | Or (a, b) -> filter ~base st a ++ filter ~base st b
+  | Or (a, b) -> base %% (filter ~base st a ++ filter ~base st b)
 
 type output_format =
   | Name


### PR DESCRIPTION
With master (https://github.com/ocaml/opam/commit/f39739b9325ea10d5c733b14c8b14f6dcf46abf2):
```
$ time opam list --available --installable -s --all-version dune.2.9.1
dune.2.9.1
opam list --available --installable -s --all-version dune.2.9.1  54.60s user 0.60s system 99% cpu 55.278 total
```
With this PR:
```
$ time opam list --available --installable -s --all-version dune.2.9.1
dune.2.9.1
./opam list --available --installable -s --all-version dune.2.9.1  2.91s user 0.37s system 98% cpu 3.317 total
```

Incidently, this also makes `OpamListCommand.filter` correct. Previously it would simply ignore its `~base` parameter if the request did not start with a `And` case