### PR TITLE
Remove unused vendored dependency: result

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -267,6 +267,7 @@ users)
   * Bump the minimum requirement to build any of the opam libraries to OCaml >= 4.08 [#5466 @kit-ty-kate]
   * shell/bootstrap-ocaml.sh: do not fail if curl/wget is missing [#5223 @kit-ty-kate]
   * Add `swhid_core` dependency [#4859 @rjbou]
+  * Remove unused vendored dependency: result [#5465 @kit-ty-kate]
 
 ## Infrastructure
   * Fix caching of Cygwin compiler on AppVeyor [#4988 @dra27]

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -32,7 +32,7 @@ URL_PKG_$(1) = $(URL_$(1))
 MD5_PKG_$(1) = $(MD5_$(1))
 endef
 
-SRC_EXTS = cppo base64 extlib re cmdliner ocamlgraph cudf dose3 opam-file-format result seq stdlib-shims spdx_licenses opam-0install-cudf 0install-solver uutf jsonm sha swhid_core
+SRC_EXTS = cppo base64 extlib re cmdliner ocamlgraph cudf dose3 opam-file-format seq stdlib-shims spdx_licenses opam-0install-cudf 0install-solver uutf jsonm sha swhid_core
 PKG_EXTS = $(SRC_EXTS) dune-local findlib ocamlbuild topkg mccs
 
 ifeq ($(MCCS_ENABLED),true)

--- a/src_ext/Makefile.packages
+++ b/src_ext/Makefile.packages
@@ -29,10 +29,7 @@ seq.pkgbuild: dune-local.pkgbuild
 
 ocamlgraph.pkgbuild: dune-local.pkgbuild stdlib-shims.pkgbuild
 
-# result.pkgbuild depends on findlib because the files are explicitly installed using it
-result.pkgbuild: dune-local.pkgbuild findlib.pkgbuild
-
-topkg.pkgbuild: findlib.pkgbuild ocamlbuild.pkgbuild result.pkgbuild
+topkg.pkgbuild: findlib.pkgbuild ocamlbuild.pkgbuild
 
 cmdliner.pkgbuild: dune-local.pkgbuild
 
@@ -49,7 +46,7 @@ opam-0install-cudf.pkgbuild: dune-local.pkgbuild cudf.pkgbuild 0install-solver.p
 
 stdlib-shims.pkgbuild: dune-local.pkgbuild
 
-base64.pkgbuild: dune-local.pkgbuild result.pkgbuild
+base64.pkgbuild: dune-local.pkgbuild
 
 dune-local.pkgbuild: findlib.pkgbuild
 
@@ -97,10 +94,6 @@ ocamlgraph-pkg-build:
 	dune installed-libraries
 	dune build @install -p ocamlgraph
 	dune install "--prefix=$(OCAMLROOT)" -p ocamlgraph ocamlgraph
-
-result-pkg-build:
-	dune build @install -p result
-	ocamlfind install result $(addprefix _build/install/default/lib/result/,META result.*)
 
 EXTS1=$(EXT_LIB) mli
 EXTS2=a i ti xa xs

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -58,11 +58,6 @@ MD5_opam-file-format = 46dadff2565d8371cdc606d33d408fc4
 
 $(call PKG_SAME,opam-file-format)
 
-URL_result = https://github.com/janestreet/result/releases/download/1.5/result-1.5.tbz
-MD5_result = 1b82dec78849680b49ae9a8a365b831b
-
-$(call PKG_SAME,result)
-
 include Makefile.dune
 
 $(call PKG_SAME,dune-local)


### PR DESCRIPTION
This doesn't seem to be used anywhere. `topkg` stopped depending on it in 1.0.4 and `base64` did it in 1.0.1