### PR TITLE
switch import: fix installed packages reinstall when import file changed

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -69,6 +69,7 @@ users)
   * On loading, check for executable external files if they are in `PATH`, and warn if not the case [#4932 @rjbou - fix #4923]
   * When inferring a 2.1+ switch invariant from 2.0 base packages, don't filter out pinned packages as that causes very wide invariants for pinned compiler packages [#5176 @dra27 - fix #4501]
   * Really install invariant formula if not installed in switch [#5188 @rjbou]
+  * On import, check that installed pinned packages changed, reinstall if so [#5181 @rjbou - fix #5173]
 
 ## Pin
   * Switch the default version when undefined from ~dev to dev [#4949 @kit-ty-kate]
@@ -301,6 +302,7 @@ users)
   * Add json output test [#5143 @rjbou]
   * Add test for opam file write with format preserved bug in #4936, fixed in #4941 [#4159 @rjbou]
   * Add test for switch upgrade from 2.0 root, with pinned compiler [#5176 @rjbou @kit-ty-kate]
+  * Add switch import (for pinned packages) test [#5181 @rjbou]
 ### Engine
   * Add `opam-cat` to normalise opam file printing [#4763 @rjbou @dra27] [2.1.0~rc2 #4715]
   * Fix meld reftest: open only with failing ones [#4913 @rjbou]

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -737,6 +737,23 @@
    (run ./run.exe %{bin:opam} %{dep:switch-creation.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-switch-import)
+ (action
+  (diff switch-import.test switch-import.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-switch-import)))
+
+(rule
+ (targets switch-import.out)
+ (deps root-N0REP0)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:switch-import.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-switch-invariant)
  (action
   (diff switch-invariant.test switch-invariant.out)))

--- a/tests/reftests/switch-import.test
+++ b/tests/reftests/switch-import.test
@@ -84,11 +84,19 @@ basedir=`echo $BASEDIR | sed "s/\\\\\\\\/\\\\\\\\\\\\\\\\/g"`
 echo "src: \"git+file://${basedir}/nip#snd-head\"}}" >> twice.snd.xp
 ### sh add-hash.sh
 ### opam switch import twice.snd.xp
-Nothing to do.
+The following actions will be performed:
+=== recompile 1 package
+  - recompile nip dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved nip.dev  (git+file://${BASEDIR}/nip#snd-head)
+-> removed   nip.dev
+-> installed nip.dev
+Done.
 ### opam pin
 nip.dev    git  git+file://${BASEDIR}/nip#snd-head
 ### opam list nip --installed --columns=name,installed-files --normalise | grep -v '^#'
-nip    ${BASEDIR}/OPAM/twice/lib/fst.out
+nip    ${BASEDIR}/OPAM/twice/lib/snd.out
 ### opam switch import twice.snd.xp --switch tierce
 The following actions will be performed:
 === install 1 package

--- a/tests/reftests/switch-import.test
+++ b/tests/reftests/switch-import.test
@@ -1,0 +1,104 @@
+N0REP0
+### OPAMYES=1
+### : Test that pinned packages are reinstalled if they are updated in the imported file :
+### <pin:nip/nip.opam>
+opam-version: "2.0"
+install: [ "cp" "fst.out" "%{lib}%" ]
+### git -C nip init -q --initial-branch=fst-head
+### git -C nip config core.autocrlf false
+### git -C nip add -A
+### git -C nip commit -qm "init"
+### git -C nip branch snd-head
+### <nip/fst.out>
+fst branch
+### git -C nip add -A
+### git -C nip commit -qm "fst file"
+### git -C nip checkout snd-head
+Switched to branch 'snd-head'
+### <pin:nip/nip.opam>
+opam-version: "2.0"
+install: [ "cp" "snd.out" "%{lib}%" ]
+### <nip/snd.out>
+snd branch
+### git -C nip add -A
+### git -C nip commit -qm "snd file"
+### opam switch create twice --empty
+### git -C nip checkout fst-head
+Switched to branch 'fst-head'
+### opam pin git+file://${BASEDIR}/nip#fst-head
+Package nip does not exist, create as a NEW package? [y/n] y
+nip is now pinned to git+file://${BASEDIR}/nip#fst-head (version dev)
+
+The following actions will be performed:
+=== install 1 package
+  - install nip dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved nip.dev  (no changes)
+-> installed nip.dev
+Done.
+### opam list nip --installed --columns=name,installed-files --normalise | grep -v '^#'
+nip    ${BASEDIR}/OPAM/twice/lib/fst.out
+### opam switch export twice.xp
+### opam-cat twice.xp
+installed: ["nip.dev"]
+opam-version: "2.0"
+pinned: "nip.dev"
+roots: ["nip.dev"]
+package "nip" {
+opam-version: "2.0"
+version: "dev"
+synopsis: "A word"
+description: "Two words."
+maintainer: "maint@tain.er"
+authors: "the testing team"
+license: "MIT"
+homepage: "egapemoh"
+bug-reports: "https://nobug"
+install: ["cp" "fst.out" "%{lib}%"]
+dev-repo: "hg+https://pkg@op.am"
+url {
+src: "git+file://${BASEDIR}/nip#fst-head"
+}
+}
+### <twice.snd.xp>
+installed: ["nip.dev"]
+opam-version: "2.0"
+pinned: "nip.dev"
+roots: ["nip.dev"]
+package "nip" {
+opam-version: "2.0"
+version: "dev"
+synopsis: "A word"
+description: "Two words."
+maintainer: "maint@tain.er"
+authors: "the testing team"
+license: "MIT"
+homepage: "egapemoh"
+bug-reports: "https://nobug"
+install: ["cp" "snd.out" "%{lib}%"]
+dev-repo: "hg+https://pkg@op.am"
+url {
+### <add-hash.sh>
+basedir=`echo $BASEDIR | sed "s/\\\\\\\\/\\\\\\\\\\\\\\\\/g"`
+echo "src: \"git+file://${basedir}/nip#snd-head\"}}" >> twice.snd.xp
+### sh add-hash.sh
+### opam switch import twice.snd.xp
+Nothing to do.
+### opam pin
+nip.dev    git  git+file://${BASEDIR}/nip#snd-head
+### opam list nip --installed --columns=name,installed-files --normalise | grep -v '^#'
+nip    ${BASEDIR}/OPAM/twice/lib/fst.out
+### opam switch import twice.snd.xp --switch tierce
+The following actions will be performed:
+=== install 1 package
+  - install nip dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved nip.dev  (git+file://${BASEDIR}/nip#snd-head)
+-> installed nip.dev
+Done.
+### opam pin
+nip.dev    git  git+file://${BASEDIR}/nip#snd-head
+### opam list nip --installed --columns=name,installed-files --normalise --switch tierce | grep -v '^#'
+nip    ${BASEDIR}/OPAM/tierce/lib/snd.out


### PR DESCRIPTION
The check for reinstall of pinned packages is done at switch loading. Switch import change overlays afterwards, so a second check need to be done to mark changed one to reinstall before launching resolution.