### PR TITLE
Fix mangling of `PATH` during cygvoke

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -301,6 +301,7 @@ users)
   * Permissions: chmod+unlink before copy [#4827 @jonahbeckford @dra27]
   * Support MSYS2: two-phase rsync on MSYS2 to allow MSYS2's behavior of copying rather than symlinking [#4817 @jonahbeckford]
   * Environment: translate PATH from Windows to Unix during opam env. [#4844 @jonahbeckford]
+  * Correct invocation of Cygwin binaries when Cygwin bin directory is first in PATH [#5293 @dra27]
 
 ## Test
   * Update crowbar with compare functions [#4918 @rjbou]

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -153,7 +153,7 @@ let cygwin_create_process_env prog args env fd1 fd2 fd3 =
         end else
           Some (key ^ "=" ^ String.concat " " settings)
     | "path" ->
-        let path_dirs = OpamStd.Sys.split_path_variable item in
+        let path_dirs = OpamStd.Sys.split_path_variable value in
         let winsys = Filename.concat (OpamStd.Sys.system ()) "." |> String.lowercase_ascii in
         let rec f prefix suffix = function
         | dir::dirs ->
@@ -175,7 +175,7 @@ let cygwin_create_process_env prog args env fd1 fd2 fd3 =
         | [] ->
             assert false
         in
-        Some (String.concat ";" (f [] [] path_dirs))
+        Some (key ^ "=" ^ String.concat ";" (f [] [] path_dirs))
     | _ ->
         Some item in
   let env = OpamStd.List.filter_map f env in


### PR DESCRIPTION
When calling Cygwin binaries, the process invocation manipulates `PATH` to ensure that Cygwin's `bin` directory appears before the Windows `system32` directory to ensure that Cygwin binaries don't unexpectedly start using Window's BSD executables (a normal Cygwin shell avoids this by forcibly putting `/usr/bin` at the beginning of `PATH`).

Unfortunately, I made a slight mistake with the first entry - it's an environment block string, so the first entry is `PATH=<dir>` and the `PATH=` part wasn't split off.

This PR corrects that; therapy will deal with the fact that I discovered this quite old bug the night before a demo...