### PR TITLE
Fix the tests to be compatible with archlinux/arm64

### DIFF
--- a/.github/scripts/main/opam-rt.sh
+++ b/.github/scripts/main/opam-rt.sh
@@ -7,5 +7,8 @@ export OCAMLRUNPARAM=b
 export PATH=~/local/bin:$PATH
 export OPAMKEEPLOGS=1
 
+# TODO: Make opam-rt compatible with non-master initial branches
+git config --global init.defaultBranch master
+
 cd $CACHE/opam-rt
 make KINDS="local git" run

--- a/.github/scripts/main/preamble.sh
+++ b/.github/scripts/main/preamble.sh
@@ -28,6 +28,7 @@ export OPAMCONFIRMLEVEL=unsafe-yes
 git config --global user.email "gha@example.com"
 git config --global user.name "Github Actions CI"
 git config --global gc.autoDetach false
+git config --global init.defaultBranch thisShouldNotHappen
 
 if [ -d ~/opam-repository ]; then
   OPAM_REPO_CACHE=file://$HOME/opam-repository

--- a/master_changes.md
+++ b/master_changes.md
@@ -333,6 +333,7 @@ users)
   * Escape regexps characters in string replacements primitives [#5009 @kit-ty-kate]
   * Automatically update default repo when adding a package file [#5004 @AltGr]
   * Make all the tests work on macOS/arm64 [#5019 @kit-ty-kate]
+  * Make all the tests work on archlinux/arm64 [#5252 @kit-ty-kate]
   * Add unix only tests handling [#5031 @AltGr]
   * Add switch-set test [#4910 @kit-ty-kate]
   * Replace vars on the right-hand of exports [#5024 @AltGr]

--- a/tests/reftests/assume-built.test
+++ b/tests/reftests/assume-built.test
@@ -6,7 +6,7 @@ build: [[ "test" "-f" "ongoing.txt" ] [ "sh" "-c" "cat ongoing.txt > out" ]]
 install: [ ["test" "-f" "out" ] ["touch" "installed"] ]
 ### <ongoing/ongoing.txt>
 versionned
-### git -C ./ongoing init -q
+### git -C ./ongoing init -q --initial-branch=master
 ### git -C ./ongoing config core.autocrlf false
 ### git -C ./ongoing add -A
 ### git -C ./ongoing commit -qm "inplace test"

--- a/tests/reftests/inplace.test
+++ b/tests/reftests/inplace.test
@@ -6,7 +6,7 @@ build: [[ "test" "-f" "ongoing.txt" ] [ "cat" "ongoing.txt" ]]
 install: [ "touch" "installed"]
 ### <ongoing/ongoing.txt>
 versionned
-### git -C ./ongoing init -q
+### git -C ./ongoing init -q --initial-branch=master
 ### git -C ./ongoing config core.autocrlf false
 ### git -C ./ongoing add -A
 ### git -C ./ongoing commit -qm "inplace test"

--- a/tests/reftests/json.unix.test
+++ b/tests/reftests/json.unix.test
@@ -276,7 +276,7 @@ Done.
     }
   ]
 }
-### opam install ko --json=out.json
+### OPAMVAR_os=linux OPAMVAR_arch=x86_64 opam install ko --json=out.json
 The following actions will be performed:
 === install 1 package
   - install ko 2
@@ -293,7 +293,7 @@ The following actions will be performed:
 +- 
 - No changes have been performed
 # Return code 31 #
-### json-cat out.json | 'macos' -> 'linux'
+### json-cat out.json
 {
   "opam-version": "currentv",
   "command-line": [
@@ -422,7 +422,7 @@ Done.
     }
   ]
 }
-### opam install ok ko --json=out.json | grep -v "switch import" | unordered
+### OPAMVAR_os=linux OPAMVAR_arch=x86_64 opam install ok ko --json=out.json | grep -v "switch import" | unordered
 The following actions will be performed:
 === install 2 packages
   - install ko 2
@@ -445,7 +445,7 @@ The following actions will be performed:
 
 The former state can be restored with:
 # Return code 31 #
-### json-cat out.json | 'macos' -> 'linux'
+### json-cat out.json
 {
   "opam-version": "currentv",
   "command-line": [

--- a/tests/reftests/lock.test
+++ b/tests/reftests/lock.test
@@ -536,7 +536,7 @@ version: "locked-version"
 ### opam pin scan ./tolock-scan --locked | grep -v '# Name'
 tolock-scan  locked-version  file://${BASEDIR}/tolock-scan  -
 ### : git pin with lock file :
-### git -C tolock init -q
+### git -C tolock init -q --initial-branch=master
 ### git -C tolock config core.autocrlf false
 ### git -C tolock add content
 ### git -C tolock commit -qm "init"

--- a/tests/reftests/pin.unix.test
+++ b/tests/reftests/pin.unix.test
@@ -14,7 +14,7 @@ echo "pin-depends: [ \"qux.dev\" \"file://$BASEDIR/qux\" ]" >> bar/bar.opam
 opam-version: "2.0"
 depexts: [ "another-inexistant" ]
 ### opam switch create pinning --empty
-### opam pin ./bar | '(apt-get|brew|port)' -> 'syspkgmanager'
+### opam pin ./bar | '(apt-get|brew|port)' -> 'syspkgmanager' | 'pacman -Su' -> 'syspkgmanager install'
 Package bar does not exist, create as a NEW package? [y/n] y
 The following additional pinnings are required by bar.dev:
   - qux.dev at file://${BASEDIR}/qux
@@ -70,7 +70,7 @@ The following actions will be performed:
 Done.
 ### opam option 'depext-bypass-=["another-inexistant" "inexistant"]'
 Removed '["another-inexistant" "inexistant"]' from field depext-bypass in switch pinning
-### opam install ./bar | '(apt-get|brew|port)' -> 'syspkgmanager'
+### opam install ./bar | '(apt-get|brew|port)' -> 'syspkgmanager' | 'pacman -Su' -> 'syspkgmanager install'
 Package bar does not exist, create as a NEW package? [y/n] y
 The following additional pinnings are required by bar.dev:
   - qux.dev at file://${BASEDIR}/qux

--- a/tests/reftests/rec-pin.test
+++ b/tests/reftests/rec-pin.test
@@ -55,7 +55,7 @@ build: [ "test" "-f" "%{name}%.t" ]
 piou
 ### <pinnes/b/root-b_g.install>
 lib: ["root-b_g.t"]
-### git -C ./pinnes init -q
+### git -C ./pinnes init -q --initial-branch=master
 ### git -C ./pinnes config core.autocrlf false
 ### git -C ./pinnes add a/i b root_g.opam root_g.t root_g.install
 ### git -C ./pinnes commit -qm "fst"
@@ -604,7 +604,7 @@ version: "l1"
 build: [ "false" ]
 ### <pin:pinnes/b/root-b_g.opam.locked>
 version: "l1"
-### git -C ./pinnes init -q
+### git -C ./pinnes init -q --initial-branch=master
 ### git -C ./pinnes config core.autocrlf false
 ### git -C ./pinnes add a/i b root_g.opam root_g.opam.locked
 ### git -C ./pinnes commit -qm "fst"

--- a/tests/reftests/source.test
+++ b/tests/reftests/source.test
@@ -4,7 +4,7 @@ print_endline "I am a source code"
 ### <pandev/root.ml>
 print_endline "i'm root"
 ### tar czf origin.tgz pandev
-### git -C ./pandev init -q
+### git -C ./pandev init -q --initial-branch=master
 ### git -C ./pandev config core.autocrlf false
 ### git -C ./pandev add -A
 ### git -C ./pandev commit -qm "init"

--- a/tests/reftests/working-dir.test
+++ b/tests/reftests/working-dir.test
@@ -5,7 +5,7 @@ opam-version: "2.0"
 build: [[ "test" "-f" "ongoing.txt" ] [ "cat" "ongoing.txt" ]]
 ### <ongoing/ongoing.txt>
 versionned
-### git -C ./ongoing init -q
+### git -C ./ongoing init -q --initial-branch=master
 ### git -C ./ongoing config core.autocrlf false
 ### git -C ./ongoing add -A
 ### git -C ./ongoing commit -qm "init"


### PR DESCRIPTION
Fixes everything except for this one, which i have no idea how to fix:
```
diff --git a/_build/default/tests/reftests/working-dir.test b/_build/default/tests/reftests/working-dir.out
index ae774ff60..0e82e5dd7 100644
--- a/_build/default/tests/reftests/working-dir.test
+++ b/_build/default/tests/reftests/working-dir.out
@@ -218,14 +218,14 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/5: [qux.4: rsync]
 Processing  2/5: [qux.4: rsync] [ongoing: test newfile.txt]
+Processing  2/5: [qux.4: rsync] [ongoing: cat newfile.txt]
+Processing  2/5: [qux.4: rsync]
+Processing  3/5: [qux.4: rsync]
 -> retrieved qux.4  (file://${BASEDIR}/qux)
-Processing  2/5: [ongoing: test newfile.txt]
 test "-f" "newfile.txt" (CWD=${BASEDIR}/OPAM/working-dir/.opam-switch/build/ongoing.dev)
-Processing  2/5: [ongoing: cat newfile.txt]
 cat "newfile.txt" (CWD=${BASEDIR}/OPAM/working-dir/.opam-switch/build/ongoing.dev)
 - new!
 -> compiled  ongoing.dev
-Processing  3/5: [qux: test present]
 -> installed ongoing.dev
 Processing  4/5: [qux: test present]
 test "-f" "present" (CWD=${BASEDIR}/OPAM/working-dir/.opam-switch/build/qux.4)
```