### PR TITLE
Explain vendored mode more clearly in configure

### DIFF
--- a/configure
+++ b/configure
@@ -8060,7 +8060,7 @@ echo Manual pages will be installed in ${mandir}
 if test "x${VENDORED}" = "xtrue"; then :
 
   echo
-  $as_echo_n "Downloading vendored source dependencies... "
+  $as_echo "Downloading vendored source dependencies..."
   ${MAKE} --no-print-directory -C src_ext SILENT=@ archives
   $as_echo done
   $as_echo_n "Extracting vendored source dependencies in src_ext/... "

--- a/configure
+++ b/configure
@@ -6810,6 +6810,7 @@ else
 
       echo "============================================================================"
       echo "Some dependencies are missing. Vendored mode has been automatically enabled."
+      echo "The sources for opam's dependencies will be extracted in src_ext and built."
       echo "============================================================================"
 
 fi
@@ -8059,10 +8060,10 @@ echo Manual pages will be installed in ${mandir}
 if test "x${VENDORED}" = "xtrue"; then :
 
   echo
-  $as_echo_n "Downloading vendored dependencies... "
+  $as_echo_n "Downloading vendored source dependencies... "
   ${MAKE} --no-print-directory -C src_ext SILENT=@ archives
   $as_echo done
-  $as_echo_n "Extracting vendored dependencies... "
+  $as_echo_n "Extracting vendored source dependencies in src_ext/... "
   ${MAKE} --no-print-directory -C src_ext SILENT=@ clone
   $as_echo done
 
@@ -8072,10 +8073,10 @@ else
   if test -z "${DUNE}"; then :
 
     echo
-    $as_echo_n "Downloading dune... "
+    $as_echo_n "Downloading dune sources... "
     ${MAKE} --no-print-directory -C src_ext SILENT=@ dune-local.download
     $as_echo done
-    $as_echo_n "Extracting dune... "
+    $as_echo_n "Extracting dune sources to src_ext/dune-local/... "
     ${MAKE} --no-print-directory -C src_ext SILENT=@ dune-local.stamp
     $as_echo done
 

--- a/configure.ac
+++ b/configure.ac
@@ -406,6 +406,7 @@ AS_IF([test "x${enable_checks}" != "xno" && {
     AS_IF([test "x${with_vendored_deps}" != "xyes"],[
       echo "============================================================================"
       echo "Some dependencies are missing. Vendored mode has been automatically enabled."
+      echo "The sources for opam's dependencies will be extracted in src_ext and built."
       echo "============================================================================"
     ])
     AC_SUBST(VENDORED,"true")
@@ -473,20 +474,20 @@ echo Manual pages will be installed in ${mandir}
 
 AS_IF([test "x${VENDORED}" = "xtrue"],[
   echo
-  AS_ECHO_N(["Downloading vendored dependencies... "])
+  AS_ECHO_N(["Downloading vendored source dependencies... "])
   ${MAKE} --no-print-directory -C src_ext SILENT=@ archives
   AS_ECHO([done])
-  AS_ECHO_N(["Extracting vendored dependencies... "])
+  AS_ECHO_N(["Extracting vendored source dependencies in src_ext/... "])
   ${MAKE} --no-print-directory -C src_ext SILENT=@ clone
   AS_ECHO([done])
 ],[
   ${MAKE} --no-print-directory -C src_ext def-ignore
   AS_IF([test -z "${DUNE}"],[
     echo
-    AS_ECHO_N(["Downloading dune... "])
+    AS_ECHO_N(["Downloading dune sources... "])
     ${MAKE} --no-print-directory -C src_ext SILENT=@ dune-local.download
     AS_ECHO([done])
-    AS_ECHO_N(["Extracting dune... "])
+    AS_ECHO_N(["Extracting dune sources to src_ext/dune-local/... "])
     ${MAKE} --no-print-directory -C src_ext SILENT=@ dune-local.stamp
     AS_ECHO([done])
   ])

--- a/configure.ac
+++ b/configure.ac
@@ -474,7 +474,7 @@ echo Manual pages will be installed in ${mandir}
 
 AS_IF([test "x${VENDORED}" = "xtrue"],[
   echo
-  AS_ECHO_N(["Downloading vendored source dependencies... "])
+  AS_ECHO(["Downloading vendored source dependencies..."])
   ${MAKE} --no-print-directory -C src_ext SILENT=@ archives
   AS_ECHO([done])
   AS_ECHO_N(["Extracting vendored source dependencies in src_ext/... "])

--- a/master_changes.md
+++ b/master_changes.md
@@ -214,6 +214,7 @@ users)
   * Bump cudf to 0.10 [#5195 @kit-ty-kate]
   * shell/bootstrap-ocaml.sh: do not fail if curl/wget is missing [#5223 #5233 @kit-ty-kate]
   * Upgrade to cmdliner >= 1.1 [#5269 @kit-ty-kate]
+  * Cleared explanation of dependency vendoring in configure [#5277 @dra27 - fix #5271]
 
 ## Infrastructure
   * Fix caching of Cygwin compiler on AppVeyor [#4988 @dra27]

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -165,7 +165,8 @@ https://opam.ocaml.org/cache/md5/$(shell echo $(MD5_$(2)$(1)) | cut -c -2)/$(MD5
 endef
 
 GET_ARCHIVE=\
-  { { { $(call FETCH,$(URL_$(2)$(1)),$(call ARCHIVE_FILE,$(1),$(2))) && $(call MD5CHECK,$(call ARCHIVE_FILE,$(1),$(2)),$(MD5_$(2)$(1))); } \
+  { echo ' * Downloading $(1)...' && \
+    { { $(call FETCH,$(URL_$(2)$(1)),$(call ARCHIVE_FILE,$(1),$(2))) && $(call MD5CHECK,$(call ARCHIVE_FILE,$(1),$(2)),$(MD5_$(2)$(1))); } \
       || { echo 'Failed to download $(URL_$(2)$(1))'; false; }; } || \
     { { $(call FETCH,$(call cache_url,$(1),$(2)),$(call ARCHIVE_FILE,$(1),$(2))) && $(call MD5CHECK,$(call ARCHIVE_FILE,$(1),$(2)),$(MD5_$(2)$(1))) && echo 'Warning: downloaded $(URL_$(2)$(1)) from opam cache'; } \
       || { echo 'Failed to download $(1) from opam cache'; false; }; }; }


### PR DESCRIPTION
The message when vendored mode is automatically turned on has an extra line:

```
============================================================================
Some dependencies are missing. Vendored mode has been automatically enabled.
The sources for opam's dependencies will be extracted in src_ext and built.
============================================================================
```
and the extraction message notes that it's extracting sources to `src_ext/`:

```
Downloading vendored source dependencies... done
Extracting vendored source dependencies in src_ext/... done
```