### PR TITLE
GHA: port to new infra, upgrade actions version

### DIFF
--- a/.github/scripts/cygwin.cmd
+++ b/.github/scripts/cygwin.cmd
@@ -15,7 +15,7 @@
 ::
 :: cygwin.cmd distro cache-directory {create|host}
 ::
-:: where distro is i686-pc-cygwin or x86_64-pc-cygwin and rebuilds the cache
+:: where distro is x86_64-pc-cygwin and rebuilds the cache
 ::
 :: Environment variables:
 ::   CYGWIN_ROOT        - Cygwin installation root directory
@@ -23,11 +23,9 @@
 
 set CYGWIN_CACHE_DIR=%2
 set CYGWIN_DISTRO=%1
-if "%CYGWIN_DISTRO%" neq "i686-pc-cygwin" (
-  if "%CYGWIN_DISTRO%" neq "x86_64-pc-cygwin" (
-    echo Invalid Cygwin distro: %1
-    exit /b 2
-  )
+if "%CYGWIN_DISTRO%" neq "x86_64-pc-cygwin" (
+  echo Invalid Cygwin distro: %1
+  exit /b 2
 )
 
 if "%3" equ "create" goto SetupCygwin
@@ -53,7 +51,6 @@ if not exist %CYGWIN_CACHE_DIR%\%CYGWIN_DISTRO%\cache.tar (
 set Path=C:\Program Files\Mercurial;C:\Program Files\Git\cmd;%CYGWIN_ROOT%\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\
 if "%3" equ "i686-w64-mingw32" set Path=%CYGWIN_ROOT%\usr\%3\sys-root\mingw\bin;%Path%
 if "%3" equ "x86_64-w64-mingw32" set Path=%CYGWIN_ROOT%\usr\%3\sys-root\mingw\bin;%Path%
-if "%3" equ "i686-pc-cygwin" set Path=%CYGWIN_ROOT%\bin;%Path%
 if "%3" equ "x86_64-pc-cygwin" set Path=%CYGWIN_ROOT%\bin;%Path%
 
 ::echo %CYGWIN_ROOT%\bin>> %GITHUB_PATH%

--- a/.github/scripts/main/create-ocaml-cache.sh
+++ b/.github/scripts/main/create-ocaml-cache.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -xue
+
+OCAML_BRANCH="$1"
+PREFIX="$2"
+EXE="$3"
+OCAML_LOCAL="$4"
+PLATFORM="$5"
+
+if [[ $OCAML_BRANCH -gt 407 ]]; then
+  if [[ -n $GITHUB_BASE_REF ]]; then
+    git tag combak
+    git fetch origin $GITHUB_BASE_REF
+    git checkout origin/$GITHUB_BASE_REF
+  fi
+  make -C src_ext dune-local.stamp
+  cd src_ext/dune-local
+  ocaml bootstrap.ml
+  cp dune.exe "$PREFIX/bin/dune$EXE"
+  cd ../..
+
+  ./configure
+  make
+  cp -a _build "$OCAML_LOCAL/"
+  rm -f "$OCAML_LOCAL/_build/log"
+  mv "$OCAML_LOCAL/_build/default/src_ext" "$OCAML_LOCAL/_build/"
+  rm -rf "$OCAML_LOCAL/_build/default"/* "$OCAML_LOCAL/_build/install"
+  mv "$OCAML_LOCAL/_build/src_ext" "$OCAML_LOCAL/_build/default/" 
+  git clean -dfX
+  if [[ -n $GITHUB_BASE_REF ]]; then
+    git checkout combak
+  fi
+fi
+
+# The Windows BSD tar can't cope with symlinks, so we pre-tar the archive and cache that!
+if [[ $PLATFORM = 'Windows' ]]; then
+  tar -C "$OCAML_LOCAL" -pcf "$OCAML_LOCAL.tar" .
+fi

--- a/.github/scripts/main/ocaml-cache.sh
+++ b/.github/scripts/main/ocaml-cache.sh
@@ -144,32 +144,8 @@ EOF
   chmod +x "$OCAML_LOCAL/bin/ocamldoc"
 fi
 
-if [[ $OCAML_BRANCH -gt 407 ]]; then
-  if [[ -n $GITHUB_BASE_REF ]]; then
-    git tag combak
-    git fetch origin $GITHUB_BASE_REF
-    git checkout origin/$GITHUB_BASE_REF
-  fi
-  make -C src_ext dune-local.stamp
-  cd src_ext/dune-local
-  ocaml bootstrap.ml
-  cp dune.exe "$PREFIX/bin/dune$EXE"
-  cd ../..
-
-  ./configure
-  make
-  cp -a _build "$OCAML_LOCAL/"
-  rm -f "$OCAML_LOCAL/_build/log"
-  mv "$OCAML_LOCAL/_build/default/src_ext" "$OCAML_LOCAL/_build/"
-  rm -rf "$OCAML_LOCAL/_build/default"/* "$OCAML_LOCAL/_build/install"
-  mv "$OCAML_LOCAL/_build/src_ext" "$OCAML_LOCAL/_build/default/" 
-  git clean -dfX
-  if [[ -n $GITHUB_BASE_REF ]]; then
-    git checkout combak
-  fi
-fi
-
-# The Windows BSD tar can't cope with symlinks, so we pre-tar the archive and cache that!
-if [[ $PLATFORM = 'Windows' ]]; then
-  tar -C "$OCAML_LOCAL" -pcf "$OCAML_LOCAL.tar" .
-fi
+# Hand-over control to a separate script in case the branch being tested
+# updates this script, which will fail on Windows (since the script is "open"
+# and can't be overwritten)
+cp -pf .github/scripts/main/create-ocaml-cache.sh ../create-ocaml-cache.sh
+exec ../create-ocaml-cache.sh "$OCAML_BRANCH" "$PREFIX" "$EXE" "$OCAML_LOCAL" "$PLATFORM"

--- a/.github/scripts/main/ocaml-cache.sh
+++ b/.github/scripts/main/ocaml-cache.sh
@@ -51,7 +51,21 @@ fi
 
 tar -xzf "ocaml-$OCAML_VERSION.tar.gz"
 
+case "${OCAML_VERSION%.*}" in
+  4.08) PATCHES='e322556b0a9097a2eff2117476193b773e1b947f 17df117b4939486d3285031900587afce5262c8c';;
+  4.09) PATCHES='8eed2e441222588dc385a98ae8bd6f5820eb0223';;
+  4.10) PATCHES='4b4c643d1d5d28738f6d900cd902851ed9dc5364';;
+  4.11) PATCHES='dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea';;
+  4.12) PATCHES='1eeb0e7fe595f5f9e1ea1edbdf785ff3b49feeeb';;
+  *) PATCHES='';;
+esac
+
 cd "ocaml-$OCAML_VERSION"
+for sha in $PATCHES; do
+  curl -sL "https://github.com/ocaml/ocaml/commit/$sha.patch" -o "../$sha.patch"
+  patch -p1 -i "../$sha.patch"
+done
+
 if [[ $PLATFORM = 'Windows' ]] ; then
   tar -xzf ../$FLEXDLL_VERSION.tar.gz
   rm -rf flexdll

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -279,7 +279,7 @@ let analyse_job ~oc ~workflow ~platforms ~keys f =
   let keys =
     let set_key (name, value) =
       [Printf.sprintf "echo %s=%s" name value;
-       Printf.sprintf "echo ::set-output name=%s::%s" name value]
+       Printf.sprintf "echo %s=%s >> $GITHUB_OUTPUT" name value]
     in
     List.flatten (List.map set_key keys)
   in

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -514,7 +514,7 @@ let main oc : unit =
   let keys = [
     ("archives", "archives-1-${{ hashFiles('src_ext/Makefile.sources', 'src_ext/Makefile', '.github/scripts/common/preamble.sh', '.github/scripts/main/preamble.sh', '.github/scripts/main/archives-cache.sh') }}-${{ env.OPAM_REPO_SHA }}");
     ("ocaml-secondary-compiler", "legacy-${{ env.OPAM_REPO_SHA }}");
-    ("ocaml-cache", "${{ hashFiles('.github/scripts/main/ocaml-cache.sh', '.github/scripts/main/preamble.sh') }}");
+    ("ocaml-cache", "${{ hashFiles('.github/scripts/main/ocaml-cache.sh', '.github/scripts/main/preamble.sh', '.github/scripts/main/create-ocaml-cache.sh') }}");
     ("cygwin", "${{ hashFiles('.github/scripts/cygwin.cmd') }}-${{ env.CYGWIN_EPOCH }}");
     ("opam-bs-cache", "${{ hashFiles('.github/scripts/main/opam-bs-cache.sh', '*.opam', '.github/scripts/main/preamble.sh') }}");
   ] in

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -202,7 +202,7 @@ let cache ?cond ?(key_prefix="needs.Analyse") ?(check_only=false) name =
       if cache.force_gzip || check_only then
         "ocaml-opam/cache@opam"
       else
-        "actions/cache@v2"
+        "actions/cache@v3"
     in
     let withs =
       if cache.force_gzip then

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -477,7 +477,7 @@ let hygiene_job (type a) ~analyse_job (platform : a platform) ~oc ~workflow f =
     ++ install_sys_dune [os_of_platform platform]
     ++ checkout ()
     ++ cache Archives
-    ++ uses "Get changed files" ~id:"files" ~continue_on_error:true (* see https://github.com/jitterbit/get-changed-files/issues/19 *) "jitterbit/get-changed-files@v1"
+    ++ uses "Get changed files" ~id:"files" (* ~continue_on_error:true see https://github.com/jitterbit/get-changed-files/issues/19 *) "Ana06/get-changed-files@v2.2.0" (* see https://github.com/jitterbit/get-changed-files/issues/55 ; Ana06'fork contains #19 and #55 fixes *) 
     ++ run "Changed files list" [
          "for changed_file in ${{ steps.files.outputs.modified }}; do";
          "  echo \"M  ${changed_file}.\"";

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -107,7 +107,7 @@ type cache = {
 type _ cache_name =
 | Archives : ((cache -> 'a) -> 'a) cache_name
 | Secondary : ((cache -> 'a) -> 'a) cache_name
-| Cygwin : ((cache -> 'a) -> [ `x86 | `x64 ] -> 'a) cache_name
+| Cygwin : ((cache -> 'a) -> 'a) cache_name
 | OCaml : ((cache -> 'a) -> _ platform -> string -> string -> 'a) cache_name
 | OpamBS : ((cache -> 'a) -> string -> string -> 'a) cache_name
 | OpamRoot : ((cache -> 'a) -> string -> 'a) cache_name
@@ -137,15 +137,14 @@ let get_cache_cont : type s . s cache_name -> s = function
          build = ["bash -exu .github/scripts/main/legacy-cache.sh"];
          build_shell = None}
   | Cygwin ->
-      fun f arch ->
-        let (arch_name, key_arch) = match arch with `x86 -> ("i686", "32") | `x64 -> ("x86_64", "64") in f
-        {name = (match arch with `x86 -> "Cygwin32" | `x64 -> "Cygwin64");
-         key = Printf.sprintf "cygwin%s-${{ %s.outputs.cygwin }}" key_arch;
-         id = "cygwin" ^ key_arch;
+      fun f -> f
+        {name = "Cygwin64";
+         key = Printf.sprintf "cygwin64-${{ %s.outputs.cygwin }}";
+         id = "cygwin64";
          force_gzip = true;
-         paths = [Printf.sprintf "%s\\%s-pc-cygwin" cygwin_cache_directory arch_name];
+         paths = [Printf.sprintf "%s\\x86_64-pc-cygwin" cygwin_cache_directory];
          always_build = false;
-         build = [Printf.sprintf {|.github\scripts\cygwin.cmd %s-pc-cygwin %s create|} arch_name cygwin_cache_directory];
+         build = [Printf.sprintf {|.github\scripts\cygwin.cmd x86_64-pc-cygwin %s create|} cygwin_cache_directory];
          build_shell = Some "cmd"}
   | OCaml ->
       fun f (type a) (platform : a platform) version host ->
@@ -311,17 +310,11 @@ let analyse_job ~oc ~workflow ~platforms ~keys f =
     ++ end_job f
 
 let cygwin_job ~analyse_job ~oc ~workflow f =
-  let cygwin32 = get_cache Cygwin `x86 in
-  let cygwin64 = get_cache Cygwin `x64 in
-  let either_missed =
-    Or(Predicate(true, CacheMiss cygwin32.id), Predicate(true, CacheMiss cygwin64.id))
-  in
+  let cygwin64 = get_cache Cygwin in
   job ~oc ~workflow ~runs_on:(Runner [Windows]) ~needs:[analyse_job] "Cygwin"
-    ++ cache ~check_only:true Cygwin `x86 
-    ++ cache ~check_only:true Cygwin `x64
-    ++ checkout ~cond:either_missed ()
-    ++ build_cache Cygwin `x86
-    ++ build_cache Cygwin `x64
+    ++ cache ~check_only:true Cygwin
+    ++ checkout ~cond:(Predicate(true, CacheMiss cygwin64.id)) ()
+    ++ build_cache Cygwin
     ++ end_job f
 
 let main_build_job ~analyse_job ~cygwin_job ?section platform start_version ~oc ~workflow f =
@@ -338,19 +331,9 @@ let main_build_job ~analyse_job ~cygwin_job ?section platform start_version ~oc 
   let (_fail_fast, matrix, _) = platform_ocaml_matrix ~fail_fast:true start_version in
   let (matrix, includes) =
     if platform = Windows then
-      let includes =
-        (* Annoyingly, it does not appear to be possible to exclude or include by pattern, i.e. to
-           have
-           include:
-              - host: i686-pc-cygwin
-                build: i686-pc-cygwin
-            and have GHA take the cross-product of that with ocamlv from the main matrix
-            So we have to duplicate the ocamlv below... *)
-        List.map (fun v -> [("ocamlv", v); ("host", "i686-pc-cygwin"); ("build", "i686-pc-cygwin")]) (snd (List.hd matrix))
-      in
       (("host", ["x86_64-pc-cygwin"; "i686-w64-mingw32"; "x86_64-w64-mingw32"; "i686-pc-windows"; "x86_64-pc-windows"]) ::
        ("build", ["x86_64-pc-cygwin"]) ::
-        matrix, includes)
+       matrix, [])
     else
       (matrix, []) in
   let matrix = ((platform <> Windows), matrix, includes) in
@@ -360,8 +343,7 @@ let main_build_job ~analyse_job ~cygwin_job ?section platform start_version ~oc 
     ++ only_on Linux (run "Install bubblewrap" ["sudo apt install bubblewrap"])
     ++ only_on Windows (git_lf_checkouts ~cond:(Predicate(true, EndsWith("matrix.host", "-pc-cygwin"))) ~shell:"cmd" ~title:"Configure LF checkout for Cygwin" ())
     ++ checkout ()
-    ++ only_on Windows (cache ~cond:(Predicate(true, Compare("matrix.build", "i686-pc-cygwin"))) Cygwin `x86)
-    ++ only_on Windows (cache ~cond:(Predicate(true, Compare("matrix.build", "x86_64-pc-cygwin"))) Cygwin `x64)
+    ++ only_on Windows (cache ~cond:(Predicate(true, Compare("matrix.build", "x86_64-pc-cygwin"))) Cygwin)
     ++ cache Archives
     ++ cache OCaml platform "${{ matrix.ocamlv }}" host
     ++ only_on Windows (unpack_cygwin "${{ matrix.build }}" "${{ matrix.host }}")

--- a/.github/workflows/depexts.yml
+++ b/.github/workflows/depexts.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - name: opam binary cache
       id: binary
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: binary/opam
         key: binary-${{ env.OPAMVERSION }}
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: opam binary cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: binary/opam
         key: binary-${{ env.OPAMVERSION }}
@@ -60,9 +60,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: opam binary cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: binary/opam
         key: binary-${{ env.OPAMVERSION }}
@@ -78,9 +78,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: opam binary cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: binary/opam
         key: binary-${{ env.OPAMVERSION }}
@@ -96,9 +96,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: opam binary cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: binary/opam
         key: binary-${{ env.OPAMVERSION }}
@@ -114,9 +114,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: opam binary cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: binary/opam
         key: binary-${{ env.OPAMVERSION }}
@@ -132,9 +132,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: opam binary cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: binary/opam
         key: binary-${{ env.OPAMVERSION }}
@@ -150,9 +150,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: opam binary cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: binary/opam
         key: binary-${{ env.OPAMVERSION }}
@@ -168,9 +168,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: opam binary cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: binary/opam
         key: binary-${{ env.OPAMVERSION }}
@@ -186,9 +186,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: opam binary cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: binary/opam
         key: binary-${{ env.OPAMVERSION }}

--- a/.github/workflows/lib.ml
+++ b/.github/workflows/lib.ml
@@ -231,7 +231,7 @@ let uses name ?id ?cond ?(continue_on_error=false) ?(withs=[]) action ~oc ~workf
   f ~oc ~workflow ~job
 
 let checkout ?cond () =
-  uses "Checkout tree" ?id:None ?cond "actions/checkout@v2"
+  uses "Checkout tree" ?id:None ?cond "actions/checkout@v3"
 
 let skip_step ~oc ~workflow ~job f = f ~oc ~workflow ~job
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -634,8 +634,7 @@ jobs:
         force-gzip: true
     - name: Get changed files
       id: files
-      uses: jitterbit/get-changed-files@v1
-      continue-on-error: true
+      uses: Ana06/get-changed-files@v2.2.0
     - name: Changed files list
       run: |
         for changed_file in ${{ steps.files.outputs.modified }}; do

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,8 +75,8 @@ jobs:
         echo archives=archives-1-${{ hashFiles('src_ext/Makefile.sources', 'src_ext/Makefile', '.github/scripts/common/preamble.sh', '.github/scripts/main/preamble.sh', '.github/scripts/main/archives-cache.sh') }}-${{ env.OPAM_REPO_SHA }} >> $GITHUB_OUTPUT
         echo ocaml-secondary-compiler=legacy-${{ env.OPAM_REPO_SHA }}
         echo ocaml-secondary-compiler=legacy-${{ env.OPAM_REPO_SHA }} >> $GITHUB_OUTPUT
-        echo ocaml-cache=${{ hashFiles('.github/scripts/main/ocaml-cache.sh', '.github/scripts/main/preamble.sh') }}
-        echo ocaml-cache=${{ hashFiles('.github/scripts/main/ocaml-cache.sh', '.github/scripts/main/preamble.sh') }} >> $GITHUB_OUTPUT
+        echo ocaml-cache=${{ hashFiles('.github/scripts/main/ocaml-cache.sh', '.github/scripts/main/preamble.sh', '.github/scripts/main/create-ocaml-cache.sh') }}
+        echo ocaml-cache=${{ hashFiles('.github/scripts/main/ocaml-cache.sh', '.github/scripts/main/preamble.sh', '.github/scripts/main/create-ocaml-cache.sh') }} >> $GITHUB_OUTPUT
         echo cygwin=${{ hashFiles('.github/scripts/cygwin.cmd') }}-${{ env.CYGWIN_EPOCH }}
         echo cygwin=${{ hashFiles('.github/scripts/cygwin.cmd') }}-${{ env.CYGWIN_EPOCH }} >> $GITHUB_OUTPUT
         echo opam-bs-cache=${{ hashFiles('.github/scripts/main/opam-bs-cache.sh', '*.opam', '.github/scripts/main/preamble.sh') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,14 +112,6 @@ jobs:
     runs-on: windows-2019
     needs: Analyse
     steps:
-    - name: Cygwin32 Cache
-      id: cygwin32
-      uses: ocaml-opam/cache@opam
-      with:
-        path: D:\Cache\cygwin\i686-pc-cygwin
-        key: cygwin32-${{ needs.Analyse.outputs.cygwin }}
-        check-only: true
-        force-gzip: true
     - name: Cygwin64 Cache
       id: cygwin64
       uses: ocaml-opam/cache@opam
@@ -129,12 +121,8 @@ jobs:
         check-only: true
         force-gzip: true
     - name: Checkout tree
-      if: steps.cygwin32.outputs.cache-hit != 'true' || steps.cygwin64.outputs.cache-hit != 'true'
+      if: steps.cygwin64.outputs.cache-hit != 'true'
       uses: actions/checkout@v3
-    - name: Create Cygwin32 cache
-      if: steps.cygwin32.outputs.cache-hit != 'true'
-      shell: cmd
-      run: .github\scripts\cygwin.cmd i686-pc-cygwin D:\Cache\cygwin create
     - name: Create Cygwin64 cache
       if: steps.cygwin64.outputs.cache-hit != 'true'
       shell: cmd
@@ -186,10 +174,6 @@ jobs:
         host: [ x86_64-pc-cygwin, i686-w64-mingw32, x86_64-w64-mingw32, i686-pc-windows, x86_64-pc-windows ]
         build: [ x86_64-pc-cygwin ]
         ocamlv: [ 4.14.0 ]
-        include:
-          - ocamlv: 4.14.0
-            host: i686-pc-cygwin
-            build: i686-pc-cygwin
       fail-fast: false
     defaults:
       run:
@@ -203,14 +187,6 @@ jobs:
         git config --system core.eol lf
     - name: Checkout tree
       uses: actions/checkout@v3
-    - name: Cygwin32 Cache
-      id: cygwin32
-      if: matrix.build == 'i686-pc-cygwin'
-      uses: ocaml-opam/cache@opam
-      with:
-        path: D:\Cache\cygwin\i686-pc-cygwin
-        key: cygwin32-${{ needs.Analyse.outputs.cygwin }}
-        force-gzip: true
     - name: Cygwin64 Cache
       id: cygwin64
       if: matrix.build == 'x86_64-pc-cygwin'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,15 +72,15 @@ jobs:
       id: keys
       run: |
         echo archives=archives-1-${{ hashFiles('src_ext/Makefile.sources', 'src_ext/Makefile', '.github/scripts/common/preamble.sh', '.github/scripts/main/preamble.sh', '.github/scripts/main/archives-cache.sh') }}-${{ env.OPAM_REPO_SHA }}
-        echo ::set-output name=archives::archives-1-${{ hashFiles('src_ext/Makefile.sources', 'src_ext/Makefile', '.github/scripts/common/preamble.sh', '.github/scripts/main/preamble.sh', '.github/scripts/main/archives-cache.sh') }}-${{ env.OPAM_REPO_SHA }}
+        echo archives=archives-1-${{ hashFiles('src_ext/Makefile.sources', 'src_ext/Makefile', '.github/scripts/common/preamble.sh', '.github/scripts/main/preamble.sh', '.github/scripts/main/archives-cache.sh') }}-${{ env.OPAM_REPO_SHA }} >> $GITHUB_OUTPUT
         echo ocaml-secondary-compiler=legacy-${{ env.OPAM_REPO_SHA }}
-        echo ::set-output name=ocaml-secondary-compiler::legacy-${{ env.OPAM_REPO_SHA }}
+        echo ocaml-secondary-compiler=legacy-${{ env.OPAM_REPO_SHA }} >> $GITHUB_OUTPUT
         echo ocaml-cache=${{ hashFiles('.github/scripts/main/ocaml-cache.sh', '.github/scripts/main/preamble.sh') }}
-        echo ::set-output name=ocaml-cache::${{ hashFiles('.github/scripts/main/ocaml-cache.sh', '.github/scripts/main/preamble.sh') }}
+        echo ocaml-cache=${{ hashFiles('.github/scripts/main/ocaml-cache.sh', '.github/scripts/main/preamble.sh') }} >> $GITHUB_OUTPUT
         echo cygwin=${{ hashFiles('.github/scripts/cygwin.cmd') }}-${{ env.CYGWIN_EPOCH }}
-        echo ::set-output name=cygwin::${{ hashFiles('.github/scripts/cygwin.cmd') }}-${{ env.CYGWIN_EPOCH }}
+        echo cygwin=${{ hashFiles('.github/scripts/cygwin.cmd') }}-${{ env.CYGWIN_EPOCH }} >> $GITHUB_OUTPUT
         echo opam-bs-cache=${{ hashFiles('.github/scripts/main/opam-bs-cache.sh', '*.opam', '.github/scripts/main/preamble.sh') }}
-        echo ::set-output name=opam-bs-cache::${{ hashFiles('.github/scripts/main/opam-bs-cache.sh', '*.opam', '.github/scripts/main/preamble.sh') }}
+        echo opam-bs-cache=${{ hashFiles('.github/scripts/main/opam-bs-cache.sh', '*.opam', '.github/scripts/main/preamble.sh') }} >> $GITHUB_OUTPUT
     - name: src_ext/archives and opam-repository Cache
       id: archives
       uses: ocaml-opam/cache@opam

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
       opam-bs-cache: ${{ steps.keys.outputs.opam-bs-cache }}
     steps:
     - name: Checkout tree
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Determine cache keys
       id: keys
       run: |
@@ -130,7 +130,7 @@ jobs:
         force-gzip: true
     - name: Checkout tree
       if: steps.cygwin32.outputs.cache-hit != 'true' || steps.cygwin64.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Create Cygwin32 cache
       if: steps.cygwin32.outputs.cache-hit != 'true'
       shell: cmd
@@ -154,7 +154,7 @@ jobs:
     - name: Install bubblewrap
       run: sudo apt install bubblewrap
     - name: Checkout tree
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: src_ext/archives and opam-repository Cache
       id: archives
       uses: ocaml-opam/cache@opam
@@ -166,7 +166,7 @@ jobs:
         force-gzip: true
     - name: OCaml ${{ matrix.ocamlv }} Cache
       id: ocaml-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/ocaml-local/**
         key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ needs.Analyse.outputs.ocaml-cache }}
@@ -202,7 +202,7 @@ jobs:
         git config --system core.autocrlf false
         git config --system core.eol lf
     - name: Checkout tree
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Cygwin32 Cache
       id: cygwin32
       if: matrix.build == 'i686-pc-cygwin'
@@ -272,7 +272,7 @@ jobs:
       fail-fast: true
     steps:
     - name: Checkout tree
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: src_ext/archives and opam-repository Cache
       id: archives
       uses: ocaml-opam/cache@opam
@@ -284,7 +284,7 @@ jobs:
         force-gzip: true
     - name: OCaml ${{ matrix.ocamlv }} Cache
       id: ocaml-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/ocaml-local/**
         key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ needs.Analyse.outputs.ocaml-cache }}
@@ -311,10 +311,10 @@ jobs:
     - name: Install system's opam package
       run: sudo apt install opam || true
     - name: Checkout tree
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: ocaml-secondary-compiler Cache
       id: legacy
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.opam
         key: ${{ runner.os }}-${{ needs.Analyse.outputs.ocaml-secondary-compiler }}
@@ -323,7 +323,7 @@ jobs:
       run: bash -exu .github/scripts/main/legacy-cache.sh
     - name: OCaml ${{ matrix.ocamlv }} Cache
       id: ocaml-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/ocaml-local/**
         key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ needs.Analyse.outputs.ocaml-cache }}
@@ -347,7 +347,7 @@ jobs:
       OPAM_TEST: 1
     steps:
     - name: Checkout tree
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install bubblewrap
       run: sudo apt install bubblewrap
     - name: src_ext/archives and opam-repository Cache
@@ -361,7 +361,7 @@ jobs:
         force-gzip: true
     - name: OCaml ${{ matrix.ocamlv }} Cache
       id: ocaml-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/ocaml-local/**
         key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ needs.Analyse.outputs.ocaml-cache }}
@@ -370,7 +370,7 @@ jobs:
       run: bash -exu .github/scripts/main/ocaml-cache.sh ${{ runner.os }} ${{ matrix.ocamlv }}
     - name: opam bootstrap Cache
       id: opam-bootstrap
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ env.OPAMBSROOT }}/**
@@ -381,7 +381,7 @@ jobs:
       run: bash -exu .github/scripts/main/opam-bs-cache.sh
     - name: opam-rt Cache
       id: opam-rt
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/opam-rt/**
         key: ${{ runner.os }}-opam-rt-${{ matrix.ocamlv }}
@@ -401,7 +401,7 @@ jobs:
       OPAM_TEST: 1
     steps:
     - name: Checkout tree
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: src_ext/archives and opam-repository Cache
       id: archives
       uses: ocaml-opam/cache@opam
@@ -413,7 +413,7 @@ jobs:
         force-gzip: true
     - name: OCaml ${{ matrix.ocamlv }} Cache
       id: ocaml-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/ocaml-local/**
         key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ needs.Analyse.outputs.ocaml-cache }}
@@ -422,7 +422,7 @@ jobs:
       run: bash -exu .github/scripts/main/ocaml-cache.sh ${{ runner.os }} ${{ matrix.ocamlv }}
     - name: opam bootstrap Cache
       id: opam-bootstrap
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ env.OPAMBSROOT }}/**
@@ -433,7 +433,7 @@ jobs:
       run: bash -exu .github/scripts/main/opam-bs-cache.sh
     - name: opam-rt Cache
       id: opam-rt
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/opam-rt/**
         key: ${{ runner.os }}-opam-rt-${{ matrix.ocamlv }}
@@ -454,7 +454,7 @@ jobs:
     - name: Install bubblewrap
       run: sudo apt install bubblewrap
     - name: Checkout tree
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: src_ext/archives and opam-repository Cache
       id: archives
       uses: ocaml-opam/cache@opam
@@ -490,7 +490,7 @@ jobs:
     - name: Install bubblewrap
       run: sudo apt install bubblewrap
     - name: Checkout tree
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: src_ext/archives and opam-repository Cache
       id: archives
       uses: ocaml-opam/cache@opam
@@ -502,7 +502,7 @@ jobs:
         force-gzip: true
     - name: OCaml ${{ matrix.ocamlv }} Cache
       id: ocaml-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/ocaml-local/**
         key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ needs.Analyse.outputs.ocaml-cache }}
@@ -511,7 +511,7 @@ jobs:
       run: bash -exu .github/scripts/main/ocaml-cache.sh ${{ runner.os }} ${{ matrix.ocamlv }}
     - name: opam bootstrap Cache
       id: opam-bootstrap
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ env.OPAMBSROOT }}/**
@@ -536,7 +536,7 @@ jobs:
       OPAMBSROOT: ~/.cache/opam.${{ matrix.solver }}.cached
     steps:
     - name: Checkout tree
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: src_ext/archives and opam-repository Cache
       id: archives
       uses: ocaml-opam/cache@opam
@@ -548,7 +548,7 @@ jobs:
         force-gzip: true
     - name: OCaml ${{ matrix.ocamlv }} Cache
       id: ocaml-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/ocaml-local/**
         key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ needs.Analyse.outputs.ocaml-cache }}
@@ -557,7 +557,7 @@ jobs:
       run: bash -exu .github/scripts/main/ocaml-cache.sh ${{ runner.os }} ${{ matrix.ocamlv }}
     - name: opam bootstrap Cache
       id: opam-bootstrap
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ env.OPAMBSROOT }}/**
@@ -583,15 +583,15 @@ jobs:
     - name: Install bubblewrap
       run: sudo apt install bubblewrap
     - name: Checkout tree
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: opam 1.2 root Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ env.OPAM12CACHE }}
         key: ${{ runner.os }}-opam1.2-root
     - name: OCaml ${{ matrix.ocamlv }} Cache
       id: ocaml-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/ocaml-local/**
         key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ needs.Analyse.outputs.ocaml-cache }}
@@ -614,15 +614,15 @@ jobs:
       fail-fast: false
     steps:
     - name: Checkout tree
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: opam 1.2 root Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ env.OPAM12CACHE }}
         key: ${{ runner.os }}-opam1.2-root
     - name: OCaml ${{ matrix.ocamlv }} Cache
       id: ocaml-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/ocaml-local/**
         key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ needs.Analyse.outputs.ocaml-cache }}
@@ -646,7 +646,7 @@ jobs:
     - name: Install system's dune and ocaml packages
       run: sudo apt install dune ocaml || true
     - name: Checkout tree
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: src_ext/archives and opam-repository Cache
       id: archives
       uses: ocaml-opam/cache@opam

--- a/master_changes.md
+++ b/master_changes.md
@@ -244,6 +244,7 @@ users)
   * Small update to GHA scripts [#5055 @dra27]
   * Adapt Windows CI to new safe.directory setting [#5119 @dra27]
   * Bid a fond farewell to AppVeyor, with thanks for 5100+ CI builds [#5134 @dra27]
+  * Remove Cygwin32 from testing, as it's been retired upstream [#5365 @dra27]
 
 ## Release scripts
   * Make the release script setup-less using QEMU, Docker and Rosetta 2 [#4947 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -426,6 +426,7 @@ users)
   * Update repo hash in depext workflow [#5153 @rjbou]
   * Fix the archlinux script [#5218 @kit-ty-kate]
   * Fix Cygwin Cache [#5281 @dra27]
+  * Upgrade actions version for new infrastructure: `actions/cache` to `v3`, `actions/checkout` to `v3`, and `jitterbit/get-changed-files@v1` to `Ana06/get-changed-files` [#5365 @rjbou]
 
 ## Shell
   * fish: fix deprecated redirection syntax `^` [#4736 @vzaliva]


### PR DESCRIPTION
* [x] Upgrade ocaml-opam/cache action (/cc @dra27) - ~~_done in `dra27/cache@opam`, not yet pushed to ocaml-opam/cache_~~
* [x] gcc10 / glibc 2.34 fixes (apply patch) for 4.08 -> 4.12
* [x] change jitterbit/get-changed-files@v1 to Ana06/get-changed-files (see https://github.com/jitterbit/get-changed-files/issues/55, `Ana06` fork contains fix that issue and remaining https://github.com/jitterbit/get-changed-files/issues/19)

Fixes #5282