### PR TITLE
[2.1] Fix all empty conflict explanation messages

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -73,6 +73,7 @@ New option/command/subcommand are prefixed with ◈.
   *
 
 ## Client
+  * [BUG] Fix all empty conflict explanations [#4982 #5263 @kit-ty-kate]
 
 ## Internal
   *
@@ -93,6 +94,7 @@ New option/command/subcommand are prefixed with ◈.
   * Add some simple tests for the "opam list" command [#5006 @kit-ty-kate]
   * Add clean test for untracked option [#4915 @rjbou]
   * Harmonise some repo hash to reduce opam repository checkout [#5031 @AltGr]
+  * Add a series of reftests showing empty conflict messages [#5253 @kit-ty-kate]
 ### Engine
   * Add `opam-cat` to normalise opam file printing [#4763 @rjbou @dra27] [2.1.0~rc2 #4715]
   * Fix meld reftest: open only with failing ones [#4913 @rjbou]

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -730,7 +730,6 @@ type explanation =
 let extract_explanations packages cudfnv2opam reasons : explanation list =
   log "Conflict reporting";
   let open Dose_algo.Diagnostic in
-  let open Set.Op in
   let module CS = ChainSet in
   (* Definitions and printers *)
   let all_opam =
@@ -793,6 +792,8 @@ let extract_explanations packages cudfnv2opam reasons : explanation list =
               (fun (n, _) -> Set.exists (fun p -> p.package = n) pkgs)
               vpkgl
           in
+          (* TODO: We should aim to use what does give us not guess the formula *)
+          (* Dose is precise enough from what i'm seeing *)
           formula_of_vpkgl cudfnv2opam packages vpkgl
         in
         let s = OpamFormula.to_string f in
@@ -813,9 +814,9 @@ let extract_explanations packages cudfnv2opam reasons : explanation list =
   let rdeps = Hashtbl.create 53 in
   let missing = Hashtbl.create 53 in
   List.iter (function
-      | Conflict (l, r, _) ->
+      | Conflict (l, r, (_pkgname, _constr)) ->
         add_set ct l (Set.singleton r);
-        add_set ct r (Set.singleton l)
+        add_set ct r (Set.singleton l);
       | Dependency (l, _, rs) ->
         add_set deps l (Set.of_list rs);
         List.iter (fun r -> add_set rdeps r (Set.singleton l)) rs
@@ -831,45 +832,31 @@ let extract_explanations packages cudfnv2opam reasons : explanation list =
     in
     Set.empty |> add_artefacts deps |> add_artefacts missing |> add_artefacts ct
   in
-  let conflicting =
-    Hashtbl.fold (fun p _ -> Set.add p) ct Set.empty
-  in
-  let all_conflicting =
-    Hashtbl.fold (fun k _ acc -> Set.add k acc) missing conflicting
-  in
-  let ct_chains =
-    (* get a covering tree from the roots to all reachable packages.
-       We keep only shortest chains, but all of them *)
-    (* The chains are stored as lists from packages back to the roots *)
-    let rec aux pchains seen acc =
-      if Map.is_empty pchains then acc else
-      let seen, new_chains =
-        Map.fold (fun p chains (seen1, new_chains) ->
-            let append_to_chains pkg acc =
-              let chain = CS.map (fun c -> pkg :: c) chains in
-              Map.update pkg (CS.union chain) CS.empty acc
-            in
-            let ds = get deps p in
-            let dsc = match Hashtbl.length missing with
-              | 0 -> ds (* Hack to fix https://github.com/ocaml/opam/issues/4373. We should try to do better at some point *)
-              | _ -> ds %% all_conflicting
-            in
-            if not (Set.is_empty dsc) then
-              dsc ++ seen1, Set.fold append_to_chains (dsc -- seen1) new_chains
-            else
-              Set.fold (fun d (seen1, new_chains) ->
-                  if Set.mem d seen then seen1, new_chains
-                  else Set.add d seen1, append_to_chains d new_chains)
-                ds (seen1, new_chains))
-          pchains (seen, Map.empty)
-      in
-      aux new_chains seen @@
-      Map.union (fun _ _ -> assert false) pchains acc
+  let _seen, ct_chains =
+    (* get a covering tree from the roots to all reachable packages. *)
+    let rec aux seen ct_chains =
+      Map.fold (fun pkg parent_chain (seen, ct_chains) ->
+          if Set.mem pkg seen then (seen, ct_chains) else
+          let dependencies = get deps pkg in
+          let seen = Set.add pkg seen in
+          Set.fold (fun dep (seen, ct_chains) ->
+              let chain = CS.map (fun c -> dep :: c) parent_chain in
+              let ct_chains = Map.update dep (CS.union chain) CS.empty ct_chains in
+              aux seen ct_chains
+            ) dependencies (seen, ct_chains)
+        ) ct_chains
+        (seen, ct_chains)
     in
     let init_chains =
       Set.fold (fun p -> Map.add p (CS.singleton [p])) roots Map.empty
     in
-    aux init_chains roots Map.empty
+    aux Set.empty init_chains
+  in
+  let ct_chains =
+    (* We keep only shortest chains. *)
+    (* TODO: choose is probably not the right thing here. *)
+    (* e.g. if two lists have the size, we should probably have both. *)
+    Map.map (fun x -> CS.singleton (CS.choose x)) ct_chains
   in
   let reasons =
     (* order "reasons" by most interesting first: version conflicts then package

--- a/tests/reftests/conflict-badversion.test
+++ b/tests/reftests/conflict-badversion.test
@@ -1,4 +1,5 @@
 f372039d
+### OPAMVAR_arch=x86_64 OPAMVAR_os=linux OPAMVAR_os_family=arch OPAMVAR_os_distribution=archarm
 ### opam switch create --fake ocaml-base-compiler.4.02.3
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
@@ -17,6 +18,16 @@ Done.
 [ERROR] Package conflict!
   * No agreement on the version of core:
     - core != 112.17.00
+  * No agreement on the version of ocaml:
+    - (invariant) -> ocaml-base-compiler = 4.02.3 -> ocaml = 4.02.3
+    - core != 112.17.00 -> ocaml < 4.00.1
+    You can temporarily relax the switch invariant with `--update-invariant'
+  * No agreement on the version of ocaml-base-compiler:
+    - (invariant) -> ocaml-base-compiler = 4.02.3
+    - core != 112.17.00 -> ocaml < 4.00.1 -> ocaml-base-compiler < 3.07+1
+  * Missing dependency:
+    - core != 112.17.00 -> ocaml < 4.00.1 -> ocaml-variants -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
 
 No solution found, exiting
 # Return code 20 #

--- a/tests/reftests/conflict-core.test
+++ b/tests/reftests/conflict-core.test
@@ -1,4 +1,5 @@
 f372039d
+### OPAMVAR_arch=x86_64 OPAMVAR_os=linux OPAMVAR_os_family=arch OPAMVAR_os_distribution=archarm
 ### opam switch create ocaml-base-compiler.4.08.0 --fake
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
@@ -18,6 +19,12 @@ Done.
     - (invariant) -> ocaml-base-compiler >= 4.08.0 -> ocaml = 4.08.0
     - core < 112.17.00 -> ocaml < 4.00.1
     You can temporarily relax the switch invariant with `--update-invariant'
+  * No agreement on the version of ocaml-base-compiler:
+    - (invariant) -> ocaml-base-compiler >= 4.08.0
+    - core < 112.17.00 -> ocaml < 4.00.1 -> ocaml-base-compiler = 3.08.4
+  * Missing dependency:
+    - core < 112.17.00 -> ocaml < 4.00.1 -> ocaml-variants >= 3.11.1 -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
 
 No solution found, exiting
 # Return code 20 #

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -170,6 +170,108 @@
    (run ./run.exe %{bin:opam} %{dep:dot-install.test} %{read-lines:testing-env}))))
 
 (alias
+ (name reftest-empty-conflicts-001)
+ (action
+  (diff empty-conflicts-001.test empty-conflicts-001.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-empty-conflicts-001)))
+
+(rule
+ (targets empty-conflicts-001.out)
+ (deps root-297366c)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:empty-conflicts-001.test} %{read-lines:testing-env}))))
+
+(alias
+ (name reftest-empty-conflicts-002)
+ (action
+  (diff empty-conflicts-002.test empty-conflicts-002.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-empty-conflicts-002)))
+
+(rule
+ (targets empty-conflicts-002.out)
+ (deps root-11ea1cb)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:empty-conflicts-002.test} %{read-lines:testing-env}))))
+
+(alias
+ (name reftest-empty-conflicts-003)
+ (action
+  (diff empty-conflicts-003.test empty-conflicts-003.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-empty-conflicts-003)))
+
+(rule
+ (targets empty-conflicts-003.out)
+ (deps root-3235916)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:empty-conflicts-003.test} %{read-lines:testing-env}))))
+
+(alias
+ (name reftest-empty-conflicts-004)
+ (action
+  (diff empty-conflicts-004.test empty-conflicts-004.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-empty-conflicts-004)))
+
+(rule
+ (targets empty-conflicts-004.out)
+ (deps root-0070613707)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:empty-conflicts-004.test} %{read-lines:testing-env}))))
+
+(alias
+ (name reftest-empty-conflicts-005)
+ (action
+  (diff empty-conflicts-005.test empty-conflicts-005.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-empty-conflicts-005)))
+
+(rule
+ (targets empty-conflicts-005.out)
+ (deps root-de897adf36c4230dfea812f40c98223b31c4521a)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:empty-conflicts-005.test} %{read-lines:testing-env}))))
+
+(alias
+ (name reftest-empty-conflicts-006)
+ (action
+  (diff empty-conflicts-006.test empty-conflicts-006.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-empty-conflicts-006)))
+
+(rule
+ (targets empty-conflicts-006.out)
+ (deps root-c1842d168d)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{bin:opam} %{dep:empty-conflicts-006.test} %{read-lines:testing-env}))))
+
+(alias
  (name reftest-env)
  (action
   (diff env.test env.out)))
@@ -567,6 +669,26 @@
            file://%{dep:opam-repo-N0REP0})))))
 
 (rule
+ (targets opam-archive-0070613707.tar.gz)
+ (action (run wget --quiet -O %{targets} https://github.com/ocaml/opam-repository/archive/0070613707.tar.gz)))
+
+(rule
+  (targets opam-repo-0070613707)
+  (action
+   (progn
+    (run mkdir -p %{targets})
+    (run tar -C %{targets} -xzf %{dep:opam-archive-0070613707.tar.gz} --strip-components=1))))
+
+(rule
+  (targets root-0070613707)
+  (action
+   (progn
+    (ignore-stdout
+    (run %{bin:opam} init --root=%{targets}
+           --no-setup --bypass-checks --no-opamrc --bare
+           file://%{dep:opam-repo-0070613707})))))
+
+(rule
  (targets opam-archive-009e00fa.tar.gz)
  (action (run wget --quiet -O %{targets} https://github.com/ocaml/opam-repository/archive/009e00fa.tar.gz)))
 
@@ -585,6 +707,66 @@
     (run %{bin:opam} init --root=%{targets}
            --no-setup --bypass-checks --no-opamrc --bare
            file://%{dep:opam-repo-009e00fa})))))
+
+(rule
+ (targets opam-archive-11ea1cb.tar.gz)
+ (action (run wget --quiet -O %{targets} https://github.com/ocaml/opam-repository/archive/11ea1cb.tar.gz)))
+
+(rule
+  (targets opam-repo-11ea1cb)
+  (action
+   (progn
+    (run mkdir -p %{targets})
+    (run tar -C %{targets} -xzf %{dep:opam-archive-11ea1cb.tar.gz} --strip-components=1))))
+
+(rule
+  (targets root-11ea1cb)
+  (action
+   (progn
+    (ignore-stdout
+    (run %{bin:opam} init --root=%{targets}
+           --no-setup --bypass-checks --no-opamrc --bare
+           file://%{dep:opam-repo-11ea1cb})))))
+
+(rule
+ (targets opam-archive-297366c.tar.gz)
+ (action (run wget --quiet -O %{targets} https://github.com/ocaml/opam-repository/archive/297366c.tar.gz)))
+
+(rule
+  (targets opam-repo-297366c)
+  (action
+   (progn
+    (run mkdir -p %{targets})
+    (run tar -C %{targets} -xzf %{dep:opam-archive-297366c.tar.gz} --strip-components=1))))
+
+(rule
+  (targets root-297366c)
+  (action
+   (progn
+    (ignore-stdout
+    (run %{bin:opam} init --root=%{targets}
+           --no-setup --bypass-checks --no-opamrc --bare
+           file://%{dep:opam-repo-297366c})))))
+
+(rule
+ (targets opam-archive-3235916.tar.gz)
+ (action (run wget --quiet -O %{targets} https://github.com/ocaml/opam-repository/archive/3235916.tar.gz)))
+
+(rule
+  (targets opam-repo-3235916)
+  (action
+   (progn
+    (run mkdir -p %{targets})
+    (run tar -C %{targets} -xzf %{dep:opam-archive-3235916.tar.gz} --strip-components=1))))
+
+(rule
+  (targets root-3235916)
+  (action
+   (progn
+    (ignore-stdout
+    (run %{bin:opam} init --root=%{targets}
+           --no-setup --bypass-checks --no-opamrc --bare
+           file://%{dep:opam-repo-3235916})))))
 
 (rule
  (targets opam-archive-7090735c.tar.gz)
@@ -647,6 +829,26 @@
            file://%{dep:opam-repo-ad4dd344})))))
 
 (rule
+ (targets opam-archive-c1842d168d.tar.gz)
+ (action (run wget --quiet -O %{targets} https://github.com/ocaml/opam-repository/archive/c1842d168d.tar.gz)))
+
+(rule
+  (targets opam-repo-c1842d168d)
+  (action
+   (progn
+    (run mkdir -p %{targets})
+    (run tar -C %{targets} -xzf %{dep:opam-archive-c1842d168d.tar.gz} --strip-components=1))))
+
+(rule
+  (targets root-c1842d168d)
+  (action
+   (progn
+    (ignore-stdout
+    (run %{bin:opam} init --root=%{targets}
+           --no-setup --bypass-checks --no-opamrc --bare
+           file://%{dep:opam-repo-c1842d168d})))))
+
+(rule
  (targets opam-archive-c1d23f0e.tar.gz)
  (action (run wget --quiet -O %{targets} https://github.com/ocaml/opam-repository/archive/c1d23f0e.tar.gz)))
 
@@ -665,6 +867,26 @@
     (run %{bin:opam} init --root=%{targets}
            --no-setup --bypass-checks --no-opamrc --bare
            file://%{dep:opam-repo-c1d23f0e})))))
+
+(rule
+ (targets opam-archive-de897adf36c4230dfea812f40c98223b31c4521a.tar.gz)
+ (action (run wget --quiet -O %{targets} https://github.com/ocaml/opam-repository/archive/de897adf36c4230dfea812f40c98223b31c4521a.tar.gz)))
+
+(rule
+  (targets opam-repo-de897adf36c4230dfea812f40c98223b31c4521a)
+  (action
+   (progn
+    (run mkdir -p %{targets})
+    (run tar -C %{targets} -xzf %{dep:opam-archive-de897adf36c4230dfea812f40c98223b31c4521a.tar.gz} --strip-components=1))))
+
+(rule
+  (targets root-de897adf36c4230dfea812f40c98223b31c4521a)
+  (action
+   (progn
+    (ignore-stdout
+    (run %{bin:opam} init --root=%{targets}
+           --no-setup --bypass-checks --no-opamrc --bare
+           file://%{dep:opam-repo-de897adf36c4230dfea812f40c98223b31c4521a})))))
 
 (rule
  (targets opam-archive-f372039d.tar.gz)

--- a/tests/reftests/empty-conflicts-001.test
+++ b/tests/reftests/empty-conflicts-001.test
@@ -20,15 +20,15 @@ Done.
     - (invariant) -> ocaml-base-compiler = 4.07.1 -> ocaml = 4.07.1
     - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> ocaml >= 4.08.0
     You can temporarily relax the switch invariant with `--update-invariant'
+  * No agreement on the version of ocaml-base-compiler:
+    - (invariant) -> ocaml-base-compiler = 4.07.1
+    - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> tls -> ocaml >= 4.08.0 -> ocaml-base-compiler = 4.08.0
   * No agreement on the version of cstruct:
     - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> tls -> cstruct < 4.0.0
     - h2-mirage >= 0.9.0 -> gluten-mirage >= 0.3.0 -> cstruct >= 6.0.0
   * No agreement on the version of cstruct:
     - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> tls -> cstruct < 6.0.0
     - h2-mirage >= 0.9.0 -> gluten-mirage >= 0.3.0 -> cstruct >= 6.0.0
-  * No agreement on the version of ocaml-base-compiler:
-    - (invariant) -> ocaml-base-compiler = 4.07.1
-    - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> tls -> ppx_sexp_conv < v0.11.0 -> ocaml = 4.02.3 -> ocaml-base-compiler = 4.02.3
   * Missing dependency:
     - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> dns-client >= 5.0.0 -> mirage-crypto-rng >= 0.8.0 -> mirage-crypto = 0.8.1
     unmet availability conditions: 'false'
@@ -42,7 +42,7 @@ Done.
     - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> dns-client >= 5.0.0 -> mirage-crypto-rng >= 0.8.0 -> mirage-crypto = 0.8.4
     unmet availability conditions: 'false'
   * Missing dependency:
-    - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> tls -> ppx_sexp_conv < v0.11.0 -> ocaml = 4.02.3 -> ocaml-variants >= 4.02.3 -> ocaml-beta
+    - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> tls -> nocrypto < 0.2.0 -> ocaml < 4.02.0 -> ocaml-variants >= 3.09.3 -> ocaml-beta
     unmet availability conditions: 'enable-ocaml-beta-repository'
 
 No solution found, exiting

--- a/tests/reftests/empty-conflicts-001.test
+++ b/tests/reftests/empty-conflicts-001.test
@@ -1,0 +1,49 @@
+297366c
+### OPAMYES=1 OPAMSTRICT=0
+### OPAMVAR_arch=x86_64 OPAMVAR_os=linux OPAMVAR_os_family=arch OPAMVAR_os_distribution=archarm
+### opam switch create test ocaml-base-compiler.4.07.1 --fake
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-base-compiler" {= "4.07.1"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-base-compiler.4.07.1
+Faking installation of ocaml-config.1
+Faking installation of ocaml.4.07.1
+Done.
+### opam install --show h2-mirage.0.9.0
+[ERROR] Package conflict!
+  * No agreement on the version of ocaml:
+    - (invariant) -> ocaml-base-compiler = 4.07.1 -> ocaml = 4.07.1
+    - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> ocaml >= 4.08.0
+    You can temporarily relax the switch invariant with `--update-invariant'
+  * No agreement on the version of cstruct:
+    - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> tls -> cstruct < 4.0.0
+    - h2-mirage >= 0.9.0 -> gluten-mirage >= 0.3.0 -> cstruct >= 6.0.0
+  * No agreement on the version of cstruct:
+    - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> tls -> cstruct < 6.0.0
+    - h2-mirage >= 0.9.0 -> gluten-mirage >= 0.3.0 -> cstruct >= 6.0.0
+  * No agreement on the version of ocaml-base-compiler:
+    - (invariant) -> ocaml-base-compiler = 4.07.1
+    - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> tls -> ppx_sexp_conv < v0.11.0 -> ocaml = 4.02.3 -> ocaml-base-compiler = 4.02.3
+  * Missing dependency:
+    - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> dns-client >= 5.0.0 -> mirage-crypto-rng >= 0.8.0 -> mirage-crypto = 0.8.1
+    unmet availability conditions: 'false'
+  * Missing dependency:
+    - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> dns-client >= 5.0.0 -> mirage-crypto-rng >= 0.8.0 -> mirage-crypto = 0.8.2
+    unmet availability conditions: 'false'
+  * Missing dependency:
+    - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> dns-client >= 5.0.0 -> mirage-crypto-rng >= 0.8.0 -> mirage-crypto = 0.8.3
+    unmet availability conditions: 'false'
+  * Missing dependency:
+    - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> dns-client >= 5.0.0 -> mirage-crypto-rng >= 0.8.0 -> mirage-crypto = 0.8.4
+    unmet availability conditions: 'false'
+  * Missing dependency:
+    - h2-mirage >= 0.9.0 -> conduit-mirage >= 2.0.2 -> tls -> ppx_sexp_conv < v0.11.0 -> ocaml = 4.02.3 -> ocaml-variants >= 4.02.3 -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
+
+No solution found, exiting
+# Return code 20 #

--- a/tests/reftests/empty-conflicts-002.test
+++ b/tests/reftests/empty-conflicts-002.test
@@ -1,0 +1,57 @@
+11ea1cb
+### OPAMYES=1 OPAMSTRICT=0
+### OPAMVAR_arch=x86_64 OPAMVAR_os=linux OPAMVAR_os_family=arch OPAMVAR_os_distribution=archarm
+### opam switch create test ocaml-base-compiler.4.14.0 --fake
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-base-compiler" {= "4.14.0"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-base-compiler.4.14.0
+Faking installation of ocaml-config.2
+Faking installation of ocaml.4.14.0
+Faking installation of ocaml-options-vanilla.1
+Done.
+### opam pin add -k version -n ppx_deriving_yojson.3.7.0 3.7.0
+ppx_deriving_yojson is now pinned to version 3.7.0
+### opam install ppx_deriving_yojson.3.7.0 --fake
+The following actions will be faked:
+  - install seq                 base    [required by yojson]
+  - install ocamlfind           1.9.5   [required by ppx_deriving]
+  - install dune                3.4.1   [required by ppx_deriving_yojson]
+  - install stdlib-shims        0.3.0   [required by ppxlib]
+  - install sexplib0            v0.15.1 [required by ppxlib]
+  - install result              1.5     [required by ppx_deriving_yojson]
+  - install ppx_derivers        1.2.1   [required by ppx_deriving]
+  - install ocaml-compiler-libs v0.12.4 [required by ppxlib]
+  - install cppo                1.6.9   [required by ppx_deriving, yojson]
+  - install ppxlib              0.27.0  [required by ppx_deriving_yojson]
+  - install yojson              2.0.2   [required by ppx_deriving_yojson]
+  - install ppx_deriving        5.2.1   [required by ppx_deriving_yojson]
+  - install ppx_deriving_yojson 3.7.0*
+===== 13 to install =====
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of dune.3.4.1
+Faking installation of cppo.1.6.9
+Faking installation of ocaml-compiler-libs.v0.12.4
+Faking installation of ocamlfind.1.9.5
+Faking installation of ppx_derivers.1.2.1
+Faking installation of result.1.5
+Faking installation of seq.base
+Faking installation of sexplib0.v0.15.1
+Faking installation of stdlib-shims.0.3.0
+Faking installation of ppxlib.0.27.0
+Faking installation of ppx_deriving.5.2.1
+Faking installation of yojson.2.0.2
+Faking installation of ppx_deriving_yojson.3.7.0
+Done.
+### opam install --show fstar.2022.01.15
+[ERROR] Package conflict!
+Sorry, no solution found: there seems to be a problem with your request.
+
+No solution found, exiting
+# Return code 20 #

--- a/tests/reftests/empty-conflicts-002.test
+++ b/tests/reftests/empty-conflicts-002.test
@@ -51,7 +51,19 @@ Faking installation of ppx_deriving_yojson.3.7.0
 Done.
 ### opam install --show fstar.2022.01.15
 [ERROR] Package conflict!
-Sorry, no solution found: there seems to be a problem with your request.
+  * No agreement on the version of ocaml:
+    - (invariant) -> ocaml-base-compiler = 4.14.0 -> ocaml = 4.14.0
+    - fstar >= 2022.01.15 -> ppxlib < 0.26.0 -> ocaml < 4.14
+    You can temporarily relax the switch invariant with `--update-invariant'
+  * No agreement on the version of ocaml-base-compiler:
+    - (invariant) -> ocaml-base-compiler = 4.14.0
+    - fstar >= 2022.01.15 -> ppxlib < 0.26.0 -> ocaml < 4.08.0 -> ocaml-base-compiler = 4.04.1
+  * No agreement on the version of ppxlib:
+    - fstar >= 2022.01.15 -> ppx_deriving_yojson -> ppxlib >= 0.26.0
+    - fstar >= 2022.01.15 -> ppxlib < 0.26.0
+  * Missing dependency:
+    - fstar >= 2022.01.15 -> ppxlib < 0.26.0 -> ocaml < 4.08.0 -> ocaml-variants >= 4.02.4 -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
 
 No solution found, exiting
 # Return code 20 #

--- a/tests/reftests/empty-conflicts-003.test
+++ b/tests/reftests/empty-conflicts-003.test
@@ -1,0 +1,23 @@
+3235916
+### OPAMYES=1 OPAMSTRICT=0
+### OPAMVAR_arch=arm64 OPAMVAR_os=linux OPAMVAR_os_family=arch OPAMVAR_os_distribution=archarm
+### opam switch create test ocaml-base-compiler.4.14.0 --fake
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-base-compiler" {= "4.14.0"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-base-compiler.4.14.0
+Faking installation of ocaml-config.2
+Faking installation of ocaml.4.14.0
+Faking installation of ocaml-options-vanilla.1
+Done.
+### opam install --show disml
+[ERROR] Package conflict!
+Sorry, no solution found: there seems to be a problem with your request.
+
+No solution found, exiting
+# Return code 20 #

--- a/tests/reftests/empty-conflicts-003.test
+++ b/tests/reftests/empty-conflicts-003.test
@@ -17,7 +17,64 @@ Faking installation of ocaml-options-vanilla.1
 Done.
 ### opam install --show disml
 [ERROR] Package conflict!
-Sorry, no solution found: there seems to be a problem with your request.
+  * No agreement on the version of yojson:
+    - disml -> ppx_deriving_yojson >= 3.3 -> yojson >= 1.6.0
+    - disml -> yojson < 1.6.0
+  * No agreement on the version of ocaml:
+    - (invariant) -> ocaml-base-compiler = 4.14.0 -> ocaml = 4.14.0
+    - disml -> ppx_deriving_yojson >= 3.3 -> ppxlib < 0.14.0 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.12
+    You can temporarily relax the switch invariant with `--update-invariant'
+  * Missing dependency:
+    - disml -> ppx_deriving_yojson >= 3.3 -> ppxlib < 0.14.0 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.06.0 -> ocaml-base-compiler < 3.07+1 | ocaml-system < 3.07+1 | ocaml-variants < 3.8~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions: 'sys-ocaml-version = "3.07"'
+    no matching version
+  * Missing dependency:
+    - disml -> ppx_deriving_yojson >= 3.3 -> ppxlib < 0.14.0 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.06.0 -> ocaml-base-compiler = 3.07+1 | ocaml-system = 3.07+1 | ocaml-variants < 3.8~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions: 'sys-ocaml-version = "3.07+1"'
+    no matching version
+  * Missing dependency:
+    - disml -> ppx_deriving_yojson >= 3.3 -> ppxlib < 0.14.0 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.06.0 -> ocaml-base-compiler = 3.07+2 | ocaml-system = 3.07+2 | ocaml-variants < 3.8~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions: 'sys-ocaml-version = "3.07+2"'
+    no matching version
+  * Missing dependency:
+    - disml -> ppx_deriving_yojson >= 3.3 -> ppxlib < 0.14.0 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.06.0 -> ocaml-base-compiler = 3.08.0 | ocaml-system < 3.08.1~ | ocaml-variants < 3.08.1~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions, e.g. 'sys-ocaml-version = "3.08.0"'
+    no matching version
+  * Missing dependency:
+    - disml -> ppx_deriving_yojson >= 3.3 -> ppxlib < 0.14.0 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.06.0 -> ocaml-base-compiler = 3.08.1 | ocaml-system < 3.08.2~ | ocaml-variants < 3.08.2~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions, e.g. 'sys-ocaml-version = "3.08.1"'
+    no matching version
+  * Missing dependency:
+    - disml -> ppx_deriving_yojson >= 3.3 -> ppxlib < 0.14.0 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.06.0 -> ocaml-base-compiler = 3.08.2 | ocaml-system < 3.08.3~ | ocaml-variants < 3.08.3~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions, e.g. 'sys-ocaml-version = "3.08.2"'
+    no matching version
+  * Missing dependency:
+    - disml -> ppx_deriving_yojson >= 3.3 -> ppxlib < 0.14.0 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.06.0 -> ocaml-base-compiler = 3.08.3 | ocaml-system < 3.08.4~ | ocaml-variants < 3.08.4~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions, e.g. 'sys-ocaml-version = "3.08.3"'
+    no matching version
+  * Missing dependency:
+    - disml -> ppx_deriving_yojson >= 3.3 -> ppxlib < 0.14.0 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.06.0 -> ocaml-base-compiler = 3.08.4 | ocaml-system < 3.08.5~ | ocaml-variants < 3.08.5~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions, e.g. 'sys-ocaml-version = "3.08.4"'
+    no matching version
+  * Missing dependency:
+    - disml -> ppx_deriving_yojson >= 3.3 -> ppxlib < 0.14.0 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.06.0 -> ocaml-base-compiler = 3.09.0 | ocaml-system < 3.09.1~ | ocaml-variants < 3.09.1~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions, e.g. 'sys-ocaml-version = "3.09.0"'
+    no matching version
+  * Missing dependency:
+    - disml -> ppx_deriving_yojson >= 3.3 -> ppxlib < 0.14.0 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml-variants = 4.08.0+beta2 -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
+  * Missing dependency:
+    - disml -> ppx_deriving_yojson >= 3.3 -> ppxlib < 0.14.0 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml-variants = 4.08.0+beta3 -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
 
 No solution found, exiting
 # Return code 20 #

--- a/tests/reftests/empty-conflicts-004.test
+++ b/tests/reftests/empty-conflicts-004.test
@@ -16,7 +16,79 @@ Faking installation of ocaml.4.14.0
 Done.
 ### opam install --show camlp5 GT ppxlib.0.25.0
 [ERROR] Package conflict!
-Sorry, no solution found: there seems to be a problem with your request.
+  * No agreement on the version of ppxlib:
+    - GT -> ppxlib < 0.25
+    - ppxlib >= 0.25.0
+  * No agreement on the version of ocaml:
+    - (invariant) -> ocaml-variants = 4.14.0+trunk -> ocaml = 4.14.0
+    - GT -> ocaml < 4.12
+    You can temporarily relax the switch invariant with `--update-invariant'
+  * No agreement on the version of ocaml-variants:
+    - (invariant) -> ocaml-variants = 4.14.0+trunk
+    - GT -> ocaml-migrate-parsetree < 2 -> ocaml < 4.06.0 -> ocaml-variants < 4.02.1~
+  * Missing dependency:
+    - GT -> ocaml < 4.12 -> ocaml-base-compiler < 3.07+1 | ocaml-system < 3.07+1 | ocaml-variants < 3.8~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions: 'sys-ocaml-version = "3.07"'
+    no matching version
+  * Missing dependency:
+    - GT -> ocaml < 4.12 -> ocaml-base-compiler = 3.07+1 | ocaml-system = 3.07+1 | ocaml-variants < 3.8~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions: 'sys-ocaml-version = "3.07+1"'
+    no matching version
+  * Missing dependency:
+    - GT -> ocaml < 4.12 -> ocaml-base-compiler = 3.07+2 | ocaml-system = 3.07+2 | ocaml-variants < 3.8~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions: 'sys-ocaml-version = "3.07+2"'
+    no matching version
+  * Missing dependency:
+    - GT -> ocaml < 4.12 -> ocaml-base-compiler = 3.08.0 | ocaml-system < 3.08.1~ | ocaml-variants < 3.08.1~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions, e.g. 'sys-ocaml-version = "3.08.0"'
+    no matching version
+  * Missing dependency:
+    - GT -> ocaml < 4.12 -> ocaml-base-compiler = 3.08.1 | ocaml-system < 3.08.2~ | ocaml-variants < 3.08.2~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions, e.g. 'sys-ocaml-version = "3.08.1"'
+    no matching version
+  * Missing dependency:
+    - GT -> ocaml < 4.12 -> ocaml-base-compiler = 3.08.2 | ocaml-system < 3.08.3~ | ocaml-variants < 3.08.3~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions, e.g. 'sys-ocaml-version = "3.08.2"'
+    no matching version
+  * Missing dependency:
+    - GT -> ocaml < 4.12 -> ocaml-base-compiler = 3.08.3 | ocaml-system < 3.08.4~ | ocaml-variants < 3.08.4~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions, e.g. 'sys-ocaml-version = "3.08.3"'
+    no matching version
+  * Missing dependency:
+    - GT -> ocaml < 4.12 -> ocaml-base-compiler = 3.08.4 | ocaml-system < 3.08.5~ | ocaml-variants < 3.08.5~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions, e.g. 'sys-ocaml-version = "3.08.4"'
+    no matching version
+  * Missing dependency:
+    - GT -> ocaml < 4.12 -> ocaml-base-compiler = 3.09.0 | ocaml-system < 3.09.1~ | ocaml-variants < 3.09.1~
+    unmet availability conditions: 'arch != "arm64" & arch != "arm32" & arch != "ppc64"'
+    unmet availability conditions, e.g. 'sys-ocaml-version = "3.09.0"'
+    no matching version
+  * Missing dependency:
+    - GT -> ocaml-migrate-parsetree < 2 -> ocaml < 4.09.0 -> ocaml-variants < 4.08.1~ -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
+  * Missing dependency:
+    - GT -> ocaml-migrate-parsetree < 2 -> ocaml < 4.09.0 -> ocaml-variants < 4.08.3~ -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
+  * Missing dependency:
+    - GT -> ocaml-migrate-parsetree < 2 -> ocaml < 4.10 -> ocaml-variants < 4.09.3~ -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
+  * Missing dependency:
+    - GT -> ocaml-migrate-parsetree < 2 -> ocaml < 4.11 -> ocaml-variants < 4.10.1~ -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
+  * Missing dependency:
+    - GT -> ocaml-migrate-parsetree < 2 -> ocaml < 4.11 -> ocaml-variants < 4.10.4~ -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
+  * Missing dependency:
+    - GT -> ocaml-migrate-parsetree < 2 -> ocaml < 4.12 -> ocaml-variants < 4.11.3~ -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
 
 No solution found, exiting
 # Return code 20 #

--- a/tests/reftests/empty-conflicts-004.test
+++ b/tests/reftests/empty-conflicts-004.test
@@ -1,0 +1,22 @@
+0070613707
+### OPAMYES=1 OPAMSTRICT=0
+### OPAMVAR_arch=arm64 OPAMVAR_os=linux OPAMVAR_os_family=arch OPAMVAR_os_distribution=archarm
+### opam switch create test ocaml-variants.4.14.0+trunk --fake
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-variants" {= "4.14.0+trunk"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-variants.4.14.0+trunk
+Faking installation of ocaml-config.2
+Faking installation of ocaml.4.14.0
+Done.
+### opam install --show camlp5 GT ppxlib.0.25.0
+[ERROR] Package conflict!
+Sorry, no solution found: there seems to be a problem with your request.
+
+No solution found, exiting
+# Return code 20 #

--- a/tests/reftests/empty-conflicts-005.test
+++ b/tests/reftests/empty-conflicts-005.test
@@ -1,0 +1,22 @@
+de897adf36c4230dfea812f40c98223b31c4521a
+### OPAMYES=1 OPAMSTRICT=0
+### OPAMVAR_arch=arm64 OPAMVAR_os=linux OPAMVAR_os_family=arch OPAMVAR_os_distribution=archarm
+### opam switch create test ocaml-variants.4.12.0+trunk --fake
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-variants" {= "4.12.0+trunk"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-variants.4.12.0+trunk
+Faking installation of ocaml-config.2
+Faking installation of ocaml.4.12.0
+Done.
+### opam install --show pgocaml_ppx.4.2.2
+[ERROR] Package conflict!
+Sorry, no solution found: there seems to be a problem with your request.
+
+No solution found, exiting
+# Return code 20 #

--- a/tests/reftests/empty-conflicts-005.test
+++ b/tests/reftests/empty-conflicts-005.test
@@ -16,7 +16,34 @@ Faking installation of ocaml.4.12.0
 Done.
 ### opam install --show pgocaml_ppx.4.2.2
 [ERROR] Package conflict!
-Sorry, no solution found: there seems to be a problem with your request.
+  * No agreement on the version of ocaml:
+    - (invariant) -> ocaml-variants = 4.12.0+trunk -> ocaml = 4.12.0
+    - pgocaml_ppx >= 4.2.2 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.06.0
+    You can temporarily relax the switch invariant with `--update-invariant'
+  * No agreement on the version of ocaml-variants:
+    - (invariant) -> ocaml-variants = 4.12.0+trunk
+    - pgocaml_ppx >= 4.2.2 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.06.0 -> ocaml-variants < 3.09.3~
+  * No agreement on the version of ocaml-migrate-parsetree:
+    - pgocaml_ppx >= 4.2.2 -> ocaml-migrate-parsetree < 2.0.0
+    - pgocaml_ppx >= 4.2.2 -> ppx_deriving >= 4.0 -> ppxlib >= 0.20.0 -> ocaml-migrate-parsetree >= 2.1.0
+  * Missing dependency:
+    - pgocaml_ppx >= 4.2.2 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.09.0 -> ocaml-variants < 4.08.1~ -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
+  * Missing dependency:
+    - pgocaml_ppx >= 4.2.2 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.09.0 -> ocaml-variants < 4.08.2~ -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
+  * Missing dependency:
+    - pgocaml_ppx >= 4.2.2 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.10 -> ocaml-variants < 4.09.2~ -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
+  * Missing dependency:
+    - pgocaml_ppx >= 4.2.2 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.11 -> ocaml-variants < 4.10.3~ -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
+  * Missing dependency:
+    - pgocaml_ppx >= 4.2.2 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.12 -> ocaml-variants < 4.11.1~ -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
+  * Missing dependency:
+    - pgocaml_ppx >= 4.2.2 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.12 -> ocaml-variants < 4.11.3~ -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
 
 No solution found, exiting
 # Return code 20 #

--- a/tests/reftests/empty-conflicts-006.test
+++ b/tests/reftests/empty-conflicts-006.test
@@ -1,0 +1,35 @@
+c1842d168d
+### OPAMYES=1 OPAMSTRICT=0
+### OPAMVAR_arch=arm64 OPAMVAR_os=linux OPAMVAR_os_family=arch OPAMVAR_os_distribution=archarm
+### opam var --global enable-ocaml-beta-repository=true
+Added '[enable-ocaml-beta-repository "true" "Set through 'opam var'"]' to field global-variables in global configuration
+### opam switch create test ocaml-variants.4.12.0+trunk --fake
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-variants" {= "4.12.0+trunk"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of base-bigarray.base
+Faking installation of base-threads.base
+Faking installation of base-unix.base
+Faking installation of ocaml-beta.disabled
+Faking installation of ocaml-variants.4.12.0+trunk
+Faking installation of ocaml-config.1
+Faking installation of ocaml.4.12.0
+Done.
+### : Fixed by https://github.com/ocaml/opam/pull/4982
+### opam install --show gen_js_api.1.0.6
+[ERROR] Package conflict!
+  * No agreement on the version of ocaml-variants:
+    - (invariant) -> ocaml-variants = 4.12.0+trunk
+    - gen_js_api >= 1.0.6 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml-variants = 4.08.0+beta2
+    You can temporarily relax the switch invariant with `--update-invariant'
+  * No agreement on the version of ocaml:
+    - (invariant) -> ocaml-variants = 4.12.0+trunk -> ocaml = 4.12.0
+    - gen_js_api >= 1.0.6 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.06.0
+  * No agreement on the version of ocaml-migrate-parsetree:
+    - gen_js_api >= 1.0.6 -> ocaml-migrate-parsetree < 2.0.0
+    - gen_js_api >= 1.0.6 -> ppxlib >= 0.9 -> ocaml-migrate-parsetree >= 2.1.0
+
+No solution found, exiting
+# Return code 20 #

--- a/tests/reftests/empty-conflicts-006.test
+++ b/tests/reftests/empty-conflicts-006.test
@@ -20,16 +20,16 @@ Done.
 ### : Fixed by https://github.com/ocaml/opam/pull/4982
 ### opam install --show gen_js_api.1.0.6
 [ERROR] Package conflict!
-  * No agreement on the version of ocaml-variants:
-    - (invariant) -> ocaml-variants = 4.12.0+trunk
-    - gen_js_api >= 1.0.6 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml-variants = 4.08.0+beta2
-    You can temporarily relax the switch invariant with `--update-invariant'
   * No agreement on the version of ocaml:
     - (invariant) -> ocaml-variants = 4.12.0+trunk -> ocaml = 4.12.0
     - gen_js_api >= 1.0.6 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.06.0
+    You can temporarily relax the switch invariant with `--update-invariant'
   * No agreement on the version of ocaml-migrate-parsetree:
     - gen_js_api >= 1.0.6 -> ocaml-migrate-parsetree < 2.0.0
     - gen_js_api >= 1.0.6 -> ppxlib >= 0.9 -> ocaml-migrate-parsetree >= 2.1.0
+  * No agreement on the version of ocaml-variants:
+    - (invariant) -> ocaml-variants = 4.12.0+trunk
+    - gen_js_api >= 1.0.6 -> ocaml-migrate-parsetree < 2.0.0 -> ocaml < 4.06.0 -> ocaml-variants < 3.09.2~
 
 No solution found, exiting
 # Return code 20 #

--- a/tests/reftests/install-pgocaml.test
+++ b/tests/reftests/install-pgocaml.test
@@ -14,10 +14,13 @@ Faking installation of ocaml.4.06.1
 Done.
 ### opam install 'pgocaml<2.0' 'pgocaml>=1.7.1' --show
 [ERROR] Package conflict!
-  * No agreement on the version of ocaml:
-    - (invariant) -> ocaml-base-compiler = 4.06.1 -> ocaml = 4.06.1
-    - pgocaml < 2.0 -> ocaml < 4.06.0
+  * No agreement on the version of ocaml-base-compiler:
+    - (invariant) -> ocaml-base-compiler = 4.06.1
+    - pgocaml < 2.0 -> ocaml < 4.06.0 -> ocaml-base-compiler = 3.07+1
     You can temporarily relax the switch invariant with `--update-invariant'
+  * Missing dependency:
+    - pgocaml < 2.0 -> ocaml < 4.06.0 -> ocaml-variants -> ocaml-beta
+    unmet availability conditions: 'enable-ocaml-beta-repository'
 
 No solution found, exiting
 # Return code 20 #

--- a/tests/reftests/install-pgocaml.test
+++ b/tests/reftests/install-pgocaml.test
@@ -1,4 +1,5 @@
 f372039d
+### OPAMVAR_arch=x86_64 OPAMVAR_os=linux OPAMVAR_os_family=arch OPAMVAR_os_distribution=archarm
 ### opam switch create --fake 4.06.1
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
@@ -16,10 +17,13 @@ Done.
 [ERROR] Package conflict!
   * No agreement on the version of ocaml-base-compiler:
     - (invariant) -> ocaml-base-compiler = 4.06.1
-    - pgocaml < 2.0 -> ocaml < 4.06.0 -> ocaml-base-compiler = 3.07+1
+    - pgocaml < 2.0 -> ocaml < 4.06.0 -> ocaml-base-compiler = 4.05.0
     You can temporarily relax the switch invariant with `--update-invariant'
+  * No agreement on the version of ocaml:
+    - (invariant) -> ocaml-base-compiler = 4.06.1 -> ocaml = 4.06.1
+    - pgocaml < 2.0 -> extlib = 1.5.3 -> ocaml < 4.05.0
   * Missing dependency:
-    - pgocaml < 2.0 -> ocaml < 4.06.0 -> ocaml-variants -> ocaml-beta
+    - pgocaml < 2.0 -> extlib = 1.5.3 -> ocaml < 4.05.0 -> ocaml-variants >= 3.10.1 -> ocaml-beta
     unmet availability conditions: 'enable-ocaml-beta-repository'
 
 No solution found, exiting


### PR DESCRIPTION
Backports https://github.com/ocaml/opam/pull/5253 and https://github.com/ocaml/opam/pull/5263 to the `2.1` branch.