### PR TITLE
Always use O_SHARE_DELETE with Unix.openfile

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -327,6 +327,7 @@ users)
   * Fix lazy compilation of regular expression in OpamFormula.atom_of_string [#5211 @dra27]
   * [BUG] Display correct exception backtrace on uncaught exception on Windows [#5216 @dra27]
   * Use grep -F instead of fgrep, as the latter is deprecated [#5309 @MisterDA]
+  * Always open files with `O_SHARE_DELETE`, which eliminates unnecessary "access denied" errors in various situations on Windows. [#5435 @dra27]
 
 ## Internal: Windows
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -249,8 +249,6 @@ type t = {
   p_tmp_files: string list;
 }
 
-let open_flags =  [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND]
-
 let output_lines oc lines =
   List.iter (fun line ->
     output_string oc line;
@@ -330,7 +328,8 @@ let create ?info_file ?env_file ?(allow_stdin=not Sys.win32) ?stdout_file ?stder
     ~verbose ~tmp_files cmd args =
   let nothing () = () in
   let tee f =
-    let fd = Unix.openfile f open_flags 0o644 in
+    let flags = [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND; Unix.O_SHARE_DELETE] in
+    let fd = Unix.openfile f flags 0o644 in
     let close_fd () = Unix.close fd in
     fd, close_fd in
   let oldcwd = Sys.getcwd () in

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -1188,7 +1188,7 @@ and flock: 'a. ([< lock_flag ] as 'a) -> ?dontblock:bool -> string -> lock =
   | flag ->
     mkdir (Filename.dirname file);
     let rdflag = if (flag :> lock_flag) = `Lock_write then Unix.O_RDWR else Unix.O_RDONLY in
-    let fd = Unix.openfile file Unix.([O_CREAT; O_CLOEXEC; rdflag]) 0o666 in
+    let fd = Unix.openfile file Unix.([O_CREAT; O_CLOEXEC; O_SHARE_DELETE; rdflag]) 0o666 in
     Hashtbl.add locks fd ();
     let lock = { fd = Some fd; file; kind = `Lock_none } in
     flock_update flag ?dontblock lock;


### PR DESCRIPTION
Follows-up https://github.com/ocaml/opam/pull/5351#issuecomment-1322077295 with a better approach. The fds used for locking and for the output of running commands are now opened with `O_SHARE_DELETE`. This has no effect on Unix, but it makes the semantics of these files more POSIX-like on Windows. In particular, it means that a switch can be deleted while the lock is still held. This is both simpler than #5351 and also philosophically more accurate - it means that nothing can attempt to take a write lock until after the directory has been completely unlinked.

It's possible that there are one or two other places - in particular, the file used when monitoring an external solver would be another candidate, but these are less critical. In particular, these two mean that cleaning up switches on error no longer displays a fault in opam and it also means that a "crashed" background process doesn't prevent a switch from being deleted.