### PR TITLE
Support --json option in opam tree

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -33,6 +33,7 @@ users)
   * Use menu for init setup [#5057 @AltGr; #5217 @dra27]
   * Do not show --yes and --no as special global options when using cmdliner >= 1.1 [#5269 @kit-ty-kate]
   * ◈ Add `tree` subcommand to display a dependency tree of currently installed packages [#5171 @cannorin - fix #3775]
+  * ◈ `tree` subcommand now supports `--json` option [#5303 @cannorin - fix #5298]
   * ◈ Add `why` subcommand to examine how the versions of currently installed packages get constrained (alias to `tree --rev-deps`) [#5171 @cannorin - fix #3775]
   * Make the plugin lookup faster when mistyping a subcommand [#5297 @kit-ty-kate]
 
@@ -363,6 +364,7 @@ users)
     * to escape `OPAMROOTVERSION` sed, it matches generated hexa temporary directory names [#5007 @AltGr #5301 @rjbou]
     * several improvments: add repo config check, update generator [#5303 @rjbou]
   * Add json output test [#5143 @rjbou]
+    * Add tree json output [#5303 @cannorin @rjbou]
   * Add test for opam file write with format preserved bug in #4936, fixed in #4941 [#4159 @rjbou]
   * Add test for switch upgrade from 2.0 root, with pinned compiler [#5176 @rjbou @kit-ty-kate]
   * Add switch import (for pinned packages) test [#5181 @rjbou]
@@ -589,3 +591,4 @@ users)
   * `OpamStd.Map`: add `filter_map` [#5337 @rjbou]
   * `OpamStd.Set`: Add `to_list_map` [#5308 @kit-ty-kate]
   * `OpamConsole.header_msg`: remove trailing space when there is no left padding [#5363 @rjbou]
+  * `OpamConsole.Tree`: add `valu` and `children` getters [#5303 @cannorin]

--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -1028,6 +1028,9 @@ module Tree = struct
     children: 'elt t list
   }
 
+  let value { value; _ } = value
+  let children { children; _ } = children
+
   let create ?(children=[]) value = { value; children }
 
   type symbols = {

--- a/src/core/opamConsole.mli
+++ b/src/core/opamConsole.mli
@@ -152,6 +152,9 @@ val print_table:
 module Tree : sig
   type 'elt t
 
+  val value: 'elt t -> 'elt
+  val children: 'elt t -> 'elt t list
+
   (** Creates a tree node. *)
   val create: ?children:'a t list -> 'a -> 'a t
 

--- a/tests/reftests/json.unix.test
+++ b/tests/reftests/json.unix.test
@@ -730,3 +730,576 @@ Done.
     }
   ]
 }
+### : tree :
+### opam switch create tree --empty
+### opam tree --json=out.json
+[ERROR] No package is installed
+# Return code 5 #
+### json-cat out.json
+{
+  "opam-version": "currentv",
+  "command-line": [
+    "${OPAM}",
+    "tree",
+    "--json=out.json"
+  ]
+}
+### <pkg:a.1>
+opam-version: "2.0"
+### <pkg:b.1>
+opam-version: "2.0"
+depends: "a"
+### <pkg:c.1>
+opam-version: "2.0"
+depends: "b"
+### <pkg:d.1>
+opam-version: "2.0"
+### <pkg:c-build.1>
+opam-version: "2.0"
+### <pkg:c.1>
+opam-version: "2.0"
+depends: [ "b" "a" "c-build" {build} ]
+### <pkg:e.1>
+opam-version: "2.0"
+depends: [ "a" "d" {<"2" & with-test}  "b" {post} ]
+### <pkg:f.1>
+opam-version: "2.0"
+depends: [ "b" {<"2"} ]
+### <pkg:g.1>
+opam-version: "2.0"
+depends: [ "b" {>="1" & <"3"} ]
+### <pkg:h.1>
+opam-version: "2.0"
+depends: [ "f" "g" ]
+### <pkg:i.1>
+opam-version: "2.0"
+depends: [
+  "b" {
+    <"3"
+    & (!with-test | <  "2")
+    & (!with-doc  | >= "1")
+  }
+]
+### <pkg:j.1>
+opam-version: "2.0"
+depends: [ "a" "k" {with-test} ]
+### <pkg:k.1>
+opam-version: "2.0"
+### opam tree a b c d e f g h i j --json=out.json
+The following actions are simulated:
+=== install 11 packages
+  - install a       1
+  - install b       1
+  - install c       1
+  - install c-build 1 [required by c]
+  - install d       1
+  - install e       1
+  - install f       1
+  - install g       1
+  - install h       1
+  - install i       1
+  - install j       1
+
+a.1
+
+b.1
+'-- a.1 [*]
+
+c.1
+|-- a.1 [*]
+|-- b.1 [*]
+'-- c-build.1 (build)
+
+d.1
+
+e.1
+'-- a.1 [*]
+
+f.1
+'-- b.1 (< 2) [*]
+
+g.1
+'-- b.1 (>= 1 & < 3) [*]
+
+h.1
+|-- f.1 [*]
+'-- g.1 [*]
+
+i.1
+'-- b.1 (< 3) [*]
+
+j.1
+'-- a.1 [*]
+### json-cat out.json
+{
+  "opam-version": "currentv",
+  "command-line": [
+    "${OPAM}",
+    "tree",
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+    "h",
+    "i",
+    "j",
+    "--json=out.json"
+  ],
+  "switch": "tree",
+  "tree": [
+    {
+      "name": "a",
+      "version": "1",
+      "dependencies": []
+    },
+    {
+      "name": "b",
+      "version": "1",
+      "dependencies": [
+        {
+          "name": "a",
+          "version": "1",
+          "satisfies": null,
+          "is_duplicate": true,
+          "dependencies": []
+        }
+      ]
+    },
+    {
+      "name": "c",
+      "version": "1",
+      "dependencies": [
+        {
+          "name": "a",
+          "version": "1",
+          "satisfies": null,
+          "is_duplicate": true,
+          "dependencies": []
+        },
+        {
+          "name": "b",
+          "version": "1",
+          "satisfies": null,
+          "is_duplicate": true,
+          "dependencies": []
+        },
+        {
+          "name": "c-build",
+          "version": "1",
+          "satisfies": "(build)",
+          "is_duplicate": false,
+          "dependencies": []
+        }
+      ]
+    },
+    {
+      "name": "d",
+      "version": "1",
+      "dependencies": []
+    },
+    {
+      "name": "e",
+      "version": "1",
+      "dependencies": [
+        {
+          "name": "a",
+          "version": "1",
+          "satisfies": null,
+          "is_duplicate": true,
+          "dependencies": []
+        }
+      ]
+    },
+    {
+      "name": "f",
+      "version": "1",
+      "dependencies": [
+        {
+          "name": "b",
+          "version": "1",
+          "satisfies": "(< 2)",
+          "is_duplicate": true,
+          "dependencies": []
+        }
+      ]
+    },
+    {
+      "name": "g",
+      "version": "1",
+      "dependencies": [
+        {
+          "name": "b",
+          "version": "1",
+          "satisfies": "(>= 1 & < 3)",
+          "is_duplicate": true,
+          "dependencies": []
+        }
+      ]
+    },
+    {
+      "name": "h",
+      "version": "1",
+      "dependencies": [
+        {
+          "name": "f",
+          "version": "1",
+          "satisfies": null,
+          "is_duplicate": true,
+          "dependencies": []
+        },
+        {
+          "name": "g",
+          "version": "1",
+          "satisfies": null,
+          "is_duplicate": true,
+          "dependencies": []
+        }
+      ]
+    },
+    {
+      "name": "i",
+      "version": "1",
+      "dependencies": [
+        {
+          "name": "b",
+          "version": "1",
+          "satisfies": "(< 3)",
+          "is_duplicate": true,
+          "dependencies": []
+        }
+      ]
+    },
+    {
+      "name": "j",
+      "version": "1",
+      "dependencies": [
+        {
+          "name": "a",
+          "version": "1",
+          "satisfies": null,
+          "is_duplicate": true,
+          "dependencies": []
+        }
+      ]
+    }
+  ]
+}
+### opam install a b c d e f j h i j --json=out.json
+The following actions will be performed:
+=== install 11 packages
+  - install a       1
+  - install b       1
+  - install c       1
+  - install c-build 1 [required by c]
+  - install d       1
+  - install e       1
+  - install f       1
+  - install g       1 [required by h]
+  - install h       1
+  - install i       1
+  - install j       1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed a.1
+-> installed b.1
+-> installed c-build.1
+-> installed c.1
+-> installed d.1
+-> installed e.1
+-> installed f.1
+-> installed g.1
+-> installed h.1
+-> installed i.1
+-> installed j.1
+Done.
+### opam tree --json=out.json
+c.1
+|-- a.1
+|-- b.1
+|   '-- a.1 [*]
+'-- c-build.1 (build)
+
+d.1
+
+e.1
+'-- a.1 [*]
+
+h.1
+|-- f.1
+|   '-- b.1 (< 2) [*]
+'-- g.1
+    '-- b.1 (>= 1 & < 3) [*]
+
+i.1
+'-- b.1 (< 3) [*]
+
+j.1
+'-- a.1 [*]
+### json-cat out.json
+{
+  "opam-version": "currentv",
+  "command-line": [
+    "${OPAM}",
+    "tree",
+    "--json=out.json"
+  ],
+  "switch": "tree",
+  "tree": [
+    {
+      "name": "c",
+      "version": "1",
+      "dependencies": [
+        {
+          "name": "a",
+          "version": "1",
+          "satisfies": null,
+          "is_duplicate": false,
+          "dependencies": []
+        },
+        {
+          "name": "b",
+          "version": "1",
+          "satisfies": null,
+          "is_duplicate": false,
+          "dependencies": [
+            {
+              "name": "a",
+              "version": "1",
+              "satisfies": null,
+              "is_duplicate": true,
+              "dependencies": []
+            }
+          ]
+        },
+        {
+          "name": "c-build",
+          "version": "1",
+          "satisfies": "(build)",
+          "is_duplicate": false,
+          "dependencies": []
+        }
+      ]
+    },
+    {
+      "name": "d",
+      "version": "1",
+      "dependencies": []
+    },
+    {
+      "name": "e",
+      "version": "1",
+      "dependencies": [
+        {
+          "name": "a",
+          "version": "1",
+          "satisfies": null,
+          "is_duplicate": true,
+          "dependencies": []
+        }
+      ]
+    },
+    {
+      "name": "h",
+      "version": "1",
+      "dependencies": [
+        {
+          "name": "f",
+          "version": "1",
+          "satisfies": null,
+          "is_duplicate": false,
+          "dependencies": [
+            {
+              "name": "b",
+              "version": "1",
+              "satisfies": "(< 2)",
+              "is_duplicate": true,
+              "dependencies": []
+            }
+          ]
+        },
+        {
+          "name": "g",
+          "version": "1",
+          "satisfies": null,
+          "is_duplicate": false,
+          "dependencies": [
+            {
+              "name": "b",
+              "version": "1",
+              "satisfies": "(>= 1 & < 3)",
+              "is_duplicate": true,
+              "dependencies": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "i",
+      "version": "1",
+      "dependencies": [
+        {
+          "name": "b",
+          "version": "1",
+          "satisfies": "(< 3)",
+          "is_duplicate": true,
+          "dependencies": []
+        }
+      ]
+    },
+    {
+      "name": "j",
+      "version": "1",
+      "dependencies": [
+        {
+          "name": "a",
+          "version": "1",
+          "satisfies": null,
+          "is_duplicate": true,
+          "dependencies": []
+        }
+      ]
+    }
+  ]
+}
+### opam tree b --rev-deps --json=out.json
+b.1
+|-- c.1
+|-- (< 2) f.1
+|   '-- h.1
+|-- (>= 1 & < 3) g.1
+|   '-- h.1 [*]
+'-- (< 3) i.1
+### json-cat out.json
+{
+  "opam-version": "currentv",
+  "command-line": [
+    "${OPAM}",
+    "tree",
+    "b",
+    "--rev-deps",
+    "--json=out.json"
+  ],
+  "switch": "tree",
+  "tree": [
+    {
+      "name": "b",
+      "version": "1",
+      "requirements": [
+        {
+          "name": "c",
+          "version": "1",
+          "demands": null,
+          "is_duplicate": false,
+          "requirements": []
+        },
+        {
+          "name": "f",
+          "version": "1",
+          "demands": "(< 2)",
+          "is_duplicate": false,
+          "requirements": [
+            {
+              "name": "h",
+              "version": "1",
+              "demands": null,
+              "is_duplicate": false,
+              "requirements": []
+            }
+          ]
+        },
+        {
+          "name": "g",
+          "version": "1",
+          "demands": "(>= 1 & < 3)",
+          "is_duplicate": false,
+          "requirements": [
+            {
+              "name": "h",
+              "version": "1",
+              "demands": null,
+              "is_duplicate": true,
+              "requirements": []
+            }
+          ]
+        },
+        {
+          "name": "i",
+          "version": "1",
+          "demands": "(< 3)",
+          "is_duplicate": false,
+          "requirements": []
+        }
+      ]
+    }
+  ]
+}
+### opam tree --rev-deps --leads-to h --json=out.json
+a.1
+'-- b.1
+    |-- (< 2) f.1
+    |   '-- h.1
+    '-- (>= 1 & < 3) g.1
+        '-- h.1 [*]
+### json-cat out.json
+{
+  "opam-version": "currentv",
+  "command-line": [
+    "${OPAM}",
+    "tree",
+    "--rev-deps",
+    "--leads-to",
+    "h",
+    "--json=out.json"
+  ],
+  "switch": "tree",
+  "tree": [
+    {
+      "name": "a",
+      "version": "1",
+      "requirements": [
+        {
+          "name": "b",
+          "version": "1",
+          "demands": null,
+          "is_duplicate": false,
+          "requirements": [
+            {
+              "name": "f",
+              "version": "1",
+              "demands": "(< 2)",
+              "is_duplicate": false,
+              "requirements": [
+                {
+                  "name": "h",
+                  "version": "1",
+                  "demands": null,
+                  "is_duplicate": false,
+                  "requirements": []
+                }
+              ]
+            },
+            {
+              "name": "g",
+              "version": "1",
+              "demands": "(>= 1 & < 3)",
+              "is_duplicate": false,
+              "requirements": [
+                {
+                  "name": "h",
+                  "version": "1",
+                  "demands": null,
+                  "is_duplicate": true,
+                  "requirements": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #5298.

This PR adds support for `--json` option in `opam tree` command.

Here is an example output: https://gist.github.com/cannorin/ae87f55695c38356a9b880e0418a7a12

Currently, the output JSON has the type `Forest` in the following TS definition:

```typescript
interface Package {
  name: string;
  version: string;
}

interface DepsTree extends Package {
  dependencies: DepsNode[];
}

interface DepsNode extends DepsTree {
  satisfies: string | null;
  is_dup: boolean;
}

interface RevdepsTree extends Package {
  requirements: RevdepsNode[];
}

interface RevdepsNode extends RevdepsTree {
  demands: string | null;
  is_dup: boolean;
}

type Forest = DepsTree[] | RevdepsTree[]
```

We discuss the structure of the output JSON in #5298.

TODO:
- [x] Add tests
- [x] ~Update doc and man~ not needed
- [x] Update `master_changes.md`
