### PR TITLE
Eliminate the separate constructors for powershell

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -254,6 +254,7 @@ users)
   * Make SHA computation faster by using ocaml-sha [#5042 @kit-ty-kate]
   * Make OpamConfigCommand.global_allowed_fields fully lazy [#5162 @LasseBlaauwbroek]
   * Overhaul Windows C stubs and update for Unicode [#5190 @dra27]
+  * Unify constructors for powershell hosts [#5203 @dra27]
 
 ## Internal: Windows
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1039,9 +1039,9 @@ let shell_opt cli validity =
     None,"csh",SH_csh;
     None,"zsh",SH_zsh;
     None,"fish",SH_fish;
-    Some cli2_2,"pwsh",SH_pwsh;
+    Some cli2_2,"pwsh",SH_pwsh Powershell_pwsh;
     Some cli2_2,"cmd",SH_win_cmd;
-    Some cli2_2,"powershell",SH_win_powershell
+    Some cli2_2,"powershell",SH_pwsh Powershell
   ] |> List.map (fun (c,s,v) -> OpamStd.Option.map_default cli_from cli_original c, s, v)
   in
   mk_enum_opt ~cli validity ["shell"] "SHELL" enum

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1216,6 +1216,7 @@ let config cli =
       | Some s -> s
       | None -> OpamStd.Sys.guess_shell_compat ()
     in
+    let pwsh = match shell with SH_pwsh _ -> true | _ -> false in
     match command, params with
     | Some `env, [] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -1225,8 +1226,7 @@ let config cli =
          `Ok (OpamConfigCommand.env gt sw
                 ~set_opamroot ~set_opamswitch
                 ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
-                ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
-                ~cmd:(shell=SH_win_cmd)
+                ~pwsh ~cmd:(shell=SH_win_cmd)
                 ~inplace_path))
     | Some `revert_env, [] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -1236,8 +1236,7 @@ let config cli =
          `Ok (OpamConfigCommand.ensure_env gt sw;
               OpamConfigCommand.print_eval_env
                 ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
-                ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
-                ~cmd:(shell=SH_win_cmd)
+                ~pwsh ~cmd:(shell=SH_win_cmd)
                 (OpamEnv.add [] [])))
     | Some `list, [] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -1529,6 +1528,7 @@ let env cli =
       | Some s -> s
       | None -> OpamStd.Sys.guess_shell_compat ()
     in
+    let pwsh = match shell with SH_pwsh _ -> true | _ -> false in
     match revert with
     | false ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -1538,14 +1538,12 @@ let env cli =
          OpamConfigCommand.env gt sw
            ~set_opamroot ~set_opamswitch
            ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
-           ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
-           ~cmd:(shell=SH_win_cmd)
+           ~pwsh ~cmd:(shell=SH_win_cmd)
            ~inplace_path);
     | true ->
       OpamConfigCommand.print_eval_env
         ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
-        ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
-        ~cmd:(shell=SH_win_cmd)
+        ~pwsh ~cmd:(shell=SH_win_cmd)
         (OpamEnv.add [] [])
   in
   let open Common_config_flags in

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -439,8 +439,9 @@ module Sys : sig
   val executable_name : string -> string
 
   (** The different families of shells we know about *)
-  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh
-    | SH_win_cmd | SH_win_powershell
+  type powershell_host = Powershell_pwsh | Powershell
+  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish
+    | SH_pwsh of powershell_host | SH_win_cmd
 
   (** Guess the shell compat-mode *)
   val guess_shell_compat: unit -> shell

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -318,9 +318,10 @@ type universe = {
 type pin_kind = [ `version | OpamUrl.backend ]
 
 (** Shell compatibility modes *)
+type powershell_host = OpamStd.Sys.powershell_host = Powershell_pwsh | Powershell
 type shell = OpamStd.Sys.shell =
-    SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh
-    | SH_win_cmd | SH_win_powershell
+  | SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh of powershell_host
+  | SH_win_cmd
 
 (** {2 Generic command-line definitions with filters} *)
 

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -48,9 +48,9 @@ let string_of_shell = function
   | SH_zsh  -> "zsh"
   | SH_sh   -> "sh"
   | SH_bash -> "bash"
-  | SH_pwsh -> "pwsh"
+  | SH_pwsh Powershell_pwsh -> "pwsh"
+  | SH_pwsh Powershell -> "powershell"
   | SH_win_cmd -> "cmd"
-  | SH_win_powershell -> "powershell"
 
 let file_null = ""
 let pos_file filename =


### PR DESCRIPTION
Record whether the shell was detected as powershell or pwsh, although this information isn't actually used at the moment. Decreases the chance of accidentally only matching on one constructor.

@jonahbeckford - I'm not sufficiently familiar with PowerShell: are there situations where we might need to care whether it's pwsh (PowerShell 6.0) or classic PowerShell Desktop/Core (5.x and earlier)? I'm wondering whether we could risk dropping the `--shell=powershell` option completely?