### PR TITLE
Silence env hooks errors

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -365,6 +365,7 @@ users)
   * dash: recognize dash as a POSIX shell for opam env [#4816 @jonahbeckford]
   * pwsh,powershell: use $env: for opam env [#4816 @jonahbeckford]
   * command prompt: use SET for opam env [#4816 @jonahbeckford]
+  * silence env hooks errors [#5260 @Firobe]
 
 ## Doc
   * Standardise `macOS` use [#4782 @kit-ty-kate]

--- a/src/state/shellscripts/env_hook.fish
+++ b/src/state/shellscripts/env_hook.fish
@@ -1,3 +1,3 @@
 function __opam_env_export_eval --on-event fish_prompt;
-    eval (opam env --shell=fish --readonly 2> /dev/null);
+    eval (opam env --shell=fish --readonly 2> /dev/null) 2> /dev/null;
 end

--- a/src/state/shellscripts/env_hook.sh
+++ b/src/state/shellscripts/env_hook.sh
@@ -1,6 +1,6 @@
 _opam_env_hook() {
  local previous_exit_status=$?;
- eval $(opam env --shell=bash --readonly 2> /dev/null <&- );
+ eval $(opam env --shell=bash --readonly 2> /dev/null <&- ) 2> /dev/null;
  return $previous_exit_status;
 };
 if ! [[ "$PROMPT_COMMAND" =~ _opam_env_hook ]]; then

--- a/src/state/shellscripts/env_hook.zsh
+++ b/src/state/shellscripts/env_hook.zsh
@@ -1,5 +1,5 @@
 _opam_env_hook() {
-    eval $(opam env --shell=zsh --readonly 2> /dev/null <&-);
+    eval $(opam env --shell=zsh --readonly 2> /dev/null <&-) 2> /dev/null;
 }
 typeset -ag precmd_functions;
 if [[ -z ${precmd_functions[(r)_opam_env_hook]} ]]; then


### PR DESCRIPTION
In some cases (such as when using [`opam-nix`](https://github.com/tweag/opam-nix)+`direnv`), we are in a shell with the env hook enabled but `opam` has been replaced by a dummy binary.

In this situation, `eval $(opam env)` will fail, which is expected. However, it will output annoying errors each time the hook is loaded. I think errors in the hook should always be silenced.
