### PR TITLE
Big speedup on reverse dependency calculation

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -157,6 +157,7 @@ users)
   * Add an explanation for "no longer available" packages [#4969 @AltGr]
   * Orphan packages are now handled at the solver level instead of a pre-processing phase, better ensuring consistency [#4969 @altgr]
   * Make the 0install solver non-optional [#4909 @kit-ty-kate]
+  * Optimised reverse dependencies calculation [#5005 @AltGr]
 
 ## Client
   * Check whether the repository might need updating more often [#4935 @kit-ty-kate]

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -518,6 +518,11 @@ module OpamString = struct
     let rec chk i = i >= x || suffix.[i] = s.[i+n-x] && chk (i+1) in
     chk 0
 
+  let for_all f s =
+    let len = String.length s in
+    let rec aux i = i >= len || f s.[i] && aux (i+1) in
+    aux 0
+
   let contains_char s c =
     try let _ = String.index s c in true
     with Not_found -> false

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -251,6 +251,7 @@ module String : sig
 
   val starts_with: prefix:string -> string -> bool
   val ends_with: suffix:string -> string -> bool
+  val for_all: (char -> bool) -> string -> bool
   val contains_char: string -> char -> bool
   val contains: sub:string -> string -> bool
   val exact_match: Re.re -> string -> bool

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -91,7 +91,7 @@ let cudf_versions_map universe packages =
 
 let name_to_cudf name =
   let name_s = OpamPackage.Name.to_string name in
-  if String.for_all (function
+  if OpamStd.String.for_all (function
       | 'a'..'z' | 'A'..'Z' | '0'..'9' | '@' | '/' | '+' | '(' | ')' | '.' | '-'
         -> true
       | _ -> false)

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -90,7 +90,14 @@ let cudf_versions_map universe packages =
     pmap OpamPackage.Map.empty
 
 let name_to_cudf name =
-  Dose_common.CudfAdd.encode (OpamPackage.Name.to_string name)
+  let name_s = OpamPackage.Name.to_string name in
+  if String.for_all (function
+      | 'a'..'z' | 'A'..'Z' | '0'..'9' | '@' | '/' | '+' | '(' | ')' | '.' | '-'
+        -> true
+      | _ -> false)
+      name_s
+  then name_s
+  else Dose_common.CudfAdd.encode name_s
 
 let constraint_to_cudf version_map name (op,v) =
   let nv = OpamPackage.create name v in


### PR DESCRIPTION
We need to revert a huge simply-linked structure; the big cost was allocating 
the intermediate data, so instead of creating the graph or going through sets, 
we use the integer identifiers already defined by Cudf and store that in a 
simple table.