### PR TITLE
Remove ancient unused ocamlinit script

### DIFF
--- a/shell/dot_ocamlinit
+++ b/shell/dot_ocamlinit
@@ -1,4 +1,0 @@
-let () =
-  try Topdirs.dir_directory (Sys.getenv "OCAML_TOPLEVEL_PATH")
-  with Not_found -> ()
-;;


### PR DESCRIPTION
I'm not seeing it being used anywhere so it might be good to remove it to avoid confusion.