### PR TITLE
depexts for MSYS2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tests/tmp/
 tests/.merlin
 tests/reftests/.merlin
 .*.swp
+.envrc
 src_ext/*.*download
 src_ext/*.*stamp
 src_ext/*.pkgbuild

--- a/master_changes.md
+++ b/master_changes.md
@@ -168,6 +168,7 @@ users)
   * Set `depext-bypass` parsing with depth 1, no needed brakcet if single package [#5154 @rjbou]
 
 ## External dependencies
+  * Support MSYS2 on Windows for depexts [#5348 @jonahbeckford]
   * Set `DEBIAN_FRONTEND=noninteractive` for unsafe-yes confirmation level [#4735 @dra27 - partially fix #4731] [2.1.0~rc2 #4739]
   * Fix depext alpine tagged repositories handling [#4763 @rjbou] [2.1.0~rc2 #4758]
   * Homebrew: Add support for casks and full-names [#4801 @kit-ty-kate]


### PR DESCRIPTION
MSYS2 on Windows uses the same package manager as Arch Linux (`pacman`). It targets several ABIs (compilers, bitiness and Windows C libraries).

This PR builds on the opam global variables that are registered when Diskuv OCaml (DKML) is installed. Those variables became available with DKML 1.1: https://gitlab.com/diskuv/diskuv-ocaml/-/blob/bd5b461b7d267ff897d053a67cce6ed5c26f27b4/CHANGES.md. Any MSYS2 distribution (not just DKML) can set those opam variables:

```console
$ opam var --global
arch                 x86_64                                                         # Inferred from system
exe                  .exe                                                           # Suffix needed for executable filenames (Windows)
...
mingw-chost          x86_64-w64-mingw32                                             # Set through 'opam var'
mingw-package-prefix mingw-w64-clang-x86_64                                         # Set through 'opam var'
mingw-prefix         /clang64                                                       # Set through 'opam var'
msys2-nativedir      C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\tools\MSYS2\ # Set through 'opam var'
msystem              CLANG64                                                        # Set through 'opam var'
msystem-carch        x86_64                                                         # Set through 'opam var'
msystem-chost        x86_64-w64-mingw32                                             # Set through 'opam var'
msystem-prefix       /clang64                                                       # Set through 'opam var'
opam-version         2.2.0~alpha0~20221104                                          # The currently running opam version
...
```

### Testing

With the following change to `conf-pkg-config`:

```diff
 depexts: [
   ["pkg-config"] {os-family = "debian"}
   ["pkgconf"] {os-distribution = "arch"}
   ["pkgconf-pkg-config"] {os-distribution = "fedora"}
   ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
   ["pkgconf-pkg-config"] {os-distribution = "mageia"}
   ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
   ["pkgconfig"] {os-distribution = "ol" & os-version <= "7"}
   ["pkgconf"] {os-distribution = "alpine"}
   ["pkgconfig"] {os-distribution = "nixos"}
   ["devel/pkgconf"] {os = "openbsd"}
   ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
   ["pkgconf"] {os = "freebsd"}
   ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
   ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
   ["pkgconf-pkg-config"] {os-distribution = "ol" & os-version >= "8"}
   ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
+  # Although not supported in Opam 2.2 (and earlier), we want the equivalent of:
+  #   ["%{mingw-package-prefix}%-pkg-config"] {os = "win32" & ?mingw-package-prefix}
+  ["mingw-w64-clang-i686-pkg-config"]   {os = "win32" & msystem = "CLANG32"}
+  ["mingw-w64-clang-x86_64-pkg-config"] {os = "win32" & msystem = "CLANG64"}
+  ["mingw-w64-i686-pkg-config"]         {os = "win32" & msystem = "MINGW32"}
+  ["mingw-w64-x86_64-pkg-config"]       {os = "win32" & msystem = "MINGW64"}
+  ["mingw-w64-ucrt-x86_64-pkg-config"]  {os = "win32" & msystem = "UCRT64"}
 ]
```

we can now do:

```
C:\> with-dkml `
  Z:\source\dkml-component-opam\_opam\share\dkml-component-staging-opam64\staging-files\windows_x86_64\bin\opam.exe `
  install Z:\source\opam-repository\packages\conf-pkg-config\conf-pkg-config.2\opam 
[conf-pkg-config.2] synchronised (no changes)
The following actions will be performed:
=== install 1 package
  ✶ conf-pkg-config 2 (pinned)

The following system packages will first need to be installed:
    mingw-w64-clang-x86_64-pkg-config

<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><><><>

opam believes some required external dependencies are missing. opam can:
> 1. Run C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\tools\MSYS2\usr\bin\pacman.exe to install them (may need root/sudo access)
  2. Display the recommended C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\tools\MSYS2\usr\bin\pacman.exe command and wait while you run it manually (e.g. in another
     terminal)
  3. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
  4. Abort the installation

[1/2/3/4] 1

+ C:\Users\beckf\AppData\Local\Programs\DiskuvOCaml\tools\MSYS2\usr\bin\pacman.exe "-Su" "--noconfirm" "mingw-w64-clang-x86_64-pkg-config"
- :: Starting core system upgrade...
-  there is nothing to do
- :: Starting full system upgrade...
- resolving dependencies...
- looking for conflicting packages...
- 
- Packages (1) mingw-w64-clang-x86_64-pkg-config-0.29.2-3
- 
- Total Installed Size:  1.39 MiB
- 
- :: Proceed with installation? [Y/n] 
- checking keyring...
- checking package integrity...
- loading package files...
- checking for file conflicts...
- :: Processing package changes...
- installing mingw-w64-clang-x86_64-pkg-config...

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
▼ retrieved conf-pkg-config.2  (file://Z:/source/opam-repository/packages/conf-pkg-config/conf-pkg-config.2)
✶ installed conf-pkg-config.2
Done.
# Run eval $(opam env) to update the current shell environment
```

(If it wasn't a test the command line would simply be `opam install conf-pkg-config`)