### PR TITLE
Fix backtrace for uncaught exceptions on Windows

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -261,6 +261,7 @@ users)
   * Overhaul Windows C stubs and update for Unicode [#5190 @dra27]
   * Unify constructors for powershell hosts [#5203 @dra27]
   * Fix lazy compilation of regular expression in OpamFormula.atom_of_string [#5211 @dra27]
+  * [BUG] Display correct exception backtrace on uncaught exception on Windows [#5216 @dra27]
 
 ## Internal: Windows
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -358,6 +358,7 @@ let rec main_catch_all f =
          "Update done, please now retry your command.\n";
        exit (OpamStd.Sys.get_exit_code `Aborted))
   | e ->
+    OpamStd.Exn.register_backtrace e;
     (try Sys.set_signal Sys.sigpipe Sys.Signal_default
      with Invalid_argument _ -> ());
     flush_all_noerror ();


### PR DESCRIPTION
There are better ways to fix this, but it got in the way and I don't want to forget about it completely!