### PR TITLE
Log the time dose3's check_request takes

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -297,6 +297,7 @@ users)
   * Add builtin support for the 'deprecated' flag.  Any packages flagged with deprecated would be avoided by the solver unless there is no other choice (e.g. some user wants to install package a which depends on b which is deprecated) If it is installed, show up a note after installation notifying the user that the package is deprecated. [#4523 @kit-ty-kate]
   * [BUG] On cudf strong and weak dependencies computation, some weak dependencies were wrongly kept, from #4627 [#5338 @rjbou @AltGr]
   * [BUG] Fix "opam list -s --coinstallable-with pkg.1 pkg.2" listing pkg.2 as coinstallable with pkg.1 [#5414 @kit-ty-kate]
+  * Log the time dose3's check_request takes [#5407 @kit-ty-kate]
 
 ## Client
   * Check whether the repository might need updating more often [#4935 @kit-ty-kate]

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -1514,7 +1514,11 @@ let call_external_solver ~version_map univ req =
     Dose_algo.Depsolver.Sat(None,Cudf.load_universe [])
 
 let check_request ?(explain=true) ~version_map univ req =
-  match Dose_algo.Depsolver.check_request ~explain (to_cudf univ req) with
+  let chrono = OpamConsole.timer () in
+  log "Checking request...";
+  let result = Dose_algo.Depsolver.check_request ~explain (to_cudf univ req) in
+  log "Request checked in %.3fs" (chrono ());
+  match result with
   | Dose_algo.Depsolver.Unsat
       (Some ({Dose_algo.Diagnostic.result = Dose_algo.Diagnostic.Failure _; _} as r)) ->
     make_conflicts ~version_map univ r


### PR DESCRIPTION
This would help debugging issues with dose3.
For example: I'm currently debugging an issue where a simple opam install takes 32GB+ of RAM and seeing something in the logs that would tell me that the call was stuck in dose3 would have made debugging slightly quicker.