### PR TITLE
Revert the addition of the unix-only cram test (#5022)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,2 @@
-(lang dune 2.7)
+(lang dune 2.0)
 (name opam)
-
-(cram enable)

--- a/master_changes.md
+++ b/master_changes.md
@@ -135,7 +135,6 @@ users)
   * Update bootstrap ocaml to 4.12.1 to integrate mingw fix [#4927 @rjbou]
   * Update bootstrap to use `-j` for Unix (Windows already does) [#4988 @dra27]
   * Update cold compiler to 4.13 [#5017 @dra27]
-  * Change minimum required Dune to 2.7 [#5022 @kit-ty-kate]
 
 ## Infrastructure
   * Fix caching of Cygwin compiler on AppVeyor [#4988 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -221,8 +221,6 @@ users)
   * Make all the tests work on macOS/arm64 [#5019 @kit-ty-kate]
 
   * Add clean test for untracked option [#4915 @rjbou]
-## Cram tests
-  * Add some unix-only cram tests to test for https://github.com/ocaml/opam/issues/4216 before fixing it [#5022 @kit-ty-kate]
 
 ## Github Actions
   * Add solver backends compile test [#4723 @rjbou] [2.1.0~rc2 #4720]

--- a/master_changes.md
+++ b/master_changes.md
@@ -223,7 +223,6 @@ users)
 
   * Add clean test for untracked option [#4915 @rjbou]
 ## Cram tests
-### Cram tests
   * Add some unix-only cram tests to test for https://github.com/ocaml/opam/issues/4216 before fixing it [#5022 @kit-ty-kate]
 
 ## Github Actions

--- a/opam-admin.opam
+++ b/opam-admin.opam
@@ -17,7 +17,7 @@ homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 depends: [
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.0.0"}
   "re" {>= "1.9.0"}
   "opam-file-format" {>= "2.1.3"}
 ]

--- a/opam-client.opam
+++ b/opam-client.opam
@@ -33,7 +33,7 @@ depends: [
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
   "cmdliner" {>= "1.0.0"}
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.0.0"}
 ]
 conflicts: [
   "extlib" {< "1.7.8"}

--- a/opam-core.opam
+++ b/opam-core.opam
@@ -31,7 +31,7 @@ depends: [
   "base-bigarray"
   "ocamlgraph"
   "re" {>= "1.9.0"}
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.0.0"}
   "cppo" {build & >= "1.1.0"}
 ]
 conflicts: "extlib-compat"

--- a/opam-devel.opam
+++ b/opam-devel.opam
@@ -29,7 +29,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "opam-client" {= version}
   "cmdliner"
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.0.0"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}
 ]

--- a/opam-format.opam
+++ b/opam-format.opam
@@ -30,5 +30,5 @@ depends: [
   "opam-core" {= version}
   "opam-file-format" {>= "2.1.3"}
   "re" {>= "1.9.0"}
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.0.0"}
 ]

--- a/opam-installer.opam
+++ b/opam-installer.opam
@@ -31,5 +31,5 @@ depends: [
   "ocaml" {(>= "4.03.0" & os != "win32") | >= "4.06.0"}
   "opam-format" {= version}
   "cmdliner" {>= "0.9.8"}
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.0.0"}
 ]

--- a/opam-repository.opam
+++ b/opam-repository.opam
@@ -28,5 +28,5 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.0.0"}
 ]

--- a/opam-solver.opam
+++ b/opam-solver.opam
@@ -32,7 +32,7 @@ depends: [
   "dose3" {>= "6.1"}
   "cudf" {>= "0.7"}
   "re" {>= "1.9.0"}
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.0.0"}
   "opam-0install-cudf" {>= "0.4"}
 ]
 depopts: [

--- a/opam-state.opam
+++ b/opam-state.opam
@@ -30,5 +30,5 @@ depends: [
   "opam-repository" {= version}
   "re" {>= "1.9.0"}
   "spdx_licenses" {>= "1.0.0"}
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.0.0"}
 ]

--- a/opam.opam
+++ b/opam.opam
@@ -18,6 +18,6 @@ homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 depends: [
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.0.0"}
   "opam-client" {= version}
 ]

--- a/tests/cram/unix/dune
+++ b/tests/cram/unix/dune
@@ -1,5 +1,3 @@
 (cram
  (enabled_if (= %{os_type} "Unix"))
- (deps
-  (package opam-devel)
-  (sandbox always)))
+ (deps (package opam-devel)))

--- a/tests/cram/unix/dune
+++ b/tests/cram/unix/dune
@@ -1,3 +1,0 @@
-(cram
- (enabled_if (= %{os_type} "Unix"))
- (deps (package opam-devel)))

--- a/tests/cram/unix/list.t
+++ b/tests/cram/unix/list.t
@@ -1,8 +1,6 @@
 Test https://github.com/ocaml/opam/issues/4216
   $ export OPAMROOT=./opamroot
   $ opam init --bare -n git+https://github.com/ocaml/opam-repository.git#0ec9bbf73a91b8e90b15bb11735859c9552a9888 > /dev/null
-  $ OCAMLRUNPARAM=b opam list --depends-on dune -s --all-versions | head -n1
+  $ opam list --depends-on dune -s --all-versions | head -n1
   0install.2.14
   Fatal error: exception Sys_error("Broken pipe")
-  Raised by primitive operation at OpamCliMain.main_catch_all in file "src/client/opamCliMain.ml", line 357, characters 4-16
-  Called from Dune__exe__OpamMain in file "src/client/opamMain.ml", line 12, characters 9-28

--- a/tests/cram/unix/list.t
+++ b/tests/cram/unix/list.t
@@ -1,6 +1,0 @@
-Test https://github.com/ocaml/opam/issues/4216
-  $ export OPAMROOT=./opamroot
-  $ opam init --bare -n git+https://github.com/ocaml/opam-repository.git#0ec9bbf73a91b8e90b15bb11735859c9552a9888 > /dev/null
-  $ opam list --depends-on dune -s --all-versions | head -n1
-  0install.2.14
-  Fatal error: exception Sys_error("Broken pipe")

--- a/tests/cram/unix/list.t
+++ b/tests/cram/unix/list.t
@@ -1,6 +1,8 @@
 Test https://github.com/ocaml/opam/issues/4216
   $ export OPAMROOT=./opamroot
   $ opam init --bare -n git+https://github.com/ocaml/opam-repository.git#0ec9bbf73a91b8e90b15bb11735859c9552a9888 > /dev/null
-  $ OCAMLRUNPARAM=-b opam list --depends-on dune -s --all-versions | head -n1
+  $ OCAMLRUNPARAM=b opam list --depends-on dune -s --all-versions | head -n1
   0install.2.14
   Fatal error: exception Sys_error("Broken pipe")
+  Raised by primitive operation at OpamCliMain.main_catch_all in file "src/client/opamCliMain.ml", line 357, characters 4-16
+  Called from Dune__exe__OpamMain in file "src/client/opamMain.ml", line 12, characters 9-28


### PR DESCRIPTION
In favour of a built-in 'reftest' feature implemented in #5031"