### PR TITLE
Compiler packages into invariant packages

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -612,7 +612,7 @@ let make_command st opam ?dir ?text_command (cmd, args) =
          (OpamSysPoll.arch env +! "unknown"));
       (OpamStd.List.concat_map " " OpamPackage.to_string
          OpamPackage.Set.(elements @@
-                          inter st.compiler_packages st.installed_roots));
+                          OpamSwitchState.invariant_root_packages st));
       if OpamPackage.Set.mem nv st.pinned then
         match OpamFile.OPAM.url opam with
         | None -> "pinned"

--- a/src/client/opamAdminCheck.ml
+++ b/src/client/opamAdminCheck.ml
@@ -57,7 +57,6 @@ let get_universe ~with_test ~with_doc ~dev opams =
         opams;
     u_installed_roots = OpamPackage.Set.empty;
     u_pinned = OpamPackage.Set.empty;
-    u_base = OpamPackage.Set.empty;
     u_invariant = OpamFormula.Empty;
     u_attrs = [];
     u_reinstall = OpamPackage.Set.empty;

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1253,7 +1253,10 @@ let remove_t ?ask ~autoremove ~force ?(formula=OpamFormula.Empty) atoms t =
           OpamSwitchState.universe t ~requested:packages Remove
         in
         let keep =
-          universe.u_base ++ t.installed_roots %% t.installed -- packages
+          OpamSwitchState.invariant_root_packages t
+          ++ t.installed_roots
+             %% t.installed
+          -- packages
         in
         let keep_cone =
           keep |> OpamSwitchState.dependencies t universe

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -513,9 +513,13 @@ let list ?(force_search=false) cli =
                 (this calls the solver and may be more costly; a package \
                 depending on an unavailable package may be available, but is \
                 never installable)";
-        cli_original, OpamListCommand.Compiler, ["base"],
+        cli_between cli2_0 cli2_1 ~replaced:"--invariant",
+        OpamListCommand.Compiler, ["base"],
           "List only the immutable base of the current switch (i.e. \
                 compiler packages)";
+        cli_from cli2_2, OpamListCommand.Compiler, ["invariant"],
+          "List only the immutable base of the current switch (i.e. \
+                invariant packages)";
         cli_original, OpamListCommand.Pinned, ["pinned"],
           "List only the pinned packages";
       ]

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2981,9 +2981,9 @@ let switch cli =
            (OpamFormula.to_string invariant);
          let st =
            if no_action || OpamFormula.satisfies_depends st.installed invariant
-           then st
-           else OpamClient.install_t
-               st ~ask:true [] None ~formula:invariant
+           then OpamSwitchAction.update_switch_state st
+           else
+               OpamClient.install_t st ~ask:true [] None ~formula:invariant
                ~deps_only:false ~assume_built:false
          in
          OpamSwitchState.drop st;

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -564,8 +564,12 @@ let detail_printer ?prettify ?normalise ?(sort=false) st nv =
          OpamPackage.version_to_string inst_nv |> fun s ->
          if OpamPackage.Set.mem inst_nv st.pinned then s % [`blue] else
          if OpamPackage.has_name st.pinned nv.name then s % [`bold;`red] else
-         if nv <> inst_nv &&
-            not (OpamPackage.Set.mem inst_nv st.compiler_packages)
+         (* If package is not installed one, check if it is part of invariant
+            formula package, and if it checks formula *)
+         if nv <> inst_nv
+         && (not (OpamPackage.Set.mem inst_nv
+                    (OpamFormula.packages st.installed st.switch_invariant))
+             || OpamFormula.verifies st.switch_invariant nv)
          then s % [`bold;`yellow] else
            s % [`magenta]
      with Not_found -> "--" % [`cyan])

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -82,7 +82,7 @@ let string_of_selector =
   | Any -> "any" % `cyan
   | Installed -> "installed" % `cyan
   | Root -> "root" % `cyan
-  | Compiler -> "base" % `cyan
+  | Compiler -> "invariant" % `cyan
   | Available -> "available" % `cyan
   | Installable -> "installable" % `cyan
   | Pinned -> "pinned" % `cyan
@@ -215,7 +215,7 @@ let apply_selector ~base st = function
   | Any -> base
   | Installed -> st.installed
   | Root -> st.installed_roots
-  | Compiler -> st.compiler_packages
+  | Compiler -> OpamSwitchState.invariant_root_packages st
   | Available -> Lazy.force st.available_packages
   | Installable ->
     OpamSolver.installable_subset

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -244,13 +244,10 @@ let install_compiler
   let t =
     if t.switch_config.OpamFile.Switch_config.synopsis = "" then
       let synopsis =
-        match OpamPackage.Set.elements base_comp with
-        | [] -> OpamSwitch.to_string t.switch
-        | [pkg] ->
-          let open OpamStd.Option.Op in
-          (OpamSwitchState.opam_opt t pkg >>= OpamFile.OPAM.synopsis) +!
-          OpamPackage.to_string pkg
-        | pkgs -> OpamStd.List.concat_map " " OpamPackage.to_string pkgs
+        if invariant = OpamFormula.Empty then
+          OpamSwitch.to_string t.switch
+        else
+          OpamFormula.to_string invariant
       in
       let switch_config =
         { t.switch_config with OpamFile.Switch_config.synopsis }

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -43,7 +43,7 @@ let list gt ~print_short =
         in
         let comp =
           OpamPackage.Map.filter
-            (fun nv _ -> OpamPackage.Set.mem nv sel.sel_roots)
+            (fun nv _ -> OpamPackage.Set.mem nv sel.sel_compiler)
             opams
           |> ifempty opams
         in
@@ -237,36 +237,10 @@ let install_compiler
         "Inconsistent resolution of packages:\n%s"
         (OpamSolver.string_of_stats stats)
   in
-  let to_install_pkgs = OpamSolver.new_packages solution in
-  let base_comp = OpamPackage.packages_of_names to_install_pkgs comp_roots in
-  let has_comp_flag =
-    let is_comp nv =
-      try OpamFile.OPAM.has_flag Pkgflag_Compiler (OpamSwitchState.opam t nv)
-      with Not_found -> false
-    in
-    (* Packages with the Compiler flag, or with a direct dependency with that
-       flag (just for the warning) *)
-    OpamPackage.Set.filter
-      (fun nv ->
-         is_comp nv ||
-         OpamPackage.Set.exists is_comp
-           (OpamFormula.packages t.packages
-              (OpamPackageVar.all_depends ~filter_default:true t
-                 (OpamSwitchState.opam t nv))))
-      base_comp
-  in
   if invariant = OpamFormula.Empty then
     OpamConsole.note
       "No invariant was set, you may want to use `opam switch set-invariant' \
-       to keep a stable compiler version on upgrades."
-  else if OpamPackage.Set.is_empty has_comp_flag then
-    OpamConsole.note
-      "Packages %s don't have the 'compiler' flag set (nor any of their \
-       direct dependencies).\n\
-       You may want to use `opam switch set-invariant' to keep a stable \
-       compiler version on upgrades."
-      (OpamStd.List.concat_map ", " OpamPackage.to_string
-         (OpamPackage.Set.elements base_comp));
+       to keep a stable compiler version on upgrades.";
   let t =
     if t.switch_config.OpamFile.Switch_config.synopsis = "" then
       let synopsis =
@@ -287,7 +261,15 @@ let install_compiler
       { t with switch_config }
     else t
   in
-  let t = { t with compiler_packages = base_comp } in
+  let t =
+    let base_comp =
+      OpamSwitchState.compute_invariant_packages
+        { t with installed = t.installed
+                             -- (OpamSolver.removed_packages solution)
+                             ++ (OpamSolver.new_packages solution) }
+    in
+    { t with compiler_packages = base_comp }
+  in
   let skip =
     if deps_only then
       let pkgs =
@@ -306,6 +288,7 @@ let install_compiler
       solution in
   OpamSolution.check_solution ~quiet:OpamClientConfig.(not !r.show) t
     (Success result);
+  OpamSwitchAction.write_selections t;
   t
 
 let create

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -710,21 +710,6 @@ let set_invariant ?(force=false) st invariant =
       (OpamStd.List.concat_map ", "
          OpamPackage.Name.to_string
          (OpamPackage.Name.Set.elements name_unknown));
-  let packages = OpamFormula.packages st.installed invariant in
-  let not_comp =
-    OpamPackage.Set.filter (fun nv ->
-        match OpamSwitchState.opam_opt st nv with
-        | Some opam -> not (OpamFile.OPAM.has_flag Pkgflag_Compiler opam)
-        | None -> false)
-      packages
-  in
-  if not (OpamPackage.Set.is_empty not_comp) then
-    OpamConsole.warning
-      "Packages %s don't have the 'compiler' flag set."
-      (OpamStd.Format.pretty_list
-         (List.map OpamPackage.Name.to_string
-            (OpamPackage.Name.Set.elements
-               (OpamPackage.names_of_packages not_comp))));
   set_invariant_raw st invariant
 
 let get_compiler_packages ?repos rt =

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -308,7 +308,6 @@ type universe = {
   u_action   : user_action;
   u_installed_roots: package_set;
   u_pinned   : package_set;
-  u_base     : package_set;
   u_invariant: formula;
   u_reinstall: package_set;
   u_attrs    : (string * package_set) list;

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -31,7 +31,6 @@ let empty_universe =
     u_action = Install;
     u_installed_roots = OpamPackage.Set.empty;
     u_pinned = OpamPackage.Set.empty;
-    u_base = OpamPackage.Set.empty;
     u_invariant = OpamFormula.Empty;
     u_reinstall = OpamPackage.Set.empty;
     u_attrs = [];

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -640,6 +640,14 @@ let new_packages sol =
       | `Reinstall _ | `Remove _ | `Build _ | `Fetch _ -> packages
   ) sol OpamPackage.Set.empty
 
+let removed_packages sol =
+  OpamCudf.ActionGraph.fold_vertex (fun action packages ->
+      match action with
+      | `Remove p | `Change (_,p,_) ->
+        OpamPackage.Set.add (OpamCudf.cudf2opam p) packages
+      | `Install _ | `Reinstall _ | `Build _ | `Fetch _ -> packages
+  ) sol OpamPackage.Set.empty
+
 let all_packages sol =
   OpamCudf.ActionGraph.fold_vertex (fun action packages ->
       List.fold_left

--- a/src/solver/opamSolver.mli
+++ b/src/solver/opamSolver.mli
@@ -32,6 +32,9 @@ val stats: solution -> stats
 (** Return the new packages in the solution *)
 val new_packages: solution -> package_set
 
+(** Return removed new packages in the solution *)
+val removed_packages: solution -> package_set
+
 (** Return all packages appearing in the solution *)
 val all_packages: solution -> package_set
 

--- a/src/state/opamSwitchAction.ml
+++ b/src/state/opamSwitchAction.ml
@@ -174,9 +174,6 @@ let update_switch_state ?installed ?installed_roots ?reinstall ?pinned st =
   let installed = installed +! st.installed in
   let reinstall0 = Lazy.force st.reinstall in
   let reinstall = (reinstall +! reinstall0) %% installed in
-  let compiler_packages =
-    OpamPackage.Set.filter (OpamFormula.verifies st.switch_invariant) installed
-  in
   let old_selections = OpamSwitchState.selections st in
   let st =
     { st with
@@ -184,8 +181,12 @@ let update_switch_state ?installed ?installed_roots ?reinstall ?pinned st =
       installed_roots = installed_roots +! st.installed_roots;
       reinstall = lazy reinstall;
       pinned = pinned +! st.pinned;
-      compiler_packages; }
+       }
   in
+  let compiler_packages =
+    OpamSwitchState.compute_invariant_packages st
+  in
+  let st = { st with compiler_packages } in
   if not OpamStateConfig.(!r.dryrun) then (
     if OpamSwitchState.selections st <> old_selections then write_selections st;
     if not (OpamPackage.Set.equal reinstall0 reinstall) then

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -966,7 +966,6 @@ let universe st
   in
   let u_depopts = get_deps OpamFile.OPAM.depopts st.opams in
   let u_conflicts = get_conflicts st st.packages st.opams in
-  let base = st.compiler_packages in
   let u_invariant =
     if OpamStateConfig.(!r.unlock_base) then OpamFormula.Empty
     else st.switch_invariant
@@ -1019,7 +1018,6 @@ let universe st
   u_conflicts;
   u_installed_roots = st.installed_roots;
   u_pinned    = OpamPinned.packages st;
-  u_base      = base;
   u_invariant;
   u_reinstall;
   u_attrs     = ["opam-query", requested;
@@ -1037,7 +1035,7 @@ let dump_pef_state st oc =
     Printf.fprintf oc "version: %s\n" (OpamPackage.version_to_string nv);
     let installed = OpamPackage.Set.mem nv st.installed in
     (* let root = OpamPackage.Set.mem nv st.installed_roots in *)
-    let base = OpamPackage.Set.mem nv st.compiler_packages in
+    let inv = OpamPackage.Set.mem nv st.compiler_packages in
     let pinned = OpamPackage.Set.mem nv st.pinned in
     let available = OpamPackage.Set.mem nv (Lazy.force st.available_packages) in
     let reinstall = OpamPackage.Set.mem nv (Lazy.force st.reinstall) in
@@ -1046,7 +1044,7 @@ let dump_pef_state st oc =
     Printf.fprintf oc "available: %b\n" available;
     if installed then output_string oc "installed: true\n";
     if pinned then output_string oc "pinned: true\n";
-    if base then output_string oc "base: true\n";
+    if inv then output_string oc "invariant-pkg: true\n";
     if reinstall then output_string oc "reinstall: true\n";
 
     (* metadata (resolved for the current switch) *)
@@ -1439,3 +1437,13 @@ let reverse_dependencies st ~build ~post =
            | Some nv -> OpamPackage.Set.add nv result
            | None -> OpamStd.Sys.exit_because `Internal_error)
          int_revdeps packages)
+
+(* invariant computation *)
+
+let invariant_root_packages st =
+  OpamPackage.Set.filter (OpamFormula.verifies st.switch_invariant) st.installed
+
+let compute_invariant_packages st =
+  let pkgs = invariant_root_packages st in
+  dependencies ~build:false ~post:true ~depopts:false ~installed:true
+    ~unavailable:false st (universe st ~requested:pkgs Query) pkgs

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -242,6 +242,14 @@ val update_repositories:
   'a global_state -> (repository_name list -> repository_name list) ->
   switch -> unit
 
+(** {2 Invariant computation} *)
+
+(* Returns installed root packages of switch invariant *)
+val invariant_root_packages: 'a switch_state -> package_set
+
+(* Compute installed invariant dependency cone *)
+val compute_invariant_packages: 'a switch_state -> package_set
+
 (** {2 User interaction and reporting } *)
 
 (** Returns [true] if the switch of the state is the one set in

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1032,6 +1032,23 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:switch-invariant.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-switch-list)
+ (action
+  (diff switch-list.test switch-list.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-switch-list)))
+
+(rule
+ (targets switch-list.out)
+ (deps root-N0REP0)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:switch-list.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-switch-set)
  (action
   (diff switch-set.test switch-set.out)))

--- a/tests/reftests/install-formula.test
+++ b/tests/reftests/install-formula.test
@@ -123,11 +123,6 @@ You may run "opam upgrade --fixup" to let opam fix the current state.
 ### opam upgrade --formula '"mirage-solo5" | "mirage-no-solo5"'
 [WARNING] Flag --formula is experimental, there is no guarantee that it will be kept; avoid using it in scripts.
 Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
-
-The following packages are not being upgraded because the new versions conflict with other installed packages:
-  - ocaml.4.10.0
-    -- ocaml-freestanding.0.4.5 is installed and requires ocaml (>= 4.05.0 & < 4.09.0)
-    -- ocaml-src.4.08.0 is installed and requires ocaml = 4.08.0
 However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.
 ### opam upgrade mirage-solo5 --formula '"mirage-no-solo5"' --best-effort

--- a/tests/reftests/json.unix.test
+++ b/tests/reftests/json.unix.test
@@ -62,8 +62,6 @@ ok     --
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
 Switch invariant: ["ok"]
-[NOTE] Packages ok.1 don't have the 'compiler' flag set (nor any of their direct dependencies).
-       You may want to use `opam switch set-invariant' to keep a stable compiler version on upgrades.
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed ok.1

--- a/tests/reftests/json.unix.test
+++ b/tests/reftests/json.unix.test
@@ -178,9 +178,9 @@ Done.
 }
 ### opam switch --json=out.json
 #   switch        compiler  description
-->  json-comp     comp.3    json-comp
+->  json-comp     comp.3    comp
     json-empty              json-empty
-    json-no-comp  ok.1      json-no-comp
+    json-no-comp  ok.1      ok
 ### json-cat out.json
 {
   "opam-version": "currentv",

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -718,6 +718,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-another-package.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2 }
 Done.
 ### # rw global state
 ### opam switch sw-comp | " ${OPAMROOTVERSION}($|,)" -> "current"
@@ -801,6 +802,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
@@ -883,6 +885,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
@@ -959,6 +962,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4
@@ -1100,6 +1104,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-another-package.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2 }
 Done.
 ### # rw global state
 ### opam switch sw-comp
@@ -1180,6 +1185,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
@@ -1256,6 +1262,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
@@ -1321,6 +1328,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4
@@ -1468,6 +1476,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-another-package.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2 }
 Done.
 ### # rw global state
 ### opam switch sw-comp
@@ -1550,6 +1559,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
@@ -1628,6 +1638,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
@@ -1693,6 +1704,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4
@@ -1827,6 +1839,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-another-package.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
@@ -1897,6 +1910,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
@@ -1969,6 +1983,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
@@ -2036,6 +2051,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4
@@ -2505,6 +2521,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-another-package.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2 }
 Done.
 ### # ro global state, rw repo state
 ### opam repo add root-config ./root-config
@@ -2573,6 +2590,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4
@@ -2632,6 +2650,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4
@@ -2692,6 +2711,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -2175,6 +2175,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-another-package.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2 }
 Done.
 ### # ro global state, rw repo state
 ### opam repo add root-config ./root-config
@@ -2255,6 +2256,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
@@ -2326,6 +2328,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
@@ -2397,6 +2400,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"

--- a/tests/reftests/opamrt-big-upgrade.test
+++ b/tests/reftests/opamrt-big-upgrade.test
@@ -312,7 +312,13 @@ Faking installation of core_extended.109.55.02
 Done.
 ### opam switch export -
 opam-version: "2.0"
-compiler: ["ocaml-base-compiler.4.01.0beta1"]
+compiler: [
+  "base-bigarray.base"
+  "base-threads.base"
+  "base-unix.base"
+  "ocaml.4.01.0beta1"
+  "ocaml-base-compiler.4.01.0beta1"
+]
 roots: [
   "async.109.53.02"
   "async_graphics.0.5.1"

--- a/tests/reftests/resolve-variables.test
+++ b/tests/reftests/resolve-variables.test
@@ -14,6 +14,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed foo.1
+[WARNING] Undefined filter variable build in dependencies of foo.1
 Done.
 ### <pkg:foo.1>
 opam-version: "2.0"
@@ -41,6 +42,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed foo.1
+[WARNING] Undefined filter variable build in dependencies of foo.1
 Done.
 ### <pkg:foo.1>
 opam-version: "2.0"
@@ -54,6 +56,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed foo.1
+[WARNING] Undefined filter variable undef in dependencies of foo.1
 Done.
 ### <pkg:foo.1>
 opam-version: "2.0"

--- a/tests/reftests/switch-import.test
+++ b/tests/reftests/switch-import.test
@@ -238,13 +238,13 @@ The following actions will be performed:
 -> installed c.1
 Done.
 ### opam-cat OPAM/orig/.opam-switch/switch-state
-compiler: ["b.1"]
+compiler: ["a.1" "b.1"]
 installed: ["a.1" "b.1" "c.1"]
 opam-version: "2.0"
 roots: ["b.1" "c.1"]
 ### opam switch export orig.xp
 ### opam-cat orig.xp
-compiler: ["b.1"]
+compiler: ["a.1" "b.1"]
 installed: ["a.1" "b.1" "c.1"]
 opam-version: "2.0"
 roots: ["b.1" "c.1"]
@@ -258,15 +258,15 @@ Switch invariant: ["b" {= "2"}]
 -> installed b.2
 Done.
 ### opam-cat OPAM/toupd/.opam-switch/switch-state
-compiler: ["b.2"]
+compiler: ["a.2" "b.2"]
 installed: ["a.2" "b.2"]
 opam-version: "2.0"
 roots: ["b.2"]
 ### opam switch import orig.xp
-  * No agreement on the version of a:
-    - (invariant) -> b >= 2 -> a >= 2
-    - a < 2
-    You can temporarily relax the switch invariant with `--update-invariant'
+The following actions will be performed:
+=== install 1 package
+  - install c 1
 
-No solution found, exiting
-# Return code 20 #
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed c.1
+Done.

--- a/tests/reftests/switch-import.test
+++ b/tests/reftests/switch-import.test
@@ -205,3 +205,68 @@ src: "https://example.com/some/fake/extra/source"
 checksum: "md5=6aef5a674977ebc5ec853dc4f85cf2bb"
 }
 }
+### # Test that invariant is not changed when importing a switch
+### <pkg:a.1>
+opam-version: "2.0"
+flags: compiler
+### <pkg:a.2>
+opam-version: "2.0"
+flags: compiler
+### <pkg:b.1>
+opam-version: "2.0"
+depends: [ "a" { = "1" } ]
+### <pkg:b.2>
+opam-version: "2.0"
+depends: [ "a" { = "2" } ]
+### <pkg:c.1>
+opam-version: "2.0"
+### opam switch create orig b.1
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["b" {= "1"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed a.1
+-> installed b.1
+Done.
+### opam install c
+The following actions will be performed:
+=== install 1 package
+  - install c 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed c.1
+Done.
+### opam-cat OPAM/orig/.opam-switch/switch-state
+compiler: ["b.1"]
+installed: ["a.1" "b.1" "c.1"]
+opam-version: "2.0"
+roots: ["b.1" "c.1"]
+### opam switch export orig.xp
+### opam-cat orig.xp
+compiler: ["b.1"]
+installed: ["a.1" "b.1" "c.1"]
+opam-version: "2.0"
+roots: ["b.1" "c.1"]
+### opam switch create toupd b.2
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["b" {= "2"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed a.2
+-> installed b.2
+Done.
+### opam-cat OPAM/toupd/.opam-switch/switch-state
+compiler: ["b.2"]
+installed: ["a.2" "b.2"]
+opam-version: "2.0"
+roots: ["b.2"]
+### opam switch import orig.xp
+  * No agreement on the version of a:
+    - (invariant) -> b >= 2 -> a >= 2
+    - a < 2
+    You can temporarily relax the switch invariant with `--update-invariant'
+
+No solution found, exiting
+# Return code 20 #

--- a/tests/reftests/switch-invariant.test
+++ b/tests/reftests/switch-invariant.test
@@ -64,9 +64,6 @@ Switch invariant: ["baz" {= "1"}]
 Done.
 ### opam upgrade -v
 Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
-
-The following packages are not being upgraded because the new versions conflict with other installed packages:
-  - bar.2
 However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.
 ### <pkg:baz.1>

--- a/tests/reftests/switch-invariant.test
+++ b/tests/reftests/switch-invariant.test
@@ -41,3 +41,74 @@ Done.
 ### opam switch set-invariant --package bar
 [WARNING] Packages bar don't have the 'compiler' flag set.
 The switch invariant was set to bar
+### <pkg:bar.1>
+opam-version: "2.0"
+### <pkg:bar.2>
+opam-version: "2.0"
+### <pkg:baz.1>
+opam-version: "2.0"
+flags: compiler
+depends: [ "bar" { = version } ]
+### <pkg:baz.2>
+opam-version: "2.0"
+flags: compiler
+depends: [ "bar" { = version } ]
+### opam switch create tonotupgrade baz.1
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["baz" {= "1"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed bar.1
+-> installed baz.1
+Done.
+### opam upgrade -v
+Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
+
+The following packages are not being upgraded because the new versions conflict with other installed packages:
+  - bar.2
+However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
+Nothing to do.
+### <pkg:baz.1>
+opam-version: "2.0"
+flags: compiler
+depends: [ "bar" ]
+### <pkg:baz.2>
+opam-version: "2.0"
+flags: compiler
+depends: [ "bar" ]
+### opam switch create tonupgrade baz.1
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["baz" {= "1"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed bar.2
+-> installed baz.1
+Done.
+### opam install bar.1
+The following actions will be performed:
+=== downgrade 1 package
+  - downgrade bar 2 to 1
+=== recompile 1 package
+  - recompile baz 1      [uses bar]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   baz.1
+-> removed   bar.2
+-> installed bar.1
+-> installed baz.1
+Done.
+### opam upgrade -v
+The following actions will be performed:
+=== recompile 1 package
+  - recompile baz 1      [uses bar]
+=== upgrade 1 package
+  - upgrade   bar 1 to 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   baz.1
+-> removed   bar.1
+-> installed bar.2
+-> installed baz.1
+Done.

--- a/tests/reftests/switch-invariant.test
+++ b/tests/reftests/switch-invariant.test
@@ -24,10 +24,8 @@ The following actions will be performed:
 -> installed foo.1
 Done.
 ### opam switch set-invariant foo
-[WARNING] Packages foo don't have the 'compiler' flag set.
 The switch invariant was set to foo
 ### opam switch set-invariant --package foo
-[WARNING] Packages foo don't have the 'compiler' flag set.
 The switch invariant was set to foo
 ### opam switch set-invariant bar
 The switch invariant was set to bar
@@ -39,7 +37,6 @@ The following actions will be performed:
 -> installed bar.1
 Done.
 ### opam switch set-invariant --package bar
-[WARNING] Packages bar don't have the 'compiler' flag set.
 The switch invariant was set to bar
 ### <pkg:bar.1>
 opam-version: "2.0"

--- a/tests/reftests/switch-list.test
+++ b/tests/reftests/switch-list.test
@@ -41,7 +41,6 @@ The following actions will be performed:
 -> installed g.1
 Done.
 ### opam switch set-invariant b
-[WARNING] Packages b don't have the 'compiler' flag set.
 The switch invariant was set to b
 ### opam switch list
 #   switch   compiler  description

--- a/tests/reftests/switch-list.test
+++ b/tests/reftests/switch-list.test
@@ -45,10 +45,13 @@ Done.
 The switch invariant was set to b
 ### opam switch list
 #   switch   compiler  description
-->  display            display
+->  display  a.1       display
 ### opam list --base
 # Packages matching: base
-# No matches found
+# Name # Installed # Synopsis
+a      1
+b      1
+e      1
 ### opam install c
 The following actions will be performed:
 === remove 1 package
@@ -66,11 +69,13 @@ The following actions will be performed:
 Done.
 ### opam switch list
 #   switch   compiler  description
-->  display  b.1       display
+->  display  c.1       display
 ### opam list --base
 # Packages matching: base
 # Name # Installed # Synopsis
 b      1
+c      1
+e      1
 ### opam install d
 The following actions will be performed:
 === recompile 1 package
@@ -85,11 +90,14 @@ The following actions will be performed:
 Done.
 ### opam switch list
 #   switch   compiler  description
-->  display  b.1       display
+->  display  c.1,d.1   display
 ### opam list --base
 # Packages matching: base
 # Name # Installed # Synopsis
 b      1
+c      1
+d      1
+e      1
 ### opam switch remove display
 Switch display and all its packages will be wiped. Are you sure? [y/n] y
 ### ::::::::::::::::::
@@ -117,11 +125,13 @@ The following actions will be performed:
 Done.
 ### opam switch list
 #   switch   compiler  description
-->  display  b.1       display
+->  display  d.1       display
 ### opam list --base
 # Packages matching: base
 # Name # Installed # Synopsis
 b      1
+d      1
+e      1
 ### opam switch remove display
 Switch display and all its packages will be wiped. Are you sure? [y/n] y
 ### :::::::::::::::::::
@@ -141,8 +151,10 @@ Done.
 ["b"]
 ### opam switch list
 #   switch   compiler  description
-->  display  b.1       display
+->  display  d.1       display
 ### opam list --base
 # Packages matching: base
 # Name # Installed # Synopsis
 b      1
+d      1
+e      1

--- a/tests/reftests/switch-list.test
+++ b/tests/reftests/switch-list.test
@@ -148,7 +148,7 @@ Done.
 ["b"]
 ### opam switch list
 #   switch   compiler  description
-->  display  d.1       display
+->  display  d.1       b
 ### opam list --invariant
 # Packages matching: invariant
 # Name # Installed # Synopsis

--- a/tests/reftests/switch-list.test
+++ b/tests/reftests/switch-list.test
@@ -1,0 +1,148 @@
+N0REP0
+### <pkg:a.1>
+opam-version: "2.0"
+flags: compiler
+depends: [ "e" "f" {build} "g" {post} ]
+### <pkg:b.1>
+opam-version: "2.0"
+depends: [ "a" | "c" | "d" ]
+### <pkg:c.1>
+opam-version: "2.0"
+conflicts: "a"
+depends: [ "e" "f" {build} "g" {post} ]
+flags: compiler
+### <pkg:d.1>
+opam-version: "2.0"
+depends: [ "e" "f" {build} "g" {post} ]
+flags: compiler
+### <pkg:e.1>
+opam-version: "2.0"
+### <pkg:f.1>
+opam-version: "2.0"
+### <pkg:g.1>
+opam-version: "2.0"
+### OPAMYES=1
+### OCAMLRUNPARAM=b
+### opam switch create display --empty
+### opam install b a
+The following actions will be performed:
+=== install 5 packages
+  - install a 1
+  - install b 1
+  - install e 1 [required by a]
+  - install f 1 [required by a]
+  - install g 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed e.1
+-> installed f.1
+-> installed a.1
+-> installed b.1
+-> installed g.1
+Done.
+### opam switch set-invariant b
+[WARNING] Packages b don't have the 'compiler' flag set.
+The switch invariant was set to b
+### opam switch list
+#   switch   compiler  description
+->  display            display
+### opam list --base
+# Packages matching: base
+# No matches found
+### opam install c
+The following actions will be performed:
+=== remove 1 package
+  - remove    a 1 [conflicts with c]
+=== recompile 1 package
+  - recompile b 1 [uses c]
+=== install 1 package
+  - install   c 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   b.1
+-> removed   a.1
+-> installed c.1
+-> installed b.1
+Done.
+### opam switch list
+#   switch   compiler  description
+->  display  b.1       display
+### opam list --base
+# Packages matching: base
+# Name # Installed # Synopsis
+b      1
+### opam install d
+The following actions will be performed:
+=== recompile 1 package
+  - recompile b 1 [uses d]
+=== install 1 package
+  - install   d 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   b.1
+-> installed d.1
+-> installed b.1
+Done.
+### opam switch list
+#   switch   compiler  description
+->  display  b.1       display
+### opam list --base
+# Packages matching: base
+# Name # Installed # Synopsis
+b      1
+### opam switch remove display
+Switch display and all its packages will be wiped. Are you sure? [y/n] y
+### ::::::::::::::::::
+### <pkg:b.1>
+opam-version: "2.0"
+# force dependency for reproducibility
+depends: "d"
+### opam switch create display --empty
+### opam switch set-invariant b
+The switch invariant was set to b
+The following actions will be performed:
+=== install 5 packages
+  - install b 1
+  - install d 1 [required by b]
+  - install e 1 [required by d]
+  - install f 1 [required by d]
+  - install g 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed e.1
+-> installed f.1
+-> installed d.1
+-> installed b.1
+-> installed g.1
+Done.
+### opam switch list
+#   switch   compiler  description
+->  display  b.1       display
+### opam list --base
+# Packages matching: base
+# Name # Installed # Synopsis
+b      1
+### opam switch remove display
+Switch display and all its packages will be wiped. Are you sure? [y/n] y
+### :::::::::::::::::::
+### opam switch create display --package b
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["b"]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed e.1
+-> installed f.1
+-> installed d.1
+-> installed b.1
+-> installed g.1
+Done.
+### opam switch invariant
+["b"]
+### opam switch list
+#   switch   compiler  description
+->  display  b.1       display
+### opam list --base
+# Packages matching: base
+# Name # Installed # Synopsis
+b      1

--- a/tests/reftests/switch-list.test
+++ b/tests/reftests/switch-list.test
@@ -46,12 +46,10 @@ The switch invariant was set to b
 ### opam switch list
 #   switch   compiler  description
 ->  display  a.1       display
-### opam list --base
-# Packages matching: base
+### opam list --invariant
+# Packages matching: invariant
 # Name # Installed # Synopsis
-a      1
 b      1
-e      1
 ### opam install c
 The following actions will be performed:
 === remove 1 package
@@ -70,12 +68,10 @@ Done.
 ### opam switch list
 #   switch   compiler  description
 ->  display  c.1       display
-### opam list --base
-# Packages matching: base
+### opam list --invariant
+# Packages matching: invariant
 # Name # Installed # Synopsis
 b      1
-c      1
-e      1
 ### opam install d
 The following actions will be performed:
 === recompile 1 package
@@ -91,13 +87,10 @@ Done.
 ### opam switch list
 #   switch   compiler  description
 ->  display  c.1,d.1   display
-### opam list --base
-# Packages matching: base
+### opam list --invariant
+# Packages matching: invariant
 # Name # Installed # Synopsis
 b      1
-c      1
-d      1
-e      1
 ### opam switch remove display
 Switch display and all its packages will be wiped. Are you sure? [y/n] y
 ### ::::::::::::::::::
@@ -106,12 +99,10 @@ opam-version: "2.0"
 # force dependency for reproducibility
 depends: "d"
 ### opam switch create display --empty
-### opam switch set-invariant b
-The switch invariant was set to b
+### opam install d
 The following actions will be performed:
-=== install 5 packages
-  - install b 1
-  - install d 1 [required by b]
+=== install 4 packages
+  - install d 1
   - install e 1 [required by d]
   - install f 1 [required by d]
   - install g 1
@@ -120,18 +111,24 @@ The following actions will be performed:
 -> installed e.1
 -> installed f.1
 -> installed d.1
--> installed b.1
 -> installed g.1
+Done.
+### opam switch set-invariant b
+The switch invariant was set to b
+The following actions will be performed:
+=== install 1 package
+  - install b 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed b.1
 Done.
 ### opam switch list
 #   switch   compiler  description
 ->  display  d.1       display
-### opam list --base
-# Packages matching: base
+### opam list --invariant
+# Packages matching: invariant
 # Name # Installed # Synopsis
 b      1
-d      1
-e      1
 ### opam switch remove display
 Switch display and all its packages will be wiped. Are you sure? [y/n] y
 ### :::::::::::::::::::
@@ -152,9 +149,15 @@ Done.
 ### opam switch list
 #   switch   compiler  description
 ->  display  d.1       display
-### opam list --base
-# Packages matching: base
+### opam list --invariant
+# Packages matching: invariant
 # Name # Installed # Synopsis
 b      1
-d      1
-e      1
+### <OPAM/display/.opam-switch/switch-config>
+opam-version: "2.0"
+invariant: ["b" { >= "1" } |"c" { >= "1" }]
+### opam install e
+[NOTE] Package e is already installed (current version is 1).
+### opam switch
+#   switch   compiler  description
+->  display  d.1       b >= 1 | c >= 1


### PR DESCRIPTION
Since invariant is defined and updated, compiler_packages is no more
consistent the way it is. To keep field name, it is still named
`compiler-packages`, but its content is now invariant formula installed
packages and their recursive dependencies. It implies also that switch
state need to be update at each time an install/removal is done, or
invariant changed.

* Remove `universe.u_base` field
* Compute invariant packages instead of compiler packages
* Change PEF `base` field into `invariant-pkg`
* opam list `--invariant` instead of `--base`
  * change column name to invariant
  * display invariant packages instead of compiler ones
* switch: fill empty synopsis with invariant instead of compiler packages

fix #5202 
fix #5201 

* [x] add function doc
* [x] remove commented code