### PR TITLE
Lock: remove url section from generated lock file

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -171,6 +171,7 @@ users)
 
 ## Lock
   * Fix lock generation of multiple interdependent packages [#4993 @AltGr]
+  * Remove url section from lock file, it is ignored on pinning [#5465 @rjbou]
 
 ## Clean
   * [NEW] Add `--untracked` option to remove interactively untracked files [{4915 @rjbou - fix #4831]

--- a/src/client/opamLockCommand.ml
+++ b/src/client/opamLockCommand.ml
@@ -304,8 +304,9 @@ let lock_opam ?(only_direct=false) st opam =
       all_depends []
     |> List.rev
   in
-  opam |>
-  OpamFile.OPAM.with_depopts OpamFormula.Empty |>
-  OpamFile.OPAM.with_depends depends_formula |>
-  OpamFile.OPAM.with_conflicts conflicts |>
-  OpamFile.OPAM.with_pin_depends pin_depends
+  opam
+  |> OpamFile.OPAM.with_depopts OpamFormula.Empty
+  |> OpamFile.OPAM.with_depends depends_formula
+  |> OpamFile.OPAM.with_conflicts conflicts
+  |> OpamFile.OPAM.with_pin_depends pin_depends
+  |> OpamFile.OPAM.with_url_opt None

--- a/tests/reftests/lock.test
+++ b/tests/reftests/lock.test
@@ -67,9 +67,6 @@ name: "tolock"
 opam-version: "2.0"
 synopsis: "A word"
 version: "1"
-url {
-src: "file://${BASEDIR}/tolock"
-}
 ### opam lock tolock --lock-suffix new
 Generated lock files for:
   - tolock.1: ${BASEDIR}/tolock.opam.new
@@ -143,9 +140,6 @@ name: "tolock"
 opam-version: "2.0"
 synopsis: "A word"
 version: "1"
-url {
-src: "file://${BASEDIR}/tolock"
-}
 ### opam pin -n ./tolock --locked
 Package tolock does not exist, create as a NEW package? [y/n] y
 tolock is now pinned to file://${BASEDIR}/tolock (version 1)


### PR DESCRIPTION
On pinning, url section is ignored