### PR TITLE
Enforce extra-source to have a checksum when using "opam switch export --freeze"

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -85,6 +85,7 @@ users)
   * When inferring a 2.1+ switch invariant from 2.0 base packages, don't filter out pinned packages as that causes very wide invariants for pinned compiler packages [#5176 @dra27 - fix #4501]
   * Really install invariant formula if not installed in switch [#5188 @rjbou]
   * On import, check that installed pinned packages changed, reinstall if so [#5181 @rjbou - fix #5173]
+  * [BUG] Enforce extra-source to have a checksum when using "opam switch export --freeze" [#5418 @kit-ty-kate]
 
 ## Config
   * Reset the "jobs" config variable when upgrading from opam 2.0 [#5284 @kit-ty-kate]

--- a/tests/reftests/switch-import.test
+++ b/tests/reftests/switch-import.test
@@ -187,6 +187,8 @@ The following actions will be faked:
 Faking installation of test.1
 Done.
 ### opam switch export --freeze switch-freeze.export
+[ERROR] test url doesn't have an associated checksum, it can't be exported with --freeze.
+# Return code 5 #
 ### opam-cat switch-freeze.export
 installed: ["test.1"]
 opam-version: "2.0"
@@ -200,5 +202,6 @@ checksum: "md5=6aef5a674977ebc5ec853dc4f85cf2bb"
 }
 extra-source "file" {
 src: "https://example.com/some/fake/extra/source"
+checksum: "md5=6aef5a674977ebc5ec853dc4f85cf2bb"
 }
 }

--- a/tests/reftests/switch-import.test
+++ b/tests/reftests/switch-import.test
@@ -110,3 +110,95 @@ Done.
 nip.dev    git  git+file://${BASEDIR}/nip#snd-head
 ### opam list nip --installed --columns=name,installed-files --normalise --switch tierce | grep -v '^#'
 nip    ${BASEDIR}/OPAM/tierce/lib/snd.out
+### opam switch create test-switch-export-freeze --empty
+### opam switch export --freeze switch-freeze.export
+### opam-cat switch-freeze.export
+opam-version: "2.0"
+### <pkg:test.1>
+opam-version: "2.0"
+url {
+  src: "https://example.com/some/fake/url.tar.gz"
+  checksum: "md5=6aef5a674977ebc5ec853dc4f85cf2bb"
+}
+extra-source "file" {
+  src: "https://example.com/some/fake/extra/source"
+  checksum: "md5=6aef5a674977ebc5ec853dc4f85cf2bb"
+}
+### opam install --fake test.1
+The following actions will be faked:
+=== install 1 package
+  - install test 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of test.1
+Done.
+### opam switch export --freeze switch-freeze.export
+### opam-cat switch-freeze.export
+installed: ["test.1"]
+opam-version: "2.0"
+roots: ["test.1"]
+package "test" {
+opam-version: "2.0"
+version: "1"
+url {
+src: "https://example.com/some/fake/url.tar.gz"
+checksum: "md5=6aef5a674977ebc5ec853dc4f85cf2bb"
+}
+extra-source "file" {
+src: "https://example.com/some/fake/extra/source"
+checksum: "md5=6aef5a674977ebc5ec853dc4f85cf2bb"
+}
+}
+### <pkg:test.1>
+opam-version: "2.0"
+url {
+  src: "https://example.com/some/fake/url.tar.gz"
+}
+extra-source "file" {
+  src: "https://example.com/some/fake/extra/source"
+  checksum: "md5=6aef5a674977ebc5ec853dc4f85cf2bb"
+}
+### opam install --fake test.1
+The following actions will be faked:
+=== recompile 1 package
+  - recompile test 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of test.1
+Done.
+### opam switch export --freeze switch-freeze.export
+[ERROR] test url doesn't have an associated checksum, it can't be exported with --freeze.
+# Return code 5 #
+### <pkg:test.1>
+opam-version: "2.0"
+url {
+  src: "https://example.com/some/fake/url.tar.gz"
+  checksum: "md5=6aef5a674977ebc5ec853dc4f85cf2bb"
+}
+extra-source "file" {
+  src: "https://example.com/some/fake/extra/source"
+}
+### opam install --fake test.1
+The following actions will be faked:
+=== recompile 1 package
+  - recompile test 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of test.1
+Done.
+### opam switch export --freeze switch-freeze.export
+### opam-cat switch-freeze.export
+installed: ["test.1"]
+opam-version: "2.0"
+roots: ["test.1"]
+package "test" {
+opam-version: "2.0"
+version: "1"
+url {
+src: "https://example.com/some/fake/url.tar.gz"
+checksum: "md5=6aef5a674977ebc5ec853dc4f85cf2bb"
+}
+extra-source "file" {
+src: "https://example.com/some/fake/extra/source"
+}
+}


### PR DESCRIPTION
Freeze-exporting packages that have extra-sources without any checksum shouldn't be allowed. This PR fixes this bug.

Side note for reviewers: you can see the diff better using github's "hide whitespace" option