### PR TITLE
Fix behaviour of menu and depexts in non-interactive environments

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -24,6 +24,7 @@ users)
   * Error report display: print action name [#5045 @AltGr]
   * Refactored depext-related questions, with a flat menu instead of nested y/n questions [#5053 @AltGr - fix #5026]
     * Fix removal of interactive special characters is output is not tty [#5155 @rjbou]
+    * Fix behaviour of menu and depexts in non-interactive environments [#5295 @AltGr]
   * [BUG] Fix default cli handling for simple flags [#5099 @rjbou]
   * Add `experimental` flags handling [#5099 @rjbou]
   * [BUG] Fix `OPAMCURL` and `OPAMFETCH` value setting [#5111 @rjbou - fix #5108]
@@ -167,11 +168,9 @@ users)
   * Fallback on dnf if yum does not exist on RHEL-based systems [#4825 @kit-ty-kate]
   * Stop zypper from upgrading packages on updates on OpenSUSE [#4978 @kit-ty-kate]
   * Increase verbose logging of command to 4 [#5151 @rjbou]
-  * [BUG] Avoid to loop eternally when `depext-runs-installs` is false in a script [#5156 @rjbou]
   * Improve the error message when neither MacPorts or Homebrew could be detected on macOS [#5240 @kit-ty-kate]
   * Introduce dummy-success & dummy-failure os-family to make testing depexts behaviour easier [#5268 @kit-ty-kate]
   * Run command as admin only when needed [#5268 @kit-ty-kate]
-  * [BUG] Do not infinitly check for depexts when the system package manager fails [#5257 @kit-ty-kate]
 
 ## Format upgrade
   * Fix format upgrade when there is missing local switches in the config file [#4763 @rjbou - fix #4713] [2.1.0~rc2 #4715]
@@ -536,7 +535,6 @@ users)
   * `OpamStd.Config.E`: add `value_t` to allow getting environment variable value dynamically [#5111 @rjbou]
   * `OpamCompat.Unix`: add `realpath` for ocaml < 4.13, and use it in `OpamSystem` [#5152 @rjbou]
   * `OpamCompat`: add `Lazy` module and `Lazy.map` function [#5176 @dra27]
-  * `OpamConsole.menu`: add `noninteractive` option to choose a different default when output is not a tty [#5156 @rjbou]
   * `OpamStd.Sys`: add `all_shells` list of all supported shells [#5217 @dra27]
   * `OpamUrl`: add `to_string_w_subpath` to display subpath inside urls (before hash) [#5219 @rjbou]
   * `OpamFilename.SubPath`: remove `pretty_string` in favor to `OpamUrl.to_string_w_subpath` [#5219 @rjbou]

--- a/src/core/opamConsole.mli
+++ b/src/core/opamConsole.mli
@@ -132,10 +132,9 @@ val confirm:
     options are set.
     [no] is the option to choose otherwise, when non interactive, on [escape].
     [default] is the option to choose on an active empty input ("\n").
-    [noninteractive] is the default in non tty output.
     Max 9 options. *)
 val menu:
-  ?default:'a -> ?noninteractive:'a -> ?unsafe_yes:'a -> ?yes:'a -> no:'a ->
+  ?default:'a -> ?unsafe_yes:'a -> ?yes:'a -> no:'a ->
   options:('a * string) list ->
   ('b, unit, string, 'a) format4 -> 'b
 

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -841,7 +841,7 @@ let setup
         match
           OpamConsole.menu "Do you want opam to configure %s?"
             (OpamConsole.colorise `bold (string_of_shell shell))
-            ~default ~noninteractive:`No ~no:`No ~options:[
+            ~default ~no:`No ~options:[
               `Yes, Printf.sprintf "Yes, update %s"
                 (OpamConsole.colorise `cyan (OpamFilename.prettify dot_profile));
               `No_hooks, Printf.sprintf "Yes, but don't setup any hooks. You'll \

--- a/tests/reftests/depexts.test
+++ b/tests/reftests/depexts.test
@@ -2,7 +2,7 @@ N0REP0
 ### <pkg:a.1>
 opam-version: "2.0"
 depexts: "depext-1"
-### OPAMNODEPEXTS=0
+### OPAMNODEPEXTS=0 OPAMCONFIRMLEVEL=unsafe-yes
 ### opam var --global os-family=dummy-failure
 Added '[os-family "dummy-failure" "Set through 'opam var'"]' to field global-variables in global configuration
 ### opam switch create test --empty
@@ -28,16 +28,7 @@ opam believes some required external dependencies are missing. opam can:
 false 
 [ERROR] System package install failed with exit code 1 at command:
             false
-This command should get the requirements installed:
-
-    false
-
-Would you like opam to:
-  1. Check again, as the package is now installed
-  2. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
-> 3. Abort the installation
-
-[1/2/3] 3
+[ERROR] These packages are still missing: depext-1
 
 [NOTE] You can retry with '--assume-depexts' to skip this check, or run 'opam option depext=false' to permanently disable handling of system packages.
 

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -75,7 +75,7 @@ The following actions will be performed:
 -> installed nip.dev
 Done.
 ### : depext update :
-### OPAMNODEPEXTS=0
+### OPAMNODEPEXTS=0 OPAMCONFIRMLEVEL=unsafe-yes
 ### opam var --global os-family=dummy-success
 Added '[os-family "dummy-success" "Set through 'opam var'"]' to field global-variables in global configuration
 ### <pin:bar/bar.opam>


### PR DESCRIPTION
The rationale is now to assume the "no" case in the menus whenever there is no input to read from.