### PR TITLE
Fix cleaning up switch on error on Windows

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -84,6 +84,7 @@ users)
   * When inferring a 2.1+ switch invariant from 2.0 base packages, don't filter out pinned packages as that causes very wide invariants for pinned compiler packages [#5176 @dra27 - fix #4501]
   * Really install invariant formula if not installed in switch [#5188 @rjbou]
   * On import, check that installed pinned packages changed, reinstall if so [#5181 @rjbou - fix #5173]
+  * Release the switch lock prior to erasing a failed switch - eliminates further error message on Windows [#5351 @dra27]
 
 ## Config
   * Reset the "jobs" config variable when upgrading from opam 2.0 [#5284 @kit-ty-kate]

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -363,16 +363,19 @@ let create
           (OpamSwitch.to_string st.switch)
     in
     OpamStd.Exn.finalise e @@ fun () ->
-    let gt, st =
-      if OpamConsole.confirm "Switch initialisation failed: clean up? \
-                              ('n' will leave the switch partially installed)"
-      then clear_switch gt st.switch, st
-      else if update_config && not simulate
-      then gt, OpamSwitchAction.set_current_switch gt st
-      else gt, st
-    in
-    OpamSwitchState.drop st;
-    OpamGlobalState.drop gt
+    if OpamConsole.confirm "Switch initialisation failed: clean up? \
+                            ('n' will leave the switch partially installed)"
+    then begin
+           OpamSwitchState.drop st;
+           OpamGlobalState.drop (clear_switch gt st.switch)
+         end
+    else let st =
+           if update_config && not simulate then
+             OpamSwitchAction.set_current_switch gt st
+           else st
+         in
+         OpamSwitchState.drop st;
+         OpamGlobalState.drop gt
 
 let switch lock gt switch =
   log "switch switch=%a" (slog OpamSwitch.to_string) switch;


### PR DESCRIPTION
If switch creation fails and the user elects to clean-up the switch, there is at present an error message displayed when the switch is erased. This is caused by the write lock on the switch still being held. The fix is to drop the switch lock prior to deletion - the global lock is still held.