### PR TITLE
Do not update .changes file during dry-run

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -45,6 +45,8 @@ users)
   * Better recognize depexts on Gentoo, NetBSD, OpenBSD [#5065 @mndrix]
   * Reimplement deps-only [#4975 @AltGr]
   * ◈ Add `--formula` option to specify a formula to install [#4975 @AltGr]
+  * [BUG] Prevent `.changes` files from being updated during dry-run [#5144 @na4zagin3 - fix #5132]
+  * Log a summary of recorded `.changes` as a `ACTION` trace log to help debug #4419 [#5144 @na4zagin3]
 
 ## Remove
   *
@@ -391,3 +393,4 @@ users)
   * `OpamSHA`: use now only `sha`, some function removed (`shaxxx`, `shaxxx_bytes`, etc.) [#5042 @kit-ty-kate]
   * `OpamCoreConfig.r`: remove openssl related config: `use_openssl` parameter & config field, and `OPAMUSEOPENSSL` environment variable [#5042 @kit-ty-kate]
   * `OpamFilename`: add a `SubPath` submodule to handle multi-platform subpath specifications. It has an effect on a lot of functions signatures [#4876 @rjbou]
+  * `OpamDirTrack`: Add `to_summary_string` to summarise changes [#5144 @na4zagin3]

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -1066,7 +1066,10 @@ let install_package t ?(test=false) ?(doc=false) ?build_dir nv =
   | Left config, changes ->
     let changes_f = OpamPath.Switch.changes root t.switch nv.name in
     if OpamStateConfig.(not !r.dryrun) then
-      OpamFile.Changes.write changes_f changes;
+      (log "changes recorded for %s: %a"
+         (OpamPackage.to_string nv)
+         (slog OpamDirTrack.to_summary_string) changes;
+       OpamFile.Changes.write changes_f changes);
     OpamConsole.msg "%s installed %s.%s\n"
       (if not (OpamConsole.utf8 ()) then "->"
        else OpamActionGraph.

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -1065,7 +1065,8 @@ let install_package t ?(test=false) ?(doc=false) ?build_dir nv =
     Done (Right e)
   | Left config, changes ->
     let changes_f = OpamPath.Switch.changes root t.switch nv.name in
-    OpamFile.Changes.write changes_f changes;
+    if OpamStateConfig.(not !r.dryrun) then
+      OpamFile.Changes.write changes_f changes;
     OpamConsole.msg "%s installed %s.%s\n"
       (if not (OpamConsole.utf8 ()) then "->"
        else OpamActionGraph.

--- a/src/core/opamDirTrack.ml
+++ b/src/core/opamDirTrack.ml
@@ -48,6 +48,22 @@ let to_string t =
         (String.capitalize_ascii (string_of_change change)) f)
     (SM.bindings t)
 
+let to_summary_string t =
+  let freq_table =
+    SM.fold (fun _ change ->
+        SM.union (+) (SM.singleton (string_of_change ~full:false change) 1))
+      t
+      SM.empty
+  in
+  let freq_list =
+    OpamStd.List.concat_map ~left:" (" ~right:")" ~nil:"" "; " (fun (change, freq) ->
+        Printf.sprintf "%s: %d" change freq)
+      (SM.bindings freq_table)
+  in
+  Printf.sprintf "%d items%s"
+    (SM.cardinal t)
+    freq_list
+
 (** uid, gid, perm *)
 type perms = int * int * int
 

--- a/src/core/opamDirTrack.mli
+++ b/src/core/opamDirTrack.mli
@@ -28,6 +28,9 @@ type t = change OpamStd.String.Map.t
 (** Returns a printable, multi-line string *)
 val to_string: t -> string
 
+(** Returns a summary of the changes as a printable, single-line string *)
+val to_summary_string: t -> string
+
 val digest_of_string: string -> digest
 val string_of_digest: digest -> string
 

--- a/tests/reftests/dot-install.test
+++ b/tests/reftests/dot-install.test
@@ -77,6 +77,7 @@ ACTION                          Installing nodot.~dev.
 
 ACTION                          creating ${BASEDIR}/OPAM/inst/share/nodot
 TRACK                           after install: 19 elements, 3 added, scanned in 0.000s
+ACTION                          changes recorded for nodot.~dev: 3 items (addition: 3)
 -> installed nodot.~dev
 Done.
 ### ocaml cat.ml nodot
@@ -101,6 +102,7 @@ ACTION                          Installing dot.~dev.
 
 ACTION                          creating ${BASEDIR}/OPAM/inst/share/dot
 TRACK                           after install: 2 elements, 2 added, scanned in 0.000s
+ACTION                          changes recorded for dot.~dev: 2 items (addition: 2)
 -> installed dot.~dev
 Done.
 ### ocaml cat.ml dot

--- a/tests/reftests/dot-install.test
+++ b/tests/reftests/dot-install.test
@@ -133,6 +133,10 @@ Done.
 hellow
 ==> dot changes
 opam-version: "2.0"
+added: [
+  "share-dot" {"D"}
+  "share-dot-file" {"F:12fc204edeae5b57713c5ad7dcb97d39"}
+]
 ### opam reinstall dot --debug-level=0
 The following actions will be performed:
 === recompile 1 package
@@ -195,7 +199,7 @@ Done.
 ==> dot installed file
 Not found: ${BASEDIR}/OPAM/inst/share/dot/file
 ==> dot changes
-opam-version: "2.0"
+Not found: ${BASEDIR}/OPAM/inst/.opam-switch/install/dot.changes
 ### OPAMDEBUGSECTIONS="SYSTEM FILE(.config)" OPAMDEBUG=-1
 ### : check install files ordering :
 ### opam install lot-of-files | grep "mkdir\|install\|FILE"

--- a/tests/reftests/dot-install.test
+++ b/tests/reftests/dot-install.test
@@ -3,13 +3,13 @@ N0REP0
 #load "str.cma"
 
 let read file =
-  let ic = open_in file in
-  let rec aux lines =
-    try aux (input_line ic :: lines)
-    with End_of_file -> lines
-  in
-  let r = Str.regexp "/\\|\\\\\\\\" in
   try
+    let ic = open_in file in
+    let rec aux lines =
+      try aux (input_line ic :: lines)
+      with End_of_file -> lines
+    in
+    let r = Str.regexp "/\\|\\\\\\\\" in
     List.rev_map
       (Str.global_replace r "-")
       (aux [])
@@ -112,6 +112,90 @@ added: [
   "share-dot" {"D"}
   "share-dot-file" {"F:12fc204edeae5b57713c5ad7dcb97d39"}
 ]
+### : Check with dry-run
+### opam reinstall dot --dry-run
+The following actions will be simulated:
+=== recompile 1 package
+  - recompile dot ~dev
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+ACTION                          download_package: dot.~dev
+ACTION                          prepare_package_source: dot.~dev at ${BASEDIR}/OPAM/inst/.opam-switch/build/dot.~dev
+ACTION                          Removing dot.~dev
+-> removed   dot.~dev
+Installing dot.~dev.
+TRACK                           after install: 0 elements, 0 added, scanned in 0.000s
+-> installed dot.~dev
+ACTION                          Cleaning up artefacts of dot.~dev
+Done.
+### ocaml cat.ml dot
+==> dot installed file
+hellow
+==> dot changes
+opam-version: "2.0"
+### opam reinstall dot --debug-level=0
+The following actions will be performed:
+=== recompile 1 package
+  - recompile dot ~dev
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   dot.~dev
+-> installed dot.~dev
+Done.
+### ocaml cat.ml dot
+==> dot installed file
+hellow
+==> dot changes
+opam-version: "2.0"
+added: [
+  "share-dot" {"D"}
+  "share-dot-file" {"F:12fc204edeae5b57713c5ad7dcb97d39"}
+]
+### opam remove dot --dry-run
+The following actions will be simulated:
+=== remove 1 package
+  - remove dot ~dev
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+ACTION                          Removing dot.~dev
+-> removed   dot.~dev
+ACTION                          Cleaning up artefacts of dot.~dev
+ACTION                          Removing the local metadata
+Done.
+### ocaml cat.ml dot
+==> dot installed file
+hellow
+==> dot changes
+opam-version: "2.0"
+added: [
+  "share-dot" {"D"}
+  "share-dot-file" {"F:12fc204edeae5b57713c5ad7dcb97d39"}
+]
+### opam remove dot --debug-level=0
+The following actions will be performed:
+=== remove 1 package
+  - remove dot ~dev
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   dot.~dev
+Done.
+### opam install --dry-run dot
+The following actions will be simulated:
+=== install 1 package
+  - install dot ~dev
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+ACTION                          download_package: dot.~dev
+ACTION                          prepare_package_source: dot.~dev at ${BASEDIR}/OPAM/inst/.opam-switch/build/dot.~dev
+Installing dot.~dev.
+TRACK                           after install: 0 elements, 0 added, scanned in 0.000s
+-> installed dot.~dev
+Done.
+### ocaml cat.ml dot
+==> dot installed file
+Not found: ${BASEDIR}/OPAM/inst/share/dot/file
+==> dot changes
+opam-version: "2.0"
 ### OPAMDEBUGSECTIONS="SYSTEM FILE(.config)" OPAMDEBUG=-1
 ### : check install files ordering :
 ### opam install lot-of-files | grep "mkdir\|install\|FILE"

--- a/tests/reftests/pat-sub.test
+++ b/tests/reftests/pat-sub.test
@@ -65,5 +65,6 @@ ACTION                          pat-sub: expanding opam variables in foo.in, gen
 
 ACTION                          Installing pat-sub.0.1.
 
+ACTION                          changes recorded for pat-sub.0.1: 0 items
 -> installed pat-sub.0.1
 Done.


### PR DESCRIPTION
This PR fixes the main bug reported at <https://github.com/ocaml/opam/issues/5132> by preventing `.changes` files from being updated during dry-run.

This PR also introduces a new trace log to `ACTION` section to make easy to investigate the issue reported at <https://github.com/ocaml/opam/issues/4419>, which may be the same as the second problem reported at <https://github.com/ocaml/opam/issues/5132>.

ToDo:

- [x] Please update `master_changes.md` file with your changes.
