### PR TITLE
lint E57: fix trigger of empty description (lint W47)

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -74,6 +74,7 @@ users)
 ## Lint
   * W68: add warning for missing license field [#4766 @kit-ty-kate - partial fix #4598]
   * W62: use the spdx_licenses library to check for valid licenses. This allows to use compound expressions such as "MIT AND (GPL-2.0-only OR LGPL-2.0-only)", as well as user defined licenses e.g. "LicenseRef-my-custom-license" [#4768 @kit-ty-kate - fixes #4598]
+  * E57 (capital on synopsis) not trigger W47 (empty descr) [#5070 @rjbou]
 
 ## Repository
   * When several checksums are specified, instead of adding in the cache only the archive by first checksum, name by best one and link others to this archive [#4696 rjbou]

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -531,7 +531,8 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
                            diff any (alt [blank; char '.']); eos]))
        in
        match t.descr with None -> false | Some d ->
-         not (Re.execp valid_re (OpamFile.Descr.synopsis d)));
+         let synopsis = OpamFile.Descr.synopsis d in
+         synopsis <> "" && not (Re.execp valid_re synopsis));
     cond 48 `Warning
       "The fields 'build-test:' and 'build-doc:' are deprecated, and should be \
        replaced by uses of the 'with-test' and 'with-doc' filter variables in \

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -410,8 +410,7 @@ license: "ISC"
 dev-repo: "hg+https://to@li.nt"
 bug-reports: "https://nobug"
 ### opam lint ./lint.opam
-${BASEDIR}/lint.opam: Warnings.
-           warning 47: Synopsis (or description first line) should start with a capital and not end with a dot
+${BASEDIR}/lint.opam: Passed.
 ### : W48: The fields 'build-test:' and 'build-doc:' are deprecated, and should be replaced by uses of the 'with-test' and 'with-doc' filter variables in the 'build:' and 'install:' fields, and by the newer 'run-test:' field
 ### <lint.opam>
 opam-version: "2.0"
@@ -619,7 +618,6 @@ dev-repo: "hg+https://to@li.nt"
 bug-reports: "https://nobug"
 ### opam lint ./lint.opam
 ${BASEDIR}/lint.opam: Errors.
-           warning 47: Synopsis (or description first line) should start with a capital and not end with a dot
              error 57: Synopsis and description must not be both empty
 # Return code 1 #
 ### : W58: Found variable, predefined one


### PR DESCRIPTION

```diff
 ### opam lint ./lint.opam
 ${BASEDIR}/lint.opam: Errors.
-           warning 47: Synopsis (or description first line) should start with a capital and not end with a dot
              error 57: Synopsis and description must not be both empty
