### PR TITLE
depext menu: don't loop eternally in scripts when automatical install is off

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -150,6 +150,7 @@ users)
   * Fallback on dnf if yum does not exist on RHEL-based systems [#4825 @kit-ty-kate]
   * Stop zypper from upgrading packages on updates on OpenSUSE [#4978 @kit-ty-kate]
   * Increase verbose logging of command to 4 [#5151 @rjbou]
+  * [BUG] Avoid to loop eternally when `depext-runs-installs` is false in a script [#5156 @rjbou]
 
 ## Format upgrade
   * Fix format upgrade when there is missing local switches in the config file [#4763 @rjbou - fix #4713] [2.1.0~rc2 #4715]
@@ -460,3 +461,4 @@ users)
   * `OpamStd.Config.E`: add `value_t` to allow getting environment variable value dynamically [#5111 @rjbou]
   * `OpamCompat.Unix`: add `realpath` for ocaml < 4.13, and use it in `OpamSystem` [#5152 @rjbou]
   * `OpamCompat`: add `Lazy` module and `Lazy.map` function [#5176 @dra27]
+  * `OpamConsole.menu`: add `noninteractive` option to choose a different default when output is not a tty [#5156 @rjbou]

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1156,6 +1156,7 @@ let install_depexts ?(force_depext=false) ?(confirm=true) t packages =
     else
       manual_install t sys_packages
   and menu t sys_packages =
+    (* Called only if run install is true *)
     let answer =
       let pkgman = OpamConsole.colorise `yellow (pkg_manager_name ()) in
       OpamConsole.menu ~unsafe_yes:`Yes ~default:`Yes ~no:`Quit
@@ -1200,7 +1201,8 @@ let install_depexts ?(force_depext=false) ?(confirm=true) t packages =
   and manual_install t sys_packages =
     print_command sys_packages;
     let answer =
-      OpamConsole.menu ~default:`Continue ~no:`Quit "Would you like opam to:"
+      OpamConsole.menu ~default:`Continue ~noninteractive:`Ignore ~no:`Quit
+        "Would you like opam to:"
         ~options:[
           `Continue, "Check again, as the package is now installed";
           `Ignore, "Attempt installation anyway, and permanently register that \

--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -952,7 +952,7 @@ let print_table ?cut oc ~sep table =
   in
   List.iter (fun l -> print_line (cleanup_trailing l)) table
 
-let menu ?default ?unsafe_yes ?yes ~no ~options fmt =
+let menu ?default ?noninteractive ?unsafe_yes ?yes ~no ~options fmt =
   assert (List.length options < 10);
   let options_nums =
     List.mapi (fun n (ans, _) -> ans, string_of_int (n+1)) options
@@ -1012,7 +1012,12 @@ let menu ?default ?unsafe_yes ?yes ~no ~options fmt =
   in
   Printf.ksprintf (fun prompt_msg ->
       formatted_msg "%s\n" prompt_msg;
-      let default = OpamStd.Option.default (fst (List.hd options)) default in
+      let default =
+        match default, noninteractive with
+        | _, Some d when not OpamStd.Sys.tty_out -> d
+        | Some d, _ -> d
+        | None, _ -> fst (List.hd options)
+      in
       menu default
     ) fmt
 

--- a/src/core/opamConsole.mli
+++ b/src/core/opamConsole.mli
@@ -132,9 +132,10 @@ val confirm:
     options are set.
     [no] is the option to choose otherwise, when non interactive, on [escape].
     [default] is the option to choose on an active empty input ("\n").
+    [noninteractive] is the default in non tty output.
     Max 9 options. *)
 val menu:
-  ?default:'a -> ?unsafe_yes:'a -> ?yes:'a -> no:'a ->
+  ?default:'a -> ?noninteractive:'a -> ?unsafe_yes:'a -> ?yes:'a -> no:'a ->
   options:('a * string) list ->
   ('b, unit, string, 'a) format4 -> 'b
 


### PR DESCRIPTION
In depext menu for manual install : 
```
Would you like opam to:
> 1. Check again, as the package is now installed
  2. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
  3. Abort the installation
```
Default is to check again is the package has been installed. So when launched in script (or test), it loops forever.
Added in `OpamConsole.menu` an [noninteractive] optional argument, that is the default if output is not a tty.