### PR TITLE
pin: don't edit if tty is not bound to a terminal

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -105,7 +105,8 @@ users)
   * [BUG] When reinstalling a package that has a dirty source, if uncommitted changes are the same than the ones stored in opam's cache, opam consider that it is up to date and nothing is updated [4879 @rjbou]
   * [BUG] Handle external dependencies when updating switch state pin status (all pins), instead as a post pin action (only when called with `opam pin` [#5047 @rjbou - fix #5046]
   * Allow opam pin remove to take a package (<pkg>.<version>) as argument [#5325 @kit-ty-kate]
-  * ◈ Add opam pin remove --all to remove all the pinned packages from a switch [#5308 @kit-ty-kate]
+  * ◈  Add opam pin remove --all to remove all the pinned packages from a switch [#5308 @kit-ty-kate]
+  * ✘ Don't edit opam file overlay if tty is not bound to a terminal [#5465 @rjbou]
 
 ## List
   * Some optimisations to 'opam list --installable' queries combined with other filters [#4882 @altgr - fix #4311]

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -234,3 +234,10 @@ The following actions will be performed:
 -> removed   qux.dev
 Done.
 ### opam pin
+### : check edit & tty :
+### opam pin inexistent ./bar
+Package inexistent does not exist, create as a NEW package? [y/n] y
+[inexistent.dev] synchronised (file://${BASEDIR}/bar)
+[NOTE] No package definition found for inexistent.dev: please complete the template
+[ERROR] No valid package definition found
+# Return code 5 #


### PR DESCRIPTION
Proposal, need more discussions.
Origin is that opam tests "broke" my terminal because it launched nano in the test.
The downside, is that it will break used workaround (even in opam-rt) `OPAMEDITOR=cp -f` for use in scripts.
(review with hide whitespace)