### PR TITLE
Fix working-dir & fetching non pinned packages

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -57,6 +57,7 @@ users)
 ## Pin
   * Switch the default version when undefined from ~dev to dev [#4949 @kit-ty-kate]
   * ◈ New option `opam pin --current` to fix a package in its current state (avoiding pending reinstallations or removals from the repository) [#4973 @AltGr - fix #4970]
+  * [BUG] Fix using `--working-dir` with non pinned packages: it was not downloading sources as they were remove from package that need sources [#5082 @rjbou - fix #5060]
 
 ## List
   * Some optimisations to 'opam list --installable' queries combined with other filters [#4882 @altgr - fix #4311]
@@ -310,6 +311,7 @@ users)
   * `OpamRepositoryConfig`: add in config record `repo_tarring` field and as an argument to config functions, and a new constructor `REPOSITORYTARRING` in `E` environment module and its access function [#5015 @rjbou]
   * New download functions for shared source, old ones kept [#4893 @rjbou]
   * `OpamClient.filter_unpinned_locally` now display a warning of skipped packages instead of debug log [#5083 @rjbou]
+  * `OpamSolution.parallel_apply`: fix sources_needed package set, now integrate requested but not locally pinned packages [#5082 @rjbou]
 
 ## opam-state
   * `OpamSwitchState.universe`: `requested` argument moved from `name_package_set` to `package_set`, to precise installed packages with `--best-effort` [#4796 @LasseBlaauwbroek]

--- a/tests/reftests/working-dir.test
+++ b/tests/reftests/working-dir.test
@@ -183,26 +183,21 @@ Done.
 The following actions will be performed:
 === install 1 package
   - install qux 4
+[NOTE] --working-dir is given but no requested package is pinned
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-[ERROR] The compilation of qux.4 failed at "test -f present".
-
-
-
-
-<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-+- The following actions failed
-| - build qux 4
-+- 
-- No changes have been performed
-# Return code 31 #
-### opam remove ongoing
+-> retrieved qux.4  (file://${BASEDIR}/qux)
+-> installed qux.4
+Done.
+### opam remove qux ongoing
 The following actions will be performed:
-=== remove 1 package
+=== remove 2 packages
   - remove ongoing dev (pinned)
+  - remove qux     4
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> removed   ongoing.dev
+-> removed   qux.4
 Done.
 ### <pin:ongoing/ongoing.opam>
 opam-version: "2.0"
@@ -223,29 +218,19 @@ The following actions will be performed:
   - install qux     4
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-Processing  1/4: [ongoing: test newfile.txt]
+Processing  1/5: [qux.4: rsync]
+Processing  2/5: [qux.4: rsync] [ongoing: test newfile.txt]
+-> retrieved qux.4  (file://${BASEDIR}/qux)
+Processing  2/5: [ongoing: test newfile.txt]
 test "-f" "newfile.txt" (CWD=${BASEDIR}/OPAM/working-dir/.opam-switch/build/ongoing.dev)
-Processing  1/4: [ongoing: cat newfile.txt]
+Processing  2/5: [ongoing: cat newfile.txt]
 cat "newfile.txt" (CWD=${BASEDIR}/OPAM/working-dir/.opam-switch/build/ongoing.dev)
 - new!
 -> compiled  ongoing.dev
-Processing  2/4: [qux: test present]
+Processing  3/5: [qux: test present]
 -> installed ongoing.dev
-Processing  3/4: [qux: test present]
+Processing  4/5: [qux: test present]
 test "-f" "present" (CWD=${BASEDIR}/OPAM/working-dir/.opam-switch/build/qux.4)
-[ERROR] The compilation of qux.4 failed at "test -f present".
-
-
-
-
-<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-+- The following actions failed
-| - build qux 4
-+- 
-+- The following changes have been performed
-| - install ongoing dev
-+- 
-
-The former state can be restored with:
-'${OPAM} install qux ongoing --working-dir -v' failed.
-# Return code 31 #
+-> compiled  qux.4
+-> installed qux.4
+Done.


### PR DESCRIPTION
They were not fetched as they were removed from set of packages that need to have its sources downloaded. Only locally pinned packages are removed with this PR.
fix #5060