### PR TITLE
Failing switch reinstall no more drop switch layout

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -129,6 +129,7 @@ users)
 ## Reftests
 ### Tests
   * Add switch removal test: failure on removal linked switch [#6276 @btjorge]
+  * Add switch reinstall test with failures [#5475 @rjbou]
 
 ### Engine
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -39,6 +39,7 @@ users)
 
 ## Switch
   * [BUG] Fix `opam switch remove <dir>` failure when it is a linked switch [#6276 @btjorge - fix #6275]
+  * [BUG] Failing switch reinstall partially delete switch layout [#5475 @rjbou - fix #5347]
 
 ## Config
 

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1764,6 +1764,27 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:switch-list.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-switch-reinstall)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (action
+  (diff switch-reinstall.test switch-reinstall.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (deps (alias reftest-switch-reinstall)))
+
+(rule
+ (targets switch-reinstall.out)
+ (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:switch-reinstall.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-switch-remove)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action

--- a/tests/reftests/switch-reinstall.test
+++ b/tests/reftests/switch-reinstall.test
@@ -47,10 +47,10 @@ The following actions will be performed:
   - install foo 1
 
 Proceed with 1 installation? [Y/n] n
+[ERROR] Failure during switch reinstall, rolling back to previous state
 # Return code 10 #
 ### opam exec -- foo
-[ERROR] Command not found 'foo'
-# Return code 127 #
+yes i'm a here, it's amazing!
 ### opam switch export xp
 ### cat xp
 opam-version: "2.0"
@@ -101,10 +101,10 @@ The following actions will be performed:
 | - build bar 1
 +- 
 - No changes have been performed
+[ERROR] Failure during switch reinstall, rolling back to previous state
 # Return code 31 #
 ### opam exec -- foo
-[ERROR] Command not found 'foo'
-# Return code 127 #
+yes i'm a here, it's amazing!
 ### opam switch export xp
 ### cat xp
 opam-version: "2.0"

--- a/tests/reftests/switch-reinstall.test
+++ b/tests/reftests/switch-reinstall.test
@@ -1,0 +1,113 @@
+N0REP0
+### <pkg:foo.1>
+opam-version: "2.0"
+install: [
+  ["cp" "foo" "%{bin}%/foo"]
+  ["chmod" "+x" "%{bin}%/foo"]
+]
+flags: compiler
+### <pkg:foo.1:foo>
+echo "yes i'm a here, it's amazing!"
+### : abort reinstall :
+### opam switch create reinstall foo -y
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["foo"]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed foo.1
+Done.
+### opam exec -- foo
+yes i'm a here, it's amazing!
+### opam switch export xp
+### cat xp
+opam-version: "2.0"
+compiler: ["foo.1"]
+roots: ["foo.1"]
+installed: ["foo.1"]
+### opam switch reinstall reinstall -y
+The following actions will be performed:
+=== install 1 package
+  - install foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed foo.1
+Done.
+### opam exec -- foo
+yes i'm a here, it's amazing!
+### opam switch export xp
+### cat xp
+opam-version: "2.0"
+compiler: ["foo.1"]
+roots: ["foo.1"]
+installed: ["foo.1"]
+### opam switch reinstall reinstall -n
+The following actions will be performed:
+=== install 1 package
+  - install foo 1
+
+Proceed with 1 installation? [Y/n] n
+# Return code 10 #
+### opam exec -- foo
+[ERROR] Command not found 'foo'
+# Return code 127 #
+### opam switch export xp
+### cat xp
+opam-version: "2.0"
+compiler: ["foo.1"]
+roots: ["foo.1"]
+installed: ["foo.1"]
+### : fail reinstall :
+### <pkg:bar.1>
+opam-version: "2.0"
+build: "false"
+### opam switch create broken-reinstall foo -y
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["foo"]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed foo.1
+Done.
+### opam install bar --fake
+The following actions will be faked:
+=== install 1 package
+  - install bar 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of bar.1
+Done.
+### opam exec -- foo
+yes i'm a here, it's amazing!
+### opam switch export xp
+### cat xp
+opam-version: "2.0"
+compiler: ["foo.1"]
+roots: ["bar.1" "foo.1"]
+installed: ["bar.1" "foo.1"]
+### opam switch reinstall broken-reinstall -y
+The following actions will be performed:
+=== install 1 package
+  - install bar 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[ERROR] The compilation of bar.1 failed at "false".
+
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - build bar 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam exec -- foo
+[ERROR] Command not found 'foo'
+# Return code 127 #
+### opam switch export xp
+### cat xp
+opam-version: "2.0"
+compiler: ["foo.1"]
+roots: ["bar.1" "foo.1"]
+installed: ["bar.1" "foo.1"]


### PR DESCRIPTION
It rolls back to previous state when opam reinstall fails
fix #5347
It is done by cleaning the switch, and saving a copy in a temporary directory. Open to discussion if there is better ways to recover.