### PR TITLE
Support atomic environment updates in OpamFile

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -380,6 +380,7 @@ users)
 
 ## Test
   * Update crowbar with compare functions [#4918 @rjbou]
+  * No more mute test debug output (level < 0) if `--readonly` is given with `--debug-level` [#5476 @rjbou]
 
 ## Reftests
 ### Tests

--- a/master_changes.md
+++ b/master_changes.md
@@ -96,6 +96,7 @@ users)
   * Display a warning on hard upgrade when the `jobs` config variable is re-written [#5305 @rjbou]
     * update note [#5305 @rjbou]
   * Add `sys-pkg-manager-cmd` field to store specific system package manager command paths [#5433 @rjbou]
+  * Regenerate the environment file when a local switch is moved [#5476 @dra27 - fix #3411]
 
 ## Pin
   * Switch the default version when undefined from ~dev to dev [#4949 @kit-ty-kate]
@@ -641,6 +642,7 @@ users)
   * `OpamFile.URL`: add `with_mirrors` [#4859 @rjbou]
   * `OpamTypes.universe`: remove `u_base` field, as it is no more needed with switch invariant [#5208 @rjbou]
   * `OpamFile`: add `atomic` value in `IO_Arg` to enable/disable atomic file writing [#5476 @dra27]
+  * `OpamFile.Environment`: enable atomic writing [#5476 @dra27]
 
 ## opam-core
   * `OpamStd.Sys`: fix `get_windows_executable_variant` to distinguish MSYS2 from Cygwin, esp. for rsync rather than symlinking [#5404 @jonahbeckford]

--- a/master_changes.md
+++ b/master_changes.md
@@ -433,10 +433,10 @@ users)
   * Fix the reftests on OCaml 5.0 [#5402 @kit-ty-kate]
   * Add `admin` command reftest [#5385 #5336 @rjbou @kit-ty-kate]
   * Add `admin` command reftest [#5386 #5385 #5336 @rjbou @kit-ty-kate]
-
-
   * Add `swhid` print tests in show, and swh fallback test [#4859 @rjbou]
   * Add `switch list` test, add some in `switch invariant` and `switch import` [#5208 @rjbou]
+  * Add opam env hooks test: change switch, set switch via `OPAMSWITCH`, entering directory, moving switch ; and opam exec with missing environment file [#5476 @rjbou @dra27]
+
 ### Engine
   * Add `opam-cat` to normalise opam file printing [#4763 @rjbou @dra27] [2.1.0~rc2 #4715]
   * Fix meld reftest: open only with failing ones [#4913 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -640,6 +640,7 @@ users)
   * `OpamFile.URL`: add `swhid` field in `t` record, and its access functions [#4859 @rjbou]
   * `OpamFile.URL`: add `with_mirrors` [#4859 @rjbou]
   * `OpamTypes.universe`: remove `u_base` field, as it is no more needed with switch invariant [#5208 @rjbou]
+  * `OpamFile`: add `atomic` value in `IO_Arg` to enable/disable atomic file writing [#5476 @dra27]
 
 ## opam-core
   * `OpamStd.Sys`: fix `get_windows_executable_variant` to distinguish MSYS2 from Cygwin, esp. for rsync rather than symlinking [#5404 @jonahbeckford]
@@ -687,3 +688,4 @@ users)
   * `OpamSystem.read_command_output`: add an optional parameter to unmerge stdout and stderr [#4859 @rjbou]
   * `OpamSWHID`: add module to handle swhid [#4859 @rjbou]
   * `OpamProcess`: expose the `command` type as a private type [#5452 @Leonidas-from-XIV]
+  * `OpamFilename`: add `with_open_out_bin` and `with_open_out_bin_atomic` [#5476 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -97,6 +97,7 @@ users)
     * update note [#5305 @rjbou]
   * Add `sys-pkg-manager-cmd` field to store specific system package manager command paths [#5433 @rjbou]
   * Regenerate the environment file when a local switch is moved [#5476 @dra27 - fix #3411]
+  * Regenerate the environment file in `opam exec` [#5476 @dra27]
 
 ## Pin
   * Switch the default version when undefined from ~dev to dev [#4949 @kit-ty-kate]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -512,7 +512,9 @@ let apply_global_options cli o =
     (* ?skip_version_checks:bool *)
     (* ?all_parens:bool *)
     (* - core options - *)
-    ?debug_level:(if o.safe_mode then Some 0 else o.debug_level)
+    ?debug_level:(match o.debug_level with
+        | Some x when x < 0 -> o.debug_level
+        | _ -> if o.safe_mode then Some 0 else o.debug_level)
     ?verbose_level:(if o.quiet then Some 0 else
                     if o.verbose = 0 then None else Some o.verbose)
     ?color:o.color

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -143,6 +143,15 @@ val open_in_bin: t -> in_channel
 val open_out: t -> out_channel
 val open_out_bin: t -> out_channel
 
+(** [with_open_out_bin filename f] opens [f] and passes the out_channel to [f].
+    If [f] raises an exception, then [filename] is deleted and then exception is
+    propagated. The out_channel does not have to be closed by [f]. *)
+val with_open_out_bin: t -> (out_channel -> unit) -> unit
+
+(** As {!with_open_out_bin} except that the file is written atomically. If [f]
+    raises an exception, then [filename] will be unaltered. *)
+val with_open_out_bin_atomic: t -> (out_channel -> unit) -> unit
+
 (** Removes everything in [filename] if existed. *)
 val remove: t -> unit
 

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -76,6 +76,7 @@ end
 
 module type IO_Arg = sig
   val internal : string
+  val atomic : bool
   type t
   val empty : t
   val of_channel : 'a typed_file -> in_channel  -> t
@@ -109,20 +110,15 @@ module MakeIO (F : IO_Arg) = struct
   let write f v =
     let filename = OpamFilename.to_string f in
     let chrono = OpamConsole.timer () in
-    let oc =
-      OpamFilename.(mkdir (dirname f));
-      try open_out_bin filename
-      with Sys_error _ -> raise (OpamSystem.File_not_found filename)
+    let write =
+      if F.atomic then
+        OpamFilename.with_open_out_bin_atomic
+      else
+        OpamFilename.with_open_out_bin
     in
-    try
-      Unix.lockf (Unix.descr_of_out_channel oc) Unix.F_LOCK 0;
-      F.to_channel f oc v;
-      close_out oc;
-      Stats.write_files := filename :: !Stats.write_files;
-      log "Wrote %s in %.3fs" filename (chrono ())
-    with e ->
-      OpamStd.Exn.finalise e @@ fun () ->
-      close_out oc; OpamFilename.remove f
+    write f (fun oc -> F.to_channel f oc v);
+    Stats.write_files := filename :: !Stats.write_files;
+    log "Wrote %s%s in %.3fs" filename (if F.atomic then " atomically" else "") (chrono ())
 
   let read_opt f =
     let filename = OpamFilename.prettify f in
@@ -199,6 +195,7 @@ end
 module DescrIO = struct
 
   let internal = "descr"
+  let atomic = false
   let format_version = OpamVersion.of_string "0"
 
   type t = string * string
@@ -291,6 +288,8 @@ module LinesBase = struct
 
   let internal = "lines"
 
+  let atomic = false
+
   let find_escapes s len =
     let rec aux acc i =
       if i < 0 then acc else
@@ -380,6 +379,7 @@ end
 
 module type LineFileArg = sig
   val internal: string
+  val atomic: bool
   type t
   val empty: t
   val pp: (string list list, t) Pp.t
@@ -416,6 +416,7 @@ end
 module Aliases = LineFile(struct
 
     let internal = "aliases"
+    let atomic = false
 
     type t = string switch_map
 
@@ -434,6 +435,7 @@ module Aliases = LineFile(struct
 module Repo_index (A : OpamStd.ABSTRACT) = LineFile(struct
 
     let internal = "repo-index"
+    let atomic = false
 
     type t = (repository_name * string option) A.Map.t
 
@@ -455,6 +457,7 @@ module Package_index = Repo_index(OpamPackage)
 module PkgList = LineFile (struct
 
     let internal = "package-version-list"
+    let atomic = false
 
     type t = package_set
 
@@ -525,6 +528,7 @@ module Pinned_legacy = struct
   include LineFile(struct
 
       let internal = "pinned"
+      let atomic = false
 
       type t = pin_option OpamPackage.Name.Map.t
 
@@ -544,6 +548,7 @@ end
 module Environment = LineFile(struct
 
     let internal = "environment"
+    let atomic = false
 
     type t = env_update list
 
@@ -576,6 +581,7 @@ module Environment = LineFile(struct
 module File_attributes = LineFile(struct
 
     let internal = "file_attributes"
+    let atomic = false
 
     type t = file_attribute_set
 
@@ -602,6 +608,7 @@ module File_attributes = LineFile(struct
 module StateTable = struct
 
   let internal = "export"
+  let atomic = false
 
   module M = OpamPackage.Name.Map
 
@@ -1019,6 +1026,7 @@ end
 
 module type SyntaxFileArg = sig
   val internal: string
+  val atomic: bool
   val format_version: OpamVersion.t
   type t
   val empty: t
@@ -1059,6 +1067,7 @@ module SyntaxFile(X: SyntaxFileArg) : IO_FILE with type t := X.t = struct
   include MakeIO(struct
       include X
       include IO
+      let atomic = false
     end)
 
 end
@@ -1235,6 +1244,7 @@ end
 module ConfigSyntax = struct
 
   let internal = "config"
+  let atomic = false
   let format_version = OpamVersion.of_string "2.1"
   let file_format_version = OpamVersion.of_string "2.0"
   let root_version = OpamVersion.of_string "2.2~alpha"
@@ -1545,6 +1555,7 @@ end
 
 module InitConfigSyntax = struct
   let internal = "init-config"
+  let atomic = false
   let format_version = OpamVersion.of_string "2.0"
 
   type t = {
@@ -1780,6 +1791,7 @@ end
 module Repos_configSyntax = struct
 
   let internal = "repos-config"
+  let atomic = false
   let format_version = OpamVersion.of_string "2.0"
   let file_format_version = OpamVersion.of_string "2.0"
 
@@ -1824,6 +1836,7 @@ end
 module Switch_configSyntax = struct
 
   let internal = "switch-config"
+  let atomic = false
   let format_version = OpamVersion.of_string "2.1"
   let file_format_version = OpamVersion.of_string "2.0"
   let oldest_compatible_format_version = OpamVersion.of_string "2.0"
@@ -1938,6 +1951,7 @@ end
 module SwitchSelectionsSyntax = struct
 
   let internal = "switch-state"
+  let atomic = false
   let format_version = OpamVersion.of_string "2.0"
   let file_format_version = OpamVersion.of_string "2.0"
 
@@ -2008,6 +2022,7 @@ end
 module Repo_config_legacySyntax = struct
 
   let internal = "repo-file"
+  let atomic = false
   let format_version = OpamVersion.of_string "1.2"
 
   type t = {
@@ -2072,6 +2087,7 @@ end
 module Dot_configSyntax = struct
 
   let internal = ".config"
+  let atomic = false
   let format_version = OpamVersion.of_string "2.0"
 
   type t = {
@@ -2164,6 +2180,7 @@ end
 module RepoSyntax = struct
 
   let internal = "repo"
+  let atomic = false
   let format_version = OpamVersion.of_string "2.0"
 
   type t = {
@@ -2253,6 +2270,7 @@ end
 module URLSyntax = struct
 
   let internal = "url-file"
+  let atomic = false
   let format_version = OpamVersion.of_string "1.2"
 
   type t = {
@@ -2366,6 +2384,7 @@ end
 module OPAMSyntax = struct
 
   let internal = "opam"
+  let atomic = false
   let format_version = OpamVersion.of_string "2.0"
 
   type t = {
@@ -3441,6 +3460,7 @@ end
 module Dot_installSyntax = struct
 
   let internal = ".install"
+  let atomic = false
   let format_version = OpamVersion.of_string "2.0"
 
   type t =  {
@@ -3608,6 +3628,7 @@ end
 
 module ChangesSyntax = struct
   let internal = "changes"
+  let atomic = false
   let format_version = OpamVersion.of_string "2.0"
 
   open OpamDirTrack
@@ -3673,6 +3694,7 @@ end
 module SwitchExportSyntax = struct
 
   let internal = "switch-export"
+  let atomic = false
   let format_version = OpamVersion.of_string "2.1"
 
   type t = {
@@ -3750,6 +3772,7 @@ end
 module CompSyntax = struct
 
   let internal = "comp"
+  let atomic = false
   let format_version = OpamVersion.of_string "1.2"
 
   type compiler = string

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -548,7 +548,7 @@ end
 module Environment = LineFile(struct
 
     let internal = "environment"
-    let atomic = false
+    let atomic = true
 
     type t = env_update list
 

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -1142,6 +1142,7 @@ end
 
 module type SyntaxFileArg = sig
   val internal: string
+  val atomic: bool
   val format_version: OpamVersion.t
   type t
   val empty: t
@@ -1152,6 +1153,7 @@ module SyntaxFile(X: SyntaxFileArg) : IO_FILE with type t := X.t
 
 module type LineFileArg = sig
   val internal: string
+  val atomic: bool
   type t
   val empty: t
   val pp: (string list list, t) OpamPp.t

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -305,17 +305,6 @@ let get_opam_raw ~set_opamroot ~set_opamswitch ?(base=[])
   let env_file = OpamPath.Switch.environment root switch in
   let upd = OpamFile.Environment.safe_read env_file in
   let upd =
-    let remove_OPAM_SWITCH_PREFIX (var, op, _, _) =
-      String.uppercase_ascii var <> "OPAM_SWITCH_PREFIX" || op <> Eq
-    in
-    List.filter remove_OPAM_SWITCH_PREFIX upd
-  in
-  let upd =
-    ("OPAM_SWITCH_PREFIX", Eq,
-     OpamFilename.Dir.to_string (OpamPath.Switch.root root switch),
-     Some "Prefix of the current opam switch") :: upd
-  in
-  let upd =
     let from_op, to_op =
       if force_path then
         EqPlusEq, PlusEq

--- a/tests/reftests/env.test
+++ b/tests/reftests/env.test
@@ -230,13 +230,15 @@ FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/enviro
 ### rm $OPAMROOT/switch1/.opam-switch/environment
 ### opam exec --readonly --debug-level=-3 -- sh -c "echo $A_VAR" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | grep -v PROC | ';' -> ':'
 CONFIG                          config-exec command=sh -c echo $A_VAR
+CONFIG                          Missing environment file, regenerate it
 STATE                           LOAD-SWITCH-STATE @ switch1
 STATE                           Switch state loaded in 0.000s
 ### opam exec --debug-level=-3 -- sh -c "echo $A_VAR" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | grep -v PROC | ';' -> ':'
 CONFIG                          config-exec command=sh -c echo $A_VAR
+CONFIG                          Missing environment file, regenerate it
 STATE                           LOAD-SWITCH-STATE @ switch1
 STATE                           Switch state loaded in 0.000s
+FILE(environment)               Wrote ${BASEDIR}/OPAM/switch1/.opam-switch/environment atomically in 0.000s
 ### opam exec --debug-level=-3 -- sh -c "echo $A_VAR" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | grep -v PROC | ';' -> ':'
 CONFIG                          config-exec command=sh -c echo $A_VAR
-STATE                           LOAD-SWITCH-STATE @ switch1
-STATE                           Switch state loaded in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/environment in 0.000s

--- a/tests/reftests/env.test
+++ b/tests/reftests/env.test
@@ -124,3 +124,110 @@ Switch invariant: ["nv"]
 -> installed nv.1
 Done.
 # Run eval $(opam env '--root=${BASEDIR}/root 2' '--switch=${BASEDIR}/switch w spaces') to update the current shell environment
+### opam env --root "$RT" --switch "./$SW" | grep "NV_VARS" | ';' -> ':'
+NV_VARS3='foo:/yet/another/different/path': export NV_VARS3:
+NV_VARS4='': export NV_VARS4:
+### OPAMNOENVNOTICE=1
+### : Env hooks :
+### <pkg:av.1>
+opam-version: "2.0"
+setenv: [ A_VAR  = "%{lib}%" ]
+### opam switch create switch1 av
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["av"]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed av.1
+Done.
+### opam switch create switch2 av
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["av"]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed av.1
+Done.
+### # switch switch
+### opam switch switch1
+### opam env --readonly --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | ';' -> ':'
+CONFIG                          config-env
+FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/environment in 0.000s
+A_VAR='${BASEDIR}/OPAM/switch1/lib': export A_VAR:
+### opam env --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | ';' -> ':'
+CONFIG                          config-env
+FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/environment in 0.000s
+A_VAR='${BASEDIR}/OPAM/switch1/lib': export A_VAR:
+### # missing environment file
+### rm $OPAMROOT/switch1/.opam-switch/environment
+### opam env --readonly --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | ';' -> ':'
+CONFIG                          config-env
+STATE                           LOAD-SWITCH-STATE @ switch1
+STATE                           Switch state loaded in 0.000s
+CONFIG                          Missing environment file, regenerate it
+A_VAR='${BASEDIR}/OPAM/switch1/lib': export A_VAR:
+### opam env --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | ';' -> ':'
+CONFIG                          config-env
+STATE                           LOAD-SWITCH-STATE @ switch1
+STATE                           Switch state loaded in 0.000s
+CONFIG                          Missing environment file, regenerate it
+FILE(environment)               Wrote ${BASEDIR}/OPAM/switch1/.opam-switch/environment in 0.000s
+A_VAR='${BASEDIR}/OPAM/switch1/lib': export A_VAR:
+### # set via OPAMSWITCH
+### OPAMSWITCH=switch2 opam env --readonly --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | ';' -> ':'
+CONFIG                          config-env
+FILE(environment)               Read ${BASEDIR}/OPAM/switch2/.opam-switch/environment in 0.000s
+A_VAR='${BASEDIR}/OPAM/switch2/lib': export A_VAR:
+### OPAMSWITCH=switch2 opam env --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | ';' -> ':'
+CONFIG                          config-env
+FILE(environment)               Read ${BASEDIR}/OPAM/switch2/.opam-switch/environment in 0.000s
+A_VAR='${BASEDIR}/OPAM/switch2/lib': export A_VAR:
+### # entering directory
+### mkdir local-sw
+### opam switch create ./local-sw av
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["av"]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed av.1
+Done.
+### sh -c "cd local-sw ; opam env --readonly --debug-level=-3" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | "\(\\\\\|/\)_opam\(\\\\|/\)lib" -> '/_opam/lib' | ';' -> ':'
+CONFIG                          config-env
+FILE(environment)               Read ${BASEDIR}/local-sw/_opam/.opam-switch/environment in 0.000s
+A_VAR='${BASEDIR}/local-sw/_opam/lib': export A_VAR:
+### sh -c "cd local-sw ; opam env --debug-level=-3" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | "\(\\\\\|/\)_opam\(\\\\|/\)lib" -> '/_opam/lib' | ';' -> ':'
+CONFIG                          config-env
+FILE(environment)               Read ${BASEDIR}/local-sw/_opam/.opam-switch/environment in 0.000s
+A_VAR='${BASEDIR}/local-sw/_opam/lib': export A_VAR:
+### # moving a switch
+### mv local-sw local-sw.new
+### opam env --switch ./local-sw.new --readonly --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | "\(\\\\\|/\)_opam\(\\\\|/\)lib" -> '/_opam/lib' | ';' -> ':'
+CONFIG                          config-env
+FILE(environment)               Read ${BASEDIR}/local-sw.new/_opam/.opam-switch/environment in 0.000s
+A_VAR='${BASEDIR}/local-sw/_opam/lib': export A_VAR:
+### opam env --switch ./local-sw.new --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | "\(\\\\\|/\)_opam\(\\\\|/\)lib" -> '/_opam/lib' | ';' -> ':'
+CONFIG                          config-env
+FILE(environment)               Read ${BASEDIR}/local-sw.new/_opam/.opam-switch/environment in 0.000s
+A_VAR='${BASEDIR}/local-sw/_opam/lib': export A_VAR:
+### opam env --switch ./local-sw.new --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | "\(\\\\\|/\)_opam\(\\\\|/\)lib" -> '/_opam/lib' | ';' -> ':'
+CONFIG                          config-env
+FILE(environment)               Read ${BASEDIR}/local-sw.new/_opam/.opam-switch/environment in 0.000s
+A_VAR='${BASEDIR}/local-sw/_opam/lib': export A_VAR:
+### : opam exec & environment regeneration :
+### opam exec --debug-level=-3 -- sh -c "echo $A_VAR" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | grep -v PROC | ';' -> ':'
+CONFIG                          config-exec command=sh -c echo $A_VAR
+FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/environment in 0.000s
+### rm $OPAMROOT/switch1/.opam-switch/environment
+### opam exec --readonly --debug-level=-3 -- sh -c "echo $A_VAR" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | grep -v PROC | ';' -> ':'
+CONFIG                          config-exec command=sh -c echo $A_VAR
+STATE                           LOAD-SWITCH-STATE @ switch1
+STATE                           Switch state loaded in 0.000s
+### opam exec --debug-level=-3 -- sh -c "echo $A_VAR" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | grep -v PROC | ';' -> ':'
+CONFIG                          config-exec command=sh -c echo $A_VAR
+STATE                           LOAD-SWITCH-STATE @ switch1
+STATE                           Switch state loaded in 0.000s
+### opam exec --debug-level=-3 -- sh -c "echo $A_VAR" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | grep -v PROC | ';' -> ':'
+CONFIG                          config-exec command=sh -c echo $A_VAR
+STATE                           LOAD-SWITCH-STATE @ switch1
+STATE                           Switch state loaded in 0.000s

--- a/tests/reftests/env.test
+++ b/tests/reftests/env.test
@@ -162,16 +162,16 @@ A_VAR='${BASEDIR}/OPAM/switch1/lib': export A_VAR:
 ### rm $OPAMROOT/switch1/.opam-switch/environment
 ### opam env --readonly --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | ';' -> ':'
 CONFIG                          config-env
+CONFIG                          Missing environment file, regenerate it
 STATE                           LOAD-SWITCH-STATE @ switch1
 STATE                           Switch state loaded in 0.000s
-CONFIG                          Missing environment file, regenerate it
 A_VAR='${BASEDIR}/OPAM/switch1/lib': export A_VAR:
 ### opam env --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | ';' -> ':'
 CONFIG                          config-env
+CONFIG                          Missing environment file, regenerate it
 STATE                           LOAD-SWITCH-STATE @ switch1
 STATE                           Switch state loaded in 0.000s
-CONFIG                          Missing environment file, regenerate it
-FILE(environment)               Wrote ${BASEDIR}/OPAM/switch1/.opam-switch/environment in 0.000s
+FILE(environment)               Wrote ${BASEDIR}/OPAM/switch1/.opam-switch/environment atomically in 0.000s
 A_VAR='${BASEDIR}/OPAM/switch1/lib': export A_VAR:
 ### # set via OPAMSWITCH
 ### OPAMSWITCH=switch2 opam env --readonly --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | ';' -> ':'
@@ -205,15 +205,24 @@ A_VAR='${BASEDIR}/local-sw/_opam/lib': export A_VAR:
 ### opam env --switch ./local-sw.new --readonly --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | "\(\\\\\|/\)_opam\(\\\\|/\)lib" -> '/_opam/lib' | ';' -> ':'
 CONFIG                          config-env
 FILE(environment)               Read ${BASEDIR}/local-sw.new/_opam/.opam-switch/environment in 0.000s
-A_VAR='${BASEDIR}/local-sw/_opam/lib': export A_VAR:
+CONFIG                          Switch has moved from ${BASEDIR}/local-sw/_opam to ${BASEDIR}/local-sw.new/_opam
+CONFIG                          Regenerating environment file
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}/local-sw.new
+STATE                           Switch state loaded in 0.000s
+A_VAR='${BASEDIR}/local-sw.new/_opam/lib': export A_VAR:
 ### opam env --switch ./local-sw.new --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | "\(\\\\\|/\)_opam\(\\\\|/\)lib" -> '/_opam/lib' | ';' -> ':'
 CONFIG                          config-env
 FILE(environment)               Read ${BASEDIR}/local-sw.new/_opam/.opam-switch/environment in 0.000s
-A_VAR='${BASEDIR}/local-sw/_opam/lib': export A_VAR:
+CONFIG                          Switch has moved from ${BASEDIR}/local-sw/_opam to ${BASEDIR}/local-sw.new/_opam
+CONFIG                          Regenerating environment file
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}/local-sw.new
+STATE                           Switch state loaded in 0.000s
+FILE(environment)               Wrote ${BASEDIR}/local-sw.new/_opam/.opam-switch/environment atomically in 0.000s
+A_VAR='${BASEDIR}/local-sw.new/_opam/lib': export A_VAR:
 ### opam env --switch ./local-sw.new --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | "\(\\\\\|/\)_opam\(\\\\|/\)lib" -> '/_opam/lib' | ';' -> ':'
 CONFIG                          config-env
 FILE(environment)               Read ${BASEDIR}/local-sw.new/_opam/.opam-switch/environment in 0.000s
-A_VAR='${BASEDIR}/local-sw/_opam/lib': export A_VAR:
+A_VAR='${BASEDIR}/local-sw.new/_opam/lib': export A_VAR:
 ### : opam exec & environment regeneration :
 ### opam exec --debug-level=-3 -- sh -c "echo $A_VAR" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | grep -v PROC | ';' -> ':'
 CONFIG                          config-exec command=sh -c echo $A_VAR


### PR DESCRIPTION
Extracted from #5417, which now just deals with the fully revertible environment updates part.

- [x] Writing the environment file in `opam env` is still taking the switch write lock, which isn't necessary
  - we keep taking write lock as something is written in switch
- [x] Add hook specific read-only option: it is like read-only, but permit environment files writing.
  - We want to keep hooks as readonly. The only downside is that when a local switch is moved, the hook takes some times (switch loading) to recompute environment ; prompt will take that time until an opam commands in the terminal with write lock writes the new environment
    - We can still add the hook-read-only (read-only except for env) in the future, when it makes sense to move a switch
- [x] Test for moving a switch (verify `PATH` updates)