### PR TITLE
Display parallelised commands in verbose mode

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -192,6 +192,7 @@ users)
   * Homogeneise is_archive tar & zip: if file exists check magic number, otherwise check extension [#4964 @rjbou]
   * [BUG] Remove windows double printing on commands and their output [#4940 @rjbou]
   * OpamParallel, MakeGraph(_).to_json: fix incorrect use of List.assoc [#5038 @Armael]
+  * [BUG] Fix display of command when parallelised [#5091 @rjbou]
 
 ## Internal: Windows
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]
@@ -309,3 +310,4 @@ users)
   * `OpamStd.ABSTRACT`: add `compare` and `equal`, that added those functions to `OpamFilename`, `OpamHash`, `OpamStd`, `OpamStd`, `OpamUrl`, and `OpamVersion` [#4918 @rjbou]
   * `OpamHash`: add `sort` from strongest to weakest kind
   * `OpamSystem.real_path`: Remove the double chdir trick on OCaml >= 4.13.0 [#4961 @kit-ty-kate]
+  * `OpamProcess.wait_one`: display command in verbose mode for finished found process [#5091 @rjbou]

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -707,6 +707,7 @@ let wait_one processes =
     in
     let return = Hashtbl.find dead_childs p.p_pid in
     Hashtbl.remove dead_childs p.p_pid;
+    verbose_print_cmd p;
     p, exit_status p return
   with Not_found ->
     let rec aux () =
@@ -723,6 +724,7 @@ let wait_one processes =
           safe_wait (List.hd processes).p_pid Unix.wait () in
       try
         let p = List.find (fun p -> p.p_pid = pid) processes in
+        verbose_print_cmd p;
         p, exit_status p return
       with Not_found ->
         Hashtbl.add dead_childs pid return;

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -701,36 +701,38 @@ let dontwait p =
 let dead_childs = Hashtbl.create 13
 let wait_one processes =
   if processes = [] then raise (Invalid_argument "wait_one");
-  try
-    let p =
-      List.find (fun p -> Hashtbl.mem dead_childs p.p_pid) processes
-    in
-    let return = Hashtbl.find dead_childs p.p_pid in
-    Hashtbl.remove dead_childs p.p_pid;
-    verbose_print_cmd p;
-    p, exit_status p return
-  with Not_found ->
-    let rec aux () =
-      let pid, return =
-        if Sys.win32 then
-          (* No Unix.wait on Windows, so use a stub wrapping
-             WaitForMultipleObjects *)
-          let pids, len =
-            let f (l, n) t = (t.p_pid::l, succ n) in
-            List.fold_left f ([], 0) processes
-          in
-          OpamStubs.waitpids pids len
-        else
-          safe_wait (List.hd processes).p_pid Unix.wait () in
-      try
-        let p = List.find (fun p -> p.p_pid = pid) processes in
-        verbose_print_cmd p;
-        p, exit_status p return
-      with Not_found ->
-        Hashtbl.add dead_childs pid return;
-        aux ()
-    in
-    aux ()
+  let p, return =
+    try
+      let p =
+        List.find (fun p -> Hashtbl.mem dead_childs p.p_pid) processes
+      in
+      let return = Hashtbl.find dead_childs p.p_pid in
+      Hashtbl.remove dead_childs p.p_pid;
+      p, return
+    with Not_found ->
+      let rec aux () =
+        let pid, return =
+          if Sys.win32 then
+            (* No Unix.wait on Windows, so use a stub wrapping
+               WaitForMultipleObjects *)
+            let pids, len =
+              let f (l, n) t = (t.p_pid::l, succ n) in
+              List.fold_left f ([], 0) processes
+            in
+            OpamStubs.waitpids pids len
+          else
+            safe_wait (List.hd processes).p_pid Unix.wait () in
+        try
+          let p = List.find (fun p -> p.p_pid = pid) processes in
+          p, return
+        with Not_found ->
+          Hashtbl.add dead_childs pid return;
+          aux ()
+      in
+      aux ()
+  in
+  if p.p_verbose then verbose_print_cmd p;
+  p, exit_status p return
 
 let dry_wait_one = function
   | {p_pid = -1; _} as p :: _ ->

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -428,6 +428,23 @@
    (run ./run.exe %{bin:opam} %{dep:orphans.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-parallel)
+ (action
+  (diff parallel.test parallel.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-parallel)))
+
+(rule
+ (targets parallel.out)
+ (deps root-N0REP0)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:parallel.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-pat-sub)
  (action
   (diff pat-sub.test pat-sub.out)))

--- a/tests/reftests/parallel.test
+++ b/tests/reftests/parallel.test
@@ -32,7 +32,7 @@ if [ $# -eq 1 ]; then
   echo "finally installed $1"
 fi
 ### opam switch create parallel --empty
-### opam install foo bar baz qux top -vv | grep -v '^Processing' | '.*(\\|")sh(\.exe)?"? "' -> 'sh "' | unordered
+### opam install foo bar baz qux top -vv | grep -v '^Processing' | '.*(/|\\|")sh(\.exe)?"? "' -> 'sh "' | unordered
 The following actions will be performed:
 === install 5 packages
   - install bar 1

--- a/tests/reftests/parallel.test
+++ b/tests/reftests/parallel.test
@@ -42,12 +42,15 @@ The following actions will be performed:
   - install qux 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+sh "sleep.sh" "bar" (CWD=${BASEDIR}/OPAM/parallel/.opam-switch/build/bar.1)
 - woke up bar
 -> compiled  bar.1
 -> installed bar.1
+sh "sleep.sh" "baz" (CWD=${BASEDIR}/OPAM/parallel/.opam-switch/build/baz.1)
 - woke up baz
 -> compiled  baz.1
 -> installed baz.1
+sh "sleep.sh" "foo" (CWD=${BASEDIR}/OPAM/parallel/.opam-switch/build/foo.1)
 -> compiled  foo.1
 -> installed foo.1
 sh "sleep.sh" "qux" (CWD=${BASEDIR}/OPAM/parallel/.opam-switch/build/qux.1)

--- a/tests/reftests/parallel.test
+++ b/tests/reftests/parallel.test
@@ -1,0 +1,61 @@
+N0REP0
+### : opam internals parallised jobs
+### <pkg:foo.1>
+opam-version: "2.0"
+build: [ "sh" "sleep.sh" name ]
+### <pkg:foo.1:sleep.sh>
+sleep 1
+### <pkg:bar.1>
+opam-version: "2.0"
+build: [ "sh" "sleep.sh" name ]
+### <pkg:bar.1:sleep.sh>
+sleep 1
+echo woke up $1
+### <pkg:baz.1>
+opam-version: "2.0"
+build: [ "sh" "sleep.sh" name ]
+### <pkg:baz.1:sleep.sh>
+sleep 1
+echo woke up $1
+### <pkg:qux.1>
+opam-version: "2.0"
+build: [ "sh" "sleep.sh" name ]
+### <pkg:qux.1:sleep.sh>
+sleep 1
+### <pkg:top.1>
+opam-version: "2.0"
+depends: [ "foo" "bar" "baz" "qux" ]
+build: [ "sh" "shout.sh" ]
+install: [ "sh" "shout.sh" name ]
+### <pkg:top.1:shout.sh>
+if [ $# -eq 1 ]; then
+  echo "finally installed $1"
+fi
+### opam switch create parallel --empty
+### opam install foo bar baz qux top -vv | grep -v '^Processing' | '.*(\\|")sh(\.exe)?"? "' -> 'sh "' | unordered
+The following actions will be performed:
+=== install 5 packages
+  - install bar 1
+  - install baz 1
+  - install top 1
+  - install foo 1
+  - install qux 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- woke up bar
+-> compiled  bar.1
+-> installed bar.1
+- woke up baz
+-> compiled  baz.1
+-> installed baz.1
+-> compiled  foo.1
+-> installed foo.1
+sh "sleep.sh" "qux" (CWD=${BASEDIR}/OPAM/parallel/.opam-switch/build/qux.1)
+-> compiled  qux.1
+-> installed qux.1
+sh "shout.sh" (CWD=${BASEDIR}/OPAM/parallel/.opam-switch/build/top.1)
+-> compiled  top.1
+sh "shout.sh" "top" (CWD=${BASEDIR}/OPAM/parallel/.opam-switch/build/top.1)
+- finally installed top
+-> installed top.1
+Done.


### PR DESCRIPTION
No display was done for jobs that are in jobs pool, unless last one (last one is called with `OpamProcess.wait` that does the print)

```diff
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+sh "sleep.sh" "bar" (CWD=${BASEDIR}/OPAM/parallel/.opam-switch/build/bar.1)
 - woke up bar
 -> compiled  bar.1
```