### PR TITLE
shell/bootstrap-ocaml.sh: do not fail if curl/wget is missing

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -203,6 +203,7 @@ users)
   * Add a 'test' target [#5129 @kit-ty-kate @mehdid - partially fixes #5058]
   * Add `with-tools` handling in selection process [#5016 @rjbou]
   * Bump cudf to 0.10 [#5195 @kit-ty-kate]
+  * shell/bootstrap-ocaml.sh: do not fail if curl/wget is missing [#5223 @kit-ty-kate]
 
 ## Infrastructure
   * Fix caching of Cygwin compiler on AppVeyor [#4988 @dra27]

--- a/shell/bootstrap-ocaml.sh
+++ b/shell/bootstrap-ocaml.sh
@@ -7,8 +7,7 @@ if command -v curl > /dev/null; then
 elif command -v wget > /dev/null; then
   CURL=wget
 else
-  echo "This script requires curl or wget"
-  exit 1
+  echo "[WARNING] This script requires curl or wget"
 fi
 BOOTSTRAP_DIR=${BOOTSTRAP_DIR:-bootstrap}
 BOOTSTRAP_ROOT=${BOOTSTRAP_ROOT:-..}


### PR DESCRIPTION
cc @hannesm suggested in https://github.com/ocaml/opam/issues/4894