### PR TITLE
OpamConfigCommand: avoid capturing the Unix.environment at top level

### DIFF
--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -602,8 +602,6 @@ let global_allowed_fields, global_allowed_sections =
   let allowed_fields =
     let open OpamStd.Option.Op in
     let open OpamFile in
-    let in_config = OpamInitDefaults.init_config () in
-    let wrapper_init = InitConfig.wrappers in_config in
     let upd_vars get set =
       (fun nc c ->  set (get nc @ get c) c),
       (fun nc c ->
@@ -612,7 +610,10 @@ let global_allowed_fields, global_allowed_sections =
              None = OpamStd.List.find_opt (fun (k',v',_) -> k = k' && v = v') gv)
              (get c)) c)
     in
-    lazy ([
+    lazy (
+      let in_config = OpamInitDefaults.init_config () in
+      let wrapper_init = InitConfig.wrappers in_config in
+      [
         "download-command", Atomic,
         Config.with_dl_tool_opt
           (InitConfig.dl_tool in_config ++ Config.dl_tool Config.empty);


### PR DESCRIPTION
This is a continuation of #4111 #4789, this time in OpamConfigCommand, which
captures (via a call to OpamInitDefault.init_config ()) the Unix environment
at startup. This is crucial if opam-client is used as a library that modifies
the environment before execution of opam functionality.


This PR is for the 2.1 branch but should apply cleanly on the main branch as well. Are there plans to continue 2.1, or will that version be abandoned in favour of 2.2?