### PR TITLE
Rebuild packages only when what is going to be installed can change

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -173,6 +173,8 @@ users)
   * Repository state: stop scanning directory once opam file is found [#4847 @rgrinberg]
   * Fix reverting environment additions to PATH-like variables when several dirs added at once [#4861 @dra27]
   * Actually allow multiple state caches to co-exist [#4934 @dra27 - fix #4554 properly this time]
+  * Don’t rebuild packages when updating dependencies or availablity, unless the current state needs to be changed [#5118 @kit-ty-kate - fix #4647]
+  * Rebuild packages when removing or adding the "plugin" flag [#5118 @kit-ty-kate]
 
 ## Opam file format
   *
@@ -327,6 +329,7 @@ users)
   * `OpamFile.Config`: order list of installed switches according their last use, update `with_switch` accordingly, and add `previous_switch` [#4910 @AltGr]
   * Change ``Fetch` action to take several packages, in order to handle shared fetching of packages [#4893 @rjbou]
   * `OpamFile.OPAM.to_string_with_preserved_format`: handle substring errors [#4941 @rjbou - fix #4936]
+  * `OpamFile.OPAM.effective_part` and `OpamFile.OPAM.effectively_equal` now take an optional `?modulo_state:bool` parameter, that if `true`, eliminates the fields relying on the state of the switch (depends, available, …). This is `false` by default. [#5118 @kit-ty-kate]
 
 ## opam-core
   * OpamSystem: avoid calling Unix.environment at top level [#4789 @hannesm]

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3210,18 +3210,19 @@ module OPAM = struct
 
   (** Extra stuff for opam files *)
 
-  let effective_part (t:t) =
+  let effective_part ?(modulo_state=false) (t:t) =
+    let t_modulo_state = if modulo_state then empty else t in
     {
       opam_version = empty.opam_version;
 
       name       = t.name;
       version    = t.version;
 
-      depends    = t.depends;
-      depopts    = t.depopts;
-      conflicts  = t.conflicts;
-      conflict_class = t.conflict_class;
-      available  = t.available;
+      depends    = t_modulo_state.depends;
+      depopts    = t_modulo_state.depopts;
+      conflicts  = t_modulo_state.conflicts;
+      conflict_class = t_modulo_state.conflict_class;
+      available  = t_modulo_state.available;
       flags      =
         (List.filter (function
              | Pkgflag_Plugin -> true
@@ -3285,8 +3286,8 @@ module OPAM = struct
       deprecated_build_doc = t.deprecated_build_doc;
     }
 
-  let effectively_equal o1 o2 =
-    effective_part o1 = effective_part o2
+  let effectively_equal ?(modulo_state=false) o1 o2 =
+    effective_part ~modulo_state o1 = effective_part ~modulo_state o2
 
   let equal o1 o2 =
     with_metadata_dir None o1 = with_metadata_dir None o2

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3224,9 +3224,9 @@ module OPAM = struct
       available  = t.available;
       flags      =
         (List.filter (function
+             | Pkgflag_Plugin -> true
              | Pkgflag_LightUninstall
              | Pkgflag_Verbose
-             | Pkgflag_Plugin
              | Pkgflag_Compiler
              | Pkgflag_Conf
              | Pkgflag_AvoidVersion

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -412,12 +412,16 @@ module OPAM: sig
 
   (** Returns the opam value (including url, descr) with all non-effective (i.e.
       user-directed information that doesn't change opam's view on the package)
-      fields set to their empty values. Useful for comparisons. *)
-  val effective_part: t -> t
+      fields set to their empty values. Useful for comparisons.
+      @param ?modulo_state if [true], eliminates the fields relying on the state
+      of the switch (depends, available, …). This is [false] by default. *)
+  val effective_part: ?modulo_state:bool -> t -> t
 
   (** Returns true if the effective parts of the two package definitions are
-      equal *)
-  val effectively_equal: t -> t -> bool
+      equal.
+      @param ?modulo_state if [true], considers the fields relying on the state
+      of the switch (depends, available, …) equal. This is [false] by default *)
+  val effectively_equal: ?modulo_state:bool -> t -> t -> bool
 
   (** Compares two package definitions, ignoring the virtual fields bound to
       file location ([metadata_dir]...) *)

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -366,7 +366,7 @@ let load lock_kind gt rt switch =
     let changed =
       OpamPackage.Map.merge (fun _ opam_new opam_installed ->
           match opam_new, opam_installed with
-          | Some r, Some i when not (OpamFile.OPAM.effectively_equal i r) ->
+          | Some r, Some i when not (OpamFile.OPAM.effectively_equal ~modulo_state:true i r) ->
             Some ()
           | _ -> None)
         opams installed_opams

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -513,6 +513,23 @@
    (run ./run.exe %{bin:opam} %{dep:pin.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-reinstall)
+ (action
+  (diff reinstall.test reinstall.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-reinstall)))
+
+(rule
+ (targets reinstall.out)
+ (deps root-N0REP0)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:reinstall.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-remove)
  (action
   (diff remove.test remove.out)))

--- a/tests/reftests/reinstall.test
+++ b/tests/reftests/reinstall.test
@@ -25,14 +25,15 @@ depends: ["b"]
 ### opam upgrade --show
 Already up-to-date.
 Nothing to do.
-### :::::: Check that a rebuild occurs if only the flags (plugin) changes (currently bugged)
+### :::::: Check that a rebuild occurs if only the flags (plugin) changes
 ### <pkg:a.1>
 opam-version: "2.0"
 flags: plugin
 depends: ["b"]
 ### opam upgrade --show
-Already up-to-date.
-Nothing to do.
+The following actions would be performed:
+=== recompile 1 package
+  - recompile a 1 [upstream or system changes]
 ### :::::: Check that nothing gets rebuild if only a constraint – that is already installed – changes
 ### <pkg:a.1>
 opam-version: "2.0"

--- a/tests/reftests/reinstall.test
+++ b/tests/reftests/reinstall.test
@@ -1,0 +1,87 @@
+N0REP0
+### :::::: do not rebuild packages when only unimportant constraint has been changed (#4647)
+### <pkg:a.1>
+opam-version: "2.0"
+depends: ["b"]
+### <pkg:b.1>
+opam-version: "2.0"
+### opam switch create default --empty
+### opam install -y a
+The following actions will be performed:
+=== install 2 packages
+  - install a 1
+  - install b 1 [required by a]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed b.1
+-> installed a.1
+Done.
+### :::::: Check that nothing gets rebuild if only the synopsis and flags (verbose) changes
+### <pkg:a.1>
+opam-version: "2.0"
+synopsis: "test"
+flags: verbose
+depends: ["b"]
+### opam upgrade --show
+Already up-to-date.
+Nothing to do.
+### :::::: Check that a rebuild occurs if only the flags (plugin) changes (currently bugged)
+### <pkg:a.1>
+opam-version: "2.0"
+flags: plugin
+depends: ["b"]
+### opam upgrade --show
+Already up-to-date.
+Nothing to do.
+### :::::: Check that nothing gets rebuild if only a constraint – that is already installed – changes
+### <pkg:a.1>
+opam-version: "2.0"
+depends: ["b" {= version}]
+### opam upgrade --show
+The following actions would be performed:
+=== recompile 1 package
+  - recompile a 1 [upstream or system changes]
+### :::::: Check that a rebuild occurs if the build field changes
+### <pkg:a.1>
+opam-version: "2.0"
+build: ["opam" "var" "switch"]
+depends: ["b" {= version}]
+### opam upgrade -y --verbose | '^\+ .+ "build"' -> '+' | '^\+ .+opam(\.exe)? ' -> '+ "opam" '
+The following actions will be performed:
+=== recompile 1 package
+  - recompile a 1 [upstream or system changes]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/4: [a: opam var]
++ "opam" "var" "switch" (CWD=${BASEDIR}/OPAM/default/.opam-switch/build/a.1)
+- default
+-> compiled  a.1
+-> removed   a.1
+-> installed a.1
+Done.
+### :::::: Check that the package gets removed if it is no longer installable
+### <pkg:a.1>
+opam-version: "2.0"
+build: ["opam" "var" "switch"]
+depends: ["b" {= "2"}]
+### opam upgrade --show
+The following actions would be performed:
+=== remove 1 package
+  - remove a 1
+### :::::: Check that rebuilding a dependency correctly rebuilds the package requiring it
+### <pkg:a.1>
+opam-version: "2.0"
+build: ["opam" "var" "switch"]
+depends: ["b" {= version}]
+### <pkg:b.1>
+opam-version: "2.0"
+depends: ["c"]
+### <pkg:c.1>
+opam-version: "2.0"
+### opam upgrade --show
+The following actions would be performed:
+=== recompile 2 packages
+  - recompile a 1 [uses b]
+  - recompile b 1 [upstream or system changes]
+=== install 1 package
+  - install   c 1 [required by b]

--- a/tests/reftests/reinstall.test
+++ b/tests/reftests/reinstall.test
@@ -39,9 +39,8 @@ The following actions would be performed:
 opam-version: "2.0"
 depends: ["b" {= version}]
 ### opam upgrade --show
-The following actions would be performed:
-=== recompile 1 package
-  - recompile a 1 [upstream or system changes]
+Already up-to-date.
+Nothing to do.
 ### :::::: Check that a rebuild occurs if the build field changes
 ### <pkg:a.1>
 opam-version: "2.0"
@@ -82,7 +81,7 @@ opam-version: "2.0"
 ### opam upgrade --show
 The following actions would be performed:
 === recompile 2 packages
-  - recompile a 1 [uses b]
-  - recompile b 1 [upstream or system changes]
+  - recompile a 1
+  - recompile b 1
 === install 1 package
-  - install   c 1 [required by b]
+  - install   c 1


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/4647

The tests are nowhere near complete but it’s a start and it shows that https://github.com/ocaml/opam/issues/4647#issuecomment-1098914526 discussed earlier is the only thing needed to get it working amazingly. Thanks a lot!

In this PR I’ve also fixed a bug where adding or removing the `plugin` flag does not reinstall a package, which shouldn’t be the case as currently plugin creating and delation are only done during the installation and removal actions respectively.

Regarding the code, I went the `?(modulo_state=false)` approach instead of duplicating the function because it made thing clearer regarding what is the difference between `effectively_part` and `effectively_part_modulo_state`