### PR TITLE
Enforce the macOS sandbox script to use /bin/bash instead of /usr/bin/env bash for a more consistent experience

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -204,6 +204,7 @@ users)
   * Get rid of OPAM_USER_PATH_RO (never used on macOS and no longer needed on Linux) [#4795 @kit-ty-kate]
   * Print error message if command doesn't exist [#4971 @kit-ty-kat - fix #4112]
   * Resolve symlink for `ccache` directory [#5267 @rjbou - fix #5194]
+  * Enforce the macOS sandbox script to use /bin/bash instead of /usr/bin/env bash for a more consistent experience [#5451 @kit-ty-kate]
 
 ## VCS
   * Pass --depth=1 to git-fetch in the Git repo backend [#4442 @dra27]

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -ue
 
 POL='(version 1)(allow default)(deny network*)(deny file-write*)'

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# This script is only used on macOS, where /bin/bash is both guaranteed to exist and
+# and to be for the native architecture, which is why /usr/bin/env bash is not used.
+# See https://github.com/ocaml/opam/issues/5450
 set -ue
 
 POL='(version 1)(allow default)(deny network*)(deny file-write*)'


### PR DESCRIPTION
For most users this is strictly equivalent, however in some cases another (possibly broken) bash could be installed and used instead.

Fixes https://github.com/ocaml/opam/issues/5450