### PR TITLE
Fix some empty conflict messages by filtering out conflicts of a package against itself early

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -313,6 +313,7 @@ users)
   * Add test for switch upgrade from 2.0 root, with pinned compiler [#5176 @rjbou @kit-ty-kate]
   * Add switch import (for pinned packages) test [#5181 @rjbou]
   * Add `--with-tools` test [#5160 @rjbou]
+  * Add a series of reftests showing empty conflict messages [#5253 @kit-ty-kate]
 ### Engine
   * Add `opam-cat` to normalise opam file printing [#4763 @rjbou @dra27] [2.1.0~rc2 #4715]
   * Fix meld reftest: open only with failing ones [#4913 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -252,6 +252,7 @@ users)
   * Check whether the repository might need updating more often [#4935 @kit-ty-kate]
   * ✘ It is no longer possible to process actions on packages that depend on a package that was removed upstream [#4969 @altgr]
   * Fix (at least some of the) empty conflict explanations [#4982 @kit-ty-kate]
+  * Fix some more empty conflict messages by filtering out conflicts of a package against itself early [#5251 @kit-ty-kate]
   * Fix json double printing [#5143 @rjbou]
 
 ## Internal

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -255,6 +255,108 @@
    (run ./run.exe %{bin:opam} %{dep:dot-install.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-empty-conflicts-001)
+ (action
+  (diff empty-conflicts-001.test empty-conflicts-001.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-empty-conflicts-001)))
+
+(rule
+ (targets empty-conflicts-001.out)
+ (deps root-297366c)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:empty-conflicts-001.test} %{read-lines:testing-env}))))
+
+(rule
+ (alias reftest-empty-conflicts-002)
+ (action
+  (diff empty-conflicts-002.test empty-conflicts-002.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-empty-conflicts-002)))
+
+(rule
+ (targets empty-conflicts-002.out)
+ (deps root-11ea1cb)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:empty-conflicts-002.test} %{read-lines:testing-env}))))
+
+(rule
+ (alias reftest-empty-conflicts-003)
+ (action
+  (diff empty-conflicts-003.test empty-conflicts-003.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-empty-conflicts-003)))
+
+(rule
+ (targets empty-conflicts-003.out)
+ (deps root-3235916)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:empty-conflicts-003.test} %{read-lines:testing-env}))))
+
+(rule
+ (alias reftest-empty-conflicts-004)
+ (action
+  (diff empty-conflicts-004.test empty-conflicts-004.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-empty-conflicts-004)))
+
+(rule
+ (targets empty-conflicts-004.out)
+ (deps root-0070613707)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:empty-conflicts-004.test} %{read-lines:testing-env}))))
+
+(rule
+ (alias reftest-empty-conflicts-005)
+ (action
+  (diff empty-conflicts-005.test empty-conflicts-005.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-empty-conflicts-005)))
+
+(rule
+ (targets empty-conflicts-005.out)
+ (deps root-de897adf36c4230dfea812f40c98223b31c4521a)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:empty-conflicts-005.test} %{read-lines:testing-env}))))
+
+(rule
+ (alias reftest-empty-conflicts-006)
+ (action
+  (diff empty-conflicts-006.test empty-conflicts-006.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-empty-conflicts-006)))
+
+(rule
+ (targets empty-conflicts-006.out)
+ (deps root-c1842d168d)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:empty-conflicts-006.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-env)
  (action
   (diff env.test env.out)))
@@ -961,6 +1063,26 @@
            file://%{dep:opam-repo-N0REP0})))))
 
 (rule
+ (targets opam-archive-0070613707.tar.gz)
+ (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/0070613707.tar.gz)))
+
+(rule
+  (targets opam-repo-0070613707)
+  (action
+   (progn
+    (run mkdir -p %{targets})
+    (run tar -C %{targets} -xzf %{dep:opam-archive-0070613707.tar.gz} --strip-components=1))))
+
+(rule
+  (targets root-0070613707)
+  (action
+   (progn
+    (ignore-stdout
+    (run %{bin:opam} init --root=%{targets}
+           --no-setup --bypass-checks --no-opamrc --bare
+           file://%{dep:opam-repo-0070613707})))))
+
+(rule
  (targets opam-archive-009e00fa.tar.gz)
  (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/009e00fa.tar.gz)))
 
@@ -979,6 +1101,66 @@
     (run %{bin:opam} init --root=%{targets}
            --no-setup --bypass-checks --no-opamrc --bare
            file://%{dep:opam-repo-009e00fa})))))
+
+(rule
+ (targets opam-archive-11ea1cb.tar.gz)
+ (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/11ea1cb.tar.gz)))
+
+(rule
+  (targets opam-repo-11ea1cb)
+  (action
+   (progn
+    (run mkdir -p %{targets})
+    (run tar -C %{targets} -xzf %{dep:opam-archive-11ea1cb.tar.gz} --strip-components=1))))
+
+(rule
+  (targets root-11ea1cb)
+  (action
+   (progn
+    (ignore-stdout
+    (run %{bin:opam} init --root=%{targets}
+           --no-setup --bypass-checks --no-opamrc --bare
+           file://%{dep:opam-repo-11ea1cb})))))
+
+(rule
+ (targets opam-archive-297366c.tar.gz)
+ (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/297366c.tar.gz)))
+
+(rule
+  (targets opam-repo-297366c)
+  (action
+   (progn
+    (run mkdir -p %{targets})
+    (run tar -C %{targets} -xzf %{dep:opam-archive-297366c.tar.gz} --strip-components=1))))
+
+(rule
+  (targets root-297366c)
+  (action
+   (progn
+    (ignore-stdout
+    (run %{bin:opam} init --root=%{targets}
+           --no-setup --bypass-checks --no-opamrc --bare
+           file://%{dep:opam-repo-297366c})))))
+
+(rule
+ (targets opam-archive-3235916.tar.gz)
+ (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/3235916.tar.gz)))
+
+(rule
+  (targets opam-repo-3235916)
+  (action
+   (progn
+    (run mkdir -p %{targets})
+    (run tar -C %{targets} -xzf %{dep:opam-archive-3235916.tar.gz} --strip-components=1))))
+
+(rule
+  (targets root-3235916)
+  (action
+   (progn
+    (ignore-stdout
+    (run %{bin:opam} init --root=%{targets}
+           --no-setup --bypass-checks --no-opamrc --bare
+           file://%{dep:opam-repo-3235916})))))
 
 (rule
  (targets opam-archive-7090735c.tar.gz)
@@ -1061,6 +1243,26 @@
            file://%{dep:opam-repo-ad4dd344})))))
 
 (rule
+ (targets opam-archive-c1842d168d.tar.gz)
+ (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/c1842d168d.tar.gz)))
+
+(rule
+  (targets opam-repo-c1842d168d)
+  (action
+   (progn
+    (run mkdir -p %{targets})
+    (run tar -C %{targets} -xzf %{dep:opam-archive-c1842d168d.tar.gz} --strip-components=1))))
+
+(rule
+  (targets root-c1842d168d)
+  (action
+   (progn
+    (ignore-stdout
+    (run %{bin:opam} init --root=%{targets}
+           --no-setup --bypass-checks --no-opamrc --bare
+           file://%{dep:opam-repo-c1842d168d})))))
+
+(rule
  (targets opam-archive-c1d23f0e.tar.gz)
  (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/c1d23f0e.tar.gz)))
 
@@ -1079,6 +1281,26 @@
     (run %{bin:opam} init --root=%{targets}
            --no-setup --bypass-checks --no-opamrc --bare
            file://%{dep:opam-repo-c1d23f0e})))))
+
+(rule
+ (targets opam-archive-de897adf36c4230dfea812f40c98223b31c4521a.tar.gz)
+ (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/de897adf36c4230dfea812f40c98223b31c4521a.tar.gz)))
+
+(rule
+  (targets opam-repo-de897adf36c4230dfea812f40c98223b31c4521a)
+  (action
+   (progn
+    (run mkdir -p %{targets})
+    (run tar -C %{targets} -xzf %{dep:opam-archive-de897adf36c4230dfea812f40c98223b31c4521a.tar.gz} --strip-components=1))))
+
+(rule
+  (targets root-de897adf36c4230dfea812f40c98223b31c4521a)
+  (action
+   (progn
+    (ignore-stdout
+    (run %{bin:opam} init --root=%{targets}
+           --no-setup --bypass-checks --no-opamrc --bare
+           file://%{dep:opam-repo-de897adf36c4230dfea812f40c98223b31c4521a})))))
 
 (rule
  (targets opam-archive-f372039d.tar.gz)

--- a/tests/reftests/empty-conflicts-001.test
+++ b/tests/reftests/empty-conflicts-001.test
@@ -1,0 +1,20 @@
+297366c
+### OPAMYES=1 OPAMSTRICT=0
+### opam switch create test ocaml-base-compiler.4.07.1 --fake
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-base-compiler" {= "4.07.1"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-base-compiler.4.07.1
+Faking installation of ocaml-config.1
+Faking installation of ocaml.4.07.1
+Done.
+### opam install --show h2-mirage.0.9.0
+[ERROR] Package conflict!
+[ERROR] Internal error while computing conflict explanations:
+        sorry about that. Please report how you got here in https://github.com/ocaml/opam/discussions/5130 if possible.
+# Return code 99 #

--- a/tests/reftests/empty-conflicts-002.test
+++ b/tests/reftests/empty-conflicts-002.test
@@ -1,0 +1,55 @@
+11ea1cb
+### OPAMYES=1 OPAMSTRICT=0
+### opam switch create test ocaml-base-compiler.4.14.0 --fake
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-base-compiler" {= "4.14.0"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-base-compiler.4.14.0
+Faking installation of ocaml-config.2
+Faking installation of ocaml.4.14.0
+Faking installation of ocaml-options-vanilla.1
+Done.
+### opam pin add -k version -n ppx_deriving_yojson.3.7.0 3.7.0
+ppx_deriving_yojson is now pinned to version 3.7.0
+### opam install ppx_deriving_yojson.3.7.0 --fake
+The following actions will be faked:
+=== install 13 packages
+  - install cppo                1.6.9          [required by ppx_deriving, yojson]
+  - install dune                3.4.1          [required by ppx_deriving_yojson]
+  - install ocaml-compiler-libs v0.12.4        [required by ppxlib]
+  - install ocamlfind           1.9.5          [required by ppx_deriving]
+  - install ppx_derivers        1.2.1          [required by ppx_deriving]
+  - install ppx_deriving        5.2.1          [required by ppx_deriving_yojson]
+  - install ppx_deriving_yojson 3.7.0 (pinned)
+  - install ppxlib              0.27.0         [required by ppx_deriving_yojson]
+  - install result              1.5            [required by ppx_deriving_yojson]
+  - install seq                 base           [required by yojson]
+  - install sexplib0            v0.15.1        [required by ppxlib]
+  - install stdlib-shims        0.3.0          [required by ppxlib]
+  - install yojson              2.0.2          [required by ppx_deriving_yojson]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of dune.3.4.1
+Faking installation of cppo.1.6.9
+Faking installation of ocaml-compiler-libs.v0.12.4
+Faking installation of ocamlfind.1.9.5
+Faking installation of ppx_derivers.1.2.1
+Faking installation of result.1.5
+Faking installation of seq.base
+Faking installation of sexplib0.v0.15.1
+Faking installation of stdlib-shims.0.3.0
+Faking installation of ppxlib.0.27.0
+Faking installation of ppx_deriving.5.2.1
+Faking installation of yojson.2.0.2
+Faking installation of ppx_deriving_yojson.3.7.0
+Done.
+### OPAMVAR_arch=x86_64 opam install --show fstar.2022.01.15
+[ERROR] Package conflict!
+[ERROR] Internal error while computing conflict explanations:
+        sorry about that. Please report how you got here in https://github.com/ocaml/opam/discussions/5130 if possible.
+# Return code 99 #

--- a/tests/reftests/empty-conflicts-003.test
+++ b/tests/reftests/empty-conflicts-003.test
@@ -1,0 +1,21 @@
+3235916
+### OPAMYES=1 OPAMSTRICT=0
+### opam switch create test ocaml-base-compiler.4.14.0 --fake
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-base-compiler" {= "4.14.0"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-base-compiler.4.14.0
+Faking installation of ocaml-config.2
+Faking installation of ocaml.4.14.0
+Faking installation of ocaml-options-vanilla.1
+Done.
+### opam install --show disml
+[ERROR] Package conflict!
+[ERROR] Internal error while computing conflict explanations:
+        sorry about that. Please report how you got here in https://github.com/ocaml/opam/discussions/5130 if possible.
+# Return code 99 #

--- a/tests/reftests/empty-conflicts-004.test
+++ b/tests/reftests/empty-conflicts-004.test
@@ -1,0 +1,20 @@
+0070613707
+### OPAMYES=1 OPAMSTRICT=0
+### opam switch create test ocaml-variants.4.14.0+trunk --fake
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-variants" {= "4.14.0+trunk"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-variants.4.14.0+trunk
+Faking installation of ocaml-config.2
+Faking installation of ocaml.4.14.0
+Done.
+### opam install --show camlp5 GT ppxlib.0.25.0
+[ERROR] Package conflict!
+[ERROR] Internal error while computing conflict explanations:
+        sorry about that. Please report how you got here in https://github.com/ocaml/opam/discussions/5130 if possible.
+# Return code 99 #

--- a/tests/reftests/empty-conflicts-005.test
+++ b/tests/reftests/empty-conflicts-005.test
@@ -1,0 +1,20 @@
+de897adf36c4230dfea812f40c98223b31c4521a
+### OPAMYES=1 OPAMSTRICT=0
+### opam switch create test ocaml-variants.4.12.0+trunk --fake
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-variants" {= "4.12.0+trunk"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-variants.4.12.0+trunk
+Faking installation of ocaml-config.2
+Faking installation of ocaml.4.12.0
+Done.
+### opam install --show pgocaml_ppx.4.2.2
+[ERROR] Package conflict!
+[ERROR] Internal error while computing conflict explanations:
+        sorry about that. Please report how you got here in https://github.com/ocaml/opam/discussions/5130 if possible.
+# Return code 99 #

--- a/tests/reftests/empty-conflicts-006.test
+++ b/tests/reftests/empty-conflicts-006.test
@@ -1,0 +1,34 @@
+c1842d168d
+### OPAMYES=1 OPAMSTRICT=0
+### opam var --global enable-ocaml-beta-repository=true
+Added '[enable-ocaml-beta-repository "true" "Set through 'opam var'"]' to field global-variables in global configuration
+### opam switch create test ocaml-variants.4.12.0+trunk --fake
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-variants" {= "4.12.0+trunk"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-beta.disabled
+Faking installation of ocaml-variants.4.12.0+trunk
+Faking installation of ocaml-config.1
+Faking installation of ocaml.4.12.0
+Done.
+### : Fixed by https://github.com/ocaml/opam/pull/4982
+### opam install --show gen_js_api.1.0.6
+[ERROR] Package conflict!
+  * No agreement on the version of ocaml-variants:
+    - (invariant) -> ocaml-variants = 4.12.0+trunk
+    - gen_js_api >= 1.0.6 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml-variants = 4.08.0+beta2
+    You can temporarily relax the switch invariant with `--update-invariant'
+  * No agreement on the version of ocaml:
+    - (invariant) -> ocaml-variants = 4.12.0+trunk -> ocaml = 4.12.0
+    - gen_js_api >= 1.0.6 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.06.0
+  * No agreement on the version of ocaml-migrate-parsetree:
+    - gen_js_api >= 1.0.6 -> ocaml-migrate-parsetree < 2.0.0
+    - gen_js_api >= 1.0.6 -> ppxlib >= 0.9 -> ocaml-migrate-parsetree >= 2.1.0
+
+No solution found, exiting
+# Return code 20 #


### PR DESCRIPTION
The "self-constraints" are used for CUDF but it is an invariant behaviour for opam (several versions of the same package cannot be installed in the same switch)

Somehow doing this early fixes **at least** https://github.com/ocaml/opam/discussions/5130#discussioncomment-3398215

TODO:
* [x] Test more of the test cases
* [x] Add them to the testsuite

Fixes part of #4373 