### PR TITLE
Update bootstrap to use FlexDLL 0.42 from ocaml/flexdll

### DIFF
--- a/.github/scripts/main/ocaml-cache.sh
+++ b/.github/scripts/main/ocaml-cache.sh
@@ -44,11 +44,11 @@ case "$HOST" in
     PREFIX="$OCAML_LOCAL";;
 esac
 
-FLEXDLL_VERSION=0.40
+FLEXDLL_VERSION=0.42
 
 curl -sLO "https://caml.inria.fr/pub/distrib/ocaml-${OCAML_VERSION%.*}/ocaml-$OCAML_VERSION.tar.gz"
 if [[ $PLATFORM = 'Windows' ]] ; then
-  curl -sLO "https://github.com/alainfrisch/flexdll/archive/refs/tags/$FLEXDLL_VERSION.tar.gz"
+  curl -sLO "https://github.com/ocaml/flexdll/archive/refs/tags/$FLEXDLL_VERSION.tar.gz"
 fi
 
 tar -xzf "ocaml-$OCAML_VERSION.tar.gz"

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -17,7 +17,7 @@ let ocamls = [
   (* Legacy versions - core libraries only *)
   "4.03.0"; "4.04.2"; "4.05.0"; "4.06.1"; "4.07.1"; 
   (* Fully supported versions *)
-   "4.08.1"; "4.09.1"; "4.10.2"; "4.11.2"; "4.12.1"; "4.13.1"; "4.14.0";
+   "4.08.1"; "4.09.1"; "4.10.2"; "4.11.2"; "4.12.1"; "4.13.1"; "4.14.1";
 ]
 
 (* Entry point for the workflow. Workflows are specified as continuations where

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,7 +136,7 @@ jobs:
     needs: Analyse
     strategy:
       matrix:
-        ocamlv: [ 4.08.1, 4.09.1, 4.10.2, 4.11.2, 4.12.1, 4.13.1, 4.14.0 ]
+        ocamlv: [ 4.08.1, 4.09.1, 4.10.2, 4.11.2, 4.12.1, 4.13.1, 4.14.1 ]
       fail-fast: true
     steps:
     - name: Install bubblewrap
@@ -173,7 +173,7 @@ jobs:
       matrix:
         host: [ x86_64-pc-cygwin, i686-w64-mingw32, x86_64-w64-mingw32, i686-pc-windows, x86_64-pc-windows ]
         build: [ x86_64-pc-cygwin ]
-        ocamlv: [ 4.14.0 ]
+        ocamlv: [ 4.14.1 ]
       fail-fast: false
     defaults:
       run:
@@ -244,7 +244,7 @@ jobs:
     needs: Analyse
     strategy:
       matrix:
-        ocamlv: [ 4.14.0 ]
+        ocamlv: [ 4.14.1 ]
       fail-fast: true
     steps:
     - name: Checkout tree
@@ -317,7 +317,7 @@ jobs:
     needs: [ Analyse, Build-Linux ]
     strategy:
       matrix:
-        ocamlv: [ 4.14.0 ]
+        ocamlv: [ 4.14.1 ]
       fail-fast: false
     env:
       OPAM_TEST: 1
@@ -371,7 +371,7 @@ jobs:
     needs: Analyse
     strategy:
       matrix:
-        ocamlv: [ 4.14.0 ]
+        ocamlv: [ 4.14.1 ]
       fail-fast: false
     env:
       OPAM_TEST: 1
@@ -457,7 +457,7 @@ jobs:
     strategy:
       matrix:
         solver: [ z3, 0install ]
-        ocamlv: [ 4.14.0 ]
+        ocamlv: [ 4.14.1 ]
       fail-fast: false
     env:
       SOLVER: ${{ matrix.solver }}
@@ -505,7 +505,7 @@ jobs:
     strategy:
       matrix:
         solver: [ z3, 0install ]
-        ocamlv: [ 4.14.0 ]
+        ocamlv: [ 4.14.1 ]
       fail-fast: false
     env:
       SOLVER: ${{ matrix.solver }}
@@ -553,7 +553,7 @@ jobs:
     needs: [ Analyse, Build-Linux ]
     strategy:
       matrix:
-        ocamlv: [ 4.14.0 ]
+        ocamlv: [ 4.14.1 ]
       fail-fast: false
     steps:
     - name: Install bubblewrap
@@ -586,7 +586,7 @@ jobs:
     needs: [ Analyse, Build-macOS ]
     strategy:
       matrix:
-        ocamlv: [ 4.14.0 ]
+        ocamlv: [ 4.14.1 ]
       fail-fast: false
     steps:
     - name: Checkout tree

--- a/master_changes.md
+++ b/master_changes.md
@@ -248,6 +248,7 @@ users)
   * Upgrade spdx_licenses to 1.2.0 [#5412 @kit-ty-kate]
   * Upgrade the vendored sha to 1.15.4 [#5424 @kit-ty-kate]
   * Upgrade src_ext vendored bootstrap dependencies [#5437 @MisterDA]
+  * Update bootstrap to use FlexDLL 0.42 from ocaml/flexdll [#5434 @MisterDA]
 
 ## Infrastructure
   * Fix caching of Cygwin compiler on AppVeyor [#4988 @dra27]

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -11,8 +11,8 @@ endif
 
 PATCH ?= patch
 
-URL_ocaml = https://caml.inria.fr/pub/distrib/ocaml-4.14/ocaml-4.14.0.tar.gz
-MD5_ocaml = 57a4fa799114b3addbf31e42c4f4a7b3
+URL_ocaml = https://caml.inria.fr/pub/distrib/ocaml-4.14/ocaml-4.14.1.tar.gz
+MD5_ocaml = c45b013a233c9a4b80c3930d723d19dd
 
 URL_flexdll = https://github.com/ocaml/flexdll/archive/0.42.tar.gz
 MD5_flexdll = 9464ae7a7e566ba7c96336cf2f34cc73

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -14,8 +14,8 @@ PATCH ?= patch
 URL_ocaml = https://caml.inria.fr/pub/distrib/ocaml-4.14/ocaml-4.14.0.tar.gz
 MD5_ocaml = 57a4fa799114b3addbf31e42c4f4a7b3
 
-URL_flexdll = https://github.com/alainfrisch/flexdll/archive/0.40.tar.gz
-MD5_flexdll = e68f7311179fa7e09408825b362c5c5a
+URL_flexdll = https://github.com/ocaml/flexdll/archive/0.42.tar.gz
+MD5_flexdll = 9464ae7a7e566ba7c96336cf2f34cc73
 
 ifndef FETCH
   ifneq ($(shell command -v curl 2>/dev/null),)


### PR DESCRIPTION
Fixes a warning when bootstrapping opam, and some other things (I guess)
cc @dra27 
