### PR TITLE
Bump vendored base64 to 3.5.1 to fix compilation on OCaml >= 5.0 in vendored mode

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -218,6 +218,7 @@ users)
   * git, hg: Use the full SHA1 revision instead of just the 8 first characters [#5342 @reynir]
 
 ## Build
+  * Bump vendored base64 to 3.5.1 to fix compilation on OCaml >= 5.0 in vendored mode [#5464 @deech]
   * Bump src_exts and fix build compat with Dune 2.9.0 [#4752 @dra27]
   * Upgrade to dose3 >= 6.1 and vendor dose3 7.0.0 [#4760 @kit-ty-kate]
   * Change minimum required OCaml to 4.03.0 [#4770 @dra27]

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -8,8 +8,8 @@ MD5_extlib = f7ca7f1c82e15a99603b88f730fd7b8a
 
 $(call PKG_SAME,extlib)
 
-URL_base64 = https://github.com/mirage/ocaml-base64/releases/download/v3.5.0/base64-v3.5.0.tbz
-MD5_base64 = 0179af18d6c1cf13d77671ee23901433
+URL_base64 = https://github.com/mirage/ocaml-base64/releases/download/v3.5.1/base64-3.5.1.tbz
+MD5_base64 = bfdd16aa8c136412878109df8791fc01
 
 $(call PKG_SAME,base64)
 


### PR DESCRIPTION
The 3.5.0 release has a dependency on `bytes` which causes a build error on OCaml `5.1.0+dev1-2022-06-09`:

```
src_ext/dune-local/dune.exe build --profile=release --root .  --promote-install-files -- opam-installer.install opam.install
File "src_ext/base64/src/dune", line 5, characters 12-17:
5 |  (libraries bytes))
                ^^^^^
Error: Library "bytes" not found.
```
