### PR TITLE
Refine the computation of atomic actions from a solver solution

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -169,6 +169,7 @@ users)
   * Make the 0install solver non-optional [#4909 @kit-ty-kate]
   * Optimised reverse dependencies calculation [#5005 @AltGr]
   * Enable cudf preprocessing for (co)insallability calculation, resulting in a x20 speedup [@AltGr]
+  * Fix false-positive detection of cyclic dependencies [@Armael #5066 - fix #4541]
 
 ## Client
   * Check whether the repository might need updating more often [#4935 @kit-ty-kate]

--- a/src/core/opamCompat.ml
+++ b/src/core/opamCompat.ml
@@ -111,6 +111,18 @@ struct
 end
 #endif
 
+module List =
+#if OCAML_VERSION >= (4, 10, 0)
+  List
+#else
+struct
+  include List
+
+  let concat_map f l =
+    List.fold_left (fun acc x -> acc @ f x) [] l
+end
+#endif
+
 #if OCAML_VERSION < (4, 7, 0)
 module Stdlib = Pervasives
 #else

--- a/src/core/opamCompat.mli
+++ b/src/core/opamCompat.mli
@@ -91,6 +91,17 @@ module Result
 end
 #endif
 
+module List
+#if OCAML_VERSION >= (4, 10, 0)
+= List
+#else
+: sig
+  include module type of List
+
+  val concat_map : ('a -> 'b list) -> 'a list -> 'b list
+end
+#endif
+
 #if OCAML_VERSION < (4, 7, 0)
 module Stdlib = Pervasives
 #else

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -468,7 +468,7 @@ let strong_and_weak_deps u deps =
 
 let expand_deps u (deps: Cudf_types.vpkgformula) =
   List.map (fun clause ->
-      List.concat_map (fun (name, cstr) ->
+      OpamCompat.List.concat_map (fun (name, cstr) ->
           Cudf.lookup_packages ~filter:cstr u name
       ) clause
   ) deps

--- a/tests/reftests/cyclic.test
+++ b/tests/reftests/cyclic.test
@@ -1,0 +1,13 @@
+7371c1d9
+### # False-positive fixed in https://github.com/ocaml/opam/pull/5066
+### opam switch create test --empty
+### opam install --show graphics.5.1.2 ocamlfind.1.9.1 ocamlfind-secondary.1.9.1 dune.2.9.1
+This should not fail anymore but fails?
+### # Real cycle
+### opam install --show --with-doc --with-test mdx.2.0.0 odoc.2.0.0
+[ERROR] Package conflict!
+The actions to process have cyclic dependencies:
+  - install mdx (= 15) -> install odoc (= 15) -> install mdx (= 15)
+
+No solution found, exiting
+# Return code 20 #

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -170,6 +170,23 @@
    (run ./run.exe %{bin:opam} %{dep:cudf-preprocess.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-cyclic)
+ (action
+  (diff cyclic.test cyclic.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-cyclic)))
+
+(rule
+ (targets cyclic.out)
+ (deps root-7371c1d9)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:cyclic.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-dot-install)
  (action
   (diff dot-install.test dot-install.out)))


### PR DESCRIPTION
Related: #4541 
Solves the issue specifically mentionned at https://github.com/ocaml/opam/issues/4541#issuecomment-1044961055

This PR refines the computation of atomic actions (and more
importantly, their dependencies) computed by opam from a solver
solution. It improves it in the sense that it eliminates some cases
where opam would complain that a solution is cyclic, even though it
would be possible to execute it while preserving dependencies.


Background
----------

(this is my limited comprehension of what happens from reading the code, I'm
 happy to be corrected!)

When opam invokes a solver with a query for installing new packages, the solver
eventually produces a new "universe" indicating which versions specifically of
which packages can be installed to satisfy the query.

In order to then actually install the packages, opam needs to perform a bit more
work: from knowing 1) the dependency constraints of all packages; and 2) the set
of packages that need to be installed, it needs to deduce in which order to
install the new packages so as to obey dependencies.

What opam does is to compute a graph of the relevant packages, where an edge "A
-> B" in the graph means that action/package A depends on B. It then checks that
this is an acyclic graph, and the install plan can be extracted e.g. by doing a
topological sort of the packages in the graph.

However, the issue is that this graph is an approximation.

Strictly speaking, a given opam package does not have a set of dependencies:
dependencies can be specified as general boolean formulas. Considering that
these formulas are put in CNF, this means that dependencies are of the form:

```
A depends on (B1 | .... | Bn) &
             (C1 | .... | Cm) &
             ...
```

When considering that package A depends on a set of packages {B1, ..., Bn, C1
... Cm, ...}, this corresponds to approximating "A depends on B1 **or** B2" as
"A depends on B1 **and** B2".

Because of this approximation, it may happen that the resulting graph contains a
cycle even though it could be possible to install all the packages while
satisfying the dependencies (in their general form as boolean formulas).



This means that in full generality we should consider the hypergraph of
packages, where, for a package A, instead of edges A->B1, ..., A->Bn ("A depends
on B1" and ... and "A depends on Bn"), we have potato-shaped hyper-edges
A->B1...Bn, A->C1...Cm, etc ("A depends on B1 or ... or Bn" and "A depends on C1
or ... or Cm" and ...).

This gives us a representation that is faithful to the general form of
dependencies. However, it is now hard (NP complete, AFAICT) to find an acyclic
schedule in this hypergraph...


What this PR implements
-----------------------

This PR avoids solving the general problem of finding an acyclic schedule in the
general hypergraph of packages. Instead, it does compute the hypergraph (this is
basically trivial) but uses this representation to improve the approximation in
a simple case. For package A, where:

```
A depends on (B1 | .... | Bn) &
             (C1 | .... | Cm) &
             ....
```

if there is a Bi that is already installed in the universe (and stays
installed), then we can consider the clause satisfied, and avoid depending on
the other Bis.

For instance, with  https://github.com/ocaml/opam/issues/4541#issuecomment-1044961055, if you put the dependencies of dune.2.9.1 in CNF, there are clauses of the form:

(ocaml >= 4.08 | ocamlfind-secondary)

before this PR, these would result on dune depending on ocamlfind-secondary (even in
a switch with ocaml >= 4.08), eventually resulting in a cycle. With this PR,
these do not result in a dependency, avoiding the cycle.



Of course, in principle there are still cases where opam will report a cycle
that does not exist; but I would suggest to see whether they actually come up in
practice before implementing a more complex approach.