### PR TITLE
Fix a bug Windows CI appearing when doc/man/opam-topics.inc changes

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -352,7 +352,7 @@ let main_build_job ~analyse_job ~cygwin_job ?section platform start_version ~oc 
   let host = host_of_platform platform in
   job ~oc ~workflow ~runs_on:(Runner [platform]) ?shell ?section ~needs ~matrix ("Build-" ^ name_of_platform platform)
     ++ only_on Linux (run "Install bubblewrap" ["sudo apt install bubblewrap"])
-    ++ only_on Windows (git_lf_checkouts ~cond:(Predicate(true, EndsWith("matrix.host", "-pc-cygwin"))) ~shell:"cmd" ~title:"Configure LF checkout for Cygwin" ())
+    ++ only_on Windows (git_lf_checkouts ~shell:"cmd" ~title:"Configure LF checkout for Windows" ())
     ++ checkout ()
     ++ only_on Windows (cache ~cond:(Predicate(true, Compare("matrix.build", "i686-pc-cygwin"))) Cygwin `x86)
     ++ only_on Windows (cache ~cond:(Predicate(true, Compare("matrix.build", "x86_64-pc-cygwin"))) Cygwin `x64)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,8 +195,7 @@ jobs:
       run:
         shell: D:\cygwin\bin\bash.exe {0}
     steps:
-    - name: Configure LF checkout for Cygwin
-      if: endsWith(matrix.host, '-pc-cygwin')
+    - name: Configure LF checkout for Windows
       shell: cmd
       run: |
         git config --system core.autocrlf false


### PR DESCRIPTION
This issue showed up in https://github.com/ocaml/opam/pull/5171:
```
 error: Your local changes to the following files would be overwritten by checkout:
	doc/man/opam-topics.inc
Please commit your changes or stash them before you switch branches.
Aborting
+ git diff
warning: in the working copy of 'doc/man/opam-topics.inc', CRLF will be replaced by LF the next time Git touches it
```