### PR TITLE
opam config & switch-config: allow depext-bypass with no bracket if single package (depth 1)

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -132,6 +132,7 @@ users)
   * Fix substring errors in preserved_format [#4941 @rjbou - fix #4936]
   * Add `with-tools` variable for recommended tools [#5016 @rjbou]
   * Add `x-locked` extension fields for overlay internal use, it stores if the files originate from a locked file, if so its extension [#5080 @rjbou]
+  * Set `depext-bypass` parsing with depth 1, no needed brakcet if single package [#5154 @rjbou]
 
 ## External dependencies
   * Set `DEBIAN_FRONTEND=noninteractive` for unsafe-yes confirmation level [#4735 @dra27 - partially fix #4731] [2.1.0~rc2 #4739]

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1464,7 +1464,7 @@ module ConfigSyntax = struct
         Pp.V.bool;
       "depext-bypass", Pp.ppacc
         with_depext_bypass depext_bypass
-        (Pp.V.map_list
+        (Pp.V.map_list ~depth:1
            (Pp.V.string -| Pp.of_module "sys-package" (module OpamSysPkg)) -|
          Pp.of_pair "System package set" OpamSysPkg.Set.(of_list, elements));
 
@@ -1869,7 +1869,7 @@ module Switch_configSyntax = struct
     "depext-bypass", Pp.ppacc
       (fun depext_bypass t -> { t with depext_bypass})
       (fun t -> t.depext_bypass)
-      (Pp.V.map_list
+      (Pp.V.map_list ~depth:1
          (Pp.V.string -| Pp.of_module "sys-package" (module OpamSysPkg)) -|
        Pp.of_pair "System package set" OpamSysPkg.Set.(of_list, elements));
   ] @

--- a/tests/reftests/var-option.test
+++ b/tests/reftests/var-option.test
@@ -343,33 +343,33 @@ Reverted field pre-session-commands in global configuration
 ### # Check addition & removal on set
 ### opam option depext-bypass
 []
-### opam option 'depext-bypass+=["tempor"]'
-Added '["tempor"]' to field depext-bypass in switch var-option
+### opam option 'depext-bypass+="tempor"'
+Added '"tempor"' to field depext-bypass in switch var-option
 ### opam option 'depext-bypass+=["incididunt"]'
 Added '["incididunt"]' to field depext-bypass in switch var-option
 ### opam option depext-bypass
 ["incididunt" "tempor"]
-### opam option 'depext-bypass-=["incididunt"]'
-Removed '["incididunt"]' from field depext-bypass in switch var-option
+### opam option 'depext-bypass-="incididunt"'
+Removed '"incididunt"' from field depext-bypass in switch var-option
 ### opam option depext-bypass
-["tempor"]
+"tempor"
 ### opam option 'depext-bypass=["incididunt" "tempor"]'
 Set to '["incididunt" "tempor"]' the field depext-bypass in switch var-option
 ### opam option 'depext-bypass-=["tempor"]'
 Removed '["tempor"]' from field depext-bypass in switch var-option
 ### opam option depext-bypass
-["incididunt"]
-### opam option 'depext-bypass-=["ut"]'
+"incididunt"
+### opam option 'depext-bypass-="ut"'
 No modification in switch var-option
 ### opam option depext-bypass
-["incididunt"]
+"incididunt"
 ### opam option 'depext-bypass-=[]'
 No modification in switch var-option
 ### opam option depext-bypass
-["incididunt"]
+"incididunt"
 ### opam option depext-bypass=
 Reverted field depext-bypass in switch var-option
-### opam option 'depext-bypass-=["tempor"]'
+### opam option 'depext-bypass-="tempor"'
 No modification in switch var-option
 ### opam option depext-bypass
 []


### PR DESCRIPTION
It is more consistent with other field, besides it fixes depext bypass hints that use the non bracket syntax (single elem).