### PR TITLE
Factorise OpamSolver.installable

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -277,7 +277,8 @@ users)
   * `OpamCudf`: add `trim_universe` [#5024 @AltGr]
   * `OpamSolver.cudf_versions_map`: no more takes a package set as argument, compute whole packages (repo + installed) and take accounet of invariant [#5024 @AltGr]
   * `OpamSolver.load_cudf_universe`: change staging of `add_invariant` [#5024 @AltGr]
-  * `OpamSolver.coinstallable_subset`: add `add_inaviant` optional argument [#5024 @AltGr]
+  * `OpamSolver.coinstallable_subset`: add `add_invariant` optional argument [#5024 @AltGr]
+  * `OpamSolver.installable`: use `installable_subset` that uses `coinstallable_subset` [#5024 @kit_ty_kate]
 ## opam-format
   * `OpamStd.ABSTRACT`: add `compare` and `equal`, that added those functions to `OpamSysPkg` and `OpamVariable` [#4918 @rjbou]
   * Add OpamPackage.Version.default returning the version number used when no version is given for a package [#4949 @kit-ty-kate]

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -532,23 +532,6 @@ let dosetrim f =
   ignore (f ~callback ~explain:false);
   !trimmed_pkgs
 
-let installable universe =
-  log "trim";
-  let simple_universe =
-    load_cudf_universe universe ~add_invariant:true
-      universe.u_available ~build:true ~post:true ()
-  in
-  let cudf_installable =
-    dosetrim (fun ~callback ~explain ->
-        Dose_algo.Depsolver.univcheck ~callback ~explain simple_universe)
-  in
-  List.fold_left
-    (fun acc pkg ->
-       if pkg.Cudf.package = OpamCudf.opam_invariant_package_name then acc
-       else OpamPackage.Set.add (OpamCudf.cudf2opam pkg) acc)
-    OpamPackage.Set.empty
-    cudf_installable
-
 let coinstallable_subset universe ?(add_invariant=true) set packages =
   log "subset of coinstallable with %a within %a"
     (slog OpamPackage.Set.to_string) set
@@ -597,6 +580,9 @@ let coinstallable_subset universe ?(add_invariant=true) set packages =
 let installable_subset universe packages =
   coinstallable_subset
     universe ~add_invariant:true OpamPackage.Set.empty packages
+
+let installable universe =
+  installable_subset universe universe.u_available
 
 module PkgGraph = Graph.Imperative.Digraph.ConcreteBidirectional(OpamPackage)
 


### PR DESCRIPTION
Built on top of https://github.com/ocaml/opam/pull/5024
It simply uses the new `installable_subset` to implement `installable`

cc @Armael 