### PR TITLE
Add a 'test' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,9 @@ uninstall: opam.install
 	$(OPAMINSTALLER) -u $(OPAMINSTALLER_FLAGS) $<
 	$(OPAMINSTALLER) -u $(OPAMINSTALLER_FLAGS) opam-installer.install
 
+.PHONY: test
+test: tests
+
 .PHONY: tests
 tests: $(DUNE_DEP) src/client/no-git-version
 	@$(DUNE) runtest $(DUNE_PROFILE_ARG) --root . $(DUNE_ARGS) src/ tests/ --no-buffer; \

--- a/master_changes.md
+++ b/master_changes.md
@@ -162,6 +162,7 @@ users)
   * Add `jsonm` (and `uutf`) dependency [#5098 @rjbou - fix #5085]
   * Bump opam-file-format to 2.1.4 [#5117 @kit-ty-kate - fix #5116]
   * Add `sha` dependency [#5042 @kit-ty-kate]
+  * Add a 'test' target [#5129 @kit-ty-kate @mehdid - partially fixes #5058]
 
 ## Infrastructure
   * Fix caching of Cygwin compiler on AppVeyor [#4988 @dra27]


### PR DESCRIPTION
Comment from the original author:
```
This patch is useful only for Debian: It helps dh_auto_test to detect
that there is a testsuite and run it accordingly. dh_auto_test checks
'test' and 'check' targets, but not 'tests'.
```
Partly f.i.x.e.s https://github.com/ocaml/opam/issues/5058