### PR TITLE
Args: externalise some package selections flags

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -452,6 +452,7 @@ users)
   * `OpamArg`: all flag definition takes now a section as an optional argument, default is set to `Manpage.s_options` [#5275 @rjbou]
   * Add `OpamTreeCommand` [#5171 @cannorin]
   * `OpamSolution`: add `dry_run` to simulate the new switch state after applying a solution [#5171 @cannorin]
+  * `OpamArg`: externalise `post`, `dev`, `doc_flag`, `test`, and `devsetup` package selection flags, to avoid redefining them [#5299 @rjbou]
 
 ## opam-repository
   * `OpamRepositoryConfig`: add in config record `repo_tarring` field and as an argument to config functions, and a new constructor `REPOSITORYTARRING` in `E` environment module and its access function [#5015 @rjbou]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1494,6 +1494,26 @@ let subpath ?section cli =
 
 let package_selection_section = "PACKAGE SELECTION OPTIONS"
 
+let post ?(section=package_selection_section) cli =
+  mk_flag ~cli cli_original ["post"]  ~section
+    "Include dependencies tagged as $(i,post)."
+
+let dev ?(section=package_selection_section) cli =
+  mk_flag ~cli cli_original ["dev"]  ~section
+    "Include development packages in dependencies."
+
+let doc_flag ?(section=package_selection_section) cli =
+  mk_flag ~cli cli_original ["doc";"with-doc"] ~section
+    "Include doc-only dependencies."
+
+let test ?(section=package_selection_section) cli =
+  mk_flag ~cli cli_original ["t";"test";"with-test"] ~section
+    "Include test-only dependencies."
+
+let dev_setup ?(section=package_selection_section) cli =
+  mk_flag ~cli (cli_from cli2_2) ["with-dev-setup"] ~section
+    "Include developer only dependencies."
+
 let package_selection cli =
   let section = package_selection_section in
   let depends_on =
@@ -1545,26 +1565,6 @@ let package_selection cli =
   let nobuild =
     mk_flag ~cli cli_original ["nobuild"]  ~section
       "Exclude build dependencies (they are included by default)."
-  in
-  let post =
-    mk_flag ~cli cli_original ["post"]  ~section
-      "Include dependencies tagged as $(i,post)."
-  in
-  let dev =
-    mk_flag ~cli cli_original ["dev"]  ~section
-      "Include development packages in dependencies."
-  in
-  let doc_flag =
-    mk_flag ~cli cli_original ["doc";"with-doc"] ~section
-      "Include doc-only dependencies."
-  in
-  let test =
-    mk_flag ~cli cli_original ["t";"test";"with-test"] ~section
-      "Include test-only dependencies."
-  in
-  let dev_setup =
-    mk_flag ~cli (cli_from cli2_2) ["with-dev-setup"] ~section
-      "Include developer only dependencies."
   in
   let field_match =
     mk_opt_all ~cli cli_original ["field-match"] "FIELD:PATTERN" ~section
@@ -1628,8 +1628,9 @@ let package_selection cli =
   in
   Term.(const filter $
         depends_on $ required_by $ conflicts_with $ coinstallable_with $
-        resolve $ recursive $ depopts $ nobuild $ post $ dev $ doc_flag $
-        test $ dev_setup $ field_match $ has_flag $ has_tag)
+        resolve $ recursive $ depopts $ nobuild $ post cli $ dev cli $
+        doc_flag cli $ test cli $ dev_setup cli $ field_match $ has_flag $
+        has_tag)
 
 let package_listing_section = "OUTPUT FORMAT OPTIONS"
 

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -212,6 +212,13 @@ val lock_suffix: ?section:string -> OpamCLIVersion.Sourced.t -> string Term.t
 (** Man section name *)
 val package_selection_section: string
 
+(** Some package selection flags. Default section is âckage seletion one *)
+val post: ?section:string -> OpamCLIVersion.Sourced.t -> bool Term.t
+val dev: ?section:string -> OpamCLIVersion.Sourced.t -> bool Term.t
+val doc_flag: ?section:string -> OpamCLIVersion.Sourced.t -> bool Term.t
+val test: ?section:string -> OpamCLIVersion.Sourced.t -> bool Term.t
+val dev_setup: ?section:string -> OpamCLIVersion.Sourced.t -> bool Term.t
+
 (** Build a package selection filter *)
 val package_selection: OpamCLIVersion.Sourced.t -> OpamListCommand.selector list Term.t
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -769,27 +769,6 @@ let tree ?(why=false) cli =
       "Display only the branches which leads to one of the $(i,PACKAGES).";
     ]
   in
-  let post =
-    mk_flag ~cli (cli_from cli2_2) ["post"] ~section:selection_docs
-      "Include dependencies tagged as $(i,post)."
-  in
-  let dev =
-    mk_flag ~cli (cli_from cli2_2) ["dev"] ~section:selection_docs
-      "Include development packages in dependencies."
-  in
-  let doc_flag =
-    mk_flag ~cli (cli_from cli2_2) ["doc";"with-doc"] ~section:selection_docs
-      "Include doc-only dependencies."
-  in
-  let test =
-    mk_flag ~cli (cli_from cli2_2) ["t";"test";"with-test"]
-      ~section:selection_docs
-      "Include test-only dependencies."
-  in
-  let dev_setup =
-    mk_flag ~cli (cli_from cli2_2) ["with-dev-setup"] ~section:selection_docs
-      "Include developper only dependencies."
-  in
   let no_cstr =
     mk_flag ~cli (cli_from cli2_2) ["no-constraint"] ~section:display_docs
       "Do not display the version constraints e.g. $(i,(>= 1.0.0))."
@@ -819,7 +798,7 @@ let tree ?(why=false) cli =
   in
   mk_command_ret ~cli (cli_from cli2_2) "tree" ~doc ~man
     Term.(const tree $global_options cli $mode $filter
-          $post $dev $doc_flag $test $dev_setup
+          $post cli $dev cli $doc_flag cli $test cli $dev_setup cli
           $no_cstr $no_switch
           $name_list)
 


### PR DESCRIPTION
And use the in `OpamCommands` instead of redefining them