### PR TITLE
Install page: clean up "pre-compiled binaries for"

### DIFF
--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -36,8 +36,10 @@ pre-compiled binary, backup your opam data if from an older version, and run
 and run `sh install.sh`)
 
 We provide pre-compiled binaries for:
-- Linux i686, amd64, arm7, arm64
-- macOS (intel 64 bits, arm64)
+- Linux (amd64, arm64, arm7, i686)
+- macOS (amd64, arm64)
+- FreeBSD (amd64)
+- OpenBSD (amd64)
 - We do not at present provide an official Windows distribution of opam, but please see [this separately maintained distribution](https://fdopen.github.io/opam-repository-mingw/)
 (other platforms are available using the other methods below)
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -223,6 +223,7 @@ users)
   * Fix `span` tag in mannual [#4855 @rjbou - fix #4848]
   * Add `avoid-version` doc [#4896 @AltGR - fix #4864]
   * Document custom licenses [#4863 @kit-ty-kate - fix #4862]
+  * Add OpenBSD & FreeBSD in the precompiled binaries list [#5001 @mndrix]
 
 ## Security fixes
   *


### PR DESCRIPTION
`shell/install.sh` includes support for both FreeBSD and OpenBSD on the amd64 architecture, so I added entries for those. I also made the formatting  and architecture names consistent for all four operating systems.

Please update `master_changes.md` file with your changes.
