### PR TITLE
Reftest: add path replacement command command

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -364,6 +364,7 @@ users)
   * Add `json-cat` printer, with some automatic remplacements [#5143 @rjbou]
   * Add some tests showing how --working-dir behaves on updated dependency constraints [#5179 @kit-ty-kate]
   * Add config (report) test [#4892 @rjbou]
+  * Add `sed-cmd` command to replace resolved path command printing by command name only [#5285 @rjbou]
 
 ## Github Actions
   * Add solver backends compile test [#4723 @rjbou] [2.1.0~rc2 #4720]

--- a/tests/reftests/assume-built.test
+++ b/tests/reftests/assume-built.test
@@ -17,7 +17,7 @@ new!
 Package ongoing does not exist, create as a NEW package? [y/n] y
 ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
 ### : assume built
-### opam install ongoing -v | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*(/|\\|")sh(\.exe)?"? "' -> 'sh "' | '.*(/|\\|")touch(\.exe)?"? "' -> 'touch "'
+### opam install ongoing -v | sed-cmd test | sed-cmd sh | sed-cmd touch
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1:
@@ -51,7 +51,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> removed   ongoing.dev
 Done.
-### opam install ongoing --assume-built -v | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*(/|\\|")touch(\.exe)?"? "' -> 'touch "' | grep -v "switch import"
+### opam install ongoing --assume-built -v | sed-cmd test | sed-cmd touch | grep -v "switch import"
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1:
@@ -81,7 +81,7 @@ test "-f" "out" (CWD=${BASEDIR}/ongoing)
 '${OPAM} install ongoing --assume-built -v' failed.
 # Return code 31 #
 ### touch ongoing/out
-### opam install ongoing --assume-built -v | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*(/|\\|")touch(\.exe)?"? "' -> 'touch "'
+### opam install ongoing --assume-built -v | sed-cmd test | sed-cmd touch
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1:
@@ -147,7 +147,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> removed   ongoing.dev
 Done.
-### opam install ongoing --assume-built --working-dir -v | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*(/|\\|")touch(\.exe)?"? "' -> 'touch "'
+### opam install ongoing --assume-built --working-dir -v | sed-cmd test | sed-cmd touch
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [ongoing.dev: git]

--- a/tests/reftests/inplace.test
+++ b/tests/reftests/inplace.test
@@ -16,7 +16,7 @@ new!
 ### opam pin ./ongoing -n
 Package ongoing does not exist, create as a NEW package? [y/n] y
 ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
-### opam install ongoing -v | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*(/|\\|")cat(\.exe)?"? "' -> 'cat "' | '.*(/|\\|")touch(\.exe)?"? "' -> 'touch "'
+### opam install ongoing -v | sed-cmd test | sed-cmd cat | sed-cmd touch
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1:
@@ -51,7 +51,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> removed   ongoing.dev
 Done.
-### opam install ongoing --inplace -v | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*(/|\\|")cat(\.exe)?"? "' -> 'cat "' | '.*(/|\\|")touch(\.exe)?"? "' -> 'touch "'
+### opam install ongoing --inplace -v | sed-cmd test | sed-cmd cat | sed-cmd touch
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [ongoing.dev: git]
@@ -89,7 +89,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> removed   ongoing.dev
 Done.
-### opam install ongoing --inplace --working-dir -v | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*(/|\\|")cat(\.exe)?"? "' -> 'cat "' | '.*(/|\\|")touch(\.exe)?"? "' -> 'touch "'
+### opam install ongoing --inplace --working-dir -v | sed-cmd test | sed-cmd cat | sed-cmd touch
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [ongoing.dev: git]

--- a/tests/reftests/parallel.test
+++ b/tests/reftests/parallel.test
@@ -32,7 +32,7 @@ if [ $# -eq 1 ]; then
   echo "finally installed $1"
 fi
 ### opam switch create parallel --empty
-### opam install foo bar baz qux top -vv | grep -v '^Processing' | '.*(/|\\|")sh(\.exe)?"? "' -> 'sh "' | unordered
+### opam install foo bar baz qux top -vv | grep -v '^Processing' | sed-cmd sh | unordered
 The following actions will be performed:
 === install 5 packages
   - install bar 1

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -6,14 +6,14 @@ build: ["test" "-f" "bar"]
 some content
 ### opam switch create tarring --empty
 ### : Internal repository storage as archive or plain directory :
-### opam update -vv | grep '^\+' | '.*(/|\\)diff(\.exe)?"? "' -> 'diff "' | '.*(/|\\)patch(\.exe)?"?.*"' -> 'patch'
+### opam update -vv | grep '^\+' | sed-cmd diff | '.*(/|\\)patch(\.exe)?"?.*"' -> 'patch'
 diff "-ruaN" "default" "default.new" (CWD=${BASEDIR}/OPAM/repo)
 patch (CWD=${BASEDIR}/OPAM/repo/default)
 ### ls $OPAMROOT/repo | grep -v "cache"
 default
 lock
 repos-config
-### opam install foo.1 -vv | grep '^\+' | '.*(/|\\|")test(\.exe)?"? "' -> 'test "'
+### opam install foo.1 -vv | grep '^\+' | sed-cmd test
 test "-f" "bar" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.1)
 ### opam repository add plain ./REPO --this-switch
 [plain] Initialised
@@ -24,7 +24,7 @@ opam-version: "2.0"
 build: ["test" "-f" "baz"]
 ### <REPO/packages/foo/foo.2/files/baz>
 some content
-### opam update default -vv | grep '^\+' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)default\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/default.tar.gz -C TMPDIR' | '.*tar(\.exe)?"? "cfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)default\.tar\.gz\.tmp" "-C" ".*" "default"' -> 'tar cfz OPAM/repo/default.tar.gz.tmp -C TMPDIR default' | '.*(/|\\)diff(\.exe)?"? "' -> 'diff "' | '.*(/|\\)patch(\.exe)?"?.*"' -> 'patch'
+### opam update default -vv | grep '^\+' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)default\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/default.tar.gz -C TMPDIR' | '.*tar(\.exe)?"? "cfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)default\.tar\.gz\.tmp" "-C" ".*" "default"' -> 'tar cfz OPAM/repo/default.tar.gz.tmp -C TMPDIR default' | sed-cmd diff | '.*(/|\\)patch(\.exe)?"?.*"' -> 'patch'
 diff "-ruaN" "default" "default.new" (CWD=${BASEDIR}/OPAM/repo)
 patch (CWD=${BASEDIR}/OPAM/repo/default)
 tar cfz OPAM/repo/default.tar.gz.tmp -C TMPDIR default
@@ -33,7 +33,7 @@ default.tar.gz
 lock
 plain
 repos-config
-### opam install foo.2 -vv | grep '^\+' | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)default\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/default.tar.gz -C TMPDIR'
+### opam install foo.2 -vv | grep '^\+' | sed-cmd test | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)default\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/default.tar.gz -C TMPDIR'
 tar xfz OPAM/repo/default.tar.gz -C TMPDIR
 test "-f" "baz" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.2)
 ### opam repository remove default --all
@@ -51,7 +51,7 @@ lock
 plain
 repos-config
 tarred.tar.gz
-### opam install foo.3 -vv | grep '^\+' | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR'
+### opam install foo.3 -vv | grep '^\+' | sed-cmd test | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR'
 tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR
 test "-f" "baz" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.3)
 ### opam repository remove plain --all
@@ -61,12 +61,12 @@ opam-version: "2.0"
 build: ["test" "-f" "baz"]
 ### <REPO/packages/foo/foo.4/files/baz>
 some content
-### opam update -vv | grep '^\+' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR' | '.*tar(\.exe)?"? "cfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz\.tmp" "-C" ".*" "tarred"' -> 'tar cfz OPAM/repo/tarred.tar.gz.tmp -C TMPDIR tarred' | '.*(/|\\)diff(\.exe)?"? "' -> 'diff "' | '.*(/|\\)patch(\.exe)?"?.*"' -> 'patch'
+### opam update -vv | grep '^\+' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR' | '.*tar(\.exe)?"? "cfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz\.tmp" "-C" ".*" "tarred"' -> 'tar cfz OPAM/repo/tarred.tar.gz.tmp -C TMPDIR tarred' | sed-cmd diff | '.*(/|\\)patch(\.exe)?"?.*"' -> 'patch'
 tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR
 diff "-ruaN" "tarred" "tarred.new" (CWD=${OPAMTMP})
 patch (CWD=${OPAMTMP}/tarred)
 tar cfz OPAM/repo/tarred.tar.gz.tmp -C TMPDIR tarred
-### opam install foo.4 -vv | grep '^\+' | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR'
+### opam install foo.4 -vv | grep '^\+' | sed-cmd test | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR'
 tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR
 test "-f" "baz" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.4)
 ### mkdir tarred-ext
@@ -83,11 +83,11 @@ opam-version: "2.0"
 build: ["test" "-f" "quux"]
 ### <REPO/packages/foo/foo.5/files/quux>
 some content
-### opam update -vv | grep '^\+' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR' | '.*(/|\\)diff(\.exe)?"? "' -> 'diff "' | '.*(/|\\)patch(\.exe)?"?.*"' -> 'patch'
+### opam update -vv | grep '^\+' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR' | sed-cmd diff | '.*(/|\\)patch(\.exe)?"?.*"' -> 'patch'
 tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR
 diff "-ruaN" "tarred" "tarred.new" (CWD=${OPAMTMP})
 patch (CWD=${OPAMTMP}/tarred)
-### opam install foo.5 -vv | grep '^\+' | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR'
+### opam install foo.5 -vv | grep '^\+' | sed-cmd test | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR'
 test "-f" "quux" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.5)
 ### ls $OPAMROOT/repo | grep -v "cache"
 lock

--- a/tests/reftests/working-dir.test
+++ b/tests/reftests/working-dir.test
@@ -35,7 +35,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> removed   ongoing.dev
 Done.
-### opam install ongoing -v | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*(/|\\|")cat(\.exe)?"? "' -> 'cat "'
+### opam install ongoing -v | sed-cmd test | sed-cmd cat
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1:
@@ -58,7 +58,7 @@ cat "ongoing.txt" (CWD=${BASEDIR}/OPAM/working-dir/.opam-switch/build/ongoing.de
 -> compiled  ongoing.dev
 -> installed ongoing.dev
 Done.
-### opam install ongoing --working-dir -v | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*(/|\\|")cat(\.exe)?"? "' -> 'cat "'
+### opam install ongoing --working-dir -v | sed-cmd test | sed-cmd cat
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [ongoing.dev: git]
@@ -89,7 +89,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> removed   ongoing.dev
 Done.
-### opam install ongoing -v | grep -v "^#" | '.*(/|\\|")test(\.exe)?"? "' -> 'test "'
+### opam install ongoing -v | grep -v "^#" | sed-cmd test
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1:
@@ -118,7 +118,7 @@ test "-f" "newfile.txt" (CWD=${BASEDIR}/OPAM/working-dir/.opam-switch/build/ongo
 - No changes have been performed
 '${OPAM} install ongoing -v' failed.
 # Return code 31 #
-### opam install ongoing --working-dir -v | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*(/|\\|")cat(\.exe)?"? "' -> 'cat "'
+### opam install ongoing --working-dir -v | sed-cmd test | sed-cmd cat
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [ongoing.dev: git]
@@ -204,7 +204,7 @@ opam-version: "2.0"
 ### <pin:ongoing/ongoing.opam>
 opam-version: "2.0"
 build: [[ "test" "-f" "newfile.txt" ] [ "cat" "newfile.txt" ]]
-### opam install qux ongoing --working-dir -v | '^Processing .+$' -> '\c' | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' | '.*(/|\\|")cat(\.exe)?"? "' -> 'cat "' | grep -v "switch import" | unordered
+### opam install qux ongoing --working-dir -v | '^Processing .+$' -> '\c' | sed-cmd test | sed-cmd cat | grep -v "switch import" | unordered
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 [ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)


### PR DESCRIPTION
Command are resolved in opam, which leads to some full path printing. Add `sed-cmd` command to help this rewrite.

```diff
-### opam install ongoing -v | '.*(/|\\|")test(\.exe)?"? "' -> 'test "' 
+### opam install ongoing -v | sed-cmd test
```