### PR TITLE
Fix lazy regexp compilation in `OpamFormula.atom_of_string`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -259,6 +259,7 @@ users)
   * Make OpamConfigCommand.global_allowed_fields fully lazy [#5162 @LasseBlaauwbroek]
   * Overhaul Windows C stubs and update for Unicode [#5190 @dra27]
   * Unify constructors for powershell hosts [#5203 @dra27]
+  * Fix lazy compilation of regular expression in OpamFormula.atom_of_string [#5211 @dra27]
 
 ## Internal: Windows
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]

--- a/src/format/opamFormula.ml
+++ b/src/format/opamFormula.ml
@@ -48,7 +48,7 @@ let short_string_of_atom = function
 let string_of_atoms atoms =
   OpamStd.List.concat_map " & " short_string_of_atom atoms
 
-let atom_of_string str =
+let atom_of_string =
   let re = lazy Re.(compile @@ whole_string @@ seq [
       group @@ rep1 @@ diff any (set ">=<.!");
       group @@ alt [ seq [ set "<>"; opt @@ char '=' ];
@@ -56,18 +56,20 @@ let atom_of_string str =
       group @@ rep1 any;
     ])
   in
-  try
-    let sub = Re.exec (Lazy.force re) str in
-    let sname = Re.Group.get sub 1 in
-    let sop = Re.Group.get sub 2 in
-    let sversion = Re.Group.get sub 3 in
-    let name = OpamPackage.Name.of_string sname in
-    let sop = if sop = "." then "=" else sop in
-    let op = OpamLexer.FullPos.relop sop in
-    let version = OpamPackage.Version.of_string sversion in
-    name, Some (op, version)
-  with Not_found | Failure _ | OpamLexer.Error _ ->
-    OpamPackage.Name.of_string str, None
+  fun str ->
+    try
+      let lazy re = re in
+      let sub = Re.exec re str in
+      let sname = Re.Group.get sub 1 in
+      let sop = Re.Group.get sub 2 in
+      let sversion = Re.Group.get sub 3 in
+      let name = OpamPackage.Name.of_string sname in
+      let sop = if sop = "." then "=" else sop in
+      let op = OpamLexer.FullPos.relop sop in
+      let version = OpamPackage.Version.of_string sversion in
+      name, Some (op, version)
+    with Not_found | Failure _ | OpamLexer.Error _ ->
+      OpamPackage.Name.of_string str, None
 
 type 'a conjunction = 'a list
 


### PR DESCRIPTION
The regular expression is compiled lazily - on each call to the function!