### PR TITLE
Reftest: add `build-env` overwrite predefined build env opam vars

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -132,6 +132,7 @@ users)
   * Update init test to make it no repo [#5327 @rjbou]
   * Add a test in admin cache for hash cache [#6103 @rjbou]
   * Add admin cache test [#6068 @rjbou]
+  * env: Add a test for `build-env` overwrites build env opam environment variables [#5377 @rjbou]
 
 ### Engine
 

--- a/tests/reftests/env.test
+++ b/tests/reftests/env.test
@@ -572,3 +572,82 @@ FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.0
 CONFIG                          config-exec command=sh -c echo $A_VAR
 FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/environment in 0.000s
 FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s
+### : Build environment variables and their overwrite :
+### # Note: OPAMROOT is not shown as it is defined in the environment
+### #       MANPATH is not kept, it is supposed to have the same behaviour thant PATH
+### sh -c "env | sort | uniq" >$ LOCALENV
+### <pkg:to-build.2>
+opam-version: "2.0"
+build: [ "sh" "getenv.sh" "1" ]
+### <pkg:to-build.2:getenv.sh>
+out=build-env
+fromtest="^PATH=\|^MANPATH=\|^LOCALENV=\|^TEMPDIR=\|^TMPDIR=\|^TMP=\|^TEMP=\|^SHLVL=\|^PWD=\|^_="
+for v in $LOCALENV; do
+  if echo "$v" | grep -q "=" ; then
+    fromtest="$fromtest\\|^$(echo "$v" | cut -f 1 -d '=')="
+  fi
+done
+env | sort | uniq | grep -v "'$fromtest'"> "$out"
+echo "PATH=$(echo $PATH | cut -f "$1" -d ':')" >> "$out"
+
+echo "doc: [ \"$out\"]" > to-build.install
+### opam switch create bd --empty
+### opam install to-build
+The following actions will be performed:
+=== install 1 package
+  - install to-build 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed to-build.2
+Done.
+### cat $OPAMROOT/bd/doc/to-build/build-env
+CDPATH=
+MAKEFLAGS=
+MAKELEVEL=
+OPAMCLI=2.0
+OPAMSWITCH=bd
+OPAM_PACKAGE_NAME=to-build
+OPAM_PACKAGE_VERSION=2
+OPAM_SWITCH_PREFIX=${BASEDIR}/OPAM/bd
+PATH=${BASEDIR}/OPAM/bd/bin
+### opam remove to-build
+The following actions will be performed:
+=== remove 1 package
+  - remove to-build 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   to-build.2
+Done.
+### <pkg:to-build.2>
+opam-version: "2.0"
+build: [ "sh" "getenv.sh" "1-2" ]
+build-env: [
+  [ CDPATH = "another-cdpath" ]
+  [ MAKEFLAGS = "another-makeflags" ]
+  [ MAKELEVEL = "another-makelevel" ]
+  [ OPAMCLI="1.0" ]
+  [ OPAMROOT="another-root" ]
+  [ OPAMSWITCH="another-switch" ]
+  [ OPAM_PACKAGE_NAME="another-package" ]
+  [ OPAM_PACKAGE_VERSION="another-version" ]
+  [ OPAM_SWITCH_PREFIX="another-switch-prefix" ]
+  [ PATH+="another-path" ]
+]
+### opam install to-build
+The following actions will be performed:
+=== install 1 package
+  - install to-build 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed to-build.2
+Done.
+### cat $OPAMROOT/bd/doc/to-build/build-env
+CDPATH=another-cdpath
+MAKEFLAGS=another-makeflags
+MAKELEVEL=another-makelevel
+OPAMCLI=1.0
+OPAMSWITCH=bd
+OPAM_PACKAGE_NAME=another-package
+OPAM_PACKAGE_VERSION=another-version
+OPAM_SWITCH_PREFIX=${BASEDIR}/OPAM/bd
+PATH=${BASEDIR}/OPAM/bd/bin:another-path


### PR DESCRIPTION
* [x] queued on ~#5286~ for paths handling, resolved by #5723

related to #5363