### PR TITLE
Stop using `mv` and switch to `robocopy` on Windows

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -329,6 +329,7 @@ users)
   * Use grep -F instead of fgrep, as the latter is deprecated [#5309 @MisterDA]
   * Always open files with `O_SHARE_DELETE`, which eliminates unnecessary "access denied" errors in various situations on Windows. [#5435 @dra27]
   * Use `Sys.rename` instead of `mv` [#5438 @dra27]
+  * Use `robocopy` instead of `cp` on Windows [#5438 @dra27]
 
 ## Internal: Windows
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]

--- a/master_changes.md
+++ b/master_changes.md
@@ -328,6 +328,7 @@ users)
   * [BUG] Display correct exception backtrace on uncaught exception on Windows [#5216 @dra27]
   * Use grep -F instead of fgrep, as the latter is deprecated [#5309 @MisterDA]
   * Always open files with `O_SHARE_DELETE`, which eliminates unnecessary "access denied" errors in various situations on Windows. [#5435 @dra27]
+  * Use `Sys.rename` instead of `mv` [#5438 @dra27]
 
 ## Internal: Windows
   * Support MSYS2: treat MSYS2 and Cygwin as equivalent [#4813 @jonahbeckford]

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -109,8 +109,10 @@ let exec dirname ?env ?name ?metadata ?keep_going cmds =
     (fun () -> OpamSystem.commands ?env ?name ?metadata ?keep_going cmds)
 
 let move_dir ~src ~dst =
-  OpamSystem.command ~verbose:(OpamSystem.verbose_for_base_commands ())
-    [ "mv"; Dir.to_string src; Dir.to_string dst ]
+  (* XXX Windows - destination must be on the same drive or this fails *)
+  Sys.rename (Dir.to_string src) (Dir.to_string dst)
+  (*OpamSystem.command ~verbose:(OpamSystem.verbose_for_base_commands ())
+    [ "mv"; Dir.to_string src; Dir.to_string dst ]*)
 
 let opt_dir dirname =
   if exists_dir dirname then Some dirname else None
@@ -260,8 +262,10 @@ let install ?warning ?exec ~src ~dst () =
 
 let move ~src ~dst =
   if src <> dst then
-    OpamSystem.command ~verbose:(OpamSystem.verbose_for_base_commands ())
-      [ "mv"; to_string src; to_string dst ]
+    (* XXX Can either be a directory in reality? If yes, Windows drive limitations *)
+    Sys.rename (to_string src) (to_string dst)
+    (*OpamSystem.command ~verbose:(OpamSystem.verbose_for_base_commands ())
+      [ "mv"; to_string src; to_string dst ]*)
 
 let readlink src =
   if exists src then

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -997,7 +997,7 @@ let make_tar_gz_job ~dir file =
   Tar.compress_command tmpfile dir @@> fun r ->
   OpamProcess.cleanup r;
   if OpamProcess.is_success r then
-    (mv tmpfile file; Done None)
+    (Sys.rename tmpfile file; Done None)
   else
     (remove_file tmpfile; Done (Some (Process_error r)))
 

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -197,10 +197,10 @@ val get_cygpath_function: command:string -> (string -> string) lazy_t
 val get_cygpath_path_transform: (string -> string) lazy_t
 
 (** [command cmd] executes the command [cmd] in the correct OPAM
-    environment. *)
-val command: ?verbose:bool -> ?env:string array -> ?name:string ->
-  ?metadata:(string * string) list -> ?allow_stdin:bool ->
-  command -> unit
+    environment. [~success] defaults to {!raise_on_process_error} *)
+val command: ?success:(OpamProcess.result -> unit) -> ?verbose:bool ->
+  ?env:string array -> ?name:string -> ?metadata:(string * string) list ->
+  ?allow_stdin:bool -> command -> unit
 
 (** [commands cmds] executes the commands [cmds] in the correct OPAM
     environment. It stops whenever one command fails unless [keep_going] is set

--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -167,7 +167,7 @@ let really_download
                     Printf.sprintf "Bad checksum, expected %s"
                       (OpamHash.to_string cksum)))
       checksum;
-  OpamSystem.mv tmp_dst dst;
+  Sys.rename tmp_dst dst;
   Done ()
 
 let download_as ?quiet ?validate ~overwrite ?compress ?checksum url dst =


### PR DESCRIPTION
Lots to clean-up in this, obviously. Overlaps with #4823 and #3217.

This PR is enough in #5220 to run `opam init` without Cygwin pre-installed.