### PR TITLE
Run garbage collection once when the main process is waiting for

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -120,6 +120,7 @@ users)
   * Prefer curl over any other download tools on every systems, if available [#6305 @kit-ty-kate]
   * Avoid issues when using wget2 where the requested url might return an html page instead of the expected content [#6303 @kit-ty-kate]
   * Ensure each repositories stored in repos-config is associated with an URL [#6249 @kit-ty-kate]
+  * Run `Gc.compact` in OpamParallel, when the main process is waiting for the children processes for the first time [#5396 @kkeundotnet]
 
 ## Internal: Windows
 
@@ -173,3 +174,4 @@ users)
   * `OpamStubs.get_stdout_ws_col`: new Unix-only function returning the number of columns of the current terminal window [#6244 @kit-ty-kate]
   * `OpamSystem`: add `is_archive_from_string` that does the same than `is_archive` but without looking at the file, only analysing the string (extension) [#6219 @rjbou]
   * `OpamSystem.remove_dir`: do not fail with an exception when directory is a symbolic link [#6276 @btjorge @rjbou - fix #6275]
+  * `OpamParallel.*.{map,reduce,iter}`: Run `Gc.compact` when the main process is waiting for the children processes for the first time [#5396 @kkeundotnet]


### PR DESCRIPTION
In https://github.com/ocaml/opam/pull/5376, @dra27 suggested running `Gc.compact` when the main process is waiting for the children processes for the first time. 

> what I was thinking here was that possibly at the point where opamProcess first is going to wait
> for the completion of running jobs, we could add a Gc.compact?

In my local running on `opam install ppxlib` with this PR, "GC compact" ran in the middle of parallel processing of actions.

```
The following actions will be performed:
=== install 1 package
  ∗ ppxlib 0.28.0
00:07.216  XSYS                            Adding to env { LC_ALL=C }
00:09.099  STATE                           depexts loaded in 1.883s
00:09.100  SOLUTION                        parallel_apply
00:09.100  SOLUTION                        Regroup shared source packages: {}

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
00:09.106  PARALLEL                        Iterate over 3 task(s) with 11 process(es)
00:09.106  PARALLEL                        Starting job 444950918 (worker -/11 -/1 1/3): ⬇ ppxlib.0.28.0
00:09.106  SOLUTION                        Fetching sources for ppxlib.0.28.0
00:09.106  ACTION                          download_package: ppxlib.0.28.0
00:09.106  SYSTEM                          rmdir /Users/kkeundotnet/.opam/4.14.0/.opam-switch/sources/ppxlib.0.28.0
00:09.109  SYSTEM                          mkdir /var/folders/gx/6809fgsd3nndyyf69y3h12_h0000gn/T/opam-14220-67d907
00:09.110  PARALLEL                        Next task in job 444950918: /usr/bin/tar xfj /Users/kkeundotnet/.opam/download-cache/sha256/d8/d87ae5f9a081206308ca964809b50a66aeb8e83d254801e8b9675448b60cf377 -C /var/folders/gx/6809fgsd3nndyyf69y3h12_h0000gn/T/opam-14220-67d907
00:09.619  PARALLEL                        GC compact (heap 490 MB -> 328 MB)
00:09.619  PARALLEL                        Collected task for job 444950918 (ret:0)
00:10.158  SYSTEM                          rmdir /var/folders/gx/6809fgsd3nndyyf69y3h12_h0000gn/T/opam-14220-67d907
⬇ retrieved ppxlib.0.28.0  (cached)
00:10.321  PARALLEL                        Job 444950918 finished
```

Similar to #5376, this PR enabled my 1GB-RAM machine to install `ppxlib` or `js_of_ocaml` without OOM.
