### PR TITLE
Use the default criteria during reinstall/upgrade when requesting at least one non-installed package

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -366,6 +366,7 @@ users)
   * Add autopin test including deps-only, dev-deps, depexts; instrument depext handling to allow depext reftesting [#5236 @AltGr]
   * Add test for init configuration with opamrc [#5315 @rjbou]
   * Test opam pin remove <pkg>.<version> [#5325 @kit-ty-kate]
+  * Add a test checking that reinstalling a non-installed package is equivalent to installing it [#5228 @kit-ty-kate]
 
 ### Engine
   * Add `opam-cat` to normalise opam file printing [#4763 @rjbou @dra27] [2.1.0~rc2 #4715]

--- a/master_changes.md
+++ b/master_changes.md
@@ -65,6 +65,7 @@ users)
   * ◈ Add `--with-tools` option to install recommended development tools from opam file (as `with-test`/`with-doc`), and its environment variable `OPAMWITHTOOLS` [#5016 @rjbou]
     * Resolve `with-tools` for post messages too [#5160 @rjbou]
     * ◈ Rename --with-tools` to `--with-dev-setup` [#5214 @rjbou - fix #4959]
+  * Use the default criteria during reinstall/upgrade when requesting at least one non-installed package [#5228 @kit-ty-kate]
 
 ## Remove
   *

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -113,6 +113,7 @@ let compute_upgrade_t
         | Some nv -> not (OpamPackage.Set.mem nv (Lazy.force t.available_packages)))
       atoms
   in
+  let criteria = if to_install = [] then `Upgrade else `Default in
   if all then
     names,
     OpamSolution.resolve t Upgrade
@@ -123,7 +124,7 @@ let compute_upgrade_t
          ~upgrade:to_upgrade
          ~deprequest:(OpamFormula.to_atom_formula formula)
          ~all:[]
-         ~criteria:`Upgrade ())
+         ~criteria ())
   else
   names,
   OpamSolution.resolve t Upgrade
@@ -132,6 +133,7 @@ let compute_upgrade_t
        ~install:to_install
        ~upgrade:to_upgrade
        ~deprequest:(OpamFormula.to_atom_formula formula)
+       ~criteria
        ())
 
 let print_requested requested formula =
@@ -1337,7 +1339,10 @@ let reinstall_t t ?ask ?(force=false) ~assume_built atoms =
     else t, atoms
   in
 
-  let request = OpamSolver.request ~install:atoms ~criteria:`Fixup () in
+  let request =
+    let criteria = if to_install = [] then `Fixup else `Default in
+    OpamSolver.request ~install:atoms ~criteria ()
+  in
 
   let t, solution =
     OpamSolution.resolve_and_apply ?ask t Reinstall

--- a/tests/reftests/reinstall.test
+++ b/tests/reftests/reinstall.test
@@ -86,7 +86,6 @@ The following actions would be performed:
 === install 1 package
   - install   c 1
 ### :::::: Check that reinstalling a non-installed package is equivalent to installing it
-### :::::: TODO: This is currently broken
 ### <pkg:d.1>
 opam-version: "2.0"
 ### opam reinstall d --cudf=reinstall --show --yes
@@ -99,15 +98,10 @@ The following actions would be performed:
 === install 1 package
   - install d 1
 ### diff install-1.cudf reinstall-1.cudf
-2c2
-< # Criteria: -removed,-count[avoid-version,changed],-count[version-lag,request],-count[version-lag,changed],-count[missing-depexts,changed],-changed
----
-> # Criteria: -changed,-count[avoid-version:,true],-count[version-lag:,false],-count[missing-depexts:,true]
 48d47
 < opam-query: 1
 # Return code 1 #
 ### :::::: Check again with one install and one non-installed
-### :::::: TODO: This is currently broken
 ### opam reinstall d a --cudf=reinstall --show --yes
 d is not installed. Install it? [y/n] y
 The following actions would be performed:
@@ -127,10 +121,6 @@ The following actions would be performed:
   - install   c 1
   - install   d 1
 ### diff install-1.cudf reinstall-1.cudf
-2c2
-< # Criteria: -removed,-count[avoid-version,changed],-count[version-lag,request],-count[version-lag,changed],-count[missing-depexts,changed],-changed
----
-> # Criteria: -changed,-count[avoid-version:,true],-count[version-lag:,false],-count[missing-depexts:,true]
 20a21
 > reinstall: true
 49d49

--- a/tests/reftests/reinstall.test
+++ b/tests/reftests/reinstall.test
@@ -85,3 +85,58 @@ The following actions would be performed:
   - recompile b 1
 === install 1 package
   - install   c 1
+### :::::: Check that reinstalling a non-installed package is equivalent to installing it
+### :::::: TODO: This is currently broken
+### <pkg:d.1>
+opam-version: "2.0"
+### opam reinstall d --cudf=reinstall --show --yes
+d is not installed. Install it? [y/n] y
+The following actions would be performed:
+=== install 1 package
+  - install d 1
+### opam install d --cudf=install --show --yes
+The following actions would be performed:
+=== install 1 package
+  - install d 1
+### diff install-1.cudf reinstall-1.cudf
+2c2
+< # Criteria: -removed,-count[avoid-version,changed],-count[version-lag,request],-count[version-lag,changed],-count[missing-depexts,changed],-changed
+---
+> # Criteria: -changed,-count[avoid-version:,true],-count[version-lag:,false],-count[missing-depexts:,true]
+48d47
+< opam-query: 1
+# Return code 1 #
+### :::::: Check again with one install and one non-installed
+### :::::: TODO: This is currently broken
+### opam reinstall d a --cudf=reinstall --show --yes
+d is not installed. Install it? [y/n] y
+The following actions would be performed:
+=== recompile 2 packages
+  - recompile a 1
+  - recompile b 1
+=== install 2 packages
+  - install   c 1
+  - install   d 1
+### opam install d a --cudf=install --show --yes
+[NOTE] Package a is already installed (current version is 1).
+The following actions would be performed:
+=== recompile 2 packages
+  - recompile a 1
+  - recompile b 1
+=== install 2 packages
+  - install   c 1
+  - install   d 1
+### diff install-1.cudf reinstall-1.cudf
+2c2
+< # Criteria: -removed,-count[avoid-version,changed],-count[version-lag,request],-count[version-lag,changed],-count[missing-depexts,changed],-changed
+---
+> # Criteria: -changed,-count[avoid-version:,true],-count[version-lag:,false],-count[missing-depexts:,true]
+20a21
+> reinstall: true
+49d49
+< opam-query: 1
+54c54
+< install: d , a
+---
+> install: d , a = 1
+# Return code 1 #


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/5224 as well as discrepancies in the result given by the solver between `opam install <pkg>` and `opam reinstall <pkg>` when `<pkg>` is not installed (see the differences in the solver output in the description of https://github.com/ocaml/opam/issues/5227)

---------
~TODO:~
- [x] Some tests should be added to prevent regressions