### PR TITLE
Remove src/client/no-git-version when calling make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ clean-ext:
 clean:
 	$(MAKE) -C doc $@
 	rm -f *.install *.env *.err *.info *.out opam$(EXE) opam-admin.top$(EXE) opam-installer$(EXE)
+	rm -f src/client/no-git-version
 	rm -rf _build Opam.Runtime.*
 
 distclean: clean clean-ext

--- a/master_changes.md
+++ b/master_changes.md
@@ -218,6 +218,7 @@ users)
   * Upgrade to cmdliner >= 1.1 [#5269 @kit-ty-kate]
   * Cleared explanation of dependency vendoring in configure [#5277 @dra27 - fix #5271]
   * Switch autoconf required version to 2.71 [#5161 @dra27]
+  * Remove src/client/no-git-version when calling make clean [#5290 @kit-ty-kate]
 
 ## Infrastructure
   * Fix caching of Cygwin compiler on AppVeyor [#4988 @dra27]


### PR DESCRIPTION
We might also want to remove this file entirely and replace it by an environment variable to make our life easier