### PR TITLE
Reftests: Clone opam-repository once and use it locally instead of downloading individual commits

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -120,6 +120,7 @@ users)
 ### Engine
  * Fix gcc < 14.3 bug on mingw i686 [#6624 @kit-ty-kate]
   * Fix support for removing local link directories [#6450 @kit-ty-kate]
+  * Clone opam-repository once and use it locally instead of downloading individual commits [#5449 @kit-ty-kate]
 
 ## Github Actions
   * bump `actions/checkout` from 4 to 5 [#6643 @kit-ty-kate]

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -2307,15 +2307,14 @@
            file://%{dep:opam-repo-N0REP0})))))
 
 (rule
- (targets opam-archive-0070613707.tar.gz)
- (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/0070613707.tar.gz)))
+ (targets opam-repository.git)
+ (action
+  (run git clone -q --bare --single-branch https://github.com/ocaml/opam-repository)))
 
 (rule
   (targets opam-repo-0070613707)
   (action
-   (progn
-    (run mkdir -p %{targets})
-    (run tar -C %{targets} -xzf %{dep:opam-archive-0070613707.tar.gz} --strip-components=1))))
+   (run git -C %{dep:./opam-repository.git} worktree add -q ../%{targets} 0070613707)))
 
 (rule
   (targets root-0070613707)
@@ -2328,15 +2327,9 @@
            file://%{dep:opam-repo-0070613707})))))
 
 (rule
- (targets opam-archive-009e00fa.tar.gz)
- (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/009e00fa.tar.gz)))
-
-(rule
   (targets opam-repo-009e00fa)
   (action
-   (progn
-    (run mkdir -p %{targets})
-    (run tar -C %{targets} -xzf %{dep:opam-archive-009e00fa.tar.gz} --strip-components=1))))
+   (run git -C %{dep:./opam-repository.git} worktree add -q ../%{targets} 009e00fa)))
 
 (rule
   (targets root-009e00fa)
@@ -2349,15 +2342,9 @@
            file://%{dep:opam-repo-009e00fa})))))
 
 (rule
- (targets opam-archive-11ea1cb.tar.gz)
- (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/11ea1cb.tar.gz)))
-
-(rule
   (targets opam-repo-11ea1cb)
   (action
-   (progn
-    (run mkdir -p %{targets})
-    (run tar -C %{targets} -xzf %{dep:opam-archive-11ea1cb.tar.gz} --strip-components=1))))
+   (run git -C %{dep:./opam-repository.git} worktree add -q ../%{targets} 11ea1cb)))
 
 (rule
   (targets root-11ea1cb)
@@ -2370,15 +2357,9 @@
            file://%{dep:opam-repo-11ea1cb})))))
 
 (rule
- (targets opam-archive-143dd2a2f59f5befbf3cb90bb2667f911737fbf8.tar.gz)
- (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/143dd2a2f59f5befbf3cb90bb2667f911737fbf8.tar.gz)))
-
-(rule
   (targets opam-repo-143dd2a2f59f5befbf3cb90bb2667f911737fbf8)
   (action
-   (progn
-    (run mkdir -p %{targets})
-    (run tar -C %{targets} -xzf %{dep:opam-archive-143dd2a2f59f5befbf3cb90bb2667f911737fbf8.tar.gz} --strip-components=1))))
+   (run git -C %{dep:./opam-repository.git} worktree add -q ../%{targets} 143dd2a2f59f5befbf3cb90bb2667f911737fbf8)))
 
 (rule
   (targets root-143dd2a2f59f5befbf3cb90bb2667f911737fbf8)
@@ -2391,15 +2372,9 @@
            file://%{dep:opam-repo-143dd2a2f59f5befbf3cb90bb2667f911737fbf8})))))
 
 (rule
- (targets opam-archive-297366c.tar.gz)
- (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/297366c.tar.gz)))
-
-(rule
   (targets opam-repo-297366c)
   (action
-   (progn
-    (run mkdir -p %{targets})
-    (run tar -C %{targets} -xzf %{dep:opam-archive-297366c.tar.gz} --strip-components=1))))
+   (run git -C %{dep:./opam-repository.git} worktree add -q ../%{targets} 297366c)))
 
 (rule
   (targets root-297366c)
@@ -2412,15 +2387,9 @@
            file://%{dep:opam-repo-297366c})))))
 
 (rule
- (targets opam-archive-3235916.tar.gz)
- (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/3235916.tar.gz)))
-
-(rule
   (targets opam-repo-3235916)
   (action
-   (progn
-    (run mkdir -p %{targets})
-    (run tar -C %{targets} -xzf %{dep:opam-archive-3235916.tar.gz} --strip-components=1))))
+   (run git -C %{dep:./opam-repository.git} worktree add -q ../%{targets} 3235916)))
 
 (rule
   (targets root-3235916)
@@ -2433,15 +2402,9 @@
            file://%{dep:opam-repo-3235916})))))
 
 (rule
- (targets opam-archive-7090735c.tar.gz)
- (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/7090735c.tar.gz)))
-
-(rule
   (targets opam-repo-7090735c)
   (action
-   (progn
-    (run mkdir -p %{targets})
-    (run tar -C %{targets} -xzf %{dep:opam-archive-7090735c.tar.gz} --strip-components=1))))
+   (run git -C %{dep:./opam-repository.git} worktree add -q ../%{targets} 7090735c)))
 
 (rule
   (targets root-7090735c)
@@ -2454,15 +2417,9 @@
            file://%{dep:opam-repo-7090735c})))))
 
 (rule
- (targets opam-archive-7371c1d9.tar.gz)
- (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/7371c1d9.tar.gz)))
-
-(rule
   (targets opam-repo-7371c1d9)
   (action
-   (progn
-    (run mkdir -p %{targets})
-    (run tar -C %{targets} -xzf %{dep:opam-archive-7371c1d9.tar.gz} --strip-components=1))))
+   (run git -C %{dep:./opam-repository.git} worktree add -q ../%{targets} 7371c1d9)))
 
 (rule
   (targets root-7371c1d9)
@@ -2475,15 +2432,9 @@
            file://%{dep:opam-repo-7371c1d9})))))
 
 (rule
- (targets opam-archive-a5d7cdc0.tar.gz)
- (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/a5d7cdc0.tar.gz)))
-
-(rule
   (targets opam-repo-a5d7cdc0)
   (action
-   (progn
-    (run mkdir -p %{targets})
-    (run tar -C %{targets} -xzf %{dep:opam-archive-a5d7cdc0.tar.gz} --strip-components=1))))
+   (run git -C %{dep:./opam-repository.git} worktree add -q ../%{targets} a5d7cdc0)))
 
 (rule
   (targets root-a5d7cdc0)
@@ -2496,15 +2447,9 @@
            file://%{dep:opam-repo-a5d7cdc0})))))
 
 (rule
- (targets opam-archive-ad4dd344.tar.gz)
- (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/ad4dd344.tar.gz)))
-
-(rule
   (targets opam-repo-ad4dd344)
   (action
-   (progn
-    (run mkdir -p %{targets})
-    (run tar -C %{targets} -xzf %{dep:opam-archive-ad4dd344.tar.gz} --strip-components=1))))
+   (run git -C %{dep:./opam-repository.git} worktree add -q ../%{targets} ad4dd344)))
 
 (rule
   (targets root-ad4dd344)
@@ -2517,15 +2462,9 @@
            file://%{dep:opam-repo-ad4dd344})))))
 
 (rule
- (targets opam-archive-c1842d168d.tar.gz)
- (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/c1842d168d.tar.gz)))
-
-(rule
   (targets opam-repo-c1842d168d)
   (action
-   (progn
-    (run mkdir -p %{targets})
-    (run tar -C %{targets} -xzf %{dep:opam-archive-c1842d168d.tar.gz} --strip-components=1))))
+   (run git -C %{dep:./opam-repository.git} worktree add -q ../%{targets} c1842d168d)))
 
 (rule
   (targets root-c1842d168d)
@@ -2538,15 +2477,9 @@
            file://%{dep:opam-repo-c1842d168d})))))
 
 (rule
- (targets opam-archive-c1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a.tar.gz)
- (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/c1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a.tar.gz)))
-
-(rule
   (targets opam-repo-c1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a)
   (action
-   (progn
-    (run mkdir -p %{targets})
-    (run tar -C %{targets} -xzf %{dep:opam-archive-c1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a.tar.gz} --strip-components=1))))
+   (run git -C %{dep:./opam-repository.git} worktree add -q ../%{targets} c1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a)))
 
 (rule
   (targets root-c1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a)
@@ -2559,15 +2492,9 @@
            file://%{dep:opam-repo-c1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a})))))
 
 (rule
- (targets opam-archive-de897adf36c4230dfea812f40c98223b31c4521a.tar.gz)
- (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/de897adf36c4230dfea812f40c98223b31c4521a.tar.gz)))
-
-(rule
   (targets opam-repo-de897adf36c4230dfea812f40c98223b31c4521a)
   (action
-   (progn
-    (run mkdir -p %{targets})
-    (run tar -C %{targets} -xzf %{dep:opam-archive-de897adf36c4230dfea812f40c98223b31c4521a.tar.gz} --strip-components=1))))
+   (run git -C %{dep:./opam-repository.git} worktree add -q ../%{targets} de897adf36c4230dfea812f40c98223b31c4521a)))
 
 (rule
   (targets root-de897adf36c4230dfea812f40c98223b31c4521a)
@@ -2580,15 +2507,9 @@
            file://%{dep:opam-repo-de897adf36c4230dfea812f40c98223b31c4521a})))))
 
 (rule
- (targets opam-archive-f372039d.tar.gz)
- (action (run curl --silent -Lo %{targets} https://github.com/ocaml/opam-repository/archive/f372039d.tar.gz)))
-
-(rule
   (targets opam-repo-f372039d)
   (action
-   (progn
-    (run mkdir -p %{targets})
-    (run tar -C %{targets} -xzf %{dep:opam-archive-f372039d.tar.gz} --strip-components=1))))
+   (run git -C %{dep:./opam-repository.git} worktree add -q ../%{targets} f372039d)))
 
 (rule
   (targets root-f372039d)


### PR DESCRIPTION
~This is faster on slower hardware but 20 seconds slower on fast hardware (2.50s on M1Pro vs. 2.30s before)~
~The size of artifacts in `_build` also jump from 5.4GB to 7.1GB sadly.~

~If anyone has an idea how to reduce the size I'd gladly take it.~

See next comment for the updated summary