### PR TITLE
doc: update switch manpage

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -430,6 +430,7 @@ users)
   * Fix `OpamAction.install_package` documentation [#5215 @rjbou - fix #5207]
   * Fix the documentation of OPAMFIXUPCRITERIA and --criteria [#5226 @kit-ty-kate]
   * Finer definition of the --ignore-constraints-on documentation [#5289 @kit-ty-kate]
+  * Up-to-date synchronisation with shell session in switch man page: mention shell hooks [#5311 @rjbou - fix #5307]
 
 ## Security fixes
   *

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2549,12 +2549,14 @@ let switch cli =
          $(b,--no-install) is specified."
         OpamArg.dir_sep OpamSwitch.external_dirname);
     `P (Printf.sprintf
-         "$(b,opam switch set) sets the default switch globally, but it is also \
-         possible to select a switch in a given shell session, using the \
-         environment. For that, use $(i,%s)."
-        OpamEnv.(
-          shell_eval_invocation shell
-            (opam_env_invocation ~switch:"SWITCH" ~set_opamswitch:true shell)
+          "$(b,opam switch set) sets the default switch globally. The shell \
+           hook, when enabled, synchronises the current shell session with \
+           this switch, unless the current directory is a local switch, when \
+           that local switch is used instead. You can always use $(i,%s) to \
+           specify the switch explicitly, which overrides the shell hook."
+          OpamEnv.(
+            shell_eval_invocation shell
+              (opam_env_invocation ~switch:"SWITCH" ~set_opamswitch:true shell)
             |> Manpage.escape));
   ] @
     mk_subdoc ~cli ~defaults:["","list";"SWITCH","set"]


### PR DESCRIPTION
fix #5307 : mention shell hooks prior to eval opam env
