### PR TITLE
Run GC compaction before applying solutions

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -293,6 +293,7 @@ users)
   * [BUG] Fix all empty conflict explanations [#4982 #5263 @kit-ty-kate]
   * Fix json double printing [#5143 @rjbou]
   * [BUG] Fix passing `archive-mirrors` field from init config file to config [#5315 @hannesm]
+  * Run GC compaction before applying solutions
 
 ## Internal
   * Add license and lowerbounds to opam files [#4714 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -293,7 +293,7 @@ users)
   * [BUG] Fix all empty conflict explanations [#4982 #5263 @kit-ty-kate]
   * Fix json double printing [#5143 @rjbou]
   * [BUG] Fix passing `archive-mirrors` field from init config file to config [#5315 @hannesm]
-  * Run GC compaction before applying solutions
+  * Run GC compaction before applying solutions [#5376 @kkeundotnet]
 
 ## Internal
   * Add license and lowerbounds to opam files [#4714 @kit-ty-kate]

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -171,6 +171,7 @@ type global_options = {
   working_dir : bool;
   ignore_pin_depends : bool;
   cli : OpamCLIVersion.t;
+  gc_before_action: bool;
 }
 
 (** Global options *)

--- a/src/client/opamClientConfig.ml
+++ b/src/client/opamClientConfig.ml
@@ -17,6 +17,7 @@ module E = struct
     | DROPWORKINGDIR of bool option
     | EDITOR of string option
     | FAKE of bool option
+    | GCBEFOREACTION of bool option
     | IGNOREPINDEPENDS of bool option
     | INPLACEBUILD of bool option
     | JSON of string option
@@ -39,6 +40,7 @@ module E = struct
   let dropworkingdir = value (function DROPWORKINGDIR b -> b | _ -> None)
   let editor = value (function EDITOR s -> s | _ -> None)
   let fake = value (function FAKE b -> b | _ -> None)
+  let gcbeforeaction = value (function GCBEFOREACTION b -> b | _ -> None)
   let ignorepindepends = value (function IGNOREPINDEPENDS b -> b | _ -> None)
   let inplacebuild = value (function INPLACEBUILD b -> b | _ -> None)
   let json = value (function JSON s -> s | _ -> None)
@@ -76,6 +78,7 @@ type t = {
   assume_depexts: bool;
   cli: OpamCLIVersion.t;
   scrubbed_environment_variables: string list;
+  gc_before_action: bool;
 }
 
 let default = {
@@ -98,6 +101,7 @@ let default = {
   assume_depexts = false;
   cli = OpamCLIVersion.current;
   scrubbed_environment_variables = [];
+  gc_before_action = false;
 }
 
 type 'a options_fun =
@@ -120,6 +124,7 @@ type 'a options_fun =
   ?assume_depexts:bool ->
   ?cli:OpamCLIVersion.t ->
   ?scrubbed_environment_variables:string list ->
+  ?gc_before_action:bool ->
   'a
 
 let setk k t
@@ -142,6 +147,7 @@ let setk k t
     ?assume_depexts
     ?cli
     ?scrubbed_environment_variables
+    ?gc_before_action
   =
   let (+) x opt = match opt with Some x -> x | None -> x in
   k {
@@ -163,7 +169,8 @@ let setk k t
     no_auto_upgrade = t.no_auto_upgrade + no_auto_upgrade;
     assume_depexts = t.assume_depexts + assume_depexts;
     cli = t.cli + cli;
-    scrubbed_environment_variables = t.scrubbed_environment_variables + scrubbed_environment_variables
+    scrubbed_environment_variables = t.scrubbed_environment_variables + scrubbed_environment_variables;
+    gc_before_action = t.gc_before_action + gc_before_action;
   }
 
 let set t = setk (fun x () -> x) t
@@ -198,6 +205,7 @@ let initk k =
     ?assume_depexts:(E.assumedepexts ())
     ?cli:None
     ?scrubbed_environment_variables:None
+    ?gc_before_action:(E.gcbeforeaction ())
 
 let init ?noop:_ = initk (fun () -> ())
 

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -19,6 +19,7 @@ module E: sig
     | DROPWORKINGDIR of bool option
     | EDITOR of string option
     | FAKE of bool option
+    | GCBEFOREACTION of bool option
     | IGNOREPINDEPENDS of bool option
     | INPLACEBUILD of bool option
     | JSON of string option
@@ -59,6 +60,7 @@ type t = private {
   assume_depexts: bool;
   cli: OpamCLIVersion.t;
   scrubbed_environment_variables: string list;
+  gc_before_action: bool;
 }
 
 type 'a options_fun =
@@ -82,6 +84,7 @@ type 'a options_fun =
   ?assume_depexts:bool ->
   ?cli:OpamCLIVersion.t ->
   ?scrubbed_environment_variables:string list ->
+  ?gc_before_action:bool ->
   'a
   (* constraint 'a = 'b -> 'c *)
 
@@ -120,6 +123,7 @@ val opam_init:
   ?assume_depexts:bool ->
   ?cli:OpamCLIVersion.t ->
   ?scrubbed_environment_variables:string list ->
+  ?gc_before_action:bool ->
   ?current_switch:OpamSwitch.t ->
   ?switch_from:OpamStateTypes.provenance ->
   ?jobs:int Lazy.t ->

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1292,7 +1292,7 @@ let apply ?ask t ~requested ?print_requested ?add_roots
     ?(skip=OpamPackage.Map.empty)
     ?(assume_built=false)
     ?(download_only=false) ?force_remove solution0 =
-  gc_compact ();
+  if OpamClientConfig.(!r.gc_before_action) then gc_compact ();
   let names = OpamPackage.names_of_packages requested in
   let print_requested = OpamStd.Option.default names print_requested in
   log "apply";


### PR DESCRIPTION
Hello. I am curious about if you are interested in running additional garbage collections for small-RAM machines. 

This PR runs garbage collection (`Gc.compact`) before applying solutions, with an additional option `--gc-before-action`.

context:
I have a tiny machine with 1 GB of RAM. When opam-installing `ppxlib` or `js_of_ocaml` in it, it died with OOM. However, building the libraries directly from their source code was fine.

In my local runnings, this PR saved about 240 MB (from 482 to 242) before starting library builds (e.g. when `opam install ppxlib`). While the save is not huge (and it is not a big deal for most of *modern* machines), it was sufficient save for my tiny machine to be able to build `ppxlib` or `js_of_ocaml` without OOM.