### PR TITLE
Reftests: handle cygwin paths

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -405,6 +405,8 @@ users)
   * Update sed-cmd to handle commands without any arguments [#5257 @kit-ty-kate]
   * Make the binary name of opam the same accross platforms (used when testing invalid commands) [#5308 @kit-ty-kate]
   * Handle cygpaths for opamp binary path [#5308 @rjbou]
+  * Handle path replacement without cygwin prefix [#5286 @rjbou]
+  * Handle path replacement for cygwin and windows paths style [#5286 @rjbou]
 
 ## Github Actions
   * Add solver backends compile test [#4723 @rjbou] [2.1.0~rc2 #4720]

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -24,17 +24,17 @@ opam-version: "2.0"
 build: ["test" "-f" "baz"]
 ### <REPO/packages/foo/foo.2/files/baz>
 some content
-### opam update default -vv | grep '^\+' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)default\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/default.tar.gz -C TMPDIR' | '.*tar(\.exe)?"? "cfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)default\.tar\.gz\.tmp" "-C" ".*" "default"' -> 'tar cfz OPAM/repo/default.tar.gz.tmp -C TMPDIR default' | sed-cmd diff | '.*(/|\\)patch(\.exe)?"?.*"' -> 'patch'
+### opam update default -vv | grep '^\+' |  sed-cmd diff | sed-cmd patch | "patch-.*" -> "patchfile" | sed-cmd tar
 diff "-ruaN" "default" "default.new" (CWD=${BASEDIR}/OPAM/repo)
-patch (CWD=${BASEDIR}/OPAM/repo/default)
-tar cfz OPAM/repo/default.tar.gz.tmp -C TMPDIR default
+patch "-p1" "-i" "${BASEDIR}/OPAM/log/patchfile
+tar "cfz" "${BASEDIR}/OPAM/repo/default.tar.gz.tmp" "-C" "${BASEDIR}/OPAM/repo" "default"
 ### ls $OPAMROOT/repo | grep -v "cache"
 default.tar.gz
 lock
 plain
 repos-config
-### opam install foo.2 -vv | grep '^\+' | sed-cmd test | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)default\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/default.tar.gz -C TMPDIR'
-tar xfz OPAM/repo/default.tar.gz -C TMPDIR
+### opam install foo.2 -vv | grep '^\+' | sed-cmd tar | sed-cmd test
+tar "xfz" "${BASEDIR}/OPAM/repo/default.tar.gz" "-C" "${OPAMTMP}"
 test "-f" "baz" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.2)
 ### opam repository remove default --all
 ### : Add tarred repo (tarred)
@@ -51,8 +51,8 @@ lock
 plain
 repos-config
 tarred.tar.gz
-### opam install foo.3 -vv | grep '^\+' | sed-cmd test | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR'
-tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR
+### opam install foo.3 -vv | grep '^\+' | sed-cmd tar | sed-cmd test
+tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
 test "-f" "baz" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.3)
 ### opam repository remove plain --all
 ### : Update tarred repo (tarred)
@@ -61,13 +61,13 @@ opam-version: "2.0"
 build: ["test" "-f" "baz"]
 ### <REPO/packages/foo/foo.4/files/baz>
 some content
-### opam update -vv | grep '^\+' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR' | '.*tar(\.exe)?"? "cfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz\.tmp" "-C" ".*" "tarred"' -> 'tar cfz OPAM/repo/tarred.tar.gz.tmp -C TMPDIR tarred' | sed-cmd diff | '.*(/|\\)patch(\.exe)?"?.*"' -> 'patch'
-tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR
+### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd patch | 'patch-.*"' -> 'patchfile"'
+tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
 diff "-ruaN" "tarred" "tarred.new" (CWD=${OPAMTMP})
-patch (CWD=${OPAMTMP}/tarred)
-tar cfz OPAM/repo/tarred.tar.gz.tmp -C TMPDIR tarred
-### opam install foo.4 -vv | grep '^\+' | sed-cmd test | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR'
-tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR
+patch "-p1" "-i" "${BASEDIR}/OPAM/log/patchfile" (CWD=${OPAMTMP}/tarred)
+tar "cfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz.tmp" "-C" "${OPAMTMP}" "tarred"
+### opam install foo.4 -vv | grep '^\+'  | sed-cmd tar | sed-cmd test
+tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
 test "-f" "baz" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.4)
 ### mkdir tarred-ext
 ### tar xf OPAM/repo/tarred.tar.gz
@@ -83,11 +83,11 @@ opam-version: "2.0"
 build: ["test" "-f" "quux"]
 ### <REPO/packages/foo/foo.5/files/quux>
 some content
-### opam update -vv | grep '^\+' | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR' | sed-cmd diff | '.*(/|\\)patch(\.exe)?"?.*"' -> 'patch'
-tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR
+### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd patch | "patch-.*" -> "patchfile"
+tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
 diff "-ruaN" "tarred" "tarred.new" (CWD=${OPAMTMP})
-patch (CWD=${OPAMTMP}/tarred)
-### opam install foo.5 -vv | grep '^\+' | sed-cmd test | '.*tar(\.exe)?"? "xfz" ".*(/|\\)OPAM(/|\\)repo(/|\\)tarred\.tar\.gz" "-C" ".*"' -> 'tar xfz OPAM/repo/tarred.tar.gz -C TMPDIR'
+patch "-p1" "-i" "${BASEDIR}/OPAM/log/patchfile
+### opam install foo.5 -vv | grep '^\+' | sed-cmd test
 test "-f" "quux" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.5)
 ### ls $OPAMROOT/repo | grep -v "cache"
 lock

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -487,7 +487,7 @@ let common_filters =
       (fun _ -> None), (fun _ -> None)
     else
     let get_path opt path =
-      cygpath ~f:(fun x -> not (String.equal x path)) [ opt ; String.escaped path ]
+      cygpath ~f:(fun x -> not (String.equal x path)) [ opt ; "--"; String.escaped path ]
     in
     get_path "-u", get_path "-w"
   in


### PR DESCRIPTION
Some windows paths were not prefixed with cygwin path, and then not catch by path regexp.
Also, for some tests we get `PATH` from environment that is in cygwin style while `Sys.getcwd` gives the windows style one. Add in `BASEDIR` regexp both style.