### PR TITLE
depexts: add more precise depext testing family

### DIFF
--- a/.github/workflows/depexts.yml
+++ b/.github/workflows/depexts.yml
@@ -17,7 +17,7 @@ defaults:
 env:
   OPAMVERSION: 2.1.0
   OPAM_REPO: https://github.com/ocaml/opam-repository.git
-  OPAM_REPO_SHA: 3d6779beedc761067596bf5c3f5c25ab57a7e3e7
+  OPAM_REPO_SHA: 8ef7eb944f649e46558ce4bd3fecaaee24ba2622
 
 jobs:
   opam-cache:

--- a/master_changes.md
+++ b/master_changes.md
@@ -198,6 +198,7 @@ users)
   * Increase verbose logging of command to 4 [#5151 @rjbou]
   * Improve the error message when neither MacPorts or Homebrew could be detected on macOS [#5240 @kit-ty-kate]
   * Introduce dummy-success & dummy-failure os-family to make testing depexts behaviour easier [#5268 @kit-ty-kate]
+    * Add specification of installed/available packages: `dummy-<success|failure>[:<*|0|pkgslist>:*|0|pkgslist>]"` [#5453 @rjbou @dra27]
   * Run command as admin only when needed [#5268 @kit-ty-kate]
   * Print depexts together with action list on `--show` [#5236 @AltGr]
   * [BUG] when checking again, more accurate check of missing packages (available and not found) [#5157 @rjbou]


### PR DESCRIPTION
** Updated to new version**

Syntax is `dummy-<success|failure>[:<*|0|pkgslist>:*|0|pkgslist>]`
Examples:
- `dummy-success`: install succeed, default: no package installed, all packages available
- `dummy-success:depext-ok:`: install succeed, only `depext-ok` installed, all packages available
- `dummy-failure::*`: install fails, no package installed, all packages available
- `dummy-success:depext-ok:depext-avail`: install succeed, only `depext-ok` installed, only `depext-avail` available
- `dunny-failure::0`: install fails, no package installed, no package available
---
** old version **

Syntax is `dummy-<success|failure>[#installed@<all|none|pkgslist>][#avail@<all|none|pkgslist>`]
Examples:
- dummy-success
- dummy-success#installed@depext-ok
- dummy-failure#avail@all
- dummy-success#installed@depext-ok#avail@depext-avail
