### PR TITLE
Move dependencies computation from `opam-solver` to `opam-state`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -108,6 +108,7 @@ users)
   * Improve performance of some opam list combination (e.g. --available --installable) [#4999 @kit-ty-kate]
   * Improve performance of opam list --conflicts-with when combined with other filters [#4999 @kit-ty-kate]
   * Fix coinstallability filter corner case [#5024 @AltGr]
+  * Improve performance for recursive `--required-by` and `depends-on` [#5337 @rjbou]
 
 ## Show
   * Add `depexts` to default printer [#4898 @rjbou]
@@ -511,8 +512,9 @@ users)
 ` [#5268 @kit-ty-kate]
   * `OpamUpdate`: change `repository` output to update function option, to not write cache and new repo config if nothing changed in `repositories` [#5146 @rjbou]
   * Add `OpamPinned.version_opt` [#5325 @kit-ty-kate]
-
   * Add optional argument `?env:(variable_contents option Lazy.t * string) OpamVariable.Map.t` to `OpamSysPoll` and `OpamSysInteract` functions. It is used to get syspolling variables from the environment first. [#4892 @rjbou]
+  * `OpamSwitchState`: move and reimplement `opam-solver` `dependencies` and `reverse_dependencies` [#5337 @rjbou]
+
 ## opam-solver
   * `OpamCudf`: Change type of `conflict_case.Conflict_cycle` (`string list list` to `Cudf.package action list list`) and `cycle_conflict`, `string_of_explanations`, `conflict_explanations_raw` types accordingly [#4039 @gasche]
   * `OpamCudf`: add `conflict_cycles` [#4039 @gasche]
@@ -528,6 +530,7 @@ users)
   * `OpamCudf`: add `trim_universe`, `opam_deprequest_package_name`, and `opam_deprequest_package` [#4975 @AltGr]
   * `OpamCudf.print_solution`: add optional `skip`, to avoid filtering solution beforehand [#4975 @AltGr]
   * `OpamCudf.filter_solution`: can do not remove recursively actions with optional `~recursive:true` [#4975 @AltGr]
+  * `OpamSolver`, `OpamCudf`: remove `dependencies` and `reverse_dependencies` [#5337 @rjbou]
 
 ## opam-format
   * Exposed `with_*` functions in `OpamFile.Dot_install` [#5169 @panglesd]
@@ -571,3 +574,4 @@ users)
   * `OpamStd.List`: add `find_map_opt` (for ocaml < 4.10) and `fold_left_map` (for ocaml < 4.11) [#5171 @cannorin]
   * `OpamCompat`: add `Int.equal` (for ocaml < 4.12)
   * `OpamFilename.clean_dir`: as the directory is recreated after removal, checks that the directory exists beforhand. It avoid creating a new empty directory uselessly [#4967 @rjbou]
+  * `OpamStd.Map`: add `filter_map` [#5337 @rjbou]

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -909,9 +909,9 @@ let assume_built_restrictions ?available_packages t atoms =
       t.pinned
   in
   let installed_dependencies =
-    OpamSolver.dependencies ~build:false ~post:false
+    OpamSwitchState.dependencies ~build:false ~post:false
       ~depopts:false ~installed:true ~unavailable:false
-      (OpamSwitchState.universe t
+      t (OpamSwitchState.universe t
          ~requested:pinned Query)
       pinned
   in
@@ -1253,7 +1253,7 @@ let remove_t ?ask ~autoremove ~force ?(formula=OpamFormula.Empty) atoms t =
           universe.u_base ++ t.installed_roots %% t.installed -- packages
         in
         let keep_cone =
-          keep |> OpamSolver.dependencies universe
+          keep |> OpamSwitchState.dependencies t universe
             ~build:true ~post:true ~depopts:true ~installed:true
         in
         let autoremove =
@@ -1262,11 +1262,11 @@ let remove_t ?ask ~autoremove ~force ?(formula=OpamFormula.Empty) atoms t =
         if atoms = [] then autoremove else
         (* restrict to the dependency cone of removed pkgs *)
         let remove_cone =
-          packages |> OpamSolver.reverse_dependencies universe
+          packages |> OpamSwitchState.reverse_dependencies t universe
             ~build:true ~post:true ~depopts:false ~installed:true
         in
         autoremove %%
-        (remove_cone |> OpamSolver.dependencies universe
+        (remove_cone |> OpamSwitchState.dependencies t universe
            ~build:true ~post:true ~depopts:false ~installed:true)
       else
         packages

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1474,8 +1474,8 @@ let config cli =
                 match OpamSwitchState.opam_opt state p with
                 | Some o -> OpamFile.OPAM.has_flag Pkgflag_Compiler o
                 | None -> false)
-            |> OpamSolver.dependencies ~depopts:true ~post:true ~build:true
-              ~installed:true
+            |> OpamSwitchState.dependencies ~depopts:true ~post:true ~build:true
+              ~installed:true state
               (OpamSwitchState.universe ~test:true ~doc:true ~dev_setup:true
                  ~requested:OpamPackage.Set.empty state Query)
             |> OpamPackage.Set.iter process;

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -225,12 +225,13 @@ let apply_selector ~base st = function
   | (Required_by ({recursive=true; _} as tog, atoms)
     | Depends_on ({recursive=true; _} as tog, atoms)) as direction ->
     let deps_fun = match direction with
-      | Required_by _ -> OpamSolver.dependencies
-      | Depends_on _ -> OpamSolver.reverse_dependencies
+      | Required_by _ -> OpamSwitchState.dependencies
+      | Depends_on _ -> OpamSwitchState.reverse_dependencies
       | _ -> assert false
     in
     deps_fun ~depopts:tog.depopts ~build:tog.build ~post:tog.post
       ~installed:false ~unavailable:true
+      st
       (get_universe st tog)
       (packages_of_atoms st atoms)
   | Required_by (tog, atoms) ->

--- a/src/client/opamLockCommand.ml
+++ b/src/client/opamLockCommand.ml
@@ -137,9 +137,9 @@ let lock_opam ?(only_direct=false) st opam =
   in
   (* Depends *)
   let all_depends =
-    OpamSolver.dependencies
+    OpamSwitchState.dependencies
       ~depopts:true ~build:true ~post:true ~installed:true
-      univ (OpamPackage.Set.singleton nv) |>
+      st univ (OpamPackage.Set.singleton nv) |>
     OpamPackage.Set.remove nv
   in
   let depends =
@@ -180,9 +180,9 @@ let lock_opam ?(only_direct=false) st opam =
       let depends_map = map_of_set `other installed in
       if only_direct then depends_map
       else
-        (OpamSolver.dependencies
+        (OpamSwitchState.dependencies
            ~depopts:false ~build:true ~post:true ~installed:true
-           univ installed
+           st univ installed
          -- all_depends)
         |> map_of_set (`other_dep typ)
         |> OpamPackage.Map.union (fun _v _o -> `other_dep typ) depends_map

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -47,6 +47,7 @@ module type MAP = sig
   val update: key -> ('a -> 'a) -> 'a -> 'a t -> 'a t
   val map_reduce:
     ?default:'b -> (key -> 'a -> 'b) -> ('b -> 'b -> 'b) -> 'a t -> 'b
+  val filter_map: (key -> 'a -> 'b option) -> 'a t -> 'b t
 end
 module type ABSTRACT = sig
   type t
@@ -316,6 +317,13 @@ module Map = struct
     let mapi f map =
       fold (fun key value map ->
           add key (f key value) map
+        ) map empty
+
+    let filter_map f map =
+      fold (fun key value map ->
+          match f key value with
+          | Some value -> add key value map
+          | None -> map
         ) map empty
 
     let values map =

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -93,6 +93,7 @@ module type MAP = sig
   val map_reduce:
     ?default:'b -> (key -> 'a -> 'b) -> ('b -> 'b -> 'b) -> 'a t -> 'b
 
+  val filter_map: (key -> 'a -> 'b option) -> 'a t -> 'b t
 end
 
 (** A signature for handling abstract keys and collections thereof *)

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -598,29 +598,6 @@ let is_artefact cpkg =
   is_opam_deprequest cpkg ||
   cpkg.Cudf.package = dose_dummy_request
 
-let dependencies universe packages =
-  Set.fixpoint (fun p -> dependency_set universe p.Cudf.depends) packages
-(* similar to Dose_algo.Depsolver.dependency_closure but with finer results on
-   version sets *)
-
-let reverse_dependencies universe =
-  let tbl = Array.make (Cudf.universe_size universe) [] in
-  Cudf.iteri_packages (fun uid p ->
-      Set.iter
-        (fun q ->
-           let i = Cudf.uid_by_package universe q in
-           tbl.(i) <- uid :: tbl.(i))
-        (dependency_set universe p.Cudf.depends))
-    universe;
-  Set.fixpoint
-    (fun p ->
-       List.fold_left
-         (fun acc uid -> Set.add (Cudf.package_by_uid universe uid) acc)
-         Set.empty
-         tbl.(Cudf.uid_by_package universe p))
-(* similar to Dose_algo.Depsolver.reverse_dependency_closure but more reliable
-   and faster *)
-
 let dependency_sort universe packages =
   let graph = Graph.of_universe universe in
   Graph.linearize graph packages |> List.rev

--- a/src/solver/opamCudf.mli
+++ b/src/solver/opamCudf.mli
@@ -58,12 +58,6 @@ module ActionGraph: OpamActionGraph.SIG with type package = Package.t
 (** Abstract type that may be returned in case of conflicts *)
 type conflict
 
-(** Return the transitive closure of dependencies of [set] *)
-val dependencies: Cudf.universe -> Set.t -> Set.t
-
-(** Return the transitive closure of reverse dependencies of [set] *)
-val reverse_dependencies: Cudf.universe -> Set.t -> Set.t
-
 (** Sorts the given packages topolgically (be careful if there are cycles, e.g.
    if the universe was loaded with [post] dependencies enabled) *)
 val dependency_sort: Cudf.universe -> Set.t -> Cudf.package list

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -585,35 +585,6 @@ let dependency_graph
     cudf_graph;
   g
 
-let filter_dependencies
-    f_direction ~depopts ~build ~post ~installed
-    ?(unavailable=false) universe packages =
-  if OpamPackage.Set.is_empty packages then OpamPackage.Set.empty else
-  let u_packages =
-    packages ++
-    if installed then universe.u_installed else
-    if unavailable then universe.u_packages else
-      universe.u_available in
-  log ~level:3 "filter_dependencies packages=%a"
-    (slog OpamPackage.Set.to_string) packages;
-  let cudf_universe, cudf_packages =
-    load_cudf_universe_with_packages
-      ~depopts ~build ~post universe u_packages packages
-  in
-  log ~level:3 "filter_dependencies: dependency";
-  let clos_packages = f_direction cudf_universe cudf_packages in
-  let result =
-    OpamCudf.Set.fold (fun cp -> OpamPackage.Set.add (OpamCudf.cudf2opam cp))
-      clos_packages OpamPackage.Set.empty
-  in
-  log "filter_dependencies result=%a"
-    (slog OpamPackage.Set.to_string) result;
-  result
-
-let dependencies = filter_dependencies OpamCudf.dependencies
-
-let reverse_dependencies = filter_dependencies OpamCudf.reverse_dependencies
-
 let dependency_sort ~depopts ~build ~post universe packages =
   let cudf_universe, cudf_packages =
     load_cudf_universe_with_packages

--- a/src/solver/opamSolver.mli
+++ b/src/solver/opamSolver.mli
@@ -98,32 +98,6 @@ val installable: universe -> package_set
 (** Like [installable], but within a subset and potentially much faster *)
 val installable_subset: universe -> package_set -> package_set
 
-(** Return the transitive dependency closures
-    of a collection of packages.
-
-    [depopts]: include optional dependencies (depopts: foo)
-    [build]: include build dependencies (depends: foo {build})
-    [post]: include post dependencies (depends: foo {post})
-    [installed]: only consider already-installed packages
-    [unavaiable]: also consider unavailable packages
-*)
-val dependencies :
-  depopts:bool -> build:bool -> post:bool ->
-  installed:bool ->
-  ?unavailable:bool ->
-  universe ->
-  package_set ->
-  package_set
-
-(** Same as [dependencies] but for reverse dependencies. *)
-val reverse_dependencies :
-  depopts:bool -> build:bool -> post:bool ->
-  installed:bool ->
-  ?unavailable:bool ->
-  universe ->
-  package_set ->
-  package_set
-
 (** Sorts the given package set in topological order (as much as possible,
     beware of cycles in particular if [post] is [true]) *)
 val dependency_sort :

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -162,6 +162,26 @@ val source_dir: 'a switch_state -> package -> dirname
     from the values of the system-specific variables *)
 val depexts: 'a switch_state -> package -> OpamSysPkg.Set.t
 
+(* {2} Helpers to retrieve computed data *)
+
+(** Return the transitive dependency closures
+    of a collection of packages.
+
+    [depopts]: include optional dependencies (depopts: foo)
+    [build]: include build dependencies (depends: foo {build})
+    [post]: include post dependencies (depends: foo {post})
+    [installed]: only consider already-installed packages
+    [unavaiable]: also consider unavailable packages
+*)
+val dependencies:
+  'a switch_state -> build:bool -> post:bool -> depopts:bool ->
+  installed:bool -> ?unavailable:bool -> universe -> package_set -> package_set
+
+(** Same as [dependencies] but for reverse dependencies. *)
+val reverse_dependencies:
+  'a switch_state -> build:bool -> post:bool -> depopts:bool ->
+  installed:bool -> ?unavailable:bool -> universe -> package_set -> package_set
+
 (** Returns required system packages of each of the given packages (elements are
     not added to the map  if they don't have system dependencies) *)
 val depexts_status_of_packages:


### PR DESCRIPTION
`OpamSolver.dependencies` and `OpamSolver.reverse_dependencies` are for the moment only used in `opam-client`. The main reason to move them is that #5208 use one of them in `opam-state` (`opamSwitchState`), making it depend on `opam-solver` and all of its dependencies. 
Besides, with the rewrite, `dependencies` is more efficient: for a big request (`opam list --required-by patdiff,memtrace_viewer,tezos,bap,mirage --recursive`, resulting to ~800 unique packages), from 1.95s to 0.67s.

Remaining:
* [x] Add some log
* [x] Comment opam-solver ones?
* [x] Add doc
* [x] Add changes
