### PR TITLE
Avoid trying to be too clever when upgrading switches from opam 2.0

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -65,6 +65,7 @@ users)
   * [BUG] Fix `set-invariant: default repos were loaded instead of switch repos [#4866 @rjbou]
   * Add support for `opam switch -` (go to previous non-local switch) [#4910 @kit-ty-kate - fix 4866]
   * On loading, check for executable external files if they are in `PATH`, and warn if not the case [#4932 @rjbou - fix #4923]
+  * Avoid trying to be too clever when upgrading switches from opam 2.0 [#5002 @kit-ty-kate - fix #4501]
 
 ## Pin
   * Switch the default version when undefined from ~dev to dev [#4949 @kit-ty-kate]

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -131,17 +131,7 @@ let infer_switch_invariant_raw
       compiler []
   in
   match List.sort (fun (_, c1) (_, c2) -> compare c1 c2) counts with
-  | (nv, _) :: _ ->
-    let versions =
-      OpamPackage.packages_of_name (Lazy.force available_packages) nv.name
-    in
-    let n = OpamPackage.Set.cardinal versions in
-    if n <= 1 then
-      OpamFormula.Atom (nv.name, Empty)
-    else if nv = OpamPackage.Set.max_elt versions then
-      OpamFormula.Atom (nv.name, Atom (`Geq, nv.version))
-    else
-      OpamFormula.Atom (nv.name, Atom (`Eq, nv.version))
+  | (nv, _) :: _ -> OpamFormula.Atom (nv.name, Atom (`Eq, nv.version))
   | [] -> OpamFormula.Empty
 
 let infer_switch_invariant st =

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -662,7 +662,7 @@ FMT_UPG                         Format upgrade done
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
-STATE                           Inferred invariant: from base packages { i-am-sys-compiler.1 }, (roots { i-am-sys-compiler.1 }) => ["i-am-sys-compiler"]
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.1 }, (roots { i-am-sys-compiler.1 }) => ["i-am-sys-compiler" {= "1"}]
 STATE                           Switch state loaded in 0.000s
 # Packages matching: installed
 # Name               # Installed # Synopsis
@@ -679,7 +679,7 @@ RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ sw-comp
 STATE                           Definition missing for installed package i-am-compiler.2, copying from repo
 STATE                           Definition missing for installed package i-am-package.2, copying from repo
-STATE                           Inferred invariant: from base packages { i-am-compiler.2 }, (roots { i-am-compiler.2 }) => ["i-am-compiler" {>= "2"}]
+STATE                           Inferred invariant: from base packages { i-am-compiler.2 }, (roots { i-am-compiler.2 }) => ["i-am-compiler" {= "2"}]
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
@@ -716,7 +716,7 @@ opam-version: "2.0"
 repositories: "default"
 switch: "sw-comp"
 ### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-config
-invariant: ["i-am-compiler" {>= "2"}]
+invariant: ["i-am-compiler" {= "2"}]
 opam-version: "2.0"
 synopsis: "switch with compiler"
 paths {
@@ -740,7 +740,7 @@ FMT_UPG                         Format upgrade done
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
-STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler"]
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler" {= "2"}]
 STATE                           Switch state loaded in 0.000s
 # Packages matching: installed
 # Name            # Installed # Synopsis
@@ -755,7 +755,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
-STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler"]
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler" {= "2"}]
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
@@ -789,7 +789,7 @@ opam-version: "2.0"
 repositories: "default"
 switch: "sw-sys-comp"
 ### opam-cat _opam/.opam-switch/switch-config
-invariant: ["i-am-sys-compiler"]
+invariant: ["i-am-sys-compiler" {= "2"}]
 opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
@@ -815,7 +815,7 @@ FMT_UPG                         Format upgrade done
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
-STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler"]
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler" {= "2"}]
 STATE                           Switch state loaded in 0.000s
 # Packages matching: installed
 # Name            # Installed # Synopsis
@@ -829,7 +829,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
-STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler"]
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler" {= "2"}]
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
@@ -863,7 +863,7 @@ opam-version: "2.0"
 repositories: "default"
 switch: "sw-sys-comp"
 ### opam-cat _opam/.opam-switch/switch-config
-invariant: ["i-am-sys-compiler"]
+invariant: ["i-am-sys-compiler" {= "2"}]
 opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
@@ -886,7 +886,7 @@ GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
-STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler"]
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler" {= "2"}]
 STATE                           Switch state loaded in 0.000s
 # Packages matching: installed
 # Name            # Installed # Synopsis
@@ -897,7 +897,7 @@ GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
-STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler"]
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler" {= "2"}]
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
@@ -925,7 +925,7 @@ opam-version: "2.0"
 repositories: "default"
 switch: "sw-sys-comp"
 ### opam-cat _opam/.opam-switch/switch-config
-invariant: ["i-am-sys-compiler"]
+invariant: ["i-am-sys-compiler" {= "2"}]
 opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/4501
See https://github.com/ocurrent/opam-repo-ci/pull/148
See https://github.com/ocurrent/docker-base-images/pull/150

I don’t see any good reason for trying to guess what the user meant instead of letting the user choose what they want afterward.

Transforming a 2.0 switch to `"<compiler-package>"` (without constraint) is dangerous (as shown above)
Transforming a 2.0 switch to `"<compiler-package>" {>= "<current-version>"}` is equally dangerous as it breaks switches named after its current compiler if the compiler is the latest. We can’t assume people with the latest compiler always want the latest