### PR TITLE
Remove unnecessary copies/move when fetching archives

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -36,6 +36,7 @@ users)
 
 ## Build (package)
   * ◈ Add `--verbose-on` option to enable verbose mode on specified package names [#5682 @desumn @rjbou]
+  * Remove unnecessary copies/move when fetching archives [#5018 @kit-ty-kate @rjbou]
 
 ## Remove
 

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -153,3 +153,159 @@ Processing  1/1: [foo.1: extract]
 Done.
 ### opam clean -c
 Clearing cache of downloaded files
+### OPAMVERBOSE=0
+### ::::::::::::::::::::::::::::::::::
+### :II: Copy/moves
+### ::::::::::::::::::::::::::::::::::
+### OPAMDEBUGSECTIONS=SYSTEM
+### :II:1: local
+### :II:1:a: archive
+### tar czf arch.tgz REPO/repo
+### <pkg:foo.1>
+opam-version: "2.0"
+### <mkurl.sh>
+file="REPO/packages/foo/foo.1/opam"
+basedir=`echo "$BASEDIR" | sed "s/\\\\\\\\/\\\\\\\\\\\\\\\\/g"`
+url="$basedir/arch.tgz"
+echo "url {" >> "$file"
+echo "src:\"$url\"" >> "$file"
+MD5=$(openssl md5 "$url" | cut -d' ' -f2)
+echo "checksum: \"md5=$MD5\"" >> "$file"
+echo "}" >> "$file"
+### sh mkurl.sh
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### opam install foo --download-only -vv --debug-level=-1 | grep -v "^+-" | sed-cmd rsync | sed-cmd tar | grep -v "state-.*.export" | "md5[/\\].*" -> "md5-dir/"
+The following actions will be performed:
+=== install 1 package
+  - install foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+SYSTEM                          rmdir ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1
+SYSTEM                          mkdir ${OPAMTMP}
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1
+Processing  1/1: [foo.1: rsync]
++ rsync "-rLptgoDvc" "--exclude" ".git" "--exclude" "_darcs" "--exclude" ".hg" "--exclude" ".#*" "--exclude" "_opam*" "--exclude" "_build" "--delete" "--delete-excluded" "${BASEDIR}/arch.tgz" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1"
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5-dir/
+SYSTEM                          copy ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/arch.tgz -> ${BASEDIR}/OPAM/download-cache/md5-dir/
+SYSTEM                          mv ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/arch.tgz -> ${OPAMTMP}/arch.tgz
+SYSTEM                          rmdir ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1
+SYSTEM                          mkdir ${OPAMTMP}
+Processing  1/1: [foo.1: extract]
++ tar "xfz" "${OPAMTMP}/arch.tgz" "-C" "${OPAMTMP}"
+SYSTEM                          copydir ${OPAMTMP}/REPO -> ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1
+SYSTEM                          rmdir ${OPAMTMP}
+SYSTEM                          rmdir ${OPAMTMP}
+Done.
+### :II:1:b: git
+### <pin:bar/opam>
+opam-version: "2.0"
+### <bar/a-file>
+content
+### git -C bar init -q --initial-branch=master
+### git -C bar config core.autocrlf false
+### git -C bar add opam a-file
+### git -C bar commit -qm "init"
+### <pkg:bar.1>
+opam-version: "2.0"
+### <mkurl.sh>
+file="REPO/packages/bar/bar.1/opam"
+basedir=`echo "$BASEDIR" | sed "s/\\\\\\\\/\\\\\\\\\\\\\\\\/g"`
+echo "url {" >> "$file"
+echo "src:\"git+file://$basedir/bar\"" >> "$file"
+echo "}" >> "$file"
+### sh mkurl.sh
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### opam install bar --download-only -vv --debug-level=-1 | grep -v "^+-" | sed-cmd git | grep -v "state-.*.export"
+The following actions will be performed:
+=== install 1 package
+  - install bar 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+SYSTEM                          mkdir ${OPAMTMP}
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1
+Processing  1/1: [bar.1: git]
++ git "init" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
++ git "config" "--local" "fetch.prune" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
++ git "config" "--local" "diff.noprefix" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
++ git "config" "--local" "core.autocrlf" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
++ git "config" "--local" "core.eol" "lf" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
++ git "config" "--local" "color.ui" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
++ git "remote" "add" "origin" "file://${BASEDIR}/bar" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
++ git "remote" "set-url" "origin" "file://${BASEDIR}/bar" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
++ git "fetch" "-q" "file://${BASEDIR}/bar" "--update-shallow" "--depth=1" "+HEAD:refs/remotes/opam-ref" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
++ git "reset" "--hard" "refs/remotes/opam-ref" "--" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
++ git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
+SYSTEM                          rmdir ${OPAMTMP}
+Done.
+### :II:2: distant
+### :II:2:a: archive
+### <pkg:baz.1>
+opam-version: "2.0"
+url {
+  src: "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
+  checksum: "md5=c9c157af4229fbb45d3f59f0d6d75dbe"
+}
+### opam install baz --download-only -vv --debug-level=-1 | grep -v "^+-" | sed-cmd wget | sed-cmd tar | "${OPAMVERSION}" -> "current" | grep -v "state-.*.export" | "md5[/\\].*" -> "md5-dir/" | grep -v "OPAM[/\\]log"
+The following actions will be performed:
+=== install 1 package
+  - install baz 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+SYSTEM                          rmdir ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1
+SYSTEM                          mkdir ${OPAMTMP}
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1
+Processing  1/1: [baz.1: http]
++ wget "-t" "3" "-O" "${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
+SYSTEM                          mv ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1/v1.0.0.tar.gz.part -> ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1/v1.0.0.tar.gz
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5-dir/
+SYSTEM                          copy ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1/v1.0.0.tar.gz -> ${BASEDIR}/OPAM/download-cache/md5-dir/
+SYSTEM                          mv ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1/v1.0.0.tar.gz -> ${OPAMTMP}/v1.0.0.tar.gz
+SYSTEM                          rmdir ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1
+SYSTEM                          mkdir ${OPAMTMP}
+Processing  1/1: [baz.1: extract]
++ tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
+SYSTEM                          copydir ${OPAMTMP}/get_line-1.0.0 -> ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1
+SYSTEM                          rmdir ${OPAMTMP}
+SYSTEM                          rmdir ${OPAMTMP}
+Done.
+### :II:2:b: git
+### <pkg:qux.1>
+opam-version: "2.0"
+url {
+  src: "git+https://github.com/ocaml-opam/opam-depext"
+}
+### opam install qux --download-only -vv --debug-level=-1 | grep -v "^+-" | sed-cmd git | grep -v "state-.*.export"
+The following actions will be performed:
+=== install 1 package
+  - install qux 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+SYSTEM                          mkdir ${OPAMTMP}
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1
+Processing  1/1: [qux.1: git]
++ git "init" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
++ git "config" "--local" "fetch.prune" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
++ git "config" "--local" "diff.noprefix" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
++ git "config" "--local" "core.autocrlf" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
++ git "config" "--local" "core.eol" "lf" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
++ git "config" "--local" "color.ui" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
++ git "remote" "add" "origin" "https://github.com/ocaml-opam/opam-depext" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/git
++ git "init" "--bare" (CWD=${BASEDIR}/OPAM/download-cache/git)
++ git "remote" "set-url" "origin" "https://github.com/ocaml-opam/opam-depext" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
++ git "fetch" "-q" "https://github.com/ocaml-opam/opam-depext" "--update-shallow" "--depth=1" "+HEAD:refs/remotes/opam-ref" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
++ git "push" git "+refs/remotes/opam-ref:refs/remotes/cd8336413a06dcd0c48d3f48df5d1940" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
++ git "reset" "--hard" "refs/remotes/opam-ref" "--" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
++ git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
+SYSTEM                          rmdir ${OPAMTMP}
+Done.

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -33,7 +33,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
-+ wget "-t" "3" "-O" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
++ wget "-t" "3" "-O" "${OPAMTMP}/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
 Processing  1/1: [foo.1: extract]
 + tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
 Done.
@@ -48,7 +48,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
-+ curl "--write-out" "%{http_code}\n" "--retry" "3" "--retry-delay" "2" "--user-agent" "opam/current" "-L" "-o" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
++ curl "--write-out" "%{http_code}\n" "--retry" "3" "--retry-delay" "2" "--user-agent" "opam/current" "-L" "-o" "${OPAMTMP}/v1.0.0.tar.gz.part" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
 Processing  1/1: [foo.1: extract]
 + tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
 Done.
@@ -107,10 +107,10 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
-+ curl "--write-out" "%{http_code}\n" "--retry" "3" "--retry-delay" "2" "--user-agent" "opam/current" "-L" "-o" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
-[ERROR] Failed to get sources of foo.1: curl error code ***The curl is a lie*** [args: --write-out %{http_code}\n --retry 3 --retry-delay 2 --user-agent opam/current -L -o ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part -- https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz]
++ curl "--write-out" "%{http_code}\n" "--retry" "3" "--retry-delay" "2" "--user-agent" "opam/current" "-L" "-o" "${OPAMTMP}/v1.0.0.tar.gz.part" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
+[ERROR] Failed to get sources of foo.1: curl error code ***The curl is a lie*** [args: --write-out %{http_code}\n --retry 3 --retry-delay 2 --user-agent opam/current -L -o ${OPAMTMP}/v1.0.0.tar.gz.part -- https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz]
 
-OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (curl: code ***The curl is a lie*** [args: --write-out %{http_code}\n --retry 3 --retry-delay 2 --user-agent opam/current -L -o ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part -- https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz] while downloading https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz)")
+OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (curl: code ***The curl is a lie*** [args: --write-out %{http_code}\n --retry 3 --retry-delay 2 --user-agent opam/current -L -o ${OPAMTMP}/v1.0.0.tar.gz.part -- https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz] while downloading https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz)")
 
 
 <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
@@ -147,7 +147,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
-+ wget "-t" "3" "-O" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
++ wget "-t" "3" "-O" "${OPAMTMP}/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
 Processing  1/1: [foo.1: extract]
 + tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
 Done.
@@ -186,18 +186,15 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 SYSTEM                          rmdir ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1
 SYSTEM                          mkdir ${OPAMTMP}
-SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1
 Processing  1/1: [foo.1: rsync]
-+ rsync "-rLptgoDvc" "--exclude" ".git" "--exclude" "_darcs" "--exclude" ".hg" "--exclude" ".#*" "--exclude" "_opam*" "--exclude" "_build" "--delete" "--delete-excluded" "${BASEDIR}/arch.tgz" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1"
++ rsync "-rLptgoDvc" "--exclude" ".git" "--exclude" "_darcs" "--exclude" ".hg" "--exclude" ".#*" "--exclude" "_opam*" "--exclude" "_build" "--delete" "--delete-excluded" "${BASEDIR}/arch.tgz" "${OPAMTMP}"
 SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5-dir/
-SYSTEM                          copy ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/arch.tgz -> ${BASEDIR}/OPAM/download-cache/md5-dir/
-SYSTEM                          mv ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/arch.tgz -> ${OPAMTMP}/arch.tgz
-SYSTEM                          rmdir ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1
-SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1
+SYSTEM                          copy ${OPAMTMP}/arch.tgz -> ${BASEDIR}/OPAM/download-cache/md5-dir/
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [foo.1: extract]
 + tar "xfz" "${OPAMTMP}/arch.tgz" "-C" "${OPAMTMP}"
 SYSTEM                          copydir ${OPAMTMP}/REPO -> ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1
 SYSTEM                          rmdir ${OPAMTMP}
 SYSTEM                          rmdir ${OPAMTMP}
 Done.
@@ -262,19 +259,16 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 SYSTEM                          rmdir ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1
 SYSTEM                          mkdir ${OPAMTMP}
-SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1
 Processing  1/1: [baz.1: http]
-+ wget "-t" "3" "-O" "${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
-SYSTEM                          mv ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1/v1.0.0.tar.gz.part -> ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1/v1.0.0.tar.gz
++ wget "-t" "3" "-O" "${OPAMTMP}/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
+SYSTEM                          mv ${OPAMTMP}/v1.0.0.tar.gz.part -> ${OPAMTMP}/v1.0.0.tar.gz
 SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5-dir/
-SYSTEM                          copy ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1/v1.0.0.tar.gz -> ${BASEDIR}/OPAM/download-cache/md5-dir/
-SYSTEM                          mv ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1/v1.0.0.tar.gz -> ${OPAMTMP}/v1.0.0.tar.gz
-SYSTEM                          rmdir ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1
-SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1
+SYSTEM                          copy ${OPAMTMP}/v1.0.0.tar.gz -> ${BASEDIR}/OPAM/download-cache/md5-dir/
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [baz.1: extract]
 + tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
 SYSTEM                          copydir ${OPAMTMP}/get_line-1.0.0 -> ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1
 SYSTEM                          rmdir ${OPAMTMP}
 SYSTEM                          rmdir ${OPAMTMP}
 Done.

--- a/tests/reftests/swhid.unix.test
+++ b/tests/reftests/swhid.unix.test
@@ -39,7 +39,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] Failed to get sources of snappy-ko.2: Download command failed
 
-OpamSolution.Fetch_fail("https://fake.exe/url.tar.gz (Download command failed: \"curl --write-out %{http_code}\\n --retry 3 --retry-delay 2 --user-agent opam/current -L -o ${BASEDIR}/OPAM/fallback/.opam-switch/sources/snappy-ko.2/url.tar.gz.part -- https://fake.exe/url.tar.gz\" exited with code 6)")
+OpamSolution.Fetch_fail("https://fake.exe/url.tar.gz (Download command failed: \"curl --write-out %{http_code}\\n --retry 3 --retry-delay 2 --user-agent opam/current -L -o ${OPAMTMP}/url.tar.gz.part -- https://fake.exe/url.tar.gz\" exited with code 6)")
 
 
 <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
@@ -68,7 +68,7 @@ The following actions will be performed:
 Processing  1/3: [snappy-swhid-dir.2: http]
 [ERROR] Failed to get sources of snappy-swhid-dir.2: Download command failed
 
-OpamSolution.Fetch_fail("https://fake.exe/url.tar.gz (Download command failed: \"curl --write-out %{http_code}\\n --retry 3 --retry-delay 2 --user-agent opam/current -L -o ${BASEDIR}/OPAM/fallback/.opam-switch/sources/snappy-swhid-dir.2/url.tar.gz.part -- https://fake.exe/url.tar.gz\" exited with code 6)")
+OpamSolution.Fetch_fail("https://fake.exe/url.tar.gz (Download command failed: \"curl --write-out %{http_code}\\n --retry 3 --retry-delay 2 --user-agent opam/current -L -o ${OPAMTMP}/url.tar.gz.part -- https://fake.exe/url.tar.gz\" exited with code 6)")
 
 
 <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>


### PR DESCRIPTION
In https://github.com/ocaml/opam/issues/4586#issuecomment-1018774363 we can see that to download an archive, opam currently does basically:
```
+ curl -L -o "${OPAM_SWITCH_PREFIX}/.opam-switch/sources/dune.2.9.1/dune-2.9.1.tbz.part" -- "${ARCHIVE}"
+ mv "${OPAM_SWITCH_PREFIX}/.opam-switch/sources/dune.2.9.1/dune-2.9.1.tbz.part" "${OPAM_SWITCH_PREFIX}/.opam-switch/sources/dune.2.9.1/dune-2.9.1.tbz"
+ mv "${OPAM_SWITCH_PREFIX}/.opam-switch/sources/dune.2.9.1/dune-2.9.1.tbz" "/tmp/opam-14-82d098/dune-2.9.1.tbz"
+ tar xfj /tmp/opam-14-82d098/dune-2.9.1.tbz -C /tmp/opam-14-1e6357
+ cp -PRp /tmp/opam-14-1e6357/dune-2.9.1/* /home/opam/.opam/4.13/.opam-switch/sources/dune.2.9.1
+ cp -PRp "${OPAM_SWITCH_PREFIX}/.opam-switch/sources/dune.2.9.1" "${OPAM_SWITCH_PREFIX}/.opam-switch/build/dune.2.9.1"
```
The three first commands can be combined into one very easily, giving us:
```
+ curl -L -o /tmp/opam-14-82d098/dune-2.9.1.tbz.part -- "${ARCHIVE}"
+ mv /tmp/opam-14-82d098/dune-2.9.1.tbz.part /tmp/opam-14-82d098/dune-2.9.1.tbz
+ tar xfj /tmp/opam-14-82d098/dune-2.9.1.tbz -C /tmp/opam-14-1e6357
+ cp -PRp /tmp/opam-14-1e6357/dune-2.9.1/* /home/opam/.opam/4.13/.opam-switch/sources/dune.2.9.1
+ cp -PRp "${OPAM_SWITCH_PREFIX}/.opam-switch/sources/dune.2.9.1" "${OPAM_SWITCH_PREFIX}/.opam-switch/build/dune.2.9.1"
```
Fixes #5939 