### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: master
 
+permissions:
+  contents: read
+
 jobs:
   diff:
     runs-on: ubuntu-latest

--- a/.github/workflows/depexts.yml
+++ b/.github/workflows/depexts.yml
@@ -21,6 +21,8 @@ env:
 
 jobs:
   opam-cache:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
     - name: opam binary cache

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -12,6 +12,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   hygiene-scripts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
