### PR TITLE
Fix cudf weak dependencies computation

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -278,7 +278,8 @@ users)
   * Enable cudf preprocessing for (co)insallability calculation, resulting in a x20 speedup [@AltGr]
   * Make sure that `--best-effort` only installs root package versions that where requested [#4796 #5261 @LasseBlaauwbroek]
   * Ask users to report errors when no explanations are given to them [#4981 @kit-ty-kate]
-  * Add bultin support for the 'deprecated' flag.  Any packages flagged with deprecated would be avoided by the solver unless there is no other choice (e.g. some user wants to install package a which depends on b which is deprecated) If it is installed, show up a note after installation notifying the user that the package is deprecated. [#4523 @kit-ty-kate]
+  * Add builtin support for the 'deprecated' flag.  Any packages flagged with deprecated would be avoided by the solver unless there is no other choice (e.g. some user wants to install package a which depends on b which is deprecated) If it is installed, show up a note after installation notifying the user that the package is deprecated. [#4523 @kit-ty-kate]
+  * [BUG] On cudf strong and weak dependencies computation, some weak dependencies were wrongly kept, from #4627 [#5338 @rjbou @AltGr]
 
 ## Client
   * Check whether the repository might need updating more often [#4935 @kit-ty-kate]

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -483,7 +483,7 @@ let strong_and_weak_deps u deps =
           (fun name _ -> not (OpamStd.String.Map.mem name strong_deps))
           by_name
       in
-      strong_deps, OpamStd.String.Map.union Set.union weak_deps by_name)
+      strong_deps, OpamStd.String.Map.union Set.inter weak_deps by_name)
     (OpamStd.String.Map.empty, OpamStd.String.Map.empty)
     deps
 

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -80,9 +80,9 @@ Nothing to do.
 ### opam upgrade ocaml --fake
 The following actions will be faked:
 === remove 1 package
-  - remove    ocaml-system        4.07.0           [conflicts with ocaml]
+  - remove    ocaml-system        4.07.0           [conflicts with ocaml-base-compiler]
 === recompile 1 package
-  - recompile ocaml-config        1                [uses ocaml-system]
+  - recompile ocaml-config        1                [uses ocaml-base-compiler]
 === upgrade 1 package
   - upgrade   ocaml               4.07.0 to 4.10.0
 === install 1 package

--- a/tests/reftests/list.test
+++ b/tests/reftests/list.test
@@ -386,11 +386,9 @@ opam-version: "2.0"
 ### # ERROR shouldnt is listed as a depenpency
 ### opam list --required-by top --recursive --all-versions --short
 choice.1
-other-choice.1
 other-choice.2
 other-choice.3
 other-choice.4
-shouldnt.1
 top.1
 unrelated.1
 ### <pkg:top.1>


### PR DESCRIPTION
On cudf strong and weak dependencies computation, some weak dependencies were wrongly kept, originated from #4627
fix test added in #5329 