### PR TITLE
Fixes to opam init menu

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -29,7 +29,7 @@ users)
   * [BUG] Fix `OPAMCURL` and `OPAMFETCH` value setting [#5111 @rjbou - fix #5108]
   * [BUG] Fix display of pinned packages in action list [#5079 @rjbou]
   * [BUG] Fix spaces in root and switch dirs [#5203 @jonahbeckford]
-  * Use menu for init setup [#5057 @AltGr]
+  * Use menu for init setup [#5057 @AltGr; #5217 @dra27]
 
 ## Plugins
   *
@@ -472,3 +472,4 @@ users)
   * `OpamCompat.Unix`: add `realpath` for ocaml < 4.13, and use it in `OpamSystem` [#5152 @rjbou]
   * `OpamCompat`: add `Lazy` module and `Lazy.map` function [#5176 @dra27]
   * `OpamConsole.menu`: add `noninteractive` option to choose a different default when output is not a tty [#5156 @rjbou]
+  * `OpamStd.Sys`: add `all_shells` list of all supported shells [#5217 @dra27]

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -907,6 +907,15 @@ module OpamSys = struct
   type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish
     | SH_pwsh of powershell_host | SH_win_cmd
 
+  let all_shells =
+    [SH_sh; SH_bash;
+     SH_zsh;
+     SH_csh;
+     SH_fish;
+     SH_pwsh Powershell_pwsh;
+     SH_pwsh Powershell;
+     SH_win_cmd]
+
   let windows_default_shell = SH_win_cmd
   let unix_default_shell = SH_sh
 

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -443,6 +443,9 @@ module Sys : sig
   type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish
     | SH_pwsh of powershell_host | SH_win_cmd
 
+  (** List of all supported shells *)
+  val all_shells : shell list
+
   (** Guess the shell compat-mode *)
   val guess_shell_compat: unit -> shell
 

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -855,7 +855,7 @@ let setup
               ~options: (List.map (fun s -> s, string_of_shell s) shells_list)
           in
           menu shell (OpamFilename.of_string (OpamStd.Sys.guess_dot_profile shell))
-            `Yes
+            default
         | `Change_file ->
           let open OpamStd.Option.Op in
           let dot_profile =

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -798,12 +798,12 @@ let check_and_print_env_warning st =
 let setup
     root ~interactive ?dot_profile ?update_config ?env_hook ?completion
     ?inplace shell =
-  let update_dot_profile, env_hook =
+  let shell, update_dot_profile, env_hook =
     match update_config, dot_profile, interactive with
-    | Some false, _, _ -> None, env_hook
+    | Some false, _, _ -> shell, None, env_hook
     | _, None, _ -> invalid_arg "OpamEnv.setup"
-    | Some true, Some dot_profile, _ -> Some dot_profile, env_hook
-    | None, _, false -> None, env_hook
+    | Some true, Some dot_profile, _ -> shell, Some dot_profile, env_hook
+    | None, _, false -> shell, None, env_hook
     | None, Some dot_profile, true ->
       OpamConsole.header_msg "Required setup - please read";
 
@@ -824,7 +824,7 @@ let setup
         (OpamConsole.colorise `bold @@ source root shell (init_file shell));
       if OpamCoreConfig.answer_is_yes () then begin
         OpamConsole.warning "Shell not updated in non-interactive mode: use --shell-setup";
-        None, env_hook
+        shell, None, env_hook
       end else
       let rec menu shell dot_profile default =
         let opam_env_inv =
@@ -846,9 +846,9 @@ let setup
                 opam_env_inv;
           ]
         with
-        | `No -> None, env_hook
-        | `Yes -> Some dot_profile, Some true
-        | `No_hooks -> Some dot_profile, Some false
+        | `No -> shell, None, env_hook
+        | `Yes -> shell, Some dot_profile, Some true
+        | `No_hooks -> shell, Some dot_profile, Some false
         | `Change_shell ->
           let shell = OpamConsole.menu ~default:shell ~no:shell
               "Please select a shell to configure"

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -852,7 +852,7 @@ let setup
         | `Change_shell ->
           let shell = OpamConsole.menu ~default:shell ~no:shell
               "Please select a shell to configure"
-              ~options: (List.map (fun s -> s, string_of_shell s) shells_list)
+              ~options: (List.map (fun s -> s, string_of_shell s) OpamStd.Sys.all_shells)
           in
           menu shell (OpamFilename.of_string (OpamStd.Sys.guess_dot_profile shell))
             default


### PR DESCRIPTION
Three little bugs, all to do with changing the shell using the new `opam init` menu:

- On bash, the option crashes opam with `Not_found` because the list of shells used is the ones for init scripts, not the complete of shells - I've introduced a list containing the full list of shells for this purpose.
- When selecting a new shell, the default was forced to "Yes". That's a slight issue when the Windows shell comes because "Yes" isn't always an option but it also doesn't really make sense - the default should stay the same
- Having selected a new shell, `opam init` then wrote the `.profile` (or whatever) using the syntax of the old shell!