### PR TITLE
Update IRC links

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Keep track of development and community news.
 * Have a question that's not a feature request or bug report?
   [Ask on the mailing list](http://lists.ocaml.org/listinfo/infrastructure).
 
-* Chat with fellow opamers on IRC. On the `irc.freenode.net` server,
+* Chat with fellow opamers on IRC. On the `irc.libera.chat` server,
   in the `#ocaml` or the `#opam` channel.
 
 ## Contributing

--- a/doc/pages/FAQ.md
+++ b/doc/pages/FAQ.md
@@ -320,7 +320,7 @@ mailing-list](http://lists.ocaml.org/listinfo/opam-devel).
 
 - https://discuss.ocaml.org is a good place for community assistance.
 
-- You may also try IRC channel `#ocaml` on Freenode.
+- You may also try IRC channel `#ocaml` on Libera.Chat.
 
 ---
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -442,6 +442,7 @@ users)
   * Fix the documentation of OPAMFIXUPCRITERIA and --criteria [#5226 @kit-ty-kate]
   * Finer definition of the --ignore-constraints-on documentation [#5289 @kit-ty-kate]
   * Up-to-date synchronisation with shell session in switch man page: mention shell hooks [#5311 @rjbou - fix #5307]
+  * Fix info for IRC channels in README.md and FAQ.md [#5340 @purplearmadillo77]
 
 ## Security fixes
   *


### PR DESCRIPTION
Fix documentation to mention IRC channels in liberachat instead of freenode.