### PR TITLE
_Correct_ trying to be too clever when upgrading switches from opam 2.0

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -517,7 +517,7 @@ let main oc : unit =
     ("CYGWIN_EPOCH", "2");
   ] in
   let keys = [
-    ("archives", "archives-${{ hashFiles('src_ext/Makefile.sources', 'src_ext/Makefile', '.github/scripts/common/preamble.sh', '.github/scripts/main/preamble.sh', '.github/scripts/main/archives-cache.sh') }}-${{ env.OPAM_REPO_SHA }}");
+    ("archives", "archives-1-${{ hashFiles('src_ext/Makefile.sources', 'src_ext/Makefile', '.github/scripts/common/preamble.sh', '.github/scripts/main/preamble.sh', '.github/scripts/main/archives-cache.sh') }}-${{ env.OPAM_REPO_SHA }}");
     ("ocaml-secondary-compiler", "legacy-${{ env.OPAM_REPO_SHA }}");
     ("ocaml-cache", "${{ hashFiles('.github/scripts/main/ocaml-cache.sh', '.github/scripts/main/preamble.sh') }}");
     ("cygwin", "${{ hashFiles('.github/scripts/cygwin.cmd') }}-${{ env.CYGWIN_EPOCH }}");

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -514,7 +514,7 @@ let main oc : unit =
     ("CYGWIN_MIRROR", "http://mirrors.kernel.org/sourceware/cygwin/");
     ("CYGWIN_ROOT", "D:\\cygwin");
     ("CYGWIN", "winsymlinks:native");
-    ("CYGWIN_EPOCH", "2");
+    ("CYGWIN_EPOCH", "3");
   ] in
   let keys = [
     ("archives", "archives-1-${{ hashFiles('src_ext/Makefile.sources', 'src_ext/Makefile', '.github/scripts/common/preamble.sh', '.github/scripts/main/preamble.sh', '.github/scripts/main/archives-cache.sh') }}-${{ env.OPAM_REPO_SHA }}");

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,8 +71,8 @@ jobs:
     - name: Determine cache keys
       id: keys
       run: |
-        echo archives=archives-${{ hashFiles('src_ext/Makefile.sources', 'src_ext/Makefile', '.github/scripts/common/preamble.sh', '.github/scripts/main/preamble.sh', '.github/scripts/main/archives-cache.sh') }}-${{ env.OPAM_REPO_SHA }}
-        echo ::set-output name=archives::archives-${{ hashFiles('src_ext/Makefile.sources', 'src_ext/Makefile', '.github/scripts/common/preamble.sh', '.github/scripts/main/preamble.sh', '.github/scripts/main/archives-cache.sh') }}-${{ env.OPAM_REPO_SHA }}
+        echo archives=archives-1-${{ hashFiles('src_ext/Makefile.sources', 'src_ext/Makefile', '.github/scripts/common/preamble.sh', '.github/scripts/main/preamble.sh', '.github/scripts/main/archives-cache.sh') }}-${{ env.OPAM_REPO_SHA }}
+        echo ::set-output name=archives::archives-1-${{ hashFiles('src_ext/Makefile.sources', 'src_ext/Makefile', '.github/scripts/common/preamble.sh', '.github/scripts/main/preamble.sh', '.github/scripts/main/archives-cache.sh') }}-${{ env.OPAM_REPO_SHA }}
         echo ocaml-secondary-compiler=legacy-${{ env.OPAM_REPO_SHA }}
         echo ::set-output name=ocaml-secondary-compiler::legacy-${{ env.OPAM_REPO_SHA }}
         echo ocaml-cache=${{ hashFiles('.github/scripts/main/ocaml-cache.sh', '.github/scripts/main/preamble.sh') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ env:
   CYGWIN_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
   CYGWIN_ROOT: D:\cygwin
   CYGWIN: winsymlinks:native
-  CYGWIN_EPOCH: 2
+  CYGWIN_EPOCH: 3
 
 defaults:
   run:

--- a/master_changes.md
+++ b/master_changes.md
@@ -65,6 +65,7 @@ users)
   * [BUG] Fix `set-invariant: default repos were loaded instead of switch repos [#4866 @rjbou]
   * Add support for `opam switch -` (go to previous non-local switch) [#4910 @kit-ty-kate - fix 4866]
   * On loading, check for executable external files if they are in `PATH`, and warn if not the case [#4932 @rjbou - fix #4923]
+  * When inferring a 2.1+ switch invariant from 2.0 base packages, don't filter out pinned packages as that causes very wide invariants for pinned compiler packages [#5176 @dra27 - fix #4501]
 
 ## Pin
   * Switch the default version when undefined from ~dev to dev [#4949 @kit-ty-kate]
@@ -293,6 +294,7 @@ users)
   * Update opam root version test do escape `OPAMROOTVERSION` sed, it matches generated hexa temporary directory names [#5007 @AltGr]
   * Add json output test [#5143 @rjbou]
   * Add test for opam file write with format preserved bug in #4936, fixed in #4941 [#4159 @rjbou]
+  * Add test for switch upgrade from 2.0 root, with pinned compiler [#5176 @rjbou @kit-ty-kate]
 ### Engine
   * Add `opam-cat` to normalise opam file printing [#4763 @rjbou @dra27] [2.1.0~rc2 #4715]
   * Fix meld reftest: open only with failing ones [#4913 @rjbou]
@@ -449,3 +451,4 @@ users)
   * `OpamJson`: use `Jsonm` and add an `of_string` function [#5142 @rjbou]
   * `OpamStd.Config.E`: add `value_t` to allow getting environment variable value dynamically [#5111 @rjbou]
   * `OpamCompat.Unix`: add `realpath` for ocaml < 4.13, and use it in `OpamSystem` [#5152 @rjbou]
+  * `OpamCompat`: add `Lazy` module and `Lazy.map` function [#5176 @dra27]

--- a/src/core/opamCompat.ml
+++ b/src/core/opamCompat.ml
@@ -130,3 +130,15 @@ module Stdlib = Pervasives
 #else
 module Stdlib = Stdlib
 #endif
+
+module Lazy =
+#if OCAML_VERSION >= (4, 13, 0)
+  Lazy
+#else
+struct
+  include Lazy
+
+  let map f x =
+    lazy (f (force x))
+end
+#endif

--- a/src/core/opamCompat.mli
+++ b/src/core/opamCompat.mli
@@ -97,3 +97,14 @@ module Stdlib = Pervasives
 #else
 module Stdlib = Stdlib
 #endif
+
+module Lazy
+#if OCAML_VERSION >= (4, 13, 0)
+= Lazy
+#else
+: sig
+  include module type of struct include Lazy end
+
+  val map : ('a -> 'b) -> 'a t -> 'b t
+end
+#endif

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -805,6 +805,23 @@
    (run ./run.exe %{bin:opam} %{dep:upgrade-format.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-upgrade-two-point-o)
+ (action
+  (diff upgrade-two-point-o.test upgrade-two-point-o.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-upgrade-two-point-o)))
+
+(rule
+ (targets upgrade-two-point-o.out)
+ (deps root-N0REP0)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:upgrade-two-point-o.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-upgrade)
  (action
   (diff upgrade.test upgrade.out)))

--- a/tests/reftests/upgrade-two-point-o.test
+++ b/tests/reftests/upgrade-two-point-o.test
@@ -24,7 +24,7 @@ synopsis: "switch with pinned compiler"
 ### OPAMDEBUGSECTIONS=STATE opam upgrade --show-action --debug-level=-1
 STATE                           LOAD-SWITCH-STATE @ pinned-comp
 STATE                           Definition missing for installed package i-am-compiler.1, copying from repo
-STATE                           Inferred invariant: from base packages { i-am-compiler.1 }, (roots { i-am-compiler.1 }) => ["i-am-compiler"]
+STATE                           Inferred invariant: from base packages { i-am-compiler.1 }, (roots { i-am-compiler.1 }) => ["i-am-compiler" {= "1"}]
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
@@ -34,6 +34,6 @@ Nothing to do.
 Ok, i-am-compiler is no longer pinned locally (version 1)
 Nothing to do.
 ### opam upgrade --show-action
-The following actions would be performed:
-=== upgrade 1 package
-  - upgrade i-am-compiler 1 to 2
+Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
+However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
+Nothing to do.

--- a/tests/reftests/upgrade-two-point-o.test
+++ b/tests/reftests/upgrade-two-point-o.test
@@ -1,0 +1,39 @@
+N0REP0
+### <pkg:i-am-compiler.1>
+opam-version: "2.0"
+flags: compiler
+### <pkg:i-am-compiler.2>
+opam-version: "2.0"
+flags: compiler
+### OPAMYES=1
+### <OPAM/config>
+opam-version: "2.0"
+repositories: "default"
+installed-switches: ["pinned-comp"]
+switch: "pinned-comp"
+default-compiler: ["i-am-compiler"]
+### <OPAM/pinned-comp/.opam-switch/switch-state>
+opam-version: "2.0"
+compiler: ["i-am-compiler.1"]
+roots: ["i-am-compiler.1"]
+installed: ["i-am-compiler.1"]
+pinned: ["i-am-compiler.1"]
+### <OPAM/pinned-comp/.opam-switch/switch-config>
+opam-version: "2.0"
+synopsis: "switch with pinned compiler"
+### OPAMDEBUGSECTIONS=STATE opam upgrade --show-action --debug-level=-1
+STATE                           LOAD-SWITCH-STATE @ pinned-comp
+STATE                           Definition missing for installed package i-am-compiler.1, copying from repo
+STATE                           Inferred invariant: from base packages { i-am-compiler.1 }, (roots { i-am-compiler.1 }) => ["i-am-compiler"]
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
+However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
+Nothing to do.
+### opam pin remove i-am-compiler
+Ok, i-am-compiler is no longer pinned locally (version 1)
+Nothing to do.
+### opam upgrade --show-action
+The following actions would be performed:
+=== upgrade 1 package
+  - upgrade i-am-compiler 1 to 2


### PR DESCRIPTION
This is an alternate approach from #5002 for fixing #4501.

When upgrading a switch from opam 2.0, opam needs to convert a list of base packages to a switch invariant. The process used for that applies three heuristics for package `foo.version`:
- If there's only one version of `foo` available, then the invariant `"foo"` is used (i.e. with no version)
- If there's more than one version, but `version` is the latest, then the invariant `"foo" {>= "version"}` is used (lower-bound with upgrades)
- Otherwise the precise `"foo" {= "version"}` is used (exactly equivalent)

All this is attempting to reconstruct whether the user originally ran `opam switch create my-switch foo` or `opam switch create my-switch foo.version`. There are two intentions:
1. Automatic _upgrade_ to the latest version of a compiler (guessed from the installation of the latest version of the compiler)
2. Automatic _update_ of the system compiler, which is largely broken in opam 2.0

If we had the chance to turn back the clock, I think intention 1 is a mistake - it's not stable over time (e.g. until 14 June 2022, `ocaml-base-compiler.4.14.0` would have inferred `"ocaml-base-compiler" {>= "4.14.0"}` but now that there's an alpha release of OCaml 5, it would instead infer `"ocaml-base-compiler" {= "4.14.0"}`) and it's very difficult to be sure that's what the user actually meant, anyway. Intention 2, on the other hand, is a big usability improvement and was a headline reason for adding switch invariants in the first place - system compiler upgrades are basically a mess in opam 2.0, but as long as you end up with `"ocaml-system"` as the switch invariant, they work as expected in 2.1+.

The bug seen on the base images in #4501 I think is simply an accident of #3894 when invariants were added. The set of available package versions was _already present_ as part of depext updating, and the trim of non-pinned versions makes sense there. The fix I propose here, therefore, is to fix the original code only: when computing the invariant, don't filter out the other versions of a pinned package.

I've tested this in Docker for both the original bug and a system compiler upgrade.

It's tempting to eliminate the `>=` heuristic completely, but on the basis that we haven't (I think) had any bug reports about it, I think it's probably better to have 2.1 and 2.2 both do the same (slightly odd) thing, than have the 2.0-2.1 upgrade differ from the 2.0-2.2 upgrade. In the future, I think this heuristic would be much better as a hint - e.g. have `opam switch create system ocaml-system.4.14.0` emit a _warning_ that you probably meant `"ocaml-system"` as the invariant, but that's for another day.