### PR TITLE
Fix opam admin add-constraint failing with Not_found in some situations

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -250,6 +250,7 @@ users)
     `--check-all` restores the previous behaviour of validating all checksums.
   * [BUG] Fix repo-upgrade internal error [#4965 @AltGr]
   * [BUG] Fix `--environment` documentation [#5235 @rjbou - fix #5184]
+  * [BUG] Fix opam admin add-constraint failing with Not_found in some situations [#5336 @kit-ty-kate - fix #5334]
 
 ## Opam installer
   *

--- a/src/format/opamFormula.ml
+++ b/src/format/opamFormula.ml
@@ -555,7 +555,7 @@ let simplify_ineq_formula vcomp f =
   let val_of_int i = vals_a.(i/2) in
   let int_of_val =
     let m = List.mapi (fun i v -> v, 2 * i + 1) vals in
-    fun v -> List.assoc v m
+    fun v -> snd (List.find (fun (v', _) -> vcomp v v' = 0) m)
   in
   (* One integer for each value appearing in f, plus one for each interval *)
   let rec mk_ranges acc n = if n < 0 then acc else mk_ranges (n::acc) (n-1) in

--- a/tests/reftests/admin-add-constraint.test
+++ b/tests/reftests/admin-add-constraint.test
@@ -5,6 +5,4 @@ depends: [
   "ocaml" {>= "5.00"}
 ]
 ### opam admin add-constraint 'ocaml<5.0'
-Fatal error:
-Not_found
-# Return code 99 #
+[WARNING] In package test.1, updated constraint ocaml {< "5.0" & >= "5.00"} cannot be satisfied, not updating (use `--force' to update anyway)

--- a/tests/reftests/admin-add-constraint.test
+++ b/tests/reftests/admin-add-constraint.test
@@ -1,0 +1,10 @@
+N0REP0
+### <packages/test/test.1/opam>
+opam-version: "2.0"
+depends: [
+  "ocaml" {>= "5.00"}
+]
+### opam admin add-constraint 'ocaml<5.0'
+Fatal error:
+Not_found
+# Return code 99 #

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1,5 +1,22 @@
 
 (rule
+ (alias reftest-admin-add-constraint)
+ (action
+  (diff admin-add-constraint.test admin-add-constraint.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-admin-add-constraint)))
+
+(rule
+ (targets admin-add-constraint.out)
+ (deps root-N0REP0)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:admin-add-constraint.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-assume-built)
  (action
   (diff assume-built.test assume-built.out)))


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/5334
<img src="https://user-images.githubusercontent.com/2611789/199073267-6f0b5519-541a-4c03-88e5-a14d492966ff.jpg" alt="old man yells at polymorphic compare meme" width="50%" height="50%" />

*one more for the books https://github.com/ocaml/ocaml/pull/9928* :disappointed: 