### PR TITLE
windows: opam root redirection when path contains spaces

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -29,6 +29,7 @@ users)
   * Enhance the Git menu by warning if the user appears to need to restart the shell to pick up PATH changes [#5963 @dra27]
   * Include Git for Windows installations in the list of possibilities where the user instructed Git-for-Windows setup not to update PATH [#5963 @dra27]
   * [BUG] Fail if `--git-location` points to a directory not containing git [#6000 @dra27]
+  * Redirect the opam root to `C:\opamroot-xxx` when the opam root contains spaces on Windows [#5457 @rjbou @dra27]
 
 ## Config report
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -214,3 +214,4 @@ users)
   * `OpamCompat`: add `Seq.find_map` from OCaml 4.14 [#6000 @dra27]
   * `OpamStd.Sys.{get_windows_executable_variant,get_cygwin_variant,is_cygwin_variant}`: renamed `~cygbin` to `?search_in_path` with a change in semantics so that it acts as though the directory was simply the first entry in PATH [#6000 @dra27]
   * `OpamConsole.Symbols`: add `collision` symbol [#5457 @dra27]
+  * `OpamSystem`: add `mk_unique_dir` that returns an unique directory name as `mk_temp_dir` but not in temporary directory [#5457 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -177,6 +177,7 @@ users)
   * Expose `OpamSolution.print_depext_msg` [#5994 @dra27]
   * Extracted `OpamSolution.install_sys_packages` from `OpamSolution.install_depexts` [#5994 @dra27]
   * `OpamInitDefaults.required_packages_for_cygwin`: no longer includes git; as the need to add that is computed in `OpamClient` [#6000 @dra27]
+  * `OpamClientConfig.opam_init`: add `original_root_dir` argument that contains the original roo directory before redirection [#5457 @rjbou]
 
 ## opam-repository
   * `OpamDownload.download_command`: separate output from stdout and stderr [#5984 @kit-ty-kate]
@@ -185,6 +186,7 @@ users)
   * `OpamEnv.cygwin_non_shadowed_programs`: exposes the list of executables (not including git) which should always come from Cygwin [#6000 @dra27]
   * `opamSysInteract.Cygwin.install`: de-label `packages` argument [#6000 @dra27]
   * `OpamSysInteract.Cygwin.check_install` renamed to `analyse_install` which now also returns whether the installation found was MSYS2 or Cygwin [#6000 @dra27]
+  * `OpamStateConfig.r`, `OpamStateConfig.init`: add `original_root_dir` field to config record and argument that contains the original root directory before redirection [#5457 @rjbou]
 
 ## opam-solver
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -178,6 +178,7 @@ users)
   * Extracted `OpamSolution.install_sys_packages` from `OpamSolution.install_depexts` [#5994 @dra27]
   * `OpamInitDefaults.required_packages_for_cygwin`: no longer includes git; as the need to add that is computed in `OpamClient` [#6000 @dra27]
   * `OpamClientConfig.opam_init`: add `original_root_dir` argument that contains the original roo directory before redirection [#5457 @rjbou]
+  * `OpamClientConfig.opam_init`: add `root_from` argument that contains the origin of used root[#5457 @dra27]
 
 ## opam-repository
   * `OpamDownload.download_command`: separate output from stdout and stderr [#5984 @kit-ty-kate]
@@ -187,6 +188,7 @@ users)
   * `opamSysInteract.Cygwin.install`: de-label `packages` argument [#6000 @dra27]
   * `OpamSysInteract.Cygwin.check_install` renamed to `analyse_install` which now also returns whether the installation found was MSYS2 or Cygwin [#6000 @dra27]
   * `OpamStateConfig.r`, `OpamStateConfig.init`: add `original_root_dir` field to config record and argument that contains the original root directory before redirection [#5457 @rjbou]
+  * `OpamStateConfig.r`, `OpamStateConfig.init`: add `root_from` field to config record and argument that contains the origin of used root[#5457 @dra27]
 
 ## opam-solver
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -192,6 +192,7 @@ users)
   * `OpamPath`: remove `OpamPath.Switch.last_env` function in favor to `OpamPath.last_env` as the files are no more stored in switch directory [#5962 @moyodiallo - fix #5823]
   * `OpamFilter.map_up`: correct handling of FDefined [#5983 @dra27]
   * `OpamFilter.fold_down_left`: correct handling of FDefined and FUndef [#5983 @dra27]
+  * `OpamPath`: add `redirected` the file name of redirected opam root [#5457 @rjbou]
 
 ## opam-core
   * `OpamStd.String`: add `split_quoted` that preserves quoted separator [#5935 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -213,3 +213,4 @@ users)
   * `OpamStubs.enumRegistry`: on Windows, retrieves all the values of a given type from a registry key, with their names [#6000 @dra27]
   * `OpamCompat`: add `Seq.find_map` from OCaml 4.14 [#6000 @dra27]
   * `OpamStd.Sys.{get_windows_executable_variant,get_cygwin_variant,is_cygwin_variant}`: renamed `~cygbin` to `?search_in_path` with a change in semantics so that it acts as though the directory was simply the first entry in PATH [#6000 @dra27]
+  * `OpamConsole.Symbols`: add `collision` symbol [#5457 @dra27]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -543,6 +543,7 @@ let apply_global_options cli o =
     (* ?solver_preferences_best_effort_prefix: *)
     (* - state options - *)
     ?root_dir:o.opt_root
+    ?original_root_dir:o.opt_root
     ?current_switch:(o.opt_switch >>| OpamSwitch.of_string)
     ?switch_from:(o.opt_switch >>| fun _ -> `Command_line)
     (* ?jobs: int *)

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -181,7 +181,7 @@ let check_and_run_external_commands () =
     let yes = if yes then Some (Some true) else None in
     OpamCoreConfig.init ?yes ?confirm_level ();
     OpamFormatConfig.init ();
-    let root_dir = OpamStateConfig.opamroot () in
+    let root_from, root_dir = OpamStateConfig.opamroot () in
     let has_init, root_upgraded =
       match OpamStateConfig.load_defaults ~lock_kind:`Lock_read root_dir with
       | None -> (false, false)
@@ -210,7 +210,7 @@ let check_and_run_external_commands () =
           env_update_resolved "PATH" PlusEq
             (OpamFilename.Dir.to_string plugins_bin)
         ] in
-        OpamStateConfig.init ~root_dir ();
+        OpamStateConfig.init ~root_from ~root_dir ();
         match OpamStateConfig.get_switch_opt () with
         | None -> env_array (OpamEnv.get_pure ~updates ())
         | Some sw ->

--- a/src/client/opamClientConfig.ml
+++ b/src/client/opamClientConfig.ml
@@ -209,7 +209,7 @@ let opam_init ?root_dir ?strict ?solver =
   let open OpamStd.Option.Op in
 
   (* (i) get root dir *)
-  let root = OpamStateConfig.opamroot ?root_dir () in
+  let root_from, root = OpamStateConfig.opamroot ?root_dir () in
 
   (* (ii) load conf file and set defaults *)
   (* the init for OpamFormat is done in advance since (a) it has an effect on
@@ -261,5 +261,5 @@ let opam_init ?root_dir ?strict ?solver =
   OpamCoreConfig.initk ?log_dir |>
   OpamRepositoryConfig.initk |>
   OpamSolverConfig.initk ?solver |>
-  OpamStateConfig.initk ~root_dir:root |>
+  OpamStateConfig.initk ~root_dir:root ~root_from |>
   initk

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -120,6 +120,7 @@ val opam_init:
   ?assume_depexts:bool ->
   ?cli:OpamCLIVersion.t ->
   ?scrubbed_environment_variables:string list ->
+  ?original_root_dir:OpamTypes.dirname ->
   ?current_switch:OpamSwitch.t ->
   ?switch_from:OpamStateTypes.provenance ->
   ?jobs:int Lazy.t ->

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -94,7 +94,7 @@ let global_options cli =
       switch_to_updated_self
         OpamStd.Option.Op.(options.debug_level ++
                            OpamCoreConfig.E.debug () +! 0 |> abs > 0)
-        (OpamStateConfig.opamroot ?root_dir:options.opt_root ());
+        (snd (OpamStateConfig.opamroot ?root_dir:options.opt_root ()));
     let root_is_ok =
       OpamStd.Option.default false (OpamClientConfig.E.rootisok ())
     in

--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -105,6 +105,7 @@ module Symbols = struct
   let downwards_double_arrow = Uchar.of_int 0x21d3
   let black_down_pointing_triangle = Uchar.of_int 0x25bc
   let downwards_black_arrow = Uchar.of_int 0x2b07
+  let collision = Uchar.of_int 0x1f4a5
 end
 
 type win32_glyph_checker = {

--- a/src/core/opamConsole.mli
+++ b/src/core/opamConsole.mli
@@ -66,6 +66,7 @@ module Symbols : sig
   val downwards_double_arrow : Uchar.t
   val downwards_black_arrow : Uchar.t
   val black_down_pointing_triangle : Uchar.t
+  val collision : Uchar.t
 end
 
 val utf8_symbol:

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -88,6 +88,13 @@ let rec mk_temp_dir ?(prefix="opam") () =
   else
     real_path s
 
+let rec mk_unique_dir ~dir ?(prefix="opam") () =
+  let s = dir / Printf.sprintf "%s-%06x" prefix (Random.int 0xFFFFFF) in
+  if Sys.file_exists s then
+    mk_unique_dir ~dir ~prefix ()
+  else
+    real_path s
+
 let safe_mkdir dir =
   try
     log "mkdir %s" dir;

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -51,6 +51,10 @@ val verbose_for_base_commands: unit -> bool
     (if [prefix] is not set), pid, and random number. *)
 val mk_temp_dir: ?prefix:string -> unit -> string
 
+(** Returns a directory name, in the [~dir], composed by {i opam}
+    (if [prefix] is not set), and a random number. *)
+val mk_unique_dir: dir:string -> ?prefix:string -> unit -> string
+
 (** [copy_file src dst] copies [src] to [dst]. Remove [dst] before the copy
     if it is a link. *)
 val copy_file: string -> string -> unit

--- a/src/format/opamPath.ml
+++ b/src/format/opamPath.ml
@@ -19,6 +19,8 @@ let ( /- ) dir f = OpamFile.make (dir // f)
 
 let config t = t /- "config"
 
+let redirected t = t // "redirected-opamroot"
+
 let init_config_files () =
   List.map OpamFile.make [
     OpamFilename.Dir.of_string (OpamStd.Sys.etc ()) // "opamrc";

--- a/src/format/opamPath.mli
+++ b/src/format/opamPath.mli
@@ -31,6 +31,9 @@ val lock: t -> filename
 (** Main configuration file: {i $opam/config} *)
 val config: t -> OpamFile.Config.t OpamFile.t
 
+(** Redirection file for opam root: {i $opam/redirected-opamroot} *)
+val redirected: t -> OpamFilename.t
+
 (** The list of configuration files location used by default ({i /etc/opamrc}
     and {i ~/.opamrc}). More general (lower priority) first. *)
 val init_config_files: unit -> OpamFile.InitConfig.t OpamFile.t list

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -53,6 +53,7 @@ end
 
 type t = {
   root_dir: OpamFilename.Dir.t;
+  original_root_dir: OpamFilename.Dir.t;
   current_switch: OpamSwitch.t option;
   switch_from: provenance;
   jobs: int Lazy.t;
@@ -86,6 +87,7 @@ let default = {
       in
       concat_and_resolve local_appdata "opam"
     );
+  original_root_dir = default_root ();
   current_switch = None;
   switch_from = `Default;
   jobs = lazy (max 1 (OpamSysPoll.cores () - 1));
@@ -108,6 +110,7 @@ let default = {
 
 type 'a options_fun =
   ?root_dir:OpamFilename.Dir.t ->
+  ?original_root_dir:OpamFilename.Dir.t ->
   ?current_switch:OpamSwitch.t ->
   ?switch_from:provenance ->
   ?jobs:(int Lazy.t) ->
@@ -126,6 +129,7 @@ type 'a options_fun =
 
 let setk k t
     ?root_dir
+    ?original_root_dir
     ?current_switch
     ?switch_from
     ?jobs
@@ -144,6 +148,7 @@ let setk k t
   let (+) x opt = match opt with Some x -> x | None -> x in
   k {
     root_dir = t.root_dir + root_dir;
+    original_root_dir = t.original_root_dir + original_root_dir;
     current_switch =
       (match current_switch with None -> t.current_switch | s -> s);
     switch_from = t.switch_from + switch_from;
@@ -176,6 +181,7 @@ let initk k =
   in
   setk (setk (fun c -> r := c; k)) !r
     ?root_dir:(E.root () >>| OpamFilename.Dir.of_string)
+    ?original_root_dir:(E.root () >>| OpamFilename.Dir.of_string)
     ?current_switch
     ?switch_from
     ?jobs:(E.jobs () >>| fun s -> lazy s)

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -54,6 +54,7 @@ end
 type t = {
   root_dir: OpamFilename.Dir.t;
   original_root_dir: OpamFilename.Dir.t;
+  root_from: provenance;
   current_switch: OpamSwitch.t option;
   switch_from: provenance;
   jobs: int Lazy.t;
@@ -70,24 +71,26 @@ type t = {
   no_depexts: bool;
 }
 
+let default_root =
+  (* On Windows, if a .opam directory is found in %HOME% or %USERPROFILE% then
+     then we'll use it. Otherwise, we use %LOCALAPPDATA%. *)
+  let home_location =
+    let open OpamFilename in
+    concat_and_resolve (Dir.of_string (OpamStd.Sys.home ())) ".opam"
+  in
+  if not Sys.win32 || OpamFilename.exists_dir home_location then
+    home_location
+  else
+  let open OpamFilename in
+  let local_appdata =
+    Dir.of_string (OpamStubs.getPathToLocalAppData ())
+  in
+  concat_and_resolve local_appdata "opam"
+
 let default = {
-  root_dir = (
-    (* On Windows, if a .opam directory is found in %HOME% or %USERPROFILE% then
-       then we'll use it. Otherwise, we use %LOCALAPPDATA%. *)
-    let home_location =
-      let open OpamFilename in
-      concat_and_resolve (Dir.of_string (OpamStd.Sys.home ())) ".opam"
-    in
-    if not Sys.win32 || OpamFilename.exists_dir home_location then
-      home_location
-    else
-      let open OpamFilename in
-      let local_appdata =
-        Dir.of_string (OpamStubs.getPathToLocalAppData ())
-      in
-      concat_and_resolve local_appdata "opam"
-    );
-  original_root_dir = default_root ();
+  root_dir = default_root;
+  original_root_dir = default_root;
+  root_from = `Default;
   current_switch = None;
   switch_from = `Default;
   jobs = lazy (max 1 (OpamSysPoll.cores () - 1));
@@ -111,6 +114,7 @@ let default = {
 type 'a options_fun =
   ?root_dir:OpamFilename.Dir.t ->
   ?original_root_dir:OpamFilename.Dir.t ->
+  ?root_from:provenance ->
   ?current_switch:OpamSwitch.t ->
   ?switch_from:provenance ->
   ?jobs:(int Lazy.t) ->
@@ -130,6 +134,7 @@ type 'a options_fun =
 let setk k t
     ?root_dir
     ?original_root_dir
+    ?root_from
     ?current_switch
     ?switch_from
     ?jobs
@@ -149,6 +154,7 @@ let setk k t
   k {
     root_dir = t.root_dir + root_dir;
     original_root_dir = t.original_root_dir + original_root_dir;
+    root_from = t.root_from + root_from;
     current_switch =
       (match current_switch with None -> t.current_switch | s -> s);
     switch_from = t.switch_from + switch_from;
@@ -174,14 +180,22 @@ let update ?noop:_ = setk (fun cfg () -> r := cfg) !r
 
 let initk k =
   let open OpamStd.Option.Op in
+  let root_dir, original_root_dir, root_from =
+    match E.root () with
+    | None -> None, None, None
+    | Some root ->
+      let root = OpamFilename.Dir.of_string root in
+      Some root, Some root, Some `Env
+  in
   let current_switch, switch_from =
     match E.switch () with
     | Some "" | None -> None, None
     | Some s -> Some (OpamSwitch.of_string s), Some `Env
   in
   setk (setk (fun c -> r := c; k)) !r
-    ?root_dir:(E.root () >>| OpamFilename.Dir.of_string)
-    ?original_root_dir:(E.root () >>| OpamFilename.Dir.of_string)
+    ?root_dir
+    ?original_root_dir
+    ?root_from
     ?current_switch
     ?switch_from
     ?jobs:(E.jobs () >>| fun s -> lazy s)
@@ -204,10 +218,14 @@ let initk k =
 let init ?noop:_ = initk (fun () -> ())
 
 let opamroot ?root_dir () =
-  let open OpamStd.Option.Op in
-  (root_dir >>+ fun () ->
-   OpamStd.Env.getopt "OPAMROOT" >>| OpamFilename.Dir.of_string)
-  +! default.root_dir
+  match root_dir with
+  | Some root -> `Command_line, root
+  | None ->
+    match OpamStd.Env.getopt "OPAMROOT" with
+    | Some root ->
+      `Env, OpamFilename.Dir.of_string root
+    | None ->
+      `Default, default.root_dir
 
 let is_newer_raw = function
   | Some v ->

--- a/src/state/opamStateConfig.mli
+++ b/src/state/opamStateConfig.mli
@@ -38,6 +38,7 @@ end
 
 type t = private {
   root_dir: OpamFilename.Dir.t;
+  original_root_dir: OpamFilename.Dir.t;
   current_switch: OpamSwitch.t option;
   switch_from: provenance;
   jobs: int Lazy.t;
@@ -56,6 +57,7 @@ type t = private {
 
 type 'a options_fun =
   ?root_dir:OpamFilename.Dir.t ->
+  ?original_root_dir:OpamFilename.Dir.t ->
   ?current_switch:OpamSwitch.t ->
   ?switch_from:provenance ->
   ?jobs:(int Lazy.t) ->

--- a/src/state/opamStateConfig.mli
+++ b/src/state/opamStateConfig.mli
@@ -39,6 +39,7 @@ end
 type t = private {
   root_dir: OpamFilename.Dir.t;
   original_root_dir: OpamFilename.Dir.t;
+  root_from: provenance;
   current_switch: OpamSwitch.t option;
   switch_from: provenance;
   jobs: int Lazy.t;
@@ -58,6 +59,7 @@ type t = private {
 type 'a options_fun =
   ?root_dir:OpamFilename.Dir.t ->
   ?original_root_dir:OpamFilename.Dir.t ->
+  ?root_from:provenance ->
   ?current_switch:OpamSwitch.t ->
   ?switch_from:provenance ->
   ?jobs:(int Lazy.t) ->
@@ -84,7 +86,7 @@ val default : t
 (** Get the initial opam root value (from default, env or optional argument).
     This allows one to get it before doing the init, which is useful to get the
     configuration file used to fill some options to init() *)
-val opamroot: ?root_dir:dirname -> unit -> dirname
+val opamroot: ?root_dir:dirname -> unit -> provenance * dirname
 
 (** Loads the global configuration file, protecting against concurrent writes *)
 val load: ?lock_kind: 'a lock -> dirname -> OpamFile.Config.t option

--- a/tests/reftests/env.test
+++ b/tests/reftests/env.test
@@ -439,60 +439,6 @@ The following actions will be performed:
 Done.
 ### opam exec -- sh -c "eval $(opam env | tr -d '\\r'); opam remove foo; opam env; eval $(opam env | tr -d '\\r'); opam env" | grep "FOO"
 FOO=''; export FOO;
-### : root and switch with spaces :
-### RT="$BASEDIR/root 2"
-### SW="switch w spaces"
-### OPAMNOENVNOTICE=0
-### opam init -na --bare --bypass-check --disable-sandbox --root "$RT" defaut ./REPO | grep -v Cygwin
-No configuration file found, using built-in defaults.
-
-<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
-[defaut] Initialised
-### opam switch create "./$SW" nv --root "$RT"
-
-<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
-Switch invariant: ["nv"]
-
-<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> installed nv.1
-Done.
-# Run eval $(opam env '--root=${BASEDIR}/root 2' '--switch=${BASEDIR}/switch w spaces') to update the current shell environment
-### opam env --root "$RT" --switch "./$SW" | grep "NV_VARS" | ';' -> ':'
-NV_VARS3='foo:/yet/another/different/path': export NV_VARS3:
-NV_VARS4='': export NV_VARS4:
-NV_VARS_5925_1='foo': export NV_VARS_5925_1:
-NV_VARS_5925_2='foo': export NV_VARS_5925_2:
-NV_VARS_5925_3='foo': export NV_VARS_5925_3:
-NV_VARS_5925_4='foo': export NV_VARS_5925_4:
-NV_VARS_5925_5='foo:': export NV_VARS_5925_5:
-NV_VARS_5925_6='foo:': export NV_VARS_5925_6:
-NV_VARS_5925_7=':foo': export NV_VARS_5925_7:
-NV_VARS_5925_8=':foo': export NV_VARS_5925_8:
-NV_VARS_5926_L_1='b::a': export NV_VARS_5926_L_1:
-NV_VARS_5926_L_2='b::a': export NV_VARS_5926_L_2:
-NV_VARS_5926_L_3=':a:b': export NV_VARS_5926_L_3:
-NV_VARS_5926_L_4=':a:b': export NV_VARS_5926_L_4:
-NV_VARS_5926_L_5='b::a': export NV_VARS_5926_L_5:
-NV_VARS_5926_L_6='b::a': export NV_VARS_5926_L_6:
-NV_VARS_5926_L_7=':a:b': export NV_VARS_5926_L_7:
-NV_VARS_5926_L_8=':a:b': export NV_VARS_5926_L_8:
-NV_VARS_5926_M_1='b:a1::a2': export NV_VARS_5926_M_1:
-NV_VARS_5926_M_2='a1::a2:b': export NV_VARS_5926_M_2:
-NV_VARS_5926_M_3='b:a1::a2': export NV_VARS_5926_M_3:
-NV_VARS_5926_M_4='a1::a2:b': export NV_VARS_5926_M_4:
-NV_VARS_5926_S_1='a:': export NV_VARS_5926_S_1:
-NV_VARS_5926_S_2=':a': export NV_VARS_5926_S_2:
-NV_VARS_5926_S_3='a:': export NV_VARS_5926_S_3:
-NV_VARS_5926_S_4=':a': export NV_VARS_5926_S_4:
-NV_VARS_5926_T_1='b:a:': export NV_VARS_5926_T_1:
-NV_VARS_5926_T_2='b:a:': export NV_VARS_5926_T_2:
-NV_VARS_5926_T_3='a::b': export NV_VARS_5926_T_3:
-NV_VARS_5926_T_4='a::b': export NV_VARS_5926_T_4:
-NV_VARS_5926_T_5='b:a:': export NV_VARS_5926_T_5:
-NV_VARS_5926_T_6='b:a:': export NV_VARS_5926_T_6:
-NV_VARS_5926_T_7='a::b': export NV_VARS_5926_T_7:
-NV_VARS_5926_T_8='a::b': export NV_VARS_5926_T_8:
-### OPAMNOENVNOTICE=1
 ### : Env hooks :
 ### <pkg:av.1>
 opam-version: "2.0"

--- a/tests/reftests/env.unix.test
+++ b/tests/reftests/env.unix.test
@@ -1,4 +1,30 @@
 N0REP0
+### : root and switches with spaces :
+### <pkg:nv.1>
+opam-version: "2.0"
+flags: compiler
+### RT="$BASEDIR/root 2"
+### SW="switch w spaces"
+### OPAMNOENVNOTICE=0
+### opam init -na --bare --bypass-check --disable-sandbox --root "$RT" defaut ./REPO
+No configuration file found, using built-in defaults.
+
+<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+[defaut] Initialised
+### opam switch create "./$SW" nv --root "$RT"
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["nv"]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed nv.1
+Done.
+# Run eval $(opam env '--root=${BASEDIR}/root 2' '--switch=${BASEDIR}/switch w spaces') to update the current shell environment
+### opam env --root "$RT" --switch "./$SW" | grep "PREFIX" | ';' -> ':'
+OPAM_SWITCH_PREFIX='${BASEDIR}/switch w spaces/_opam': export OPAM_SWITCH_PREFIX:
+### opam var root --root "$RT"
+${BASEDIR}/root 2
+### OPAMNOENVNOTICE=1
 ### : setenv & build env rewriting :
 ### opam switch create rewriting --empty
 ### ::::::::::::::::::


### PR DESCRIPTION
On Windows, opam may install a local cygwin, but cygwin doesn't support having a space in its path. We need then to redirect all opam root into a path with no space. Redirection is done at first init, and afterwards it is followed for each opam call.
So opam root directory can contain either:
*  an unique file `redirected-opamroot` that contains the new path
* or the already known opam root.

* [x] update changes
* [x] update message with relevant root dir
* [x] set default path, or give user the choice
* [x] add an error if `--root`/`OPAMROOT` path contains space
* [x] add readme.txt in C:\opamroot

related to #5220