### PR TITLE
Fix case-preserving environment updates on Windows

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -341,6 +341,7 @@ users)
   * Support MSYS2: two-phase rsync on MSYS2 to allow MSYS2's behavior of copying rather than symlinking [#4817 @jonahbeckford]
   * Environment: translate PATH from Windows to Unix during opam env. [#4844 @jonahbeckford]
   * Correct invocation of Cygwin binaries when Cygwin bin directory is first in PATH [#5293 @dra27]
+  * [BUG] Fix case insensitive variable handling [#5356 @dra27]
 
 ## Test
   * Update crowbar with compare functions [#4918 @rjbou]
@@ -392,6 +393,7 @@ users)
   * Test opam pin remove <pkg>.<version> [#5325 @kit-ty-kate]
   * Add a test checking that reinstalling a non-installed package is equivalent to installing it [#5228 @kit-ty-kate]
   * Add a test showing that we still get the reason for installing a package when using opam reinstall on non-installed packages [#5229 @kit-ty-kate]
+  * Add a windows test to check case insensitive environment variable handling [#5356 @dra27]
 
 ### Engine
   * Add `opam-cat` to normalise opam file printing [#4763 @rjbou @dra27] [2.1.0~rc2 #4715]
@@ -611,3 +613,4 @@ users)
   * `OpamStd.List`: add comparison function argument to some `OpamList` functions [#5374 @kit-ty-kate @rjbou]
   * `OpamStd.Option`: add `equal` function [#5374 @rjbou]
   * `OpamStd.Compare`: add module to flag polymorphic comparison functions in opam codebase [#5374 @kit-ty-kate @rjbou]
+  * `OpamStd.Env.`: introduce OpamStd.Env.Name to abstract environment variable names [#5356 @dra27]

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1479,7 +1479,7 @@ let config cli =
               (OpamSwitchState.universe ~test:true ~doc:true ~dev_setup:true
                  ~requested:OpamPackage.Set.empty state Query)
             |> OpamPackage.Set.iter process;
-            if List.mem "." (OpamStd.Sys.split_path_variable (Sys.getenv "PATH"))
+            if not Sys.win32 && List.mem "." (OpamStd.Sys.split_path_variable (Sys.getenv "PATH"))
             then OpamConsole.warning
                 "PATH contains '.' : this is a likely cause of trouble.";
             `Ok ()

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -175,6 +175,7 @@ let rec print_fish_env env =
     print_fish_env r
 
 let print_eval_env ~csh ~sexp ~fish ~pwsh ~cmd env =
+  let env = (env : OpamTypes.env :> (string * string * string option) list) in
   if sexp then
     print_sexp_env env
   else if csh then
@@ -283,7 +284,7 @@ let exec gt ~set_opamroot ~set_opamswitch ~inplace_path ~no_switch command =
     if no_switch then
       let revert = OpamEnv.add [] [] in
       List.map (fun ((var, _, _) as base) ->
-          match List.find_opt (fun (v,_,_) -> v = var) revert with
+          match List.find_opt (fun (v,_,_) -> OpamStd.Env.Name.equal v var) revert with
           | Some reverted -> reverted
           | None -> base) base
     else if OpamFile.exists env_file then

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -762,6 +762,17 @@ module Env = struct
       | curr::after -> aux (curr::before) after
     in aux [] v
 
+  let escape_single_quotes ?(using_backslashes=false) =
+    if using_backslashes then
+      Re.(replace (compile (set "\\\'")) ~f:(fun g -> "\\"^Group.get g 0))
+    else
+      Re.(replace_string (compile (char '\'')) ~by:"'\"'\"'")
+
+  let escape_powershell =
+    (* escape single quotes with two single quotes.
+       https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.1 *)
+    Re.(replace_string (compile (char '\'')) ~by:"''")
+
   let list =
     let lazy_env = lazy (
       let e = Unix.environment () in
@@ -782,17 +793,6 @@ module Env = struct
       fun n -> OpamList.assoc String.equal n (list ())
 
   let getopt n = try Some (get n) with Not_found -> None
-
-  let escape_single_quotes ?(using_backslashes=false) =
-    if using_backslashes then
-      Re.(replace (compile (set "\\\'")) ~f:(fun g -> "\\"^Group.get g 0))
-    else
-      Re.(replace_string (compile (char '\'')) ~by:"'\"'\"'")
-
-  let escape_powershell =
-    (* escape single quotes with two single quotes.
-       https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.1 *)
-    Re.(replace_string (compile (char '\'')) ~by:"''")
 end
 
 

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -413,11 +413,21 @@ module Env : sig
 
   (** {3 Environment variable handling} *)
 
+  (** Environment variable names *)
+  module Name : sig
+    include ABSTRACT with type t = private string
+
+    val equal_string: t -> string -> bool
+
+  end
+
   val get: string -> string
 
   val getopt: string -> string option
 
-  val list: unit -> (string * string) list
+  val getopt_full: Name.t -> Name.t * string option
+
+  val list: unit -> (Name.t * string) list
 end
 
 (** {2 System query and exit handling} *)

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -386,6 +386,9 @@ end
 (** {2 Manipulation and query of environment variables} *)
 
 module Env : sig
+
+  (** {3 Generic functions} *)
+
   (** Remove from a c-separated list of string the ones with the given prefix *)
   val reset_value: prefix:string -> char -> string -> string list
 
@@ -395,12 +398,6 @@ module Env : sig
       other elements with the same [prefix] they are kept in the second list.
   *)
   val cut_value: prefix:string -> char -> string -> string list * string list
-
-  val get: string -> string
-
-  val getopt: string -> string option
-
-  val list: unit -> (string * string) list
 
   (** Utility function for shell single-quoted strings. In most shells,
       backslash escapes are not allowed and a single quote needs to be replaced
@@ -413,6 +410,14 @@ module Env : sig
 
   (** Utility function for PowerShell strings. *)
   val escape_powershell: string -> string
+
+  (** {3 Environment variable handling} *)
+
+  val get: string -> string
+
+  val getopt: string -> string option
+
+  val list: unit -> (string * string) list
 end
 
 (** {2 System query and exit handling} *)

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -413,7 +413,29 @@ module Env : sig
 
   (** {3 Environment variable handling} *)
 
-  (** Environment variable names *)
+  (** Environment variable names. Windows has complicated semantics for
+      environment variables. The retrieval functions are case insensitive, but
+      it's "legal" for the environment block to contain entries which differ
+      only by case. If environment variables are set entirely using CRT or Win32
+      API functions, then there isn't usually a problem, the issue arises when
+      creating a program where the environment block is instead passed. In this
+      model, it's very easy to end up with two bindings in the same block. When
+      dealing with Windows programs, this will mostly be transparent, but it's a
+      problem with Cygwin which actively allows "duplicate" entries which differ
+      by case only and implements Posix semantics on top of this. The problem is
+      constantly with us thanks to the use of PATH on Unix, and Path on Windows!
+      opam tries to ensure that environment variables are looked up according to
+      the OS semantics (so case insensitively on Windows) and OpamEnv goes to
+      some trouble to ensure that updates to environment variables are case
+      preserving (i.e. PATH+=foo gets transformed to Path+=foo if Path exists
+      in the environment block).
+
+      Key to this is not accidentally treating environment variable names as
+      strings, without using the appropriate comparison functions. Name.t
+      represents environment variable names as private strings, providing
+      comparison operators to handle them, and still allowing the possibility
+      to coerce them to strings.
+      *)
   module Name : sig
     include ABSTRACT with type t = private string
 

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -353,7 +353,9 @@ let real_path p =
 type command = string list
 
 let default_env () =
-  OpamStd.Env.list () |> List.map (fun (var, v) -> var^"="^v) |> Array.of_list
+  (OpamStd.Env.list () :> (string * string) list)
+    |> List.map (fun (var, v) -> var^"="^v)
+    |> Array.of_list
 
 let env_var env var =
   let len = Array.length env in

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -401,7 +401,7 @@ type stats = {
 }
 
 (** Environement variables: var name, value, optional comment *)
-type env = (string * string * string option) list
+type env = (OpamStd.Env.Name.t * string * string option) list
 
 (** Environment updates *)
 type env_update = string * OpamParserTypes.FullPos.env_update_op_kind * string * string option

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -105,12 +105,12 @@ let env_array l =
   (* The env list may contain successive bindings of the same variable, make
      sure to keep only the last *)
   let bindings =
-    List.fold_left (fun acc (k,v,_) -> OpamStd.String.Map.add k v acc)
-      OpamStd.String.Map.empty l
+    List.fold_left (fun acc (k,v,_) -> OpamStd.Env.Name.Map.add k v acc)
+      OpamStd.Env.Name.Map.empty l
   in
-  let a = Array.make (OpamStd.String.Map.cardinal bindings) "" in
-  OpamStd.String.Map.fold
-    (fun k v i -> a.(i) <- String.concat "=" [k;v]; succ i)
+  let a = Array.make (OpamStd.Env.Name.Map.cardinal bindings) "" in
+  OpamStd.Env.Name.Map.fold
+    (fun k v i -> a.(i) <- (k :> string) ^ "=" ^ v; succ i)
     bindings 0
   |> ignore;
   a

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -442,6 +442,26 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:env.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-env.win32)
+ (enabled_if (= %{os_type} "Win32"))
+ (action
+  (diff env.win32.test env.win32.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (= %{os_type} "Win32"))
+ (deps (alias reftest-env.win32)))
+
+(rule
+ (targets env.win32.out)
+ (deps root-N0REP0)
+ (enabled_if (= %{os_type} "Win32"))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:env.win32.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-init)
  (action
   (diff init.test init.out)))

--- a/tests/reftests/env.win32.test
+++ b/tests/reftests/env.win32.test
@@ -13,4 +13,4 @@ The following actions will be performed:
 -> installed vne.1
 Done.
 ### opam env | grep 'Foo|FOO' | "SET " -> "" | "'" -> "" | '; .*' -> ""
-Foo=bar;foo
+FOO=bar;foo

--- a/tests/reftests/env.win32.test
+++ b/tests/reftests/env.win32.test
@@ -1,0 +1,16 @@
+N0REP0
+### <pkg:vne.1>
+opam-version: "2.0"
+setenv: [ Foo += "bar" ]
+### opam switch create --empty test
+### FOO=foo
+### opam install vne
+The following actions will be performed:
+=== install 1 package
+  - install vne 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed vne.1
+Done.
+### opam env | grep 'Foo|FOO' | "SET " -> "" | "'" -> "" | '; .*' -> ""
+Foo=bar;foo


### PR DESCRIPTION
There's existing code (of mine) which tries to deal with the fact that environment variable names are case insensitive on Windows. In `OpamStd.Env`, this is dealt with largely correctly in `get`, but the handling in `OpamEnv` is not. When dealing with environment _updates_, it's necessary to transform the names of any updates - i.e. `PATH += "foo"` needs to be transformed to `Path += "foo"` to use the same case as the base environment.

The problem is manifesting itself principally with `PATH`, which by default is actually `Path` on Windows. When reverting the updates in `OpamEnv.get_pure` (for example, to evaluate `eval_variables`), the switch's `bin` directory is correctly ignored when resolving the command, but when the command is executed, it re-emerges, because of a duplicate instruction in the env block for both `Path` (with the switch directory, as that comes from the calling environment) and `PATH` (as determined in `OpamEnv.get_pure`, which reverts the updates previously made).

In particular, with this branch, `opam config list` stops reporting the _switch's_ compiler settings in `sys-ocaml-arch`, `sys-ocaml-cc`, and `sys-ocaml-libc`, but I still need to mull some more whether this is strictly the correct approach (and the environment update code is already nightmarishly complicated even on Unix...)