### PR TITLE
Improve performance by disabling repo tarring

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -18,6 +18,7 @@ users)
   * Add cli 2.2 handling [#4853 @rjbou]
   * --no-depexts is the default in CLI 2.0 mode [#4908 @dra27]
   * [BUG] Fix behaviour on closed stdout/stderr [#4901 @altgr - fix #4216]
+  * Add `OPAMREPOSITORYTARRING` environment variable to enable repository tarring optimisation, it is disabled by default because it is an optimisation only on some os/configurations [#5015 @rjbou]
 
 ## Plugins
   *
@@ -73,6 +74,10 @@ users)
 ## Repository
   * When several checksums are specified, instead of adding in the cache only the archive by first checksum, name by best one and link others to this archive [#4696 rjbou]
   * Update opam repository man doc regarding removal of the last repository in a switch [#4435 - fixes #4381]
+  * Don't display global message when `this-switch` is given [#4899 @rjbou - fix #4889]
+  * Set the priority of user-set archive-mirrors higher than the repositories'.
+    This allows opam-repository to use the default opam.ocaml.org cache and be more resilient to changed/force-pushed or unavailable archives. [#4830 @kit-ty-kate - fixes #4411]
+  * Repository tarring "optimisation" no more needed, removed in favor of a plain directory. It still can be used with environment variable `OPAMREPOSITORYTARRING`.  [#5015 @kit-ty-kate @rjbou @AltGr - fix #4586]
 
 ## Lock
   *
@@ -107,11 +112,6 @@ users)
   * Always mount every directories under / on Linux [#4795 @kit-ty-kate]
   * Get rid of OPAM_USER_PATH_RO (never used on macOS and no longer needed on Linux) [#4795 @kit-ty-kate]
   * Print error message if command doesn't exist [#4971 @kit-ty-kat - fix #4112]
-
-## Repository
-  * Don't display global message when `this-switch` is given [#4899 @rjbou - fix #4889]
-  * Set the priority of user-set archive-mirrors higher than the repositories'.
-    This allows opam-repository to use the default opam.ocaml.org cache and be more resilient to changed/force-pushed or unavailable archives. [#4830 @kit-ty-kate - fixes #4411]
 
 ## VCS
   * Pass --depth=1 to git-fetch in the Git repo backend [#4442 @dra27]
@@ -203,6 +203,7 @@ users)
   * Add some simple tests for the "opam list" command [#5006 @kit-ty-kate]
   * Add clean test for untracked option [#4915 @rjbou]
   * Harmonise some repo hash to reduce opam repository checkout [#5031 @AltGr]
+  * Add repo optim enable/disable test [#5015 @rjbou]
 ### Engine
   * Add `opam-cat` to normalise opam file printing [#4763 @rjbou @dra27] [2.1.0~rc2 #4715]
   * Fix meld reftest: open only with failing ones [#4913 @rjbou]
@@ -257,6 +258,7 @@ users)
   * `OpamStd.ABSTRACT`: add `compare` and `equal`, that added those functions to `OpamCLIVersion` [#4918 @rjbou]
   * `OpamConfigCommand`: add a labelled argument `no_switch` to `exec` [#4957 @kit-ty-kate]
 ## opam-repository
+  * `OpamRepositoryConfig`: add in config record `repo_tarring` field and as an argument to config functions, and a new constructor `REPOSITORYTARRING` in `E` environment module and its access function [#5015 @rjbou]
 ## opam-state
 ## opam-solver
   * `OpamCudf`: Change type of `conflict_case.Conflict_cycle` (`string list list` to `Cudf.package action list list`) and `cycle_conflict`, `string_of_explanations`, `conflict_explanations_raw` types accordingly [#4039 @gasche]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -209,6 +209,12 @@ let environment_variables =
        'download-command' value from the main config file.";
       "NOCHECKSUMS", cli_original, (fun v -> NOCHECKSUMS (env_bool v)),
       "enables option --no-checksums when available.";
+      "REPOSITORYTARRING", cli_from cli2_2,
+      (fun b -> REPOSITORYTARRING (env_bool b)),
+      "internally store the repositories as tar.gz files. This can be much \
+       faster on filesystems that don't cope well with scanning large trees \
+       but have good caching in /tmp. However this is slower in the \
+       general case.";
       "REQUIRECHECKSUMS", cli_original,
       (fun v -> REQUIRECHECKSUMS (env_bool v)),
       "Enables option `--require-checksums' when available \

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -149,6 +149,7 @@ val opam_init:
   ?validation_hook:OpamTypes.arg list option ->
   ?retries:int ->
   ?force_checksums:bool option ->
+  ?repo_tarring:bool ->
   ?debug_level:int ->
   ?debug_sections:OpamStd.Config.sections ->
   ?verbose_level:OpamStd.Config.level ->

--- a/src/client/opamRepositoryCommand.ml
+++ b/src/client/opamRepositoryCommand.ml
@@ -256,16 +256,17 @@ let update_with_auto_upgrade rt repo_names =
            let open OpamProcess.Job.Op in
            let repo_root = OpamRepositoryState.get_repo_root rt r in
            OpamAdminRepoUpgrade.do_upgrade repo_root;
-           OpamProcess.Job.run
-             (OpamFilename.make_tar_gz_job
-                (OpamRepositoryPath.tar rt.repos_global.root r.repo_name)
-                repo_root
-              @@| function
-              | Some e ->
-                Printf.ksprintf failwith
-                  "Failed to regenerate local repository archive: %s"
-                  (Printexc.to_string e)
-              | None -> ());
+           if OpamRepositoryConfig.(!r.repo_tarring) then
+             OpamProcess.Job.run
+               (OpamFilename.make_tar_gz_job
+                  (OpamRepositoryPath.tar rt.repos_global.root r.repo_name)
+                  repo_root
+                @@| function
+                | Some e ->
+                  Printf.ksprintf failwith
+                    "Failed to regenerate local repository archive: %s"
+                    (Printexc.to_string e)
+                | None -> ());
            let def =
              OpamFile.Repo.safe_read (OpamRepositoryPath.repo repo_root) |>
              OpamFile.Repo.with_root_url r.repo_url

--- a/src/repository/opamRepositoryConfig.ml
+++ b/src/repository/opamRepositoryConfig.ml
@@ -16,6 +16,7 @@ module E = struct
     | CURL of string option
     | FETCH of string option
     | NOCHECKSUMS of bool option
+    | REPOSITORYTARRING of bool option
     | REQUIRECHECKSUMS of bool option
     | RETRIES of int option
     | VALIDATIONHOOK of string option
@@ -24,6 +25,7 @@ module E = struct
   let curl = value (function CURL s -> s | _ -> None)
   let fetch = value (function FETCH s -> s | _ -> None)
   let nochecksums = value (function NOCHECKSUMS b -> b | _ -> None)
+  let repositorytarring = value (function REPOSITORYTARRING b -> b | _ -> None)
   let requirechecksums = value (function REQUIRECHECKSUMS b -> b | _ -> None)
   let retries = value (function RETRIES i -> i | _ -> None)
   let validationhook = value (function VALIDATIONHOOK s -> s | _ -> None)
@@ -37,6 +39,7 @@ type t = {
   validation_hook: arg list option;
   retries: int;
   force_checksums: bool option;
+  repo_tarring : bool;
 }
 
 type 'a options_fun =
@@ -44,6 +47,7 @@ type 'a options_fun =
   ?validation_hook:arg list option ->
   ?retries:int ->
   ?force_checksums:bool option ->
+  ?repo_tarring:bool ->
   'a
 
 let default = {
@@ -75,6 +79,7 @@ let default = {
   validation_hook = None;
   retries = 3;
   force_checksums = None;
+  repo_tarring = false;
 }
 
 let setk k t
@@ -82,6 +87,7 @@ let setk k t
     ?validation_hook
     ?retries
     ?force_checksums
+    ?repo_tarring
   =
   let (+) x opt = match opt with Some x -> x | None -> x in
   k {
@@ -89,6 +95,7 @@ let setk k t
     validation_hook = t.validation_hook + validation_hook;
     retries = t.retries + retries;
     force_checksums = t.force_checksums + force_checksums;
+    repo_tarring = t.repo_tarring + repo_tarring;
   }
 
 let set t = setk (fun x () -> x) t
@@ -139,5 +146,6 @@ let initk k =
     ?validation_hook
     ?retries:(E.retries ())
     ?force_checksums
+    ?repo_tarring:(E.repositorytarring ())
 
 let init ?noop:_ = initk (fun () -> ())

--- a/src/repository/opamRepositoryConfig.mli
+++ b/src/repository/opamRepositoryConfig.mli
@@ -16,6 +16,7 @@ module E : sig
     | CURL of string option
     | FETCH of string option
     | NOCHECKSUMS of bool option
+    | REPOSITORYTARRING of bool option
     | REQUIRECHECKSUMS of bool option
     | RETRIES of int option
     | VALIDATIONHOOK of string option
@@ -33,6 +34,7 @@ type t = {
   validation_hook: OpamTypes.arg list option;
   retries: int;
   force_checksums: bool option;
+  repo_tarring : bool;
 }
 
 type 'a options_fun =
@@ -40,6 +42,7 @@ type 'a options_fun =
   ?validation_hook:OpamTypes.arg list option ->
   ?retries:int ->
   ?force_checksums:bool option ->
+  ?repo_tarring:bool ->
   'a
 
 include OpamStd.Config.Sig

--- a/tests/reftests/dot-install.test
+++ b/tests/reftests/dot-install.test
@@ -115,8 +115,7 @@ added: [
 ### opam install lot-of-files | grep "mkdir\|install\|FILE"
   - install lot-of-files ~dev
 SYSTEM                          mkdir ${BASEDIR}/OPAM/inst/.opam-switch/build/lot-of-files.~dev
-SYSTEM                          mkdir ${OPAMTMP}
-SYSTEM                          copy ${OPAMTMP}/default/packages/lot-of-files/lot-of-files.~dev/files/lot-of-files.install.in -> ${BASEDIR}/OPAM/inst/.opam-switch/build/lot-of-files.~dev/lot-of-files.install.in
+SYSTEM                          copy ${BASEDIR}/OPAM/repo/default/packages/lot-of-files/lot-of-files.~dev/files/lot-of-files.install.in -> ${BASEDIR}/OPAM/inst/.opam-switch/build/lot-of-files.~dev/lot-of-files.install.in
 FILE(.config)                   Wrote ${BASEDIR}/OPAM/inst/.opam-switch/config/lot-of-files.config in 0.000s
 SYSTEM                          install ${BASEDIR}/OPAM/inst/.opam-switch/build/lot-of-files.~dev/fichier -> ${BASEDIR}/OPAM/inst/bin/fichier (755)
 SYSTEM                          mkdir ${BASEDIR}/OPAM/inst/lib/lot-of-files
@@ -134,4 +133,4 @@ SYSTEM                          install ${BASEDIR}/OPAM/inst/.opam-switch/build/
 -> installed lot-of-files.~dev
 SYSTEM                          mkdir ${BASEDIR}/OPAM/inst/.opam-switch/packages/lot-of-files.~dev
 SYSTEM                          mkdir ${BASEDIR}/OPAM/inst/.opam-switch/packages/lot-of-files.~dev/files
-SYSTEM                          copy ${OPAMTMP}/default/packages/lot-of-files/lot-of-files.~dev/files/lot-of-files.install.in -> ${BASEDIR}/OPAM/inst/.opam-switch/packages/lot-of-files.~dev/files/lot-of-files.install.in
+SYSTEM                          copy ${BASEDIR}/OPAM/repo/default/packages/lot-of-files/lot-of-files.~dev/files/lot-of-files.install.in -> ${BASEDIR}/OPAM/inst/.opam-switch/packages/lot-of-files.~dev/files/lot-of-files.install.in

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -462,6 +462,23 @@
    (run ./run.exe %{bin:opam} %{dep:remove.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-repository)
+ (action
+  (diff repository.test repository.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-repository)))
+
+(rule
+ (targets repository.out)
+ (deps root-N0REP0)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:repository.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-show)
  (action
   (diff show.test show.out)))

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -1,6 +1,6 @@
 009e00fa
 ### OPAMYES=1
-### tar xzf ${OPAMROOT}/repo/default.tar.gz
+### cp -R ${OPAMROOT}/repo/default .
 ### rm -rf ${OPAMROOT}
 ### <opamrc>
 eval-variables: [ sys-ocaml-version ["false"] "no system compiler" ]

--- a/tests/reftests/legacy-git.test
+++ b/tests/reftests/legacy-git.test
@@ -711,12 +711,12 @@ OK
 
 <><> Upgrading repositories from older opam format ><><><><><><><><><><><><><><>
 Upgrading repository "test"...
-Updated ${OPAMTMP}/test/packages/P1.0/opam
-Updated ${OPAMTMP}/test/packages/P1.1/opam
-Updated ${OPAMTMP}/test/packages/P2.1/opam
-Updated ${OPAMTMP}/test/packages/P3.1~weird-version.test/opam
-Updated ${OPAMTMP}/test/packages/P4.1/opam
-Updated ${OPAMTMP}/test/packages/P5.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P1.0/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P1.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P2.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P3.1~weird-version.test/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P4.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P5.1/opam
 Now run 'opam upgrade' to apply any package updates.
 ### opam switch create system "--formula=[\"ocaml\" {= \"system\"}]"
 
@@ -1095,14 +1095,14 @@ git: "GIT/P4"
 
 <><> Upgrading repositories from older opam format ><><><><><><><><><><><><><><>
 Upgrading repository "test"...
-Updated ${OPAMTMP}/test/packages/P1.0/opam
-Updated ${OPAMTMP}/test/packages/P1.1/opam
-Updated ${OPAMTMP}/test/packages/P2.1/opam
-Updated ${OPAMTMP}/test/packages/P3.1~weird-version.test/opam
-Updated ${OPAMTMP}/test/packages/P4.1/opam
-Updated ${OPAMTMP}/test/packages/P4.2/opam
-Updated ${OPAMTMP}/test/packages/P4.3/opam
-Updated ${OPAMTMP}/test/packages/P5.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P1.0/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P1.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P2.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P3.1~weird-version.test/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P4.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P4.2/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P4.3/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P5.1/opam
 
 <><> Synchronising development packages <><><><><><><><><><><><><><><><><><><><>
 [P1.1] synchronised (git+file://${BASEDIR}/GIT/P1-1)

--- a/tests/reftests/legacy-local.test
+++ b/tests/reftests/legacy-local.test
@@ -650,12 +650,12 @@ archive-mirrors: "cache"
 
 <><> Upgrading repositories from older opam format ><><><><><><><><><><><><><><>
 Upgrading repository "test"...
-Updated ${OPAMTMP}/test/packages/P1.0/opam
-Updated ${OPAMTMP}/test/packages/P1.1/opam
-Updated ${OPAMTMP}/test/packages/P2.1/opam
-Updated ${OPAMTMP}/test/packages/P3.1~weird-version.test/opam
-Updated ${OPAMTMP}/test/packages/P4.1/opam
-Updated ${OPAMTMP}/test/packages/P5.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P1.0/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P1.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P2.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P3.1~weird-version.test/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P4.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P5.1/opam
 Now run 'opam upgrade' to apply any package updates.
 ### opam switch create system "--formula=[\"ocaml\" {= \"system\"}]"
 
@@ -1025,15 +1025,15 @@ P5     --                   Testing optional dependencies
 
 <><> Upgrading repositories from older opam format ><><><><><><><><><><><><><><>
 Upgrading repository "test"...
-Updated ${OPAMTMP}/test/packages/P1.0/opam
-Updated ${OPAMTMP}/test/packages/P1.1/opam
-Updated ${OPAMTMP}/test/packages/P1.2/opam
-Updated ${OPAMTMP}/test/packages/P2.1/opam
-Updated ${OPAMTMP}/test/packages/P3.1~weird-version.test/opam
-Updated ${OPAMTMP}/test/packages/P4.1/opam
-Updated ${OPAMTMP}/test/packages/P4.2/opam
-Updated ${OPAMTMP}/test/packages/P4.3/opam
-Updated ${OPAMTMP}/test/packages/P5.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P1.0/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P1.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P1.2/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P2.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P3.1~weird-version.test/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P4.1/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P4.2/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P4.3/opam
+Updated ${BASEDIR}/OPAM/repo/test/packages/P5.1/opam
 Now run 'opam upgrade' to apply any package updates.
 ### : LIST :
 ### opam list -A

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -1,0 +1,56 @@
+N0REP0
+### <pkg:foo.1>
+opam-version: "2.0"
+build: ["test" "-f" "bar"]
+### <pkg:foo.1:bar>
+some content
+### opam switch create tarring --empty
+### : Internal repository storage as archive or plain directory :
+### opam update -vv | grep '^\+' | '.*(/|\\)diff(\.exe)?"? "' -> 'diff "'
+diff "-ruaN" "default" "default.new" (CWD=${BASEDIR}/OPAM/repo)
+### ls $OPAMROOT/repo | grep -v "cache"
+default
+lock
+repos-config
+### opam install foo -vv | grep '^\+' | '.*(/|\\|")test(\.exe)?"? "' -> 'test "'
+test "-f" "bar" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.1)
+### opam remove foo
+The following actions will be performed:
+  - remove foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.1
+Done.
+### OPAMREPOSITORYTARRING=1
+### opam repository add tarred ./REPO --set-default
+[tarred] Initialised
+### ls $OPAMROOT/repo | grep -v "cache"
+default
+lock
+repos-config
+tarred.tar.gz
+### opam repository remove default --all
+### opam update -vv | grep '^\+' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR' | '.*tar(\.exe)?"? "cfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz\.tmp" "-C" ".*" "tarred"' -> 'tar cfz OPAM/repo/tarred.tar.gz.tmp -C TMPDIR tarred' | '.*(/|\\)diff(\.exe)?"? "' -> 'diff "'
+tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR
+diff "-ruaN" "tarred" "tarred.new" (CWD=${OPAMTMP})
+tar cfz OPAM/repo/tarred.tar.gz.tmp -C TMPDIR tarred
+### opam install foo -vv | grep '^\+' | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR'
+tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR
+test "-f" "bar" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.1)
+### ls $OPAMROOT/repo | grep -v "cache"
+lock
+repos-config
+tarred.tar.gz
+### OPAMREPOSITORYTARRING=0
+### opam update -vv | grep '^\+' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR' | '.*(/|\\)diff(\.exe)?"? "' -> 'diff "'
+tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR
+diff "-ruaN" "tarred" "tarred.new" (CWD=${OPAMTMP})
+tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR
+### ls $OPAMROOT/repo | grep -v "cache"
+lock
+repos-config
+tarred
+### ls $OPAMROOT/repo/tarred
+packages
+repo
+### diff -ru ./REPO $OPAMROOT/repo/tarred


### PR DESCRIPTION
~that need a new name, ftm it is hideously named `OPAMNOREPOTARRING`~
/cc @AltGr 
fix #4586 
edit:
By default disabled,  environment variable `OPAMREPOSITORYTARRING` permit to enable it.