### PR TITLE
Remove unused variable `siz`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -240,6 +240,7 @@ users)
   * Update the bootstrap compiler to 4.14.0 [#5250 @kit-ty-kate]
   * Upgrade the vendored dune to 3.5.0 to fix make cold in an OCaml 5.0 env [#5355 @kit-ty-kate]
   * Upgrade vendored deps to support lib-ext in OCaml 5.0 [#5355 @kit-ty-kate / @dra27]
+  * Remove unused variable in opamACL.c [#5403 @purplearmadillo77]
 
 ## Infrastructure
   * Fix caching of Cygwin compiler on AppVeyor [#4988 @dra27]

--- a/src/stubs/libacl/opamACL.c
+++ b/src/stubs/libacl/opamACL.c
@@ -41,7 +41,6 @@ CAMLprim value OPAM_get_acl_executable_info(value file, value owner)
   if (acl)
   {
     acl_entry_t entry;
-    size_t siz;
 
     if (acl_get_entry(acl, ACL_FIRST_ENTRY, &entry) == 1)
     {


### PR DESCRIPTION
When compiling opam (most recent git) with GCC 11.3.0 on Cygwin64, I get the following error when developer mode is enabled (and NOT during normal compilation since `-Werror` is only activated in developer mode):
```
File "src/stubs/libacl/dune", line 12, characters 19-26:
12 |     (names         opamACL)
                        ^^^^^^^
opamACL.c: In function ‘OPAM_get_acl_executable_info’:
opamACL.c:44:12: error: unused variable ‘siz’ [-Werror=unused-variable]
   44 |     size_t siz;
      |            ^~~
cc1: all warnings being treated as errors
make: *** [Makefile:144: build-opam] Error 1
```
It doesn’t seem like the `siz` variable is used at all in this file, so I’ve removed it.

Additionally, I wasn't sure which category this would fall under in the changes file - I've currently put it under "Build" since the above was a building problem.