### PR TITLE
Do not infinitly check for depexts when the system package manager fails

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -370,6 +370,7 @@ users)
   * Add some tests showing how --working-dir behaves on updated dependency constraints [#5179 @kit-ty-kate]
   * Add config (report) test [#4892 @rjbou]
   * Add `sed-cmd` command to replace resolved path command printing by command name only [#5285 @rjbou]
+  * Update sed-cmd to handle commands without any arguments [#5257 @kit-ty-kate]
 
 ## Github Actions
   * Add solver backends compile test [#4723 @rjbou] [2.1.0~rc2 #4720]

--- a/master_changes.md
+++ b/master_changes.md
@@ -168,6 +168,7 @@ users)
   * Improve the error message when neither MacPorts or Homebrew could be detected on macOS [#5240 @kit-ty-kate]
   * Introduce dummy-success & dummy-failure os-family to make testing depexts behaviour easier [#5268 @kit-ty-kate]
   * Run command as admin only when needed [#5268 @kit-ty-kate]
+  * [BUG] Do not infinitly check for depexts when the system package manager fails [#5257 @kit-ty-kate]
 
 ## Format upgrade
   * Fix format upgrade when there is missing local switches in the config file [#4763 @rjbou - fix #4713] [2.1.0~rc2 #4715]

--- a/master_changes.md
+++ b/master_changes.md
@@ -342,6 +342,7 @@ users)
   * Add rebuild test [#5258 @rjbou]
   * Add test for opam tree command [#5171 @cannorin]
   * Update and reintegrate pin & depext test `pin.unix` in `pin` test, with test environment, there is no more need to have it only on unix [#5268 @rjbou @kit-ty-kate]
+  * Add a reftest testing for system package manager failure [#5257 @kit-ty-kate]
 
 ### Engine
   * Add `opam-cat` to normalise opam file printing [#4763 @rjbou @dra27] [2.1.0~rc2 #4715]

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1158,7 +1158,7 @@ let install_depexts ?(force_depext=false) ?(confirm=true) t packages =
     else if OpamFile.Config.depext_run_installs t.switch_global.config then
       if confirm then menu t sys_packages else auto_install t sys_packages
     else
-      manual_install t sys_packages
+      manual_install ~noninteractive:`Ignore t sys_packages
   and menu t sys_packages =
     (* Called only if run install is true *)
     let answer =
@@ -1205,10 +1205,10 @@ let install_depexts ?(force_depext=false) ?(confirm=true) t packages =
     OpamConsole.msg "\n    %s\n\n"
       (OpamConsole.colorise `bold
          (OpamStd.List.concat_map "\n    " (String.concat " ") commands))
-  and manual_install t sys_packages =
+  and manual_install ~noninteractive t sys_packages =
     print_command sys_packages;
     let answer =
-      OpamConsole.menu ~default:`Continue ~noninteractive:`Ignore ~no:`Quit
+      OpamConsole.menu ~default:`Continue ~noninteractive ~no:`Quit
         "Would you like opam to:"
         ~options:[
           `Continue, "Check again, as the package is now installed";
@@ -1228,7 +1228,7 @@ let install_depexts ?(force_depext=false) ?(confirm=true) t packages =
       map_sysmap (fun _ -> OpamSysPkg.Set.empty) t
     with Failure msg ->
       OpamConsole.error "%s" msg;
-      check_again t sys_packages
+      manual_install ~noninteractive:`Quit t sys_packages
   and check_again t sys_packages =
     let needed, _notfound = OpamSysInteract.packages_status sys_packages in
     let installed = OpamSysPkg.Set.diff sys_packages needed in

--- a/tests/reftests/depexts.test
+++ b/tests/reftests/depexts.test
@@ -1,0 +1,44 @@
+N0REP0
+### <pkg:a.1>
+opam-version: "2.0"
+depexts: "depext-1"
+### OPAMNODEPEXTS=0
+### opam var --global os-family=dummy-failure
+Added '[os-family "dummy-failure" "Set through 'opam var'"]' to field global-variables in global configuration
+### opam switch create test --empty
+### : Erroneous package manager install is not blocking :
+### opam install a | sed-cmd false
+The following actions will be performed:
+=== install 1 package
+  - install a 1
+
+The following system packages will first need to be installed:
+    depext-1
+
+<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><><><>
+
+opam believes some required external dependencies are missing. opam can:
+> 1. Run false to install them (may need root/sudo access)
+  2. Display the recommended false command and wait while you run it manually (e.g. in another terminal)
+  3. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
+  4. Abort the installation
+
+[1/2/3/4] 1
+
+false 
+[ERROR] System package install failed with exit code 1 at command:
+            false
+This command should get the requirements installed:
+
+    false
+
+Would you like opam to:
+  1. Check again, as the package is now installed
+  2. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
+> 3. Abort the installation
+
+[1/2/3] 3
+
+[NOTE] You can retry with '--assume-depexts' to skip this check, or run 'opam option depext=false' to permanently disable handling of system packages.
+
+# Return code 10 #

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -221,6 +221,23 @@
    (run ./run.exe %{bin:opam} %{dep:cudf-preprocess.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-depexts)
+ (action
+  (diff depexts.test depexts.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-depexts)))
+
+(rule
+ (targets depexts.out)
+ (deps root-N0REP0)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:depexts.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-deprecated)
  (action
   (diff deprecated.test deprecated.out)))

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -418,16 +418,17 @@ module Parse = struct
           | "|" :: "sed-cmd" :: cmd :: r ->
             let re =
               seq [
+                Re.str "+ ";
                 rep any;
                 alt [ set "/\\\"" ];
                 Re.str cmd;
                 opt @@ Re.str ".exe";
                 opt @@ char '"';
-                Re.str " \""
+                Re.str " "
               ]
-(*                 Printf.sprintf ".*(/|\\\\|\")%s(\\.exe)?\"? \"" cmd *)
+(*                 Printf.sprintf "+ .*(/|\\\\|\")%s(\\.exe)?\"? " cmd *)
                 in
-            let str = Printf.sprintf "%s \"" cmd in
+            let str = Printf.sprintf "%s " cmd in
             get_rewr (unordered, (re, Sed str) :: acc) r
           | ">$" :: output :: [] ->
             unordered, List.rev acc, Some (get_str output)


### PR DESCRIPTION
```
[1/2/3/4] 1
+ /usr/bin/sudo "apt-get" "install" "-qq" "-yy" "autoconf" "gnuplot-x11"
[ERROR] System package install failed with exit code 100 at command:
            sudo apt-get install -qq -yy autoconf gnuplot-x11
- E: Unable to correct problems, you have held broken packages.
[ERROR] These packages are still missing: autoconf gnuplot-x11

opam believes some required external dependencies are missing. opam can:
> 1. Run apt-get to install them (may need root/sudo access)
  2. Display the recommended apt-get command and wait while you run it manually 
(e.g. in another terminal)
  3. Attempt installation anyway, and permanently register that this external de
pendency is present, but not detectable
  4. Abort the installation

[1/2/3/4] 1
+ /usr/bin/sudo "apt-get" "install" "-qq" "-yy" "autoconf" "gnuplot-x11"
- E: Unable to correct problems, you have held broken packages.
[ERROR] System package install failed with exit code 100 at command:
            sudo apt-get install -qq -yy autoconf gnuplot-x11
[ERROR] These packages are still missing: autoconf gnuplot-x11

opam believes some required external dependencies are missing. opam can:
> 1. Run apt-get to install them (may need root/sudo access)
  2. Display the recommended apt-get command and wait while you run it manually 
(e.g. in another terminal)
  3. Attempt installation anyway, and permanently register that this external de
pendency is present, but not detectable
  4. Abort the installation

[1/2/3/4] 1
+ /usr/bin/sudo "apt-get" "install" "-qq" "-yy" "autoconf" "gnuplot-x11"
- E: Unable to correct problems, you have held broken packages.
[...]
```