### PR TITLE
Move cold compiler on master to 4.13.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,10 +254,10 @@ endif
 
 .PHONY: compiler cold
 compiler:
-	env MAKE=$(MAKE) BOOTSTRAP_EXTRA_OPTS= BOOTSTRAP_OPT_TARGET=opt.opt BOOTSTRAP_ROOT=.. BOOTSTRAP_DIR=bootstrap ./shell/bootstrap-ocaml.sh $(OCAML_PORT)
+	env MAKE=$(MAKE) BOOTSTRAP_EXTRA_OPTS= BOOTSTRAP_TARGETS=world.opt BOOTSTRAP_ROOT=.. BOOTSTRAP_DIR=bootstrap ./shell/bootstrap-ocaml.sh $(OCAML_PORT)
 
 src_ext/secondary/ocaml/bin/ocaml:
-	env MAKE=$(MAKE) BOOTSTRAP_EXTRA_OPTS="--disable-ocamldoc --disable-debug-runtime --disable-debugger" BOOTSTRAP_OPT_TARGET=opt BOOTSTRAP_ROOT=../.. BOOTSTRAP_DIR=src_ext/secondary ./shell/bootstrap-ocaml.sh $(OCAML_PORT)
+	env MAKE=$(MAKE) BOOTSTRAP_EXTRA_OPTS="--disable-ocamldoc --disable-debug-runtime --disable-debugger" BOOTSTRAP_TARGETS="world opt" BOOTSTRAP_ROOT=../.. BOOTSTRAP_DIR=src_ext/secondary ./shell/bootstrap-ocaml.sh $(OCAML_PORT)
 
 cold: compiler
 	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" CAML_LD_LIBRARY_PATH= ./configure --with-vendored-deps --without-dune --enable-cold-check $(CONFIGURE_ARGS)

--- a/master_changes.md
+++ b/master_changes.md
@@ -129,6 +129,7 @@ users)
   * Fix dose3 download url since gforge is gone [#4870 @avsm]
   * Update bootstrap ocaml to 4.12.1 to integrate mingw fix [#4927 @rjbou]
   * Update bootstrap to use `-j` for Unix (Windows already does) [#4988 @dra27]
+  * Update cold compiler to 4.13 [#5017 @dra27]
 
 ## Infrastructure
   * Fix caching of Cygwin compiler on AppVeyor [#4988 @dra27]

--- a/shell/bootstrap-ocaml.sh
+++ b/shell/bootstrap-ocaml.sh
@@ -12,7 +12,7 @@ else
 fi
 BOOTSTRAP_DIR=${BOOTSTRAP_DIR:-bootstrap}
 BOOTSTRAP_ROOT=${BOOTSTRAP_ROOT:-..}
-BOOTSTRAP_OPT_TARGET=${BOOTSTRAP_OPT_TARGET:-opt.opt}
+BOOTSTRAP_TARGETS=${BOOTSTRAP_TARGETS:-world.opt}
 mkdir -p "$BOOTSTRAP_DIR"
 cd "$BOOTSTRAP_DIR"
 URL=`sed -ne 's/URL_ocaml *= *//p' $BOOTSTRAP_ROOT/src_ext/Makefile | tr -d '\r'`
@@ -145,8 +145,9 @@ if [ -n "$1" -a -n "${COMSPEC}" -a -x "${COMSPEC}" ] ; then
                   --build=$BUILD --host=$HOST \
                   --disable-stdlib-manpages \
                   $BOOTSTRAP_EXTRA_OPTS
-    PATH="${PATH_PREPEND}${PREFIX}/bin:${PATH}" Lib="${LIB_PREPEND}${Lib}" Include="${INC_PREPEND}${Include}" make -j world
-    PATH="${PATH_PREPEND}${PREFIX}/bin:${PATH}" Lib="${LIB_PREPEND}${Lib}" Include="${INC_PREPEND}${Include}" make -j $BOOTSTRAP_OPT_TARGET
+    for target in $BOOTSTRAP_TARGETS; do
+      PATH="${PATH_PREPEND}${PREFIX}/bin:${PATH}" Lib="${LIB_PREPEND}${Lib}" Include="${INC_PREPEND}${Include}" make -j $target
+    done
     PATH="${PATH_PREPEND}${PREFIX}/bin:${PATH}" Lib="${LIB_PREPEND}${Lib}" Include="${INC_PREPEND}${Include}" make install
   fi
   OCAMLLIB=${WINPREFIX}/lib/ocaml
@@ -154,8 +155,9 @@ else
   PREFIX=`cd .. ; pwd`/ocaml
   if [ ${GEN_CONFIG_ONLY} -eq 0 ] ; then
     ./configure --prefix "${PREFIX}" $BOOTSTRAP_EXTRA_OPTS --disable-stdlib-manpages
-    ${MAKE:-make} -j world
-    ${MAKE:-make} -j $BOOTSTRAP_OPT_TARGET
+    for target in $BOOTSTRAP_TARGETS; do
+      ${MAKE:-make} -j $target
+    done
     ${MAKE:-make} install
   fi
   OCAMLLIB=${PREFIX}/lib/ocaml

--- a/shell/bootstrap-ocaml.sh
+++ b/shell/bootstrap-ocaml.sh
@@ -127,9 +127,17 @@ if [ -n "$1" -a -n "${COMSPEC}" -a -x "${COMSPEC}" ] ; then
   if [ -n "${PATH_PREPEND}" ] ; then
     PATH_PREPEND="${PATH_PREPEND}:"
   fi
+  cd ..
+  if [ ! -e ${FLEXDLL} ]; then
+    cp $BOOTSTRAP_ROOT/src_ext/archives/${FLEXDLL} . 2>/dev/null || ${CURL} ${FV_URL}
+  fi
+  cd ${V}
   PREFIX=`cd .. ; pwd`/ocaml
   WINPREFIX=`echo ${PREFIX} | cygpath -f - -m`
   if [ ${GEN_CONFIG_ONLY} -eq 0 ] ; then
+    tar -xzf $BOOTSTRAP_ROOT/${FLEXDLL}
+    rm -rf flexdll
+    mv flexdll-* flexdll
     PATH="${PATH_PREPEND}${PREFIX}/bin:${PATH}" \
     Lib="${LIB_PREPEND}${Lib}" \
     Include="${INC_PREPEND}${Include}" \
@@ -137,17 +145,6 @@ if [ -n "$1" -a -n "${COMSPEC}" -a -x "${COMSPEC}" ] ; then
                   --build=$BUILD --host=$HOST \
                   --disable-stdlib-manpages \
                   $BOOTSTRAP_EXTRA_OPTS
-  fi
-  cd ..
-  if [ ! -e ${FLEXDLL} ]; then
-    cp $BOOTSTRAP_ROOT/src_ext/archives/${FLEXDLL} . 2>/dev/null || ${CURL} ${FV_URL}
-  fi
-  cd ${V}
-  if [ ${GEN_CONFIG_ONLY} -eq 0 ] ; then
-    tar -xzf $BOOTSTRAP_ROOT/${FLEXDLL}
-    rm -rf flexdll
-    mv flexdll-* flexdll
-    PATH="${PATH_PREPEND}${PREFIX}/bin:${PATH}" Lib="${LIB_PREPEND}${Lib}" Include="${INC_PREPEND}${Include}" make -j flexdll
     PATH="${PATH_PREPEND}${PREFIX}/bin:${PATH}" Lib="${LIB_PREPEND}${Lib}" Include="${INC_PREPEND}${Include}" make -j world
     PATH="${PATH_PREPEND}${PREFIX}/bin:${PATH}" Lib="${LIB_PREPEND}${Lib}" Include="${INC_PREPEND}${Include}" make -j $BOOTSTRAP_OPT_TARGET
     PATH="${PATH_PREPEND}${PREFIX}/bin:${PATH}" Lib="${LIB_PREPEND}${Lib}" Include="${INC_PREPEND}${Include}" make install

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -11,11 +11,11 @@ endif
 
 PATCH ?= patch
 
-URL_ocaml = https://caml.inria.fr/pub/distrib/ocaml-4.12/ocaml-4.12.1.tar.gz
-MD5_ocaml = 4b494fe0f06af9f3ff5047fc26993e3f
+URL_ocaml = https://caml.inria.fr/pub/distrib/ocaml-4.13/ocaml-4.13.1.tar.gz
+MD5_ocaml = a55ca12a4e6edf83cb4777abdb7b2f4d
 
-URL_flexdll = https://github.com/alainfrisch/flexdll/archive/0.39.tar.gz
-MD5_flexdll = c8493c7b6e95c4763b89213a9a710af5
+URL_flexdll = https://github.com/alainfrisch/flexdll/archive/0.40.tar.gz
+MD5_flexdll = e68f7311179fa7e09408825b362c5c5a
 
 ifndef FETCH
   ifneq ($(shell command -v curl 2>/dev/null),)

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -1,5 +1,5 @@
-URL_cppo = https://github.com/ocaml-community/cppo/releases/download/v1.6.7/cppo-v1.6.7.tbz
-MD5_cppo = 65c668196c3dabf34d9e887952e5bbb4
+URL_cppo = https://github.com/ocaml-community/cppo/archive/v1.6.8.tar.gz
+MD5_cppo = fed401197d86f9089e89f6cbdf1d660d
 
 $(call PKG_SAME,cppo)
 
@@ -13,8 +13,8 @@ MD5_base64 = 0179af18d6c1cf13d77671ee23901433
 
 $(call PKG_SAME,base64)
 
-URL_re = https://github.com/ocaml/ocaml-re/releases/download/1.9.0/re-1.9.0.tbz
-MD5_re = bddaed4f386a22cace7850c9c7dac296
+URL_re = https://github.com/ocaml/ocaml-re/releases/download/1.10.3/re-1.10.3.tbz
+MD5_re = a36347dcfaf71c95916f96f72b0cf2ce
 
 $(call PKG_SAME,re)
 
@@ -64,8 +64,8 @@ MD5_result = 1b82dec78849680b49ae9a8a365b831b
 $(call PKG_SAME,result)
 
 # NB If minimum OCaml version for Dune changes, update DUNE_SECONDARY in configure.ac
-URL_dune-local = https://github.com/ocaml/dune/releases/download/2.9.0/dune-2.9.0.tbz
-MD5_dune-local = 90a12dc2a312df699533cbe7d18ece11
+URL_dune-local = https://github.com/ocaml/dune/releases/download/2.9.1/dune-2.9.1.tbz
+MD5_dune-local = 0929081f80064ecb836ffdef983100f4
 
 $(call PKG_SAME,dune-local)
 
@@ -75,8 +75,8 @@ MD5_PKG_findlib = 65e6dc9b305ccbed1267275fe180f538
 URL_PKG_ocamlbuild = https://github.com/ocaml/ocamlbuild/archive/0.14.0.tar.gz
 MD5_PKG_ocamlbuild = a7bf2fe594cd16907807c756b14d501f
 
-URL_PKG_topkg = http://erratique.ch/software/topkg/releases/topkg-1.0.3.tbz
-MD5_PKG_topkg = e285f7a296d77ee7d831ba9a6bfb396f
+URL_PKG_topkg = https://erratique.ch/software/topkg/releases/topkg-1.0.4.tbz
+MD5_PKG_topkg = 324330fc265a7839cf9577e9cc79f5c7
 
 URL_seq = https://github.com/c-cube/seq/archive/0.2.2.tar.gz
 MD5_seq = 9033e02283aa3bde9f97f24e632902e3
@@ -88,7 +88,7 @@ MD5_stdlib-shims = 09db7af8b4a3a96048a61cb6ae2496ef
 
 $(call PKG_SAME,stdlib-shims)
 
-URL_spdx_licenses = https://github.com/kit-ty-kate/spdx_licenses/releases/download/v1.0.0/spdx_licenses-v1.0.0.tbz
-MD5_spdx_licenses = 5393e25f7aa3e2b2a4e880d8dcbcc8e4
+URL_spdx_licenses = https://github.com/kit-ty-kate/spdx_licenses/releases/download/v1.1.0/spdx_licenses-v1.1.0.tbz
+MD5_spdx_licenses = af8493759aa35b629a324caa3f5ced65
 
 $(call PKG_SAME,spdx_licenses)


### PR DESCRIPTION
- Move the cold compiler to 4.13 in order to have a version which doesn't suffer from the `SIGSTKSZ` problem with glibc 2.34
- Bump the src_ext dependencies to latest versions while here
- In 4.13, the FlexDLL sources needed to be available _before_ `configure` is run, so move the extraction further up
- The Cygwin32 build is _really_ struggling to build a compiler and run the testsuite at once - the final commit tweaks the build processes so that instead of running `make world` followed by `make opt.opt` we do the fractionally faster `make world.opt` (if the secondary compiler were being built, it does `make world` followed by `make opt`).