### PR TITLE
Github deprecation of `git://` protocol updates

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -651,7 +651,10 @@ URLs are provided as strings. They can refer to:
 - URLs of the form `http://`, `https://`, `ftp://`, `ssh://`, `file://`, `rsync://`
 - Version control URLs for git, mercurial and darcs: `git://`, `hg://`,
   `darcs://`. This assumes http transport for `hg` and `darcs`, _i.e._
-  `hg://` is short for `hg+http://`
+  `hg://` is short for `hg+http://`.
+  - Note that Github
+  [disabled](https://github.blog/2021-09-01-improving-git-protocol-security-github/)
+  `git://` protocol support.
 - Version control bound to a specific URL: `<vc>+<scheme>://`, e.g. `git://`,
   `hg+https://`, `git+file://`, etc. (**NOTE:** this has been added in opam 1.2.1)
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -224,6 +224,7 @@ users)
   * Add lint test [#4967 @rjbou]
   * Add lock test [#4963 @rjbou]
   * Add working dir/inplace/assume-built test [#5081 @rjbou]
+  * Fix github url: `git://` form no more handled [#5097 @rjbou]
 ### Engine
   * Add `opam-cat` to normalise opam file printing [#4763 @rjbou @dra27] [2.1.0~rc2 #4715]
   * Fix meld reftest: open only with failing ones [#4913 @rjbou]
@@ -273,6 +274,7 @@ users)
   * Add OpenBSD & FreeBSD in the precompiled binaries list [#5001 @mndrix]
   * install.md: fix brew instructions, spelling [#4421 @johnwhitington]
   * document the options of OpamSolver.dependencies [#5040 @gasche @Armael]
+  * Add github `git://` protocol deprecation note [#5097 @rjbou]
 
 ## Security fixes
   *

--- a/tests/reftests/legacy-git.test
+++ b/tests/reftests/legacy-git.test
@@ -1034,7 +1034,7 @@ P1.1
 P2.1
 P3.1~weird-version.test
 P4.1
-### opam reinstall P1 --yes
+### opam reinstall P1 --yes | unordered
 The following actions will be performed:
 === recompile 4 packages
   - recompile P1 1                                  I ll always bother you displaying this message

--- a/tests/reftests/upgrade-format.test
+++ b/tests/reftests/upgrade-format.test
@@ -108,17 +108,17 @@ Faking installation of seq.base
 Faking installation of re.1.9.0
 Faking installation of opam-core.2.0.7
 Done.
-### opam pin add git://github.com/ocaml/opam.git#59a71e3cf1 -yn
+### opam pin add git+https://github.com/ocaml/opam.git#59a71e3cf1 -yn
 This will pin the following packages: opam-client, opam-core, opam-devel, opam-format, opam-installer, opam-repository, opam-solver, opam-state. Continue? [Y/n] y
-opam-client is now pinned to git://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
+opam-client is now pinned to git+https://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
 [NOTE] Package opam-core is currently pinned to file://${BASEDIR} (version 2.0.7).
-opam-core is now pinned to git://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
-opam-devel is now pinned to git://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
-opam-format is now pinned to git://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
-opam-installer is now pinned to git://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
-opam-repository is now pinned to git://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
-opam-solver is now pinned to git://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
-opam-state is now pinned to git://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
+opam-core is now pinned to git+https://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
+opam-devel is now pinned to git+https://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
+opam-format is now pinned to git+https://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
+opam-installer is now pinned to git+https://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
+opam-repository is now pinned to git+https://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
+opam-solver is now pinned to git+https://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
+opam-state is now pinned to git+https://github.com/ocaml/opam.git#59a71e3cf1 (version 2.1.0~beta3)
 ### opam install opam-format --show
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>


### PR DESCRIPTION
Affects only a test + a note in manual 