### PR TITLE
Variable for package manager

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -90,6 +90,8 @@ users)
 ## Config
   * Reset the "jobs" config variable when upgrading from opam 2.0 [#5284 @kit-ty-kate]
   * Display a warning on hard upgrade when the `jobs` config variable is re-written [#5305 @rjbou]
+    * update note [#5305 @rjbou]
+  * Add `sys-pkg-manager-cmd` field to store specific system package manager command paths [#5433 @rjbou]
 
 ## Pin
   * Switch the default version when undefined from ~dev to dev [#4949 @kit-ty-kate]
@@ -174,7 +176,7 @@ users)
   * [BUG] Variables are now expanded in build-env (as for setenv) [#5352 @dra27]
 
 ## External dependencies
-  * Support MSYS2 on Windows for depexts [#5348 @jonahbeckford]
+  * Support MSYS2 on Windows for depexts [#5348 @jonahbeckford #5433 @rjbou]
   * Set `DEBIAN_FRONTEND=noninteractive` for unsafe-yes confirmation level [#4735 @dra27 - partially fix #4731] [2.1.0~rc2 #4739]
   * Fix depext alpine tagged repositories handling [#4763 @rjbou] [2.1.0~rc2 #4758]
   * Homebrew: Add support for casks and full-names [#4801 @kit-ty-kate]
@@ -562,6 +564,7 @@ users)
   * `OpamGlobalState`: add `as_necessary_repo_switch_upgrade` that checks conditions and call `OpamFormatUpgrade.repo_switch_hard_upgrade` [#5305 @rjbou]
   * `OpamSwitchState`, `OpamRepositoryState`: at the beginning of `load` function, check if an upgrade is needed with `OpamGlobalState.as_necessary_repo_switch_upgrade` [#5305 @rjbou]
   * `OpamStataTypes.global_state`: add `global_state_to_upgrade` field to keep incomplete upgrade information [#5305 @rjbou]
+  * `OpamSysInteract`: add global config argument to function, in order to be able to retrieve system package manager path for MSYS2, and in the future Cygwin, etc. [#5433 @rjbou]
 
 ## opam-solver
   * `OpamCudf`: Change type of `conflict_case.Conflict_cycle` (`string list list` to `Cudf.package action list list`) and `cycle_conflict`, `string_of_explanations`, `conflict_explanations_raw` types accordingly [#4039 @gasche]

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1159,10 +1159,10 @@ let install_t t ?ask ?(ignore_conflicts=false) ?(depext_only=false)
       in
       let extra_message =
         if has_missing_depexts then
+          let gt = t.switch_global in
           OpamStd.Option.map_default (fun s -> s ^ ".\n\n") ""
-            (OpamSysInteract.repo_enablers ())
-        else
-          ""
+            (OpamSysInteract.repo_enablers ~env:gt.global_variables gt.config)
+        else ""
       in
       OpamConsole.errmsg "%s%s"
         (OpamCudf.string_of_explanations

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2023,9 +2023,9 @@ let update cli =
       ?jobs:OpamStd.Option.Op.(jobs >>| fun j -> lazy j)
       ();
     OpamClientConfig.update ();
-    if depexts_only then OpamSysInteract.update ();
-    if depexts_only && not (repos_only || dev_only) then () else
     OpamGlobalState.with_ `Lock_write @@ fun gt ->
+    if depexts_only then OpamSysInteract.update gt.config;
+    if depexts_only && not (repos_only || dev_only) then () else
     let success, changed, rt =
       OpamClient.update gt
         ~repos_only:(repos_only && not dev_only)

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -722,6 +722,21 @@ let global_allowed_fields, global_allowed_sections =
                 (Config.depext_bypass c -- Config.depext_bypass nc) c)
           )),
         Config.with_depext_bypass (Config.depext_bypass Config.empty);
+        "sys-pkg-manager-cmd", Modifiable (
+            (fun nc c -> Config.with_sys_pkg_manager_cmd
+                (OpamStd.String.Map.union (fun nc _c -> nc)
+                (Config.sys_pkg_manager_cmd nc) (Config.sys_pkg_manager_cmd c)) c),
+            (fun nc c ->
+               let to_remove = OpamStd.String.Map.keys (Config.sys_pkg_manager_cmd nc) in
+               let nmap =
+                 List.fold_left (fun map key ->
+                     OpamStd.String.Map.remove key map)
+                   (Config.sys_pkg_manager_cmd c) to_remove
+               in
+               Config.with_sys_pkg_manager_cmd nmap c)
+          ),
+        Config.with_sys_pkg_manager_cmd (Config.sys_pkg_manager_cmd Config.empty);
+
       ] @ List.map (fun f ->
         f, Atomic, Config.with_criteria
           (Config.criteria Config.empty))

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1264,6 +1264,7 @@ module ConfigSyntax = struct
     depext_run_installs : bool;
     depext_cannot_install : bool;
     depext_bypass: OpamSysPkg.Set.t;
+    sys_pkg_manager_cmd: filename OpamStd.String.Map.t;
   }
 
   let opam_version t = t.opam_version
@@ -1306,6 +1307,7 @@ module ConfigSyntax = struct
   let depext_cannot_install t = t.depext_cannot_install
   let depext_bypass t = t.depext_bypass
 
+  let sys_pkg_manager_cmd t = t.sys_pkg_manager_cmd
 
   let with_opam_version opam_version t = { t with opam_version }
   let with_opam_root_version opam_root_version t = { t with opam_root_version }
@@ -1353,6 +1355,8 @@ module ConfigSyntax = struct
   let with_depext_cannot_install depext_cannot_install t =
     { t with depext_cannot_install }
   let with_depext_bypass depext_bypass t = { t with depext_bypass }
+  let with_sys_pkg_manager_cmd sys_pkg_manager_cmd t =
+    { t with sys_pkg_manager_cmd }
 
   let empty = {
     opam_version = file_format_version;
@@ -1377,6 +1381,7 @@ module ConfigSyntax = struct
     depext_run_installs = true;
     depext_cannot_install = false;
     depext_bypass = OpamSysPkg.Set.empty;
+    sys_pkg_manager_cmd = OpamStd.String.Map.empty;
   }
 
   (* When adding a field, make sure to add it in
@@ -1473,6 +1478,13 @@ module ConfigSyntax = struct
         (Pp.V.map_list ~depth:1
            (Pp.V.string -| Pp.of_module "sys-package" (module OpamSysPkg)) -|
          Pp.of_pair "System package set" OpamSysPkg.Set.(of_list, elements));
+      "sys-pkg-manager-cmd", Pp.ppacc
+        with_sys_pkg_manager_cmd sys_pkg_manager_cmd
+        ((Pp.V.map_list ~depth:2
+            (Pp.V.map_pair
+               Pp.V.string
+               (Pp.V.string -| Pp.of_module "filename" (module OpamFilename))))
+         -| Pp.of_pair "Distribution Map" OpamStd.String.Map.(of_list, bindings));
 
       (* deprecated fields *)
       "alias", Pp.ppacc_opt

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -169,6 +169,7 @@ module Config: sig
   val with_depext_run_installs: bool -> t -> t
   val with_depext_cannot_install: bool -> t -> t
   val with_depext_bypass: OpamSysPkg.Set.t -> t -> t
+  val with_sys_pkg_manager_cmd: filename OpamStd.String.Map.t -> t -> t
 
   (** Return the opam version *)
   val opam_version: t  -> opam_version
@@ -223,6 +224,8 @@ module Config: sig
   val depext_run_installs: t -> bool
   val depext_cannot_install: t -> bool
   val depext_bypass: t -> OpamSysPkg.Set.t
+
+  val sys_pkg_manager_cmd: t -> filename OpamStd.String.Map.t
 
   val fields: (string * (t, value) OpamPp.field_parser) list
 

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -196,7 +196,7 @@ let depexts_status_of_packages_raw
   in
   let syspkg_set = syspkg_set -- bypass in
   let ret =
-    match OpamSysInteract.packages_status ?env syspkg_set with
+    match OpamSysInteract.packages_status ?env global_config syspkg_set with
     | avail, not_found ->
       let avail, not_found =
         if OpamStateConfig.(!r.no_depexts) then

--- a/src/state/opamSysInteract.mli
+++ b/src/state/opamSysInteract.mli
@@ -17,24 +17,25 @@ open OpamStateTypes
      * second one, not found set: packages not found on the defined repositories
    [env] is used to determine host specification. *)
 val packages_status:
-  ?env:gt_variables -> OpamSysPkg.Set.t -> OpamSysPkg.Set.t * OpamSysPkg.Set.t
+  ?env:gt_variables -> OpamFile.Config.t -> OpamSysPkg.Set.t ->
+  OpamSysPkg.Set.t * OpamSysPkg.Set.t
 
 (* Return the commands to run to install given system packages.
    [env] is used to determine host specification. *)
 val install_packages_commands:
-  ?env:gt_variables -> OpamSysPkg.Set.t ->
+  ?env:gt_variables -> OpamFile.Config.t -> OpamSysPkg.Set.t ->
   ([`AsAdmin of string | `AsUser of string] * string list) list
 
 (* Install given system packages, by calling local system package manager.
    [env] is used to determine host specification. *)
-val install: ?env:gt_variables -> OpamSysPkg.Set.t -> unit
+val install: ?env:gt_variables -> OpamFile.Config.t -> OpamSysPkg.Set.t -> unit
 
-val update: ?env:gt_variables -> unit -> unit
+val update: ?env:gt_variables -> OpamFile.Config.t -> unit
 
-val package_manager_name: ?env:gt_variables -> unit -> string
+val package_manager_name: ?env:gt_variables -> OpamFile.Config.t -> string
 
 (* Determine if special packages may need installing to enable other
    repositories.
    Presently used to check for epel-release on CentOS and RHEL.
    [env] is used to determine host specification. *)
-val repo_enablers: ?env:gt_variables -> unit -> string option
+val repo_enablers: ?env:gt_variables -> OpamFile.Config.t -> string option

--- a/tests/reftests/var-option.test
+++ b/tests/reftests/var-option.test
@@ -204,6 +204,7 @@ solver                         {}
 solver-criteria                {}
 solver-fixup-criteria          {}
 solver-upgrade-criteria        {}
+sys-pkg-manager-cmd            {}
 wrap-build-commands            {}
 wrap-install-commands          {}
 wrap-remove-commands           {}
@@ -372,6 +373,35 @@ Reverted field depext-bypass in switch var-option
 No modification in switch var-option
 ### opam option depext-bypass
 []
+### # Check addition & removal on map
+### opam option sys-pkg-manager-cmd
+[]
+### opam option 'sys-pkg-manager-cmd+=["tempor" "path/to"]'
+Added '["tempor" "path/to"]' to field sys-pkg-manager-cmd in global configuration
+### opam option 'sys-pkg-manager-cmd+=["incididunt" "path/to"]'
+Added '["incididunt" "path/to"]' to field sys-pkg-manager-cmd in global configuration
+### opam option sys-pkg-manager-cmd
+[["incididunt" "${BASEDIR}/path/to"] ["tempor" "${BASEDIR}/path/to"]]
+### opam option 'sys-pkg-manager-cmd-=["incididunt" "path/to"]'
+Removed '["incididunt" "path/to"]' from field sys-pkg-manager-cmd in global configuration
+### opam option sys-pkg-manager-cmd
+["tempor" "${BASEDIR}/path/to"]
+### opam option 'sys-pkg-manager-cmd=[["incididunt" "path/to"]["tempor" "path/to"]]'
+Set to '[["incididunt" "path/to"]["tempor" "path/to"]]' the field sys-pkg-manager-cmd in global configuration
+### opam option 'sys-pkg-manager-cmd-=["tempor" "path/to"]'
+Removed '["tempor" "path/to"]' from field sys-pkg-manager-cmd in global configuration
+### opam option sys-pkg-manager-cmd
+["incididunt" "${BASEDIR}/path/to"]
+### opam option 'sys-pkg-manager-cmd-=["ut" "/inexist/ant"]'
+No modification in global configuration
+### opam option sys-pkg-manager-cmd
+["incididunt" "${BASEDIR}/path/to"]
+### opam option sys-pkg-manager-cmd=
+Reverted field sys-pkg-manager-cmd in global configuration
+### opam option 'sys-pkg-manager-cmd-=["tempor" "path/to"]'
+No modification in global configuration
+### opam option sys-pkg-manager-cmd
+[]
 ### # Check addition & removal on list
 ### opam option 'setenv+=lorem="labore"'
 Added 'lorem="labore"' to field setenv in switch var-option
@@ -456,7 +486,7 @@ Removed variable dolore in global configuration
 # Return code 2 #
 ### opam option bar=sit --global
 [ERROR] There is no option named 'bar'. The allowed options are:
-jobs download-command download-jobs archive-mirrors solver-criteria solver-upgrade-criteria solver-fixup-criteria best-effort-prefix-criteria solver global-variables eval-variables repository-validation-command depext depext-run-installs depext-cannot-install depext-bypass pre-build-commands pre-install-commands pre-remove-commands pre-session-commands wrap-build-commands wrap-install-commands wrap-remove-commands post-build-commands post-install-commands post-remove-commands post-session-commands
+jobs download-command download-jobs archive-mirrors solver-criteria solver-upgrade-criteria solver-fixup-criteria best-effort-prefix-criteria solver global-variables eval-variables repository-validation-command depext depext-run-installs depext-cannot-install depext-bypass sys-pkg-manager-cmd pre-build-commands pre-install-commands pre-remove-commands pre-session-commands wrap-build-commands wrap-install-commands wrap-remove-commands post-build-commands post-install-commands post-remove-commands post-session-commands
 # Return code 2 #
 ### opam option bar=sit --switch var-option
 [ERROR] There is no option named 'bar'. The allowed options are:
@@ -556,6 +586,7 @@ solver                         {}
 solver-criteria                {}
 solver-fixup-criteria          {}
 solver-upgrade-criteria        {}
+sys-pkg-manager-cmd            {}
 wrap-build-commands            {}
 wrap-install-commands          {}
 wrap-remove-commands           {}
@@ -585,6 +616,7 @@ solver                         {}
 solver-criteria                {}
 solver-fixup-criteria          {}
 solver-upgrade-criteria        {}
+sys-pkg-manager-cmd            {}
 wrap-build-commands            {}
 wrap-install-commands          {}
 wrap-remove-commands           {}


### PR DESCRIPTION
Add global config field `sys-pkg-manager-cmd` to be able to specify for MSYS2 & Cygwin the command path. In can be used later to specify more precisely used package manager when several exists in the machine, see. #4440
It also permit to not rely on defined variables with the full integration in config file. cc @jonahbeckford 
related to #5348