### PR TITLE
opam update: Avoid reloading repository contents when the repo has not changed

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -112,6 +112,7 @@ users)
     This allows opam-repository to use the default opam.ocaml.org cache and be more resilient to changed/force-pushed or unavailable archives. [#4830 @kit-ty-kate - fixes #4411]
   * Repository tarring "optimisation" no more needed, removed in favor of a plain directory. It still can be used with environment variable `OPAMREPOSITORYTARRING`.  [#5015 @kit-ty-kate @rjbou @AltGr - fix #4586]
     * Fix loading a plain repository froma tarred one [#5109 @rjbou]
+  * Avoid reloading repository contents when the repo has no changes [#5043 @Armael]
 
 ## Lock
   * Fix lock generation of multiple interdependent packages [#4993 @AltGr]
@@ -360,6 +361,7 @@ users)
   * `OpamSolution.parallel_apply`: fix sources_needed package set, now integrate requested but not locally pinned packages [#5082 @rjbou]
   * Add `?subpath` to `OpamRepository.fetch_dev_packages`, `OpamVCS.is_up_to_date` and vcs specific functions in `OpamDarcs`, `OpamHG`, and `OpamGit` [#4876 @rjbou]
   * `OpamRepositoryConfig.E`: add `curl_t` and `fetch_t` to get their respective environement vairbales value dynamically, without lazyness. It is used in `opamClient.InitDefaults`, that can be called at topelevel [#5111 @rjbou]
+  * `OpamRepository.update`: Return a change state result of the repo update [#5043 @Armael]
 
 ## opam-state
   * `OpamSwitchState.universe`: `requested` argument moved from `name_package_set` to `package_set`, to precise installed packages with `--best-effort` [#4796 @LasseBlaauwbroek]

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -540,7 +540,8 @@ let update repo repo_root =
   | Update_empty ->
     log "update empty, no validation performed";
     apply_repo_update repo repo_root Update_empty @@+ fun () ->
-    B.repo_update_complete repo_root repo.repo_url
+    B.repo_update_complete repo_root repo.repo_url @@+ fun () ->
+    Done `No_changes
   | (Update_full _ | Update_patch _) as upd ->
     OpamProcess.Job.catch (fun exn ->
         cleanup_repo_update upd;
@@ -552,7 +553,8 @@ let update repo repo_root =
       failwith "Invalid repository signatures, update aborted"
     | true ->
       apply_repo_update repo repo_root upd @@+ fun () ->
-      B.repo_update_complete repo_root repo.repo_url
+      B.repo_update_complete repo_root repo.repo_url @@+ fun () ->
+      Done `Changes
 
 let on_local_version_control url ~default f =
   match url.OpamUrl.backend with

--- a/src/repository/opamRepository.mli
+++ b/src/repository/opamRepository.mli
@@ -23,8 +23,9 @@ val packages_with_prefixes: dirname -> string option package_map
 (** {2 Repository backends} *)
 
 (** Update {i $opam/repo/$repo}. Raises [Failure] in case the update couldn't be
-    achieved. *)
-val update: repository -> dirname -> unit OpamProcess.job
+    achieved. Returns [`No_changes] if the update did not bring any changes, and
+    [`Changes] otherwise. *)
+val update: repository -> dirname -> [`Changes | `No_changes] OpamProcess.job
 
 (** [pull_shared_tree ?cache_dir ?cache_url labels_dirnames checksums urls]
     Fetch an URL and put the resulting tree into the supplied directories

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -131,7 +131,7 @@ The following actions will be performed:
 -> removed   foo.5
 -> installed foo.4
 Done.
-### opam update --debug-level=-3 | unordered
+### opam update --debug-level=-3
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
 CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-003ACE73.cache in 0.000s
@@ -139,12 +139,6 @@ FILE(opam)                      Read ${BASEDIR}/OPAM/tarring/.opam-switch/packag
 
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [tarred] no changes from file://${BASEDIR}/REPO
-FILE(repo)                      Read ${BASEDIR}/OPAM/repo/tarred/repo in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/tarred/packages/foo/foo.4/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/tarred/packages/foo/foo.3/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/tarred/packages/foo/foo.2/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/tarred/packages/foo/foo.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/tarred/packages/foo/foo.5/opam in 0.000s
 FILE(repos-config)              Wrote ${BASEDIR}/OPAM/repo/repos-config in 0.000s
 CACHE(repository)               Writing the repository cache to ${BASEDIR}/OPAM/repo/state-003ACE73.cache ...
 CACHE(repository)               ${BASEDIR}/OPAM/repo/state-003ACE73.cache written in 0.000s

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -97,3 +97,71 @@ tarred
 packages
 repo
 ### diff -ru ./REPO $OPAMROOT/repo/tarred
+### # Noop update with no changes
+### <REPO/packages/foo/foo.4/opam>
+opam-version: "2.0"
+build: ["test" "-f" "rab"]
+### <REPO/packages/foo/foo.4/files/rab>
+some content
+### OPAMDEBUGSECTIONS="FILE(opam) FILE(repo) FILE(repos-config)  CACHE(repository)"
+### opam update --debug-level=-3 | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-003ACE73.cache in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/tarring/.opam-switch/packages/foo.5/opam in 0.000s
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[tarred] synchronised from file://${BASEDIR}/REPO
+FILE(repo)                      Read ${BASEDIR}/OPAM/repo/tarred/repo in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/tarred/packages/foo/foo.4/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/tarred/packages/foo/foo.3/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/tarred/packages/foo/foo.2/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/tarred/packages/foo/foo.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/tarred/packages/foo/foo.5/opam in 0.000s
+FILE(repos-config)              Wrote ${BASEDIR}/OPAM/repo/repos-config in 0.000s
+CACHE(repository)               Writing the repository cache to ${BASEDIR}/OPAM/repo/state-003ACE73.cache ...
+CACHE(repository)               ${BASEDIR}/OPAM/repo/state-003ACE73.cache written in 0.000s
+Now run 'opam upgrade' to apply any package updates.
+### opam install foo.4
+The following actions will be performed:
+=== downgrade 1 package
+  - downgrade foo 5 to 4
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.5
+-> installed foo.4
+Done.
+### opam update --debug-level=-3 | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-003ACE73.cache in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/tarring/.opam-switch/packages/foo.4/opam in 0.000s
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[tarred] no changes from file://${BASEDIR}/REPO
+FILE(repo)                      Read ${BASEDIR}/OPAM/repo/tarred/repo in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/tarred/packages/foo/foo.4/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/tarred/packages/foo/foo.3/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/tarred/packages/foo/foo.2/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/tarred/packages/foo/foo.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/tarred/packages/foo/foo.5/opam in 0.000s
+FILE(repos-config)              Wrote ${BASEDIR}/OPAM/repo/repos-config in 0.000s
+CACHE(repository)               Writing the repository cache to ${BASEDIR}/OPAM/repo/state-003ACE73.cache ...
+CACHE(repository)               ${BASEDIR}/OPAM/repo/state-003ACE73.cache written in 0.000s
+### opam list --all --all-versions
+# Packages matching: any
+# Package # Installed # Synopsis
+foo.1     4
+foo.2     4
+foo.3     4
+foo.4     4
+foo.5     4
+### opam install foo.1
+The following actions will be performed:
+=== downgrade 1 package
+  - downgrade foo 4 to 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.4
+-> installed foo.1
+Done.


### PR DESCRIPTION
Currently, `opam update` will reload the state of a repository (reading .opam files, etc) even when the repository has not changed (as detected by the backend).
This PR is an attempt at optimizing this case: if the backend says that a repository has not changed, avoid reloading its contents, allowing for quicker `opam update`s.

(a review is particularly welcome as I am not familiar with this part of opam's code; I might have missed some subtleties wrt synchronization of the on-disk view of the repo and the "repo" in-memory data structure...)