### PR TITLE
GHA: Fix the archlinux script

### DIFF
--- a/.github/scripts/depexts/generate-actions.sh
+++ b/.github/scripts/depexts/generate-actions.sh
@@ -33,8 +33,7 @@ EOF
 # no automake
     cat >$dir/Dockerfile << EOF
 FROM archlinux
-RUN pacman -Sy
-RUN pacman -S --noconfirm $mainlibs $ocaml gcc diffutils
+RUN pacman -Syu --noconfirm $mainlibs $ocaml gcc diffutils
 EOF
     ;;
  centos)

--- a/master_changes.md
+++ b/master_changes.md
@@ -349,6 +349,7 @@ users)
   * Upgrade packages for sovler jobs, in case depext changed [#5010 @rjbou]
   * Fix github safe directory issues in depext workflow [#5153 @rjbou]
   * Update repo hash in depext workflow [#5153 @rjbou]
+  * Fix the archlinux script [#5218 @kit-ty-kate]
 
 ## Shell
   * fish: fix deprecated redirection syntax `^` [#4736 @vzaliva]


### PR DESCRIPTION
archlinux does not upgrade dependencies by default without the 'u' argument and leads to issues where some packages can get installed with several versions of glibc
