### PR TITLE
OpamParallel, MakeGraph(_).to_json: fix incorrect use of List.assoc

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -176,6 +176,7 @@ users)
   * Add specific comparison function on several module (that includes `OpamStd.ABSTRACT`) [#4918 @rjbou]
   * Homogeneise is_archive tar & zip: if file exists check magic number, otherwise check extension [#4964 @rjbou]
   * [BUG] Remove windows double printing on commands and their output [#4940 @rjbou]
+  * OpamParallel, MakeGraph(_).to_json: fix incorrect use of List.assoc [#5038 @Armael]
 
 ## Internal: Windows
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]

--- a/src/core/opamParallel.ml
+++ b/src/core/opamParallel.ml
@@ -383,8 +383,12 @@ module MakeGraph (X: VERTEX) = struct
       let vertex_to_json (i, v) = (string_of_int i, X.to_json v) in
       `O (List.map vertex_to_json vertex_map) in
     let edges =
-      let vertex_inv_map = List.map (fun (i, v) -> (v, i)) vertex_map in
-      let index v = List.assoc v vertex_inv_map in
+      let module VertexMap = Map.Make(Vertex) in
+      let vertex_inv_map =
+        List.fold_left (fun m (i, v) -> VertexMap.add v i m)
+          VertexMap.empty vertex_map
+      in
+      let index v = VertexMap.find v vertex_inv_map in
       let index_to_json v = `String (string_of_int (index v)) in
       let edge_to_json edge =
         let () = E.label edge in


### PR DESCRIPTION
The use of `List.assoc` is incorrect: it relies on the polymorphic equality on an unknown type of vertices (a parameter of the functor), which thus might not be comparable with (=).

Spotted by @art-w , cc @gasche 