### PR TITLE
Make OpamConfigCommand.global_allowed_fields fully lazy

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -248,6 +248,7 @@ users)
   * [BUG] Fix display of command when parallelised [#5091 @rjbou]
   * Add some debug log to OpamCudf.extract_explanations to help debug #4373 [#4981 @kit-ty-kate]
   * Make SHA computation faster by using ocaml-sha [#5042 @kit-ty-kate]
+  * Make OpamConfigCommand.global_allowed_fields fully lazy [#5162 @LasseBlaauwbroek]
 
 ## Internal: Windows
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -610,19 +610,20 @@ let set_opt_switch gt ?st field value =
 
 let global_allowed_fields, global_allowed_sections =
   let allowed_fields =
-    let open OpamStd.Option.Op in
-    let open OpamFile in
-    let in_config = OpamInitDefaults.init_config () in
-    let wrapper_init = InitConfig.wrappers in_config in
-    let upd_vars get set =
-      (fun nc c ->  set (get nc @ get c) c),
-      (fun nc c ->
-         let gv = get nc in
-         set (List.filter (fun (k,v,_) ->
-             None = OpamStd.List.find_opt (fun (k',v',_) -> k = k' && v = v') gv)
-             (get c)) c)
-    in
-    lazy ([
+    lazy (
+      let open OpamStd.Option.Op in
+      let open OpamFile in
+      let in_config = OpamInitDefaults.init_config () in
+      let wrapper_init = InitConfig.wrappers in_config in
+      let upd_vars get set =
+        (fun nc c ->  set (get nc @ get c) c),
+        (fun nc c ->
+           let gv = get nc in
+           set (List.filter (fun (k,v,_) ->
+               None = OpamStd.List.find_opt (fun (k',v',_) -> k = k' && v = v') gv)
+               (get c)) c)
+      in
+      [
         "download-command", Atomic,
         Config.with_dl_tool_opt
           (InitConfig.dl_tool in_config ++ Config.dl_tool Config.empty);


### PR DESCRIPTION
When it is not lazy, it causes other lazy values to be forced, notably
`OpamStd.Env.list`. This is unexpected, and a bit of a problem for people using
Opam as a library because they may want to set additional environment variables
before callin Opam.

Additionally, I'd expect this to be faster.