### PR TITLE
Better recognition of depexts on Gentoo, NetBSD, OpenBSD

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -32,6 +32,7 @@ users)
 
 ## Install
   * Make the status of pinned packages more explicit during installation [#4987 @kit-ty-kate - fix #4925]
+  * Better recognize depexts on Gentoo, NetBSD, OpenBSD [#5065 @mndrix]
 
 ## Remove
   *

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -193,11 +193,17 @@ let packages_status packages =
         let short_name =
           match String.rindex pkg '/' with
           | exception Not_found -> pkg
-          | idx -> String.sub pkg idx (String.length pkg - idx)
+          | idx -> String.sub pkg (idx+1) (String.length pkg - idx - 1)
+        in
+        let no_flavor =
+          match String.index short_name ',' with
+          | exception Not_found -> short_name
+          | idx -> String.sub short_name 0 idx
         in
         set
         |> OpamSysPkg.Set.add (OpamSysPkg.of_string pkg)
         |> OpamSysPkg.Set.add (OpamSysPkg.of_string short_name)
+        |> OpamSysPkg.Set.add (OpamSysPkg.of_string no_flavor)
       ) OpamSysPkg.Set.empty l
   in
   let compute_sets_with_virtual get_avail_w_virtuals get_installed  =


### PR DESCRIPTION
Gentoo, NetBSD, and OpenBSD name packages in a /-separated
hierarchy.  For example, libgmp is available as "dev-libs/gmp"
(on Gentoo[1]) or "devel/gmp" (on NetBSD[2] and OpenBSD[3]).

The first fix in this commit (the change to the `short_name` function)
removes the leading "/" from the package's short name.  Prior to this
commit, if `pkg` were "dev-libs/gmp", then `short_name` would be
"/gmp". That doesn't match the depext name of "gmp" so opam thought
the package wasn't installed.

OpenBSD also uses flavors and subpackages[4] in some of its package
names.  For example, OpenBSD has two subpackages for the "devel/gmp"
package: main and cxx. That means that the full name for libgmp on
OpenBSD is likely to be "devel/gmp,-main".  Prior to this commit,
`short_name` for this package was "gmp,-main".  This commit introduces
`no_flavor` which removes the flavors and subpackages from package
names, if present.  That causes "devel/gmp,-main" on OpenBSD to have a
`no_flavor` name of "gmp".  This name matches the depext name, so that
opam can recognize that libgmp is installed.

1: https://packages.gentoo.org/packages/dev-libs/gmp
2: https://cdn.netbsd.org/pub/pkgsrc/current/pkgsrc/devel/gmp/index.html
3: https://github.com/openbsd/ports/tree/b12d29201e832eb5a230d54449ff2a13502c9fbb/devel/gmp
4: https://man.openbsd.org/OpenBSD-7.0/pkgpath.7

Please update `master_changes.md` file with your changes.
