### PR TITLE
Reset the "jobs" config variable when upgrading from opam 2.0

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -83,6 +83,9 @@ users)
   * Really install invariant formula if not installed in switch [#5188 @rjbou]
   * On import, check that installed pinned packages changed, reinstall if so [#5181 @rjbou - fix #5173]
 
+## Config
+  * Reset the "jobs" config variable when upgrading from opam 2.0 [#5284 @kit-ty-kate]
+
 ## Pin
   * Switch the default version when undefined from ~dev to dev [#4949 @kit-ty-kate]
   * ◈ New option `opam pin --current` to fix a package in its current state (avoiding pending reinstallations or removals from the repository) [#4973 @AltGr - fix #4970]

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -681,11 +681,15 @@ No configuration file found, using built-in defaults.
 ### opam option jobs | "${OPAMROOTVERSION}$" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.0 to current
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. If it really was intended, you can set it again using:
+           opam option jobs=1 --global
 FMT_UPG                         Format upgrade done
 ### # ro global state, ro repo state, ro switch state
 ### opam list | "${OPAMROOTVERSION}$" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.0 to current
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. If it really was intended, you can set it again using:
+           opam option jobs=1 --global
 FMT_UPG                         Format upgrade done
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          No cache found
@@ -702,6 +706,8 @@ i-am-sys-compiler    1           One-line description
 ### opam install i-am-another-package --switch sw-comp | "${OPAMROOTVERSION}$" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.0 to current
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. If it really was intended, you can set it again using:
+           opam option jobs=1 --global
 FMT_UPG                         Format upgrade done
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -727,6 +733,8 @@ This version of opam requires an update to the layout of ${BASEDIR}/OPAM from ve
 You may want to back it up before going further.
 
 Continue? [y/n] y
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. If it really was intended, you can set it again using:
+           opam option jobs=1 --global
 Format upgrade done.
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -768,6 +776,8 @@ roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### opam list | "${OPAMROOTVERSION}$" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.0 to current
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. If it really was intended, you can set it again using:
+           opam option jobs=1 --global
 FMT_UPG                         Format upgrade done
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          No cache found
@@ -783,6 +793,8 @@ i-am-sys-compiler 2           One-line description
 ### opam install i-am-package | "${OPAMROOTVERSION}$" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.0 to current
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. If it really was intended, you can set it again using:
+           opam option jobs=1 --global
 FMT_UPG                         Format upgrade done
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -807,6 +819,8 @@ This version of opam requires an update to the layout of ${BASEDIR}/OPAM from ve
 You may want to back it up before going further.
 
 Continue? [y/n] y
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. If it really was intended, you can set it again using:
+           opam option jobs=1 --global
 Format upgrade done.
 Set to '4' the field jobs in global configuration
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
@@ -848,6 +862,8 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### opam list | "${OPAMROOTVERSION}$" -> " current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.0 to  current
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. If it really was intended, you can set it again using:
+           opam option jobs=1 --global
 FMT_UPG                         Format upgrade done
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          No cache found
@@ -862,6 +878,8 @@ i-am-sys-compiler 2           One-line description
 ### opam install i-am-package | "${OPAMROOTVERSION}$" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.0 to current
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. If it really was intended, you can set it again using:
+           opam option jobs=1 --global
 FMT_UPG                         Format upgrade done
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -886,6 +904,8 @@ This version of opam requires an update to the layout of ${BASEDIR}/OPAM from ve
 You may want to back it up before going further.
 
 Continue? [y/n] y
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. If it really was intended, you can set it again using:
+           opam option jobs=1 --global
 Format upgrade done.
 Set to '4' the field jobs in global configuration
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
@@ -998,6 +1018,8 @@ This version of opam requires an update to the layout of ${BASEDIR}/OPAM from ve
 You may want to back it up before going further.
 
 Continue? [y/n] y
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. If it really was intended, you can set it again using:
+           opam option jobs=1 --global
 Format upgrade done.
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          No cache found

--- a/tests/reftests/upgrade-two-point-o.test
+++ b/tests/reftests/upgrade-two-point-o.test
@@ -22,6 +22,8 @@ pinned: ["i-am-compiler.1"]
 opam-version: "2.0"
 synopsis: "switch with pinned compiler"
 ### OPAMDEBUGSECTIONS=STATE opam upgrade --show-action --debug-level=-1
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. If it really was intended, you can set it again using:
+           opam option jobs=1 --global
 STATE                           LOAD-SWITCH-STATE @ pinned-comp
 STATE                           Definition missing for installed package i-am-compiler.1, copying from repo
 STATE                           Inferred invariant: from base packages { i-am-compiler.1 }, (roots { i-am-compiler.1 }) => ["i-am-compiler" {= "1"}]
@@ -31,9 +33,13 @@ Everything as up-to-date as possible (run with --verbose to show unavailable upg
 However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.
 ### opam pin remove i-am-compiler
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. If it really was intended, you can set it again using:
+           opam option jobs=1 --global
 Ok, i-am-compiler is no longer pinned locally (version 1)
 Nothing to do.
 ### opam upgrade --show-action
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. If it really was intended, you can set it again using:
+           opam option jobs=1 --global
 Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
 However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.


### PR DESCRIPTION
See https://github.com/ocurrent/ocaml-dockerfile/pull/92