### PR TITLE
Release note for messages in opam-repository repo

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -221,6 +221,7 @@ users)
 
 ## Release scripts
   * Make the release script setup-less using QEMU, Docker and Rosetta 2 [#4947 @kit-ty-kate]
+  * Update release notes for messages in opam-repository [#5276 @dra27]
 
 ## Admin
   * ✘ `opam admin cache` now ignores all already present cache files. Option

--- a/release/readme.md
+++ b/release/readme.md
@@ -24,6 +24,7 @@
 
 * add hashes in `install.sh` (and check signatures)
 * publish opam packages in opam-repository
+* update versions (and messages, if necessary) in https://github.com/ocaml/opam-repository/blob/master/repo
 
 ## Announce!
 


### PR DESCRIPTION
In tandem with https://github.com/ocaml/opam-repository/pull/22069, a reminder in the release checklist to keep the `repo` file's versions and messages up-to-date