### PR TITLE
git, hg: Use full revision

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -199,6 +199,7 @@ users)
   * Use 4.08's unnamed functor arguments to silence warning 67 [#4775 @dra27]
   * git: disable colored output [#4884 @rjbou]
   * Check if a source is up to date with subpath [#4876 @rjbou]
+  * git, hg: Use the full SHA1 revision instead of just the 8 first characters [#5342 @reynir]
 
 ## Build
   * Bump src_exts and fix build compat with Dune 2.9.0 [#4752 @dra27]

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -159,10 +159,7 @@ module VCS : OpamVCS.VCS = struct
        match r.OpamProcess.r_stdout with
        | []      -> Done None
        | full::_ ->
-         if String.length full > 8 then
-           Done (Some (String.sub full 0 8))
-         else
-           Done (Some full))
+         Done (Some full))
 
   let clean repo_root =
     git repo_root [ "clean"; "-fdx" ]

--- a/src/repository/opamHg.ml
+++ b/src/repository/opamHg.ml
@@ -53,8 +53,7 @@ module VCS = struct
     match r.OpamProcess.r_stdout with
     | [] -> Done None
     | full::_ ->
-      if String.length full > 8 then Done (Some (String.sub full 0 8))
-      else Done (Some full)
+      Done (Some full)
 
   let clean repo_root =
     hg repo_root ["revert"; "--all"; "--no-backup"]


### PR DESCRIPTION
Before, the revision was at most the first 8 bytes in the revision. This can be problematic for reproducibility since the revision may then be ambiguous. I don't know much about mercurial and how their revisions look like.

CC @hannesm 