### PR TITLE
Depext filter enhancement: resolve package variables

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1182,8 +1182,10 @@ let install_t t ?ask ?(ignore_conflicts=false) ?(depext_only=false)
           dname_map OpamPackage.Map.empty
       in
       if depext_only then
-        (OpamSolution.install_depexts ~force_depext:true ~confirm:false t
-           (OpamSolver.all_packages solution)), None
+        (match OpamSolution.install_depexts ~force_depext:true
+                 ~confirm:false t (OpamSolver.all_packages solution) with
+        | Success t -> t, None
+        | Conflicts not_found -> t, Some (Success (Missing_depexts not_found)))
       else
       let add_roots =
         OpamStd.Option.map (function

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -379,7 +379,7 @@ let parallel_apply t
       (* Turns out these depexts weren't needed after all. Remember that and
          make the bypass permanent. *)
       try
-        (OpamPackage.Map.find nv (Lazy.force !t_ref.sys_packages)).s_available
+        (OpamPackage.Map.find nv (Lazy.force !t_ref.sys_packages)).sys_available
       with Not_found -> OpamSysPkg.Set.empty
     in
     let bypass = OpamSysPkg.Set.union missing_depexts !bypass_ref in
@@ -1137,8 +1137,8 @@ let get_depexts ?(force=false) ?(recover=false) t packages =
     OpamPackage.Set.fold (fun pkg (avail,nf) ->
         match OpamPackage.Map.find_opt pkg sys_packages with
         | Some sys ->
-          OpamSysPkg.(Set.union avail sys.s_available),
-          OpamSysPkg.(Set.union nf sys.s_not_found)
+          OpamSysPkg.(Set.union avail sys.sys_available),
+          OpamSysPkg.(Set.union nf sys.sys_not_found)
         | None -> avail, nf)
       packages (OpamSysPkg.Set.empty, OpamSysPkg.Set.empty)
   in
@@ -1157,8 +1157,7 @@ let install_depexts ?(force_depext=false) ?(confirm=true) t packages =
           match OpamPackage.Map.find_opt nv sys_map with
           | Some status ->
             OpamPackage.Map.add
-              nv { status with OpamSysPkg.s_available =
-                                 f status.OpamSysPkg.s_available }
+              nv { status with sys_available = f status.sys_available }
               sys_map
           | None -> sys_map)
         packages

--- a/src/client/opamSolution.mli
+++ b/src/client/opamSolution.mli
@@ -80,7 +80,8 @@ val dry_run: 'a switch_state -> OpamSolver.solution -> 'a switch_state
    launched, without asking user (used by the `--depext-only` option). If
    [force_depext] is true, it overrides [OpamFile.Config.depext] value. *)
 val install_depexts:
-  ?force_depext:bool -> ?confirm:bool -> rw switch_state -> package_set -> rw switch_state
+  ?force_depext:bool -> ?confirm:bool -> rw switch_state -> package_set ->
+  (rw switch_state, OpamSysPkg.Set.t OpamPackage.Map.t) result
 
 (** {2 Atoms} *)
 

--- a/src/format/opamSysPkg.ml
+++ b/src/format/opamSysPkg.ml
@@ -43,24 +43,3 @@ module Map = OpamStd.Map.Make(O)
 let raw_set set =
   OpamStd.String.Set.fold (fun spkg set-> Set.add (of_string spkg) set)
     set Set.empty
-
-type status =
-  {
-    s_available : Set.t;
-    (** Package available but not installed *)
-
-    s_not_found : Set.t;
-    (** Package unavailable on this system *)
-  }
-
-
-let status_empty =
-  {
-    s_available  = Set.empty;
-    s_not_found  = Set.empty;
-  }
-
-let string_of_status sp =
-  Printf.sprintf "available: %s; not_found: %s"
-    (Set.to_string sp.s_available)
-    (Set.to_string sp.s_not_found)

--- a/src/format/opamSysPkg.mli
+++ b/src/format/opamSysPkg.mli
@@ -13,17 +13,3 @@ type t
 include OpamStd.ABSTRACT with type t := t
 
 val raw_set: OpamStd.String.Set.t -> Set.t
-
-(** System packages status *)
-type status =
-  {
-    s_available : Set.t;
-    (** Package available but not installed *)
-
-    s_not_found : Set.t;
-    (** Package unavailable on this system *)
-  }
-
-val status_empty: status
-
-val string_of_status: status -> string

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -419,4 +419,10 @@ type json = OpamJson.t
 
 type sys_package = OpamSysPkg.t
 
-type sys_pkg_status = OpamSysPkg.status
+type sys_pkg_status = {
+  sys_available : OpamSysPkg.Set.t;
+  (** Package available but not installed *)
+
+  sys_not_found : OpamSysPkg.Set.t;
+  (** Package unavailable on this system *)
+}

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -426,3 +426,10 @@ type sys_pkg_status = {
   sys_not_found : OpamSysPkg.Set.t;
   (** Package unavailable on this system *)
 }
+
+(** List [sys_pkg_status] but keep filter with unresolved variable at switch
+    load, in order to be resolved when applying solution *)
+type sys_pkg_status_w_filter = {
+  sys_available_wf :  filter OpamSysPkg.Map.t ;
+  sys_not_found_wf :  filter OpamSysPkg.Map.t;
+}

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -275,6 +275,7 @@ type solution_result =
   | OK of package action list (** List of successful actions *)
   | Aborted
   | Partial_error of actions_result
+  | Missing_depexts of OpamSysPkg.Set.t package_map
 
 (** Solver result *)
 type ('a, 'b) result =

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -221,3 +221,14 @@ let map_success f = function
 let iter_success f = function
   | Success x -> f x
   | Conflicts _ -> ()
+
+(** System packages *)
+let sys_pkg_status_empty = {
+  sys_available  = OpamSysPkg.Set.empty;
+  sys_not_found  = OpamSysPkg.Set.empty;
+}
+
+let string_of_sys_pkg_status sp =
+  Printf.sprintf "available: %s; not_found: %s"
+    (OpamSysPkg.Set.to_string sp.sys_available)
+    (OpamSysPkg.Set.to_string sp.sys_not_found)

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -232,3 +232,8 @@ let string_of_sys_pkg_status sp =
   Printf.sprintf "available: %s; not_found: %s"
     (OpamSysPkg.Set.to_string sp.sys_available)
     (OpamSysPkg.Set.to_string sp.sys_not_found)
+
+let sys_pkg_status_wf_empty = {
+  sys_available_wf  = OpamSysPkg.Map.empty;
+  sys_not_found_wf  = OpamSysPkg.Map.empty;
+}

--- a/src/format/opamTypesBase.mli
+++ b/src/format/opamTypesBase.mli
@@ -81,3 +81,4 @@ val iter_success: ('a -> unit) -> ('a, 'b) result -> unit
 val sys_pkg_status_empty: sys_pkg_status
 val string_of_sys_pkg_status: sys_pkg_status -> string
 
+val sys_pkg_status_wf_empty: sys_pkg_status_w_filter

--- a/src/format/opamTypesBase.mli
+++ b/src/format/opamTypesBase.mli
@@ -76,3 +76,8 @@ val all_package_flags: package_flag list
 (** Map on a solver result *)
 val map_success: ('a -> 'b) -> ('a,'fail) result -> ('b,'fail) result
 val iter_success: ('a -> unit) -> ('a, 'b) result -> unit
+
+(** System packages *)
+val sys_pkg_status_empty: sys_pkg_status
+val string_of_sys_pkg_status: sys_pkg_status -> string
+

--- a/src/state/opamStateTypes.mli
+++ b/src/state/opamStateTypes.mli
@@ -135,7 +135,7 @@ type +'lock switch_state = {
   packages: package_set;
   (** The set of all known packages *)
 
-  sys_packages: sys_pkg_status package_map Lazy.t;
+  sys_packages: sys_pkg_status_w_filter package_map Lazy.t;
   (** Map of package and their system dependencies packages status. Only
       initialised for otherwise available packages *)
 

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -209,8 +209,8 @@ let depexts_status_of_packages_raw
           avail, not_found
       in
       OpamPackage.Map.map (fun set ->
-          { OpamSysPkg.s_available = set %% avail;
-            OpamSysPkg.s_not_found = set %% not_found}
+          { sys_available = set %% avail;
+            sys_not_found = set %% not_found}
         ) syspkg_map
     | exception (Failure msg) ->
       OpamConsole.note "%s\nYou can disable this check using 'opam \
@@ -223,9 +223,9 @@ let depexts_status_of_packages_raw
 
 let depexts_unavailable_raw sys_packages nv =
   match OpamPackage.Map.find_opt nv sys_packages with
-  | Some { OpamSysPkg.s_not_found; _}
-    when not (OpamSysPkg.Set.is_empty s_not_found) ->
-    Some s_not_found
+  | Some { sys_not_found; _}
+    when not (OpamSysPkg.Set.is_empty sys_not_found) ->
+    Some sys_not_found
   | _ -> None
 
 let load lock_kind gt rt switch =
@@ -536,8 +536,8 @@ let load lock_kind gt rt switch =
     let sys_packages =
       OpamPackage.Map.filter (fun pkg spkg ->
           OpamPackage.Set.mem pkg installed
-          && not (OpamSysPkg.Set.is_empty spkg.OpamSysPkg.s_available
-                  && OpamSysPkg.Set.is_empty spkg.OpamSysPkg.s_not_found))
+          && not (OpamSysPkg.Set.is_empty spkg.sys_available
+                  && OpamSysPkg.Set.is_empty spkg.sys_not_found))
         (Lazy.force sys_packages)
     in
     if OpamPackage.Map.is_empty sys_packages then
@@ -548,8 +548,7 @@ let load lock_kind gt rt switch =
     let sgl_pkg = OpamPackage.Set.is_singleton changed in
     let open OpamSysPkg.Set.Op in
     let missing_map =
-      OpamPackage.Map.map (fun sys ->
-          sys.OpamSysPkg.s_available ++ sys.OpamSysPkg.s_not_found)
+      OpamPackage.Map.map (fun sys -> sys.sys_available ++ sys.sys_not_found)
         sys_packages
     in
     let missing_set =
@@ -994,8 +993,7 @@ let universe st
   in
   let missing_depexts =
     OpamPackage.Map.fold (fun nv status acc ->
-        if OpamSysPkg.Set.is_empty status.OpamSysPkg.s_available
-        then acc
+        if OpamSysPkg.Set.is_empty status.sys_available then acc
         else OpamPackage.Set.add nv acc)
       (Lazy.force st.sys_packages)
       OpamPackage.Set.empty

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -185,7 +185,7 @@ val reverse_dependencies:
 (** Returns required system packages of each of the given packages (elements are
     not added to the map  if they don't have system dependencies) *)
 val depexts_status_of_packages:
-  'a switch_state -> package_set -> OpamSysPkg.status package_map
+  'a switch_state -> package_set -> sys_pkg_status package_map
 
 (** Returns not found depexts for the package *)
 val depexts_unavailable: 'a switch_state -> package -> OpamSysPkg.Set.t option

--- a/tests/reftests/depexts.test
+++ b/tests/reftests/depexts.test
@@ -33,3 +33,199 @@ false
 [NOTE] You can retry with '--assume-depexts' to skip this check, or run 'opam option depext=false' to permanently disable handling of system packages.
 
 # Return code 10 #
+### : filter with installed :
+### opam var --global os-family=dummy-success
+Added '[os-family "dummy-success" "Set through 'opam var'"]' to field global-variables in global configuration
+### <pkg:conf-b.1>
+opam-version: "2.0"
+depends: "conf-os"
+### <pkg:conf-os.1>
+opam-version: "2.0"
+depends: [ "conf-os1" | "conf-os2" ]
+depexts:[
+  [ "os1-depext" ] { conf-os1:installed }
+  [ "os2-depext" ] { conf-os2:installed }
+]
+### <pkg:conf-os2.1>
+opam-version: "2.0"
+conflicts: "conf-os1"
+### <pkg:conf-os1.1>
+opam-version: "2.0"
+conflicts: "conf-os2"
+### opam install conf-os | sed-cmd echo
+The following actions will be performed:
+=== install 2 packages
+  - install conf-os  1
+  - install conf-os1 1 [required by conf-os]
+
+The following system packages will first need to be installed:
+    os1-depext
+
+<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><><><>
+
+opam believes some required external dependencies are missing. opam can:
+> 1. Run echo to install them (may need root/sudo access)
+  2. Display the recommended echo command and wait while you run it manually (e.g. in another terminal)
+  3. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
+  4. Abort the installation
+
+[1/2/3/4] 1
+
+echo "os1-depext"
+- os1-depext
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed conf-os1.1
+-> installed conf-os.1
+Done.
+### opam remove conf-os
+[WARNING] Opam package conf-os.1 depends on the following system package that can no longer be found: os1-depext
+The following actions will be performed:
+=== remove 1 package
+  - remove conf-os 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   conf-os.1
+Done.
+### OPAMVAR_os_family=dummy-success::0 opam install conf-os --show
+[ERROR] Package conf-os depends on the unavailable system package 'os1-depext'. You can use `--no-depexts' to attempt installation anyway.
+# Return code 5 #
+### OPAMVAR_os_family=dummy-success::0 opam install conf-os
+[ERROR] Package conf-os depends on the unavailable system package 'os1-depext'. You can use `--no-depexts' to attempt installation anyway.
+# Return code 5 #
+### opam remove conf-os1 -a
+The following actions will be performed:
+=== remove 1 package
+  - remove conf-os1 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   conf-os1.1
+Done.
+### OPAMVAR_os_family=dummy-success::0 opam install conf-os --show
+The following actions would be performed:
+=== install 2 packages
+  - install conf-os  1
+  - install conf-os1 1 [required by conf-os]
+[WARNING] These additional system packages are required, but not available on your system: os1-depext
+### OPAMVAR_os_family=dummy-success::0 opam install conf-os
+The following actions will be performed:
+=== install 2 packages
+  - install conf-os  1
+  - install conf-os1 1 [required by conf-os]
+[WARNING] These additional system packages are required, but not available on your system: os1-depext
+[ERROR] Some packages have missing dependencies after resolution:
+           - conf-os.1: os1-depext
+
+# Return code 5 #
+### OPAMVAR_os_family=dummy-success::os1-depext opam install conf-os --show
+The following actions would be performed:
+=== install 2 packages
+  - install conf-os  1
+  - install conf-os1 1 [required by conf-os]
+
+The following system packages will first need to be installed:
+    os1-depext
+### OPAMVAR_os_family=dummy-success::os1-depext opam install conf-os | sed-cmd echo
+The following actions will be performed:
+=== install 2 packages
+  - install conf-os  1
+  - install conf-os1 1 [required by conf-os]
+
+The following system packages will first need to be installed:
+    os1-depext
+
+<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><><><>
+
+opam believes some required external dependencies are missing. opam can:
+> 1. Run echo to install them (may need root/sudo access)
+  2. Display the recommended echo command and wait while you run it manually (e.g. in another terminal)
+  3. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
+  4. Abort the installation
+
+[1/2/3/4] 1
+
+echo "os1-depext"
+- os1-depext
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed conf-os1.1
+-> installed conf-os.1
+Done.
+### opam remove conf-os -a
+[WARNING] Opam package conf-os.1 depends on the following system package that can no longer be found: os1-depext
+The following actions will be performed:
+=== remove 2 packages
+  - remove conf-os  1
+  - remove conf-os1 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   conf-os.1
+-> removed   conf-os1.1
+Done.
+### OPAMVAR_os_family=dummy-success:os1-depext:os2-depext opam install conf-os
+The following actions will be performed:
+=== install 2 packages
+  - install conf-os  1
+  - install conf-os1 1 [required by conf-os]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed conf-os1.1
+-> installed conf-os.1
+Done.
+### opam remove conf-os -a
+[WARNING] Opam package conf-os.1 depends on the following system package that can no longer be found: os1-depext
+The following actions will be performed:
+=== remove 2 packages
+  - remove conf-os  1
+  - remove conf-os1 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   conf-os.1
+-> removed   conf-os1.1
+Done.
+### <pkg:c.3>
+opam-version: "2.0"
+### <pkg:conf-b.1>
+opam-version: "2.0"
+depends: "conf-os"
+### <pkg:conf-oss.1>
+opam-version: "2.0"
+depends: [ "conf-os1" | "conf-os2" "c" ]
+depexts:[
+  [ "depext-1" ]   { os-family="dummy-success" }
+  [ "os1-depext" ] { os-family="dummy-success" & conf-os1:installed }
+  [ "os2-depext" ] { os-family="dummy-success" & conf-os1:installed & c:version > "2"}
+  [ "os3-depext" ] { os-family="dummy-success" & conf-os1:installed & c:version > "4"}
+]
+### opam install conf-oss | sed-cmd echo
+The following actions will be performed:
+=== install 3 packages
+  - install c        3 [required by conf-oss]
+  - install conf-os1 1 [required by conf-oss]
+  - install conf-oss 1
+
+The following system packages will first need to be installed:
+    depext-1 os1-depext os2-depext
+
+<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><><><>
+
+opam believes some required external dependencies are missing. opam can:
+> 1. Run echo to install them (may need root/sudo access)
+  2. Display the recommended echo command and wait while you run it manually (e.g. in another terminal)
+  3. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
+  4. Abort the installation
+
+[1/2/3/4] 1
+
+echo "depext-1" "os1-depext" "os2-depext"
+- depext-1 os1-depext os2-depext
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed c.3
+-> installed conf-os1.1
+-> installed conf-oss.1
+Done.
+### opam option depext-bypass --global
+[]
+### opam option depext-bypass --switch test
+[]


### PR DESCRIPTION
`depexts:` filter can now handle package variables. They are stored and resolved on the go & gradually. On install, packages appearing in solution are considered as installed for resolving. See `depexts.test` for examples.

* [x] queued on #5453 
* [ ] add test on unavailability