### PR TITLE
Make the plugin lookup faster when mistyping a subcommand

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -33,6 +33,7 @@ users)
   * Do not show --yes and --no as special global options when using cmdliner >= 1.1 [#5269 @kit-ty-kate]
   * ◈ Add `tree` subcommand to display a dependency tree of currently installed packages [#5171 @cannorin - fix #3775]
   * ◈ Add `why` subcommand to examine how the versions of currently installed packages get constrained (alias to `tree --rev-deps`) [#5171 @cannorin - fix #3775]
+  * Make the plugin lookup faster when mistyping a subcommand [#5297 @kit-ty-kate]
 
 ## Plugins
   *

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -234,7 +234,7 @@ let check_and_run_external_commands () =
         let prefixed_name = OpamPath.plugin_prefix ^ name in
         let candidates =
           OpamPackage.packages_of_names
-            (Lazy.force st.available_packages)
+            st.packages
             (OpamPackage.Name.Set.of_list @@
              (OpamStd.List.filter_map
                 (fun s ->
@@ -246,6 +246,12 @@ let check_and_run_external_commands () =
           OpamPackage.Set.filter (fun nv ->
               OpamFile.OPAM.has_flag Pkgflag_Plugin (OpamSwitchState.opam st nv))
             candidates
+        in
+        let plugins =
+          if OpamPackage.Set.is_empty plugins then
+            plugins
+          else
+            OpamPackage.Set.inter plugins (Lazy.force st.available_packages)
         in
         let installed = OpamPackage.Set.inter plugins st.installed in
         if OpamPackage.Set.is_empty candidates then (cli, argv)

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -248,6 +248,8 @@ let check_and_run_external_commands () =
             candidates
         in
         let plugins =
+          (* NOTE: Delay the availablity check as late as possible for performance reasons *)
+          (* See https://github.com/ocaml/opam/issues/5296 *)
           if OpamPackage.Set.is_empty plugins then
             plugins
           else


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/5296

Before this patch, typing `opam upgrde` would take: 1.6s
After this patch, it only takes: 0.2s