### PR TITLE
Overhaul the Windows C stubs and update them for Unicode

### DIFF
--- a/configure
+++ b/configure
@@ -4945,7 +4945,7 @@ fi
     if  test "x${CC64}" != "xno" ; then :
 
       echo "${CC64} -o " > src/stubs/win32/cc64
-      echo " -Wdeclaration-after-statement " >> src/stubs/win32/cc64
+      echo " -Wdeclaration-after-statement -municode " >> src/stubs/win32/cc64
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -212,7 +212,7 @@ AS_IF([ test ${WIN32} -eq 1 ],[
     AC_CHECK_TOOL(CC64,[${T_CC64}],[no])
     AS_IF([ test "x${CC64}" != "xno" ],[
       echo "${CC64} -o " > src/stubs/win32/cc64
-      echo " -Wdeclaration-after-statement " >> src/stubs/win32/cc64
+      echo " -Wdeclaration-after-statement -municode " >> src/stubs/win32/cc64
     ])
   ],[
     AC_MSG_CHECKING([whether Microsoft Linker needs a PATH shim])

--- a/master_changes.md
+++ b/master_changes.md
@@ -252,6 +252,7 @@ users)
   * Add some debug log to OpamCudf.extract_explanations to help debug #4373 [#4981 @kit-ty-kate]
   * Make SHA computation faster by using ocaml-sha [#5042 @kit-ty-kate]
   * Make OpamConfigCommand.global_allowed_fields fully lazy [#5162 @LasseBlaauwbroek]
+  * Overhaul Windows C stubs and update for Unicode [#5190 @dra27]
 
 ## Internal: Windows
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]

--- a/src/stubs/win32/build-putenv.ml
+++ b/src/stubs/win32/build-putenv.ml
@@ -32,4 +32,4 @@ let () =
     f ();
     (prefix, suffix)
   in
-  exit (Sys.command (Printf.sprintf "%s%s%s%s" prefix Sys.argv.(1) suffix Sys.argv.(2)))
+  exit (Sys.command (Printf.sprintf "%s%s%s-DUNICODE -D_UNICODE %s" prefix Sys.argv.(1) suffix Sys.argv.(2)))

--- a/src/stubs/win32/dune-win32
+++ b/src/stubs/win32/dune-win32
@@ -19,6 +19,9 @@
   (wrapped         false))
 
 (rule
+  (copy opamWin32Stubs.ml opamWin32Stubs.mli))
+
+(rule
   (targets opam-putenv.exe)
   (deps    opamInject.c)
   (action  (run ocaml %{dep:build-putenv.ml} %{targets} %{dep:opam-putenv.c} %{dep:cc64})))

--- a/src/stubs/win32/dune-win32
+++ b/src/stubs/win32/dune-win32
@@ -12,7 +12,7 @@
     (language      c)
     (names         opamInject opamWindows)
     (flags         :standard
-                   -DCAML_NAME_SPACE
+                   -DUNICODE -D_UNICODE -DCAML_NAME_SPACE
                    (:include ../c-flags.sexp)))
   (c_library_flags (:standard
                    (:include c-libraries.sexp)))

--- a/src/stubs/win32/dune-win32
+++ b/src/stubs/win32/dune-win32
@@ -12,6 +12,7 @@
     (language      c)
     (names         opamInject opamWindows)
     (flags         :standard
+                   -DCAML_NAME_SPACE
                    (:include ../c-flags.sexp)))
   (c_library_flags (:standard
                    (:include c-libraries.sexp)))

--- a/src/stubs/win32/opamWindows.c
+++ b/src/stubs/win32/opamWindows.c
@@ -248,17 +248,10 @@ CAMLprim value OPAMW_GetWindowsVersion(value unit)
 
   CAMLlocal1(result);
   result = caml_alloc_tuple(4);
-#if OCAML_VERSION >= 40600
   Store_field(result, 0, Val_int(caml_win32_major));
   Store_field(result, 1, Val_int(caml_win32_minor));
   Store_field(result, 2, Val_int(caml_win32_build));
   Store_field(result, 3, Val_int(caml_win32_revision));
-#else
-  Store_field(result, 0, Val_int(0));
-  Store_field(result, 1, Val_int(0));
-  Store_field(result, 2, Val_int(0));
-  Store_field(result, 3, Val_int(0));
-#endif
 
   CAMLreturn(result);
 }

--- a/src/stubs/win32/opamWindows.c
+++ b/src/stubs/win32/opamWindows.c
@@ -8,7 +8,6 @@
 /*                                                                        */
 /**************************************************************************/
 
-#define CAML_NAME_SPACE
 /* We need the UTF16 conversion functions */
 #define CAML_INTERNALS
 #include <stdio.h>

--- a/src/stubs/win32/opamWindows.c
+++ b/src/stubs/win32/opamWindows.c
@@ -488,6 +488,7 @@ CAMLprim value OPAMW_HasGlyph(value checker, value scalar)
 CAMLprim value OPAMW_process_putenv(value pid, value key, value val)
 {
   char* result;
+  DWORD dwProcessId = Int32_val(pid);
 
   if (!caml_string_is_c_safe(key) || !caml_string_is_c_safe(val))
     caml_invalid_argument("OPAMW_process_putenv");
@@ -500,10 +501,12 @@ CAMLprim value OPAMW_process_putenv(value pid, value key, value val)
   if (caml_string_length(key) > 4095 || caml_string_length(val) > 4095)
     caml_invalid_argument("Strings too long");
 
+  caml_enter_blocking_section();
   result =
     InjectSetEnvironmentVariable(Int32_val(pid),
                                  String_val(key),
                                  String_val(val));
+  caml_leave_blocking_section();
 
   if (result == NULL)
     return Val_true;
@@ -553,7 +556,7 @@ CAMLprim value OPAMW_SHGetFolderPath(value nFolder, value dwFlags)
     caml_failwith("OPAMW_SHGetFolderPath");
 }
 
-CAMLprim value OPAMW_SendMessageTimeout(value hWnd,
+CAMLprim value OPAMW_SendMessageTimeout(value vhWnd,
                                         value uTimeout,
                                         value fuFlags,
                                         value vmsg,
@@ -567,6 +570,7 @@ CAMLprim value OPAMW_SendMessageTimeout(value hWnd,
   WPARAM wParam;
   LPARAM lParam;
   UINT msg;
+  HWND hWnd = (HWND)Nativeint_val(vhWnd);
 
   switch (Int_val(vmsg))
   {
@@ -586,6 +590,7 @@ CAMLprim value OPAMW_SendMessageTimeout(value hWnd,
       }
   }
 
+  caml_enter_blocking_section();
   lResult =
     SendMessageTimeout((HWND)Nativeint_val(hWnd),
                         msg,
@@ -594,6 +599,7 @@ CAMLprim value OPAMW_SendMessageTimeout(value hWnd,
                         Int_val(fuFlags),
                         Int_val(uTimeout),
                         &dwReturnValue);
+  caml_leave_blocking_section();
 
   switch (Int_val(vmsg))
   {

--- a/src/stubs/win32/opamWindows.c
+++ b/src/stubs/win32/opamWindows.c
@@ -310,6 +310,9 @@ CAMLprim value OPAMW_WriteRegistry(value hKey,
   DWORD cbData = 0;
   DWORD type = 0;
 
+  if (!caml_string_is_c_safe(lpSubKey) || !caml_string_is_c_safe(lpValueName))
+    caml_invalid_argument("OPAMW_WriteRegistry");
+
   switch (RegOpenKeyEx(roots[Int_val(hKey)],
                        String_val(lpSubKey),
                        0,
@@ -404,11 +407,15 @@ CAMLprim value OPAMW_CreateGlyphChecker(value fontName)
   CAMLparam0();
   CAMLlocal1(result);
   value handle;
+  HDC hDC;
+
+  if (!caml_string_is_c_safe(fontName))
+    caml_invalid_argument("OPAMW_CreateGlyphChecker");
 
   /*
    * Any device context will do to load the font, so use the Screen DC.
    */
-  HDC hDC = GetDC(NULL);
+  hDC = GetDC(NULL);
 
   if (hDC)
   {
@@ -481,6 +488,9 @@ CAMLprim value OPAMW_HasGlyph(value checker, value scalar)
 CAMLprim value OPAMW_process_putenv(value pid, value key, value val)
 {
   char* result;
+
+  if (!caml_string_is_c_safe(key) || !caml_string_is_c_safe(val))
+    caml_invalid_argument("OPAMW_process_putenv");
 
   /*
    * MSDN is all over the place as to what the technical limits are for
@@ -564,6 +574,8 @@ CAMLprim value OPAMW_SendMessageTimeout(value hWnd,
       {
         msg = WM_SETTINGCHANGE;
         wParam = Int_val(vwParam);
+        if (!caml_string_is_c_safe(vlParam))
+          caml_invalid_argument("OPAMW_SendMessageTimeout");
         lParam = (LPARAM)String_val(vlParam);
         break;
       }
@@ -644,9 +656,12 @@ CAMLprim value OPAMW_GetConsoleAlias(value alias, value exeName)
   value result;
 
   DWORD nLength = 8192;
-  LPTSTR buffer = (LPTSTR)malloc(nLength);
+  LPTSTR buffer;
 
-  if (!buffer)
+  if (!caml_string_is_c_safe(alias) || !caml_string_is_c_safe(exeName))
+    caml_invalid_argument("OPAMW_GetConsoleAlias");
+
+  if (!(buffer = (LPTSTR)malloc(nLength)))
     caml_raise_out_of_memory();
 
   if (GetConsoleAlias((LPTSTR)String_val(alias), buffer, nLength,


### PR DESCRIPTION
Slightly easier seen commit-by-commit. This PR:
- Removes some cruft from an earlier build system where the stubs were always built (including on Linux) if `#ifdef _WIN32`
- Removes a small amount of code related to support OCaml < 4.06
- Uses a somewhat less naïve application of OCaml's GC laws, which results in both shorter and technically more efficient code w.r.t. the GC
- Adds missing uses of `caml_string_is_c_safe` (this is a guard which stops OCaml strings containing `\0` from being passed to C functions which expect null-terminated strings) and releasing the runtime lock on a couple of longer-lived functions

Finally, the main focus is to switch the PR to use Unicode properly, in particular for the environment stubs implementation.