### PR TITLE
`opam admin list --environement` values

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -218,6 +218,7 @@ users)
   * ✘ `opam admin cache` now ignores all already present cache files. Option
     `--check-all` restores the previous behaviour of validating all checksums.
   * [BUG] Fix repo-upgrade internal error [#4965 @AltGr]
+  * [BUG] Fix `--environment` documentation [#5235 @rjbou - fix #5184]
 
 ## Opam installer
   *

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -740,7 +740,7 @@ let pattern_list_arg =
 
 let env_arg cli =
   OpamArg.mk_opt ~cli OpamArg.cli_original ["environment"]
-    "VAR=VALUE[;VAR=VALUE]"
+    "VAR=VALUE[,VAR=VALUE]"
     (Printf.sprintf
        "Use the given opam environment, in the form of a list of \
         comma-separated 'var=value' bindings, when resolving variables. This \


### PR DESCRIPTION
`opam admin list --environment` have a wrong description which lead to a non-sense environment
```diff
-   "VAR=VALUE[;VAR=VALUE]"
+   "VAR=VALUE[,VAR=VALUE]"
```
/cc @balsoft