### PR TITLE
Fix: distinguish MSYS2 from Cygwin

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -563,7 +563,7 @@ users)
   * `OpamFilter`: add `?custom` argument in `to_string` to tweak the output [#5171 @cannorin]
 
 ## opam-core
-  * `OpamStd.Sys`: fix `get_windows_executable_variant` to distinguish MSYS2 from Cygwin, esp. for rsync rather than symlinking [@jonahbeckford]
+  * `OpamStd.Sys`: fix `get_windows_executable_variant` to distinguish MSYS2 from Cygwin, esp. for rsync rather than symlinking [#5404 @jonahbeckford]
   * OpamSystem: avoid calling Unix.environment at top level [#4789 @hannesm]
   * `OpamStd.ABSTRACT`: add `compare` and `equal`, that added those functions to `OpamFilename`, `OpamHash`, `OpamStd`, `OpamStd`, `OpamUrl`, and `OpamVersion` [#4918 @rjbou]
   * `OpamHash`: add `sort` from strongest to weakest kind

--- a/master_changes.md
+++ b/master_changes.md
@@ -563,6 +563,7 @@ users)
   * `OpamFilter`: add `?custom` argument in `to_string` to tweak the output [#5171 @cannorin]
 
 ## opam-core
+  * `OpamStd.Sys`: fix `get_windows_executable_variant` to distinguish MSYS2 from Cygwin, esp. for rsync rather than symlinking [@jonahbeckford]
   * OpamSystem: avoid calling Unix.environment at top level [#4789 @hannesm]
   * `OpamStd.ABSTRACT`: add `compare` and `equal`, that added those functions to `OpamFilename`, `OpamHash`, `OpamStd`, `OpamStd`, `OpamUrl`, and `OpamVersion` [#4918 @rjbou]
   * `OpamHash`: add `sort` from strongest to weakest kind

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1137,11 +1137,8 @@ module OpamSys = struct
         let rec f a =
           match input_line c with
           | x ->
-            (* Treat MSYS2's variant of `cygwin1.dll` called `msys-2.0.dll` equivalently.
-               Confer https://www.msys2.org/wiki/How-does-MSYS2-differ-from-Cygwin/ *)
             let tx = String.trim x in
-            if (OpamString.ends_with ~suffix:"cygwin1.dll" tx ||
-                OpamString.ends_with ~suffix:"msys-2.0.dll" tx) then
+            if OpamString.ends_with ~suffix:"cygwin1.dll" tx then
               if OpamString.starts_with ~prefix:"  " x then
                 f `Cygwin
               else if a = `Native then

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1176,6 +1176,8 @@ module OpamSys = struct
       fun _ -> `Native
 
   let is_cygwin_variant cmd =
+    (* Treat MSYS2's variant of `cygwin1.dll` called `msys-2.0.dll` equivalently.
+       Confer https://www.msys2.org/wiki/How-does-MSYS2-differ-from-Cygwin/ *)
     match get_windows_executable_variant cmd with
     | `Native -> `Native
     | `Cygwin


### PR DESCRIPTION
The original code looked like it had a bad merge at some point in its history (duplicates the `if` condition):

```ocaml
            if (OpamString.ends_with ~suffix:"cygwin1.dll" tx ||
                OpamString.ends_with ~suffix:"msys-2.0.dll" tx) then
            (* ... *)
            else if OpamString.ends_with ~suffix:"msys-2.0.dll" tx then
```

Without this PR, MSYS2 uses `cp -PRr` instead of the intended `rsync`; `rsync` is a reasonable fallback for the lack of symlinks in MSYS2, and it copies binaries correctly (ex. if both `dune` and `dune.exe` are in the same directory, `cp` will fail).

The PR does not affect Cygwin which by default uses symlinks.

This PR is the real fix to https://github.com/ocaml/dune/blob/fa3aa2891ac74828a81f73894fe247f69c530c81/ci/build-test.sh#L82-L94 and similar failures.
