### PR TITLE
More clear message for pinned package update that have local changes

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -114,6 +114,7 @@ users)
 
 ## Update / Upgrade
   * [BUG] if a package is pinned from a locked file, it is automatically updated/upgraded accordingly a lock file (same extension) [#5080 @rjbou]
+  * More clear message for pinned package update that have local changes, with no working dir given, or no arguments specified [#5300 @rjbou - fix #5294]
 
 ## Exec
   * [NEW] Add `opam exec --no-switch` [#4957 @kit-ty-kate - fix #4951]

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -273,7 +273,8 @@ let pinned_package st ?version ?(autolock=false) ?(working_dir=false) name =
          OpamRepository.is_dirty ?subpath url
          @@| function false -> () | true ->
            OpamConsole.note
-             "Ignoring uncommitted changes in %s%s (`--working-dir' not active)."
+             "Ignoring uncommitted changes in %s%s \
+              (`--working-dir' not specified or specified with no argument)."
              url.OpamUrl.path
              (OpamStd.Option.to_string (fun sp ->
                   Filename.dir_sep ^ OpamFilename.SubPath.to_string sp) subpath))

--- a/tests/reftests/assume-built.test
+++ b/tests/reftests/assume-built.test
@@ -21,7 +21,7 @@ ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1:
-[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not active).
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not specified or specified with no argument).
 Processing  1/1: [ongoing.dev: git]
 [ongoing.dev] synchronised (no changes)
 
@@ -55,7 +55,7 @@ Done.
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1:
-[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not active).
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not specified or specified with no argument).
 Processing  1/1: [ongoing.dev: git]
 [ongoing.dev] synchronised (no changes)
 
@@ -85,7 +85,7 @@ test "-f" "out" (CWD=${BASEDIR}/ongoing)
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1:
-[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not active).
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not specified or specified with no argument).
 Processing  1/1: [ongoing.dev: git]
 [ongoing.dev] synchronised (no changes)
 
@@ -118,7 +118,7 @@ Done.
 ### opam install ongoing qux --assume-built
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
-[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not active).
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not specified or specified with no argument).
 [ongoing.dev] synchronised (no changes)
 
 [WARNING] Package qux is not pinned locally and assume built option is set, skipping

--- a/tests/reftests/inplace.test
+++ b/tests/reftests/inplace.test
@@ -20,7 +20,7 @@ ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1:
-[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not active).
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not specified or specified with no argument).
 Processing  1/1: [ongoing.dev: git]
 [ongoing.dev] synchronised (no changes)
 

--- a/tests/reftests/lock.test
+++ b/tests/reftests/lock.test
@@ -581,7 +581,7 @@ The following actions would be performed:
   - install tolock 1 (pinned)
 ### opam install ./tolock --locked
 tolock is now pinned to git+file://${BASEDIR}/tolock#master (version 1)
-[NOTE] Ignoring uncommitted changes in ${BASEDIR}/tolock (`--working-dir' not active).
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/tolock (`--working-dir' not specified or specified with no argument).
 [tolock.1] synchronised (no changes)
 The following actions will be performed:
 === install 4 packages
@@ -641,7 +641,7 @@ The following actions would be performed:
   - install tolock 1 (pinned)
 ### opam install ./tolock --locked
 tolock is now pinned to git+file://${BASEDIR}/tolock#master (version 1)
-[NOTE] Ignoring uncommitted changes in ${BASEDIR}/tolock (`--working-dir' not active).
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/tolock (`--working-dir' not specified or specified with no argument).
 [tolock.1] synchronised (no changes)
 The following actions will be performed:
 === install 4 packages

--- a/tests/reftests/update-upgrade.test
+++ b/tests/reftests/update-upgrade.test
@@ -421,3 +421,88 @@ The following actions will be performed:
 -> installed quux.dev5
 -> installed s-foo.7
 Done.
+### : with working-dir :
+### <pin:ongoing/ongoing.opam>
+opam-version: "2.0"
+build: [[ "test" "-f" "ongoing.txt" ] [ "cat" "ongoing.txt" ]]
+### <ongoing/ongoing.txt>
+versionned
+### git -C ./ongoing init -q --initial-branch=master
+### git -C ./ongoing config core.autocrlf false
+### git -C ./ongoing add -A
+### git -C ./ongoing commit -qm "init"
+### opam pin ./ongoing
+Package ongoing does not exist, create as a NEW package? [y/n] y
+ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
+
+The following actions will be performed:
+=== install 1 package
+  - install ongoing dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved ongoing.dev  (no changes)
+-> installed ongoing.dev
+Done.
+### <ongoing/newfile.txt>
+new!
+### <pin:ongoing/ongoing.opam>
+opam-version: "2.0"
+build: [[ "test" "-f" "newfile.txt" ] [ "cat" "newfile.txt" ]]
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[second] no changes from file://${BASEDIR}/REPO2
+[default] no changes from file://${BASEDIR}/REPO
+
+<><> Synchronising development packages <><><><><><><><><><><><><><><><><><><><>
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not active).
+[ongoing.dev] synchronised (no changes)
+[quux.dev5] synchronised (no changes)
+### opam update --working-dir
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[second] no changes from file://${BASEDIR}/REPO2
+[default] no changes from file://${BASEDIR}/REPO
+
+<><> Synchronising development packages <><><><><><><><><><><><><><><><><><><><>
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not active).
+[ongoing.dev] synchronised (no changes)
+[quux.dev5] synchronised (no changes)
+### opam update --working-dir ongoing
+
+<><> Synchronising development packages <><><><><><><><><><><><><><><><><><><><>
+[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)
+[ongoing] Installing new package description from upstream git+file://${BASEDIR}/ongoing#master
+Now run 'opam upgrade' to apply any package updates.
+### opam upgrade --working-dir
+The following actions will be performed:
+=== recompile 1 package
+  - recompile ongoing dev (pinned) [upstream or system changes]
+[NOTE] --working-dir is given but no requested package is pinned
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved ongoing.dev  (git+file://${BASEDIR}/ongoing#master)
+[ERROR] The compilation of ongoing.dev failed at "test -f newfile.txt".
+
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - build ongoing dev
++- 
+- No changes have been performed
+# Return code 31 #
+### opam upgrade --working-dir ongoing
+
+<><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
+[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)
+
+The following actions will be performed:
+=== recompile 1 package
+  - recompile ongoing dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   ongoing.dev
+-> installed ongoing.dev
+Done.

--- a/tests/reftests/update-upgrade.test
+++ b/tests/reftests/update-upgrade.test
@@ -455,7 +455,7 @@ build: [[ "test" "-f" "newfile.txt" ] [ "cat" "newfile.txt" ]]
 [default] no changes from file://${BASEDIR}/REPO
 
 <><> Synchronising development packages <><><><><><><><><><><><><><><><><><><><>
-[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not active).
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not specified or specified with no argument).
 [ongoing.dev] synchronised (no changes)
 [quux.dev5] synchronised (no changes)
 ### opam update --working-dir
@@ -465,7 +465,7 @@ build: [[ "test" "-f" "newfile.txt" ] [ "cat" "newfile.txt" ]]
 [default] no changes from file://${BASEDIR}/REPO
 
 <><> Synchronising development packages <><><><><><><><><><><><><><><><><><><><>
-[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not active).
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not specified or specified with no argument).
 [ongoing.dev] synchronised (no changes)
 [quux.dev5] synchronised (no changes)
 ### opam update --working-dir ongoing

--- a/tests/reftests/working-dir.test
+++ b/tests/reftests/working-dir.test
@@ -39,7 +39,7 @@ Done.
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1:
-[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not active).
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not specified or specified with no argument).
 Processing  1/1: [ongoing.dev: git]
 [ongoing.dev] synchronised (no changes)
 
@@ -93,7 +93,7 @@ Done.
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1:
-[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not active).
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/ongoing (`--working-dir' not specified or specified with no argument).
 Processing  1/1: [ongoing.dev: git]
 [ongoing.dev] synchronised (no changes)
 


### PR DESCRIPTION
When no working dir given, or no arguments specified 
fix #5294 
