### PR TITLE
Replace fgrep with grep -F

### DIFF
--- a/configure
+++ b/configure
@@ -4167,7 +4167,7 @@ fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for compiler type" >&5
 printf %s "checking for compiler type... " >&6; }
-CCOMP_TYPE=`$OCAML shell/print_config.ml ccomp_type 2>/dev/null | fgrep -v "Cannot find" || $OCAMLC -config | tr -d '\r' | sed -n -e "s/ccomp_type: //p"`
+CCOMP_TYPE=`$OCAML shell/print_config.ml ccomp_type 2>/dev/null | grep -F -v "Cannot find" || $OCAMLC -config | tr -d '\r' | sed -n -e "s/ccomp_type: //p"`
 if  test "$?" -eq 0
 then :
 
@@ -4178,7 +4178,7 @@ fi
 printf "%s\n" "$CCOMP_TYPE" >&6; }
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for compiler architecture" >&5
 printf %s "checking for compiler architecture... " >&6; }
-ARCH=`$OCAML shell/print_config.ml arch 2>/dev/null | fgrep -v "Cannot find" || $OCAMLC -config | tr -d '\r' | sed -n -e "s/architecture: //p"`
+ARCH=`$OCAML shell/print_config.ml arch 2>/dev/null | grep -F -v "Cannot find" || $OCAMLC -config | tr -d '\r' | sed -n -e "s/architecture: //p"`
 if  test "$?" -eq 0
 then :
 
@@ -4189,7 +4189,7 @@ fi
 printf "%s\n" "$ARCH" >&6; }
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for compiler system" >&5
 printf %s "checking for compiler system... " >&6; }
-SYSTEM=`$OCAML shell/print_config.ml system 2>/dev/null | fgrep -v "Cannot find" || $OCAMLC -config | tr -d '\r' | sed -n -e "s/system: //p"`
+SYSTEM=`$OCAML shell/print_config.ml system 2>/dev/null | grep -F -v "Cannot find" || $OCAMLC -config | tr -d '\r' | sed -n -e "s/system: //p"`
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $SYSTEM" >&5
 printf "%s\n" "$SYSTEM" >&6; }
 
@@ -6090,7 +6090,7 @@ then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for a workable solution for ln -s" >&5
 printf %s "checking for a workable solution for ln -s... " >&6; }
   ln -s configure conftestLink
-  if test "`cmd /c dir conftestLink 2>/dev/null | fgrep SYMLINK`" = ""
+  if test "`cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK`" = ""
 then :
   LN_S="cp -a"
 else $as_nop

--- a/configure.ac
+++ b/configure.ac
@@ -110,15 +110,15 @@ AS_IF([test "x${enable_version_check}" != "xno"], [
 ])
 
 AC_MSG_CHECKING([for compiler type])
-CCOMP_TYPE=`$OCAML shell/print_config.ml ccomp_type 2>/dev/null | fgrep -v "Cannot find" || $OCAMLC -config | tr -d '\r' | sed -n -e "s/ccomp_type: //p"`
+CCOMP_TYPE=`$OCAML shell/print_config.ml ccomp_type 2>/dev/null | grep -F -v "Cannot find" || $OCAMLC -config | tr -d '\r' | sed -n -e "s/ccomp_type: //p"`
 AS_IF([ test "$?" -eq 0 ],,[AC_MSG_ERROR([failed])] )
 AC_MSG_RESULT([$CCOMP_TYPE])
 AC_MSG_CHECKING([for compiler architecture])
-ARCH=`$OCAML shell/print_config.ml arch 2>/dev/null | fgrep -v "Cannot find" || $OCAMLC -config | tr -d '\r' | sed -n -e "s/architecture: //p"`
+ARCH=`$OCAML shell/print_config.ml arch 2>/dev/null | grep -F -v "Cannot find" || $OCAMLC -config | tr -d '\r' | sed -n -e "s/architecture: //p"`
 AS_IF([ test "$?" -eq 0 ],,[AC_MSG_ERROR([failed])] )
 AC_MSG_RESULT([$ARCH])
 AC_MSG_CHECKING([for compiler system])
-SYSTEM=`$OCAML shell/print_config.ml system 2>/dev/null | fgrep -v "Cannot find" || $OCAMLC -config | tr -d '\r' | sed -n -e "s/system: //p"`
+SYSTEM=`$OCAML shell/print_config.ml system 2>/dev/null | grep -F -v "Cannot find" || $OCAMLC -config | tr -d '\r' | sed -n -e "s/system: //p"`
 AC_MSG_RESULT([$SYSTEM])
 AC_SUBST(SYSTEM)
 
@@ -293,7 +293,7 @@ fi
 AS_IF([test "${OCAML_OS_TYPE}" = "Win32"],[
   AC_MSG_CHECKING([for a workable solution for ln -s])
   ln -s configure conftestLink
-  AS_IF([test "`cmd /c dir conftestLink 2>/dev/null | fgrep SYMLINK`" = ""],[LN_S="cp -a"],[LN_S="ln -s"])
+  AS_IF([test "`cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK`" = ""],[LN_S="cp -a"],[LN_S="ln -s"])
   AC_MSG_RESULT([$LN_S])
 ],[
   LN_S="ln -s"

--- a/master_changes.md
+++ b/master_changes.md
@@ -294,6 +294,7 @@ users)
   * Unify constructors for powershell hosts [#5203 @dra27]
   * Fix lazy compilation of regular expression in OpamFormula.atom_of_string [#5211 @dra27]
   * [BUG] Display correct exception backtrace on uncaught exception on Windows [#5216 @dra27]
+  * Use grep -F instead of fgrep, as the latter is deprecated [#5309 @MisterDA]
 
 ## Internal: Windows
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]

--- a/shell/check_linker
+++ b/shell/check_linker
@@ -5,7 +5,7 @@ FIRST=1
 FAULT=0
 PREPEND=
 while IFS= read -r line; do
-  OUTPUT=$("$line" --version 2>/dev/null | head -1 | fgrep "Microsoft (R) Incremental Linker")
+  OUTPUT=$("$line" --version 2>/dev/null | head -1 | grep -F "Microsoft (R) Incremental Linker")
   if [ "x$OUTPUT" = "x" -a $FIRST -eq 1 ] ; then
     FAULT=1
   elif [ $FAULT -eq 1 ] ; then

--- a/src_ext/Makefile.packages
+++ b/src_ext/Makefile.packages
@@ -1,6 +1,6 @@
 EXT_LIB:=$(shell PATH="$(PATH)" ocamlc -config | tr -d '\r' | sed -ne "s/ext_lib: \.//p")
 EXT_DLL:=$(shell PATH="$(PATH)" ocamlc -config | tr -d '\r' | sed -ne "s/ext_dll: \.//p")
-EXT_EXE:=$(if $(filter Win32,$(shell PATH="$(PATH)" ocamlc -config | fgrep os_type)),.exe)
+EXT_EXE:=$(if $(filter Win32,$(shell PATH="$(PATH)" ocamlc -config | grep -F os_type)),.exe)
 OCAMLBIN:=$(dir $(shell PATH="$(PATH)" command -v ocamlc))
 # SITELIB must *not* be evaluated with := (because it must be evaluated *after*
 # ocamlfind has been compiled)

--- a/src_ext/update-sources.sh
+++ b/src_ext/update-sources.sh
@@ -40,7 +40,7 @@ while read name prefix version url; do
       fi
     fi
   fi
-done < <(fgrep URL_ Makefile.sources | sed -e "s/URL\(_\(PKG_\)\?\)\([^ =]*\) *= *\(.*\/\(\([^0-9][^-]*\)*-\)\?v\?\)\([0-9.]\+\([-+.][^\/]*\)\?\)\(\.tbz\|\.tar\.gz\)/\3 \1 \7 \4\7\9/" | sort)
+done < <(grep -F URL_ Makefile.sources | sed -e "s/URL\(_\(PKG_\)\?\)\([^ =]*\) *= *\(.*\/\(\([^0-9][^-]*\)*-\)\?v\?\)\([0-9.]\+\([-+.][^\/]*\)\?\)\(\.tbz\|\.tar\.gz\)/\3 \1 \7 \4\7\9/" | sort)
 echo -e "\nComplete."
 if [[ ${#DISAGREEMENTS[@]} -gt 0 ]] ; then
   echo "Disagreements over version:${DISAGREEMENTS[@]}"


### PR DESCRIPTION
> The egrep and fgrep commands, which have been deprecated since release 2.5.3 (2007), now warn that they are obsolescent and should be replaced by grep -E and grep -F.

https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html