### PR TITLE
Implement accessors for `OpamProcess.command` type

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -678,3 +678,4 @@ users)
   * `OpamURL`: add module `SWHID` that contains helpers from and to internal swhid url [#4859 @rjbou]
   * `OpamSystem.read_command_output`: add an optional parameter to unmerge stdout and stderr [#4859 @rjbou]
   * `OpamSWHID`: add module to handle swhid [#4859 @rjbou]
+  * `OpamProcess`: expose the `command` type as a private type [#5452 @Leonidas-from-XIV]

--- a/src/core/opamProcess.mli
+++ b/src/core/opamProcess.mli
@@ -12,7 +12,18 @@
 (** Process and job handling, with logs, termination status, etc. *)
 
 (** The type of shell commands *)
-type command
+type command = private {
+  cmd: string;
+  args: string list;
+  cmd_text: string option;
+  cmd_dir: string option;
+  cmd_env: string array option;
+  cmd_stdin: bool option;
+  cmd_stdout: string option;
+  cmd_verbose: bool option;
+  cmd_name: string option;
+  cmd_metadata: (string * string) list option;
+}
 
 (** Builds a shell command for later execution.
     @param env         environment for the command


### PR DESCRIPTION
This is useful when wanting to implement other runners for `OpamProcess.Job.Op`, e.g. based on Dune's Fibers, Lwt or Async as it allows to run the process using their process spawning abstractions.