### PR TITLE
Adopt the OCaml Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md).
+
+# Enforcement
+
+This project follows the OCaml Code of Conduct
+[enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).

--- a/master_changes.md
+++ b/master_changes.md
@@ -254,6 +254,7 @@ users)
   * Remove Cygwin32 from testing, as it's been retired upstream [#5365 @dra27]
   * Ensure all the compilers can be built on Ubuntu 22.04 [#5391 @dra27]
   * Workaround brew problem on macOS GHA runner testing Z3 [#5405 @dra27]
+  * Adopt the OCaml Code of Conduct [#5419 @dra27]
 
 ## Release scripts
   * Make the release script setup-less using QEMU, Docker and Rosetta 2 [#4947 @kit-ty-kate]


### PR DESCRIPTION
The OCaml Code of Conduct can be found in [ocaml/code-of-conduct](https://github.com/ocaml/code-of-conduct) and has been discussed [in this Discourse thread](https://discuss.ocaml.org/t/ocaml-community-code-of-conduct/10494).

It's been adopted in ocaml/ocaml#11761 and ocaml/dune#6875, and we propose adopting it for ocaml/opam as well.