### PR TITLE
opam lint: Enforce synopsis being always present

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -145,6 +145,7 @@ users)
   * [BUG] Fix linting packages from repository with tarred repositories, the file in temporary repository was no more avaiable when lint is done [#5068 @rjbou]
   * Update repository package filename display [#5068 @rjbou]
   * E67: check checksums only for vcs urls [#4960 @rjbou]
+  * E57: Enforce synopsis to always be there, restoring behaviour from opam 2.1 [#5442 @kit-ty-kate]
 
 ## Repository
   * When several checksums are specified, instead of adding in the cache only the archive by first checksum, name by best one and link others to this archive [#4696 rjbou]

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -654,8 +654,8 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
       "It is discouraged for non-compiler packages to use 'setenv:'"
       (t.env <> [] && not (has_flag Pkgflag_Compiler t));
     cond 57 `Error
-      "Synopsis and description must not be both empty"
-      (t.descr = None || t.descr = Some OpamFile.Descr.empty);
+      "Synopsis must not be empty"
+      (match t.descr with None -> true | Some d -> String.equal (OpamFile.Descr.synopsis d) "");
     (let vars = all_variables ~exclude_post:false ~command:[] t in
      let exists svar =
        List.exists (fun v -> v = OpamVariable.Full.of_string svar) vars

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -385,7 +385,7 @@ install : [ "install" ]
 ${BASEDIR}/lint.opam: Errors.
              error 46: Package is flagged "conf" but has source, install or remove instructions
 # Return code 1 #
-### : W47: Synopsis (or description first line) should start with a capital and not end with a dot
+### : W47: Synopsis should start with a capital and not end with a dot
 ### <lint.opam>
 opam-version: "2.0"
 synopsis: "a word"
@@ -399,18 +399,6 @@ bug-reports: "https://nobug"
 ### opam lint ./lint.opam
 ${BASEDIR}/lint.opam: Warnings.
            warning 47: Synopsis should start with a capital and not end with a dot
-### <lint.opam>
-opam-version: "2.0"
-synopsis: ""
-description: "a words."
-authors: "the testing team"
-homepage: "egapemoh"
-maintainer: "maint@tain.er"
-license: "ISC"
-dev-repo: "hg+https://to@li.nt"
-bug-reports: "https://nobug"
-### opam lint ./lint.opam
-${BASEDIR}/lint.opam: Passed.
 ### : W48: The fields 'build-test:' and 'build-doc:' are deprecated, and should be replaced by uses of the 'with-test' and 'with-doc' filter variables in the 'build:' and 'install:' fields, and by the newer 'run-test:' field
 ### <lint.opam>
 opam-version: "2.0"
@@ -606,7 +594,19 @@ setenv: [ idoit="anyway" ]
 ### opam lint ./lint.opam
 ${BASEDIR}/lint.opam: Warnings.
            warning 56: It is discouraged for non-compiler packages to use 'setenv:'
-### : E57: Synopsis and description must not be both empty
+### : E57: Synopsis must not be empty
+### <lint.opam>
+opam-version: "2.0"
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Errors.
+             error 57: Synopsis must not be empty
+# Return code 1 #
 ### <lint.opam>
 opam-version: "2.0"
 synopsis: ""
@@ -619,7 +619,34 @@ dev-repo: "hg+https://to@li.nt"
 bug-reports: "https://nobug"
 ### opam lint ./lint.opam
 ${BASEDIR}/lint.opam: Errors.
-             error 57: Synopsis and description must not be both empty
+             error 57: Synopsis must not be empty
+# Return code 1 #
+### <lint.opam>
+opam-version: "2.0"
+description: "a words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Errors.
+             error 57: Synopsis must not be empty
+# Return code 1 #
+### <lint.opam>
+opam-version: "2.0"
+synopsis: ""
+description: "a words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Errors.
+             error 57: Synopsis must not be empty
 # Return code 1 #
 ### : W58: Found variable, predefined one
 ### <lint.opam>

--- a/tests/reftests/source.test
+++ b/tests/reftests/source.test
@@ -73,7 +73,7 @@ Successfully extracted to ${BASEDIR}/pandore.3
            warning 25: Missing field 'authors'
            warning 35: Missing field 'homepage'
            warning 36: Missing field 'bug-reports'
-             error 57: Synopsis and description must not be both empty
+             error 57: Synopsis must not be empty
            warning 68: Missing field 'license'
 pandore is now pinned to file://${BASEDIR}/pandore.3 (version 3)
 

--- a/tests/reftests/upgrade-format.test
+++ b/tests/reftests/upgrade-format.test
@@ -35,7 +35,7 @@ conflicts: "extlib-compat"
 available: ocaml-version >= "4.02.3"
 ### opam show --raw ./opam-core.opam
 [WARNING] Failed checks on opam-core package definition from source at file://${BASEDIR}:
-             error 57: Synopsis and description must not be both empty
+             error 57: Synopsis must not be empty
 opam-version: "2.0"
 name: "opam-core"
 version: "2.0.7"


### PR DESCRIPTION
Built on top of https://github.com/ocaml/opam/pull/5069

Since https://github.com/ocaml/opam/pull/5070, opam doesn't enforce `synopsis` to be present, only the presence of either synopsis or description is required.

This breaks the behaviour from opam 2.1 and older which always required synopsis to be present and non-empty.

It is desirable to keep this check around to ensure `opam list` shows something helpful (i.e. anything but blank space)