### PR TITLE
[documentation] document the options of OpamSolver.dependencies

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -246,6 +246,7 @@ users)
   * Document custom licenses [#4863 @kit-ty-kate - fix #4862]
   * Add OpenBSD & FreeBSD in the precompiled binaries list [#5001 @mndrix]
   * install.md: fix brew instructions, spelling [#4421 @johnwhitington]
+  * document the options of OpamSolver.dependencies [#5040 @gasche @Armael]
 
 ## Security fixes
   *

--- a/src/solver/opamSolver.mli
+++ b/src/solver/opamSolver.mli
@@ -96,7 +96,14 @@ val installable: universe -> package_set
 val installable_subset: universe -> package_set -> package_set
 
 (** Return the transitive dependency closures
-    of a collection of packages.*)
+    of a collection of packages.
+
+    [depopts]: include optional dependencies (depopts: foo)
+    [build]: include build dependencies (depends: foo {build})
+    [post]: include post dependencies (depends: foo {post})
+    [installed]: only consider already-installed packages
+    [unavaiable]: also consider unavailable packages
+*)
 val dependencies :
   depopts:bool -> build:bool -> post:bool ->
   installed:bool ->
@@ -105,7 +112,7 @@ val dependencies :
   package_set ->
   package_set
 
-(** Same as [dependencies] but for reverse dependencies *)
+(** Same as [dependencies] but for reverse dependencies. *)
 val reverse_dependencies :
   depopts:bool -> build:bool -> post:bool ->
   installed:bool ->


### PR DESCRIPTION
This is a documentation-only PR: @Armael and myself were looking at `OpamSolver.dependencis`, and we did not know what the labelled argument were referring to. (We are still not fully sure that our documentation is correct.)