### PR TITLE
'opam env' for directories with spaces

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -27,6 +27,7 @@ users)
   * Add `experimental` flags handling [#5099 @rjbou]
   * [BUG] Fix `OPAMCURL` and `OPAMFETCH` value setting [#5111 @rjbou - fix #5108]
   * [BUG] Fix display of pinned packages in action list [#5079 @rjbou]
+  * [BUG] Fix spaces in root and switch dirs [#5203 @jonahbeckford]
 
 ## Plugins
   *
@@ -274,9 +275,8 @@ users)
   * Add switch-invariant test [#4866 @rjbou]
   * opam root version: add local switch cases [#4763 @rjbou] [2.1.0~rc2 #4715]
   * opam root version: add reinit test casess [#4763 @rjbou] [2.1.0~rc2 #4750]
-  * Add & update env tests [#4861 #4841 @rjbou @dra27]
   * Port opam-rt tests: orphans, dep-cycles, reinstall, and big-upgrade [#4979 @AltGr]
-  * Add & update env tests [#4861 #4841 #4974 @rjbou @dra27 @AltGr]
+  * Add & update env tests [#4861 #4841 #4974 #5203 @rjbou @dra27 @AltGr]
   * Add remove test [#5004 @AltGr]
   * Add some simple tests for the "opam list" command [#5006 @kit-ty-kate]
   * Add clean test for untracked option [#4915 @rjbou]

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1502,7 +1502,7 @@ let env cli =
          to have further shell commands be evaluated in the proper opam \
          context."
         OpamEnv.(
-          shell_eval_invocation shell (opam_env_invocation ())
+          shell_eval_invocation shell (opam_env_invocation shell)
             |> Manpage.escape));
     `P "This is a shortcut, and equivalent to $(b,opam config env).";
   ] in
@@ -2470,7 +2470,7 @@ let switch cli =
          environment. For that, use $(i,%s)."
         OpamEnv.(
           shell_eval_invocation shell
-            (opam_env_invocation ~switch:"SWITCH" ~set_opamswitch:true ())
+            (opam_env_invocation ~switch:"SWITCH" ~set_opamswitch:true shell)
             |> Manpage.escape));
   ] @
     mk_subdoc ~cli ~defaults:["","list";"SWITCH","set"]

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -380,7 +380,7 @@ let shell_eval_invocation shell cmd =
     overrides *)
 let opam_env_invocation ?root ?switch ?(set_opamswitch=false) shell =
   let quoted_arg arg = match shell with
-    | SH_win_powershell | SH_pwsh -> Printf.sprintf " --%s=\"%s\"" arg
+    | SH_win_cmd | SH_win_powershell | SH_pwsh -> Printf.sprintf " --%s=\"%s\"" arg
     | _ -> Printf.sprintf " --%s='%s'" arg
   in
   let root = OpamStd.Option.map_default (quoted_arg "root") "" root in

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -380,8 +380,10 @@ let shell_eval_invocation shell cmd =
     overrides *)
 let opam_env_invocation ?root ?switch ?(set_opamswitch=false) shell =
   let quoted_arg arg = match shell with
-    | SH_win_cmd | SH_win_powershell | SH_pwsh -> Printf.sprintf " --%s=\"%s\"" arg
-    | _ -> Printf.sprintf " --%s='%s'" arg
+    | SH_win_cmd | SH_win_powershell | SH_pwsh ->
+      Printf.sprintf " --%s=\"%s\"" arg
+    | SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish ->
+      Printf.sprintf " --%s='%s'" arg
   in
   let root = OpamStd.Option.map_default (quoted_arg "root") "" root in
   let switch = OpamStd.Option.map_default (quoted_arg "switch") "" switch in

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -78,7 +78,7 @@ val shell_eval_invocation:
 (** Returns "opam env" invocation string together with optional root and switch
     overrides *)
 val opam_env_invocation:
-  ?root:string -> ?switch:string -> ?set_opamswitch:bool -> unit -> string
+  ?root:string -> ?switch:string -> ?set_opamswitch:bool -> OpamTypes.shell -> string
 
 (** The shell command to run by the user to set his OPAM environment, adapted to
     the current shell (as returned by [eval `opam config env`]) *)

--- a/tests/reftests/env.test
+++ b/tests/reftests/env.test
@@ -70,6 +70,4 @@ Switch invariant: ["nv"]
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed nv.1
 Done.
-# Run eval $(opam env --root=${BASEDIR}/root 2 --switch=${BASEDIR}/switch w spaces) to update the current shell environment
-### opam env --sw "./$SW" | grep OPAM_SWITCH_PREFIX | ';' -> ':'
-OPAM_SWITCH_PREFIX='${BASEDIR}/switch w spaces/_opam': export OPAM_SWITCH_PREFIX:
+# Run eval $(opam env '--root=${BASEDIR}/root 2' '--switch=${BASEDIR}/switch w spaces') to update the current shell environment

--- a/tests/reftests/env.test
+++ b/tests/reftests/env.test
@@ -53,3 +53,23 @@ OPAM_SWITCH_PREFIX=${BASEDIR}/OPAM/conffile
 ### opam exec --no-switch -- env | grep "^NV_VARS|^OPAM_SWITCH_PREFIX|${OPAM}"
 NV_VARS=/another/path
 OPAM=${OPAM}
+### : root and switch with spaces :
+### RT="$BASEDIR/root 2"
+### SW="switch w spaces"
+### OPAMNOENVNOTICE=0
+### opam init -na --bare --bypass-check --disable-sandbox --root "$RT" defaut ./REPO
+No configuration file found, using built-in defaults.
+
+<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+[defaut] Initialised
+### opam switch create "./$SW" nv --root "$RT"
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["nv"]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed nv.1
+Done.
+# Run eval $(opam env --root=${BASEDIR}/root 2 --switch=${BASEDIR}/switch w spaces) to update the current shell environment
+### opam env --sw "./$SW" | grep OPAM_SWITCH_PREFIX | ';' -> ':'
+OPAM_SWITCH_PREFIX='${BASEDIR}/switch w spaces/_opam': export OPAM_SWITCH_PREFIX:


### PR DESCRIPTION
- [x] Please update `master_changes.md` file with your changes.

Fixes #5204 .

It was not just a Windows problem, although only macOS of the *nix variants commonly uses spaces in their directory names.