### PR TITLE
Add opam pin remove --all

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -102,6 +102,7 @@ users)
   * [BUG] When reinstalling a package that has a dirty source, if uncommitted changes are the same than the ones stored in opam's cache, opam consider that it is up to date and nothing is updated [4879 @rjbou]
   * [BUG] Handle external dependencies when updating switch state pin status (all pins), instead as a post pin action (only when called with `opam pin` [#5047 @rjbou - fix #5046]
   * Allow opam pin remove to take a package (<pkg>.<version>) as argument [#5325 @kit-ty-kate]
+  * ◈ Add opam pin remove --all to remove all the pinned packages from a switch [#5308 @kit-ty-kate]
 
 ## List
   * Some optimisations to 'opam list --installable' queries combined with other filters [#4882 @altgr - fix #4311]

--- a/master_changes.md
+++ b/master_changes.md
@@ -577,3 +577,4 @@ users)
   * `OpamCompat`: add `Int.equal` (for ocaml < 4.12)
   * `OpamFilename.clean_dir`: as the directory is recreated after removal, checks that the directory exists beforhand. It avoid creating a new empty directory uselessly [#4967 @rjbou]
   * `OpamStd.Map`: add `filter_map` [#5337 @rjbou]
+  * `OpamStd.Set`: Add `to_list_map` [#5308 @kit-ty-kate]

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -16,6 +16,7 @@ module type SET = sig
   val choose_one : t -> elt
   val choose_opt : t -> elt option
   val of_list: elt list -> t
+  val to_list_map: (elt -> 'b) -> t -> 'b list
   val to_string: t -> string
   val to_json: t OpamJson.encoder
   val of_json: t OpamJson.decoder
@@ -221,6 +222,9 @@ module Set = struct
 
     let of_list l =
       List.fold_left (fun set e -> add e set) empty l
+
+    let to_list_map f set =
+      fold (fun x acc -> f x :: acc) set []
 
     let to_string s =
       if S.cardinal s > max_print then

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -29,6 +29,7 @@ module type SET = sig
   val choose_opt: t -> elt option
 
   val of_list: elt list -> t
+  val to_list_map: (elt -> 'b) -> t -> 'b list
   val to_string: t -> string
   val to_json: t OpamJson.encoder
   val of_json: t OpamJson.decoder

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -176,13 +176,61 @@ echo "another-inexistant" "inexistant"
 -> installed bar.dev
 Done.
 ### : Test opam pin remove <pkg>.<version>
-### opam pin
-bar.dev    rsync             file://${BASEDIR}/bar
-foo.1      local definition
-nip.dev    rsync             file://${BASEDIR}/nip
-qux.dev    rsync             file://${BASEDIR}/qux
 ### opam pin remove --no-action bar.dev
 Ok, bar is no longer pinned to file://${BASEDIR}/bar (version dev)
 ### opam pin remove --no-action nip.wrong-version
 [ERROR] nip is pinned but not to version wrong-version. Skipping.
 # Return code 2 #
+### : Test opam pin remove --all
+### OPAMNODEPEXTS=1
+### opam pin add --no-action bar.dev ./bar
+[bar.dev] synchronised (file://${BASEDIR}/bar)
+bar is now pinned to file://${BASEDIR}/bar (version dev)
+### opam pin
+bar.dev    rsync             file://${BASEDIR}/bar
+foo.1      local definition
+nip.dev    rsync             file://${BASEDIR}/nip
+qux.dev    rsync             file://${BASEDIR}/qux
+### opam pin remove --no-action --all
+Ok, qux is no longer pinned to file://${BASEDIR}/qux (version dev)
+Ok, nip is no longer pinned to file://${BASEDIR}/nip (version dev)
+Ok, foo is no longer pinned locally (version 1)
+Ok, bar is no longer pinned to file://${BASEDIR}/bar (version dev)
+### opam pin
+### opam pin ./bar
+The following additional pinnings are required by bar.dev:
+  - qux.dev at file://${BASEDIR}/qux
+Pin and install them? [y/n] y
+[qux.dev] synchronised (no changes)
+qux is now pinned to file://${BASEDIR}/qux (version dev)
+bar is now pinned to file://${BASEDIR}/bar (version dev)
+
+Already up-to-date.
+Nothing to do.
+### opam pin --current foo
+foo is now pinned locally (version 1)
+### opam pin
+bar.dev    rsync             file://${BASEDIR}/bar
+foo.1      local definition
+qux.dev    rsync             file://${BASEDIR}/qux
+### opam pin remove --all foo
+opam: opamMain.exe: Too many arguments.
+      Usage: opamMain.exe pin [OPTION]... remove PACKAGES...|TARGET
+      
+# Return code 2 #
+### opam pin remove --all
+Ok, qux is no longer pinned to file://${BASEDIR}/qux (version dev)
+Ok, foo is no longer pinned locally (version 1)
+Ok, bar is no longer pinned to file://${BASEDIR}/bar (version dev)
+The following actions will be performed:
+=== remove 3 packages
+  - remove bar dev
+  - remove foo 1
+  - remove qux dev
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   bar.dev
+-> removed   foo.1
+-> removed   qux.dev
+Done.
+### opam pin


### PR DESCRIPTION
I often find the need to clean all pins from the current switch i am working on, be it because the pin packages have all been released or other reasons, and listing all the packages or repos one by one can be extremely tedious.