### PR TITLE
No opam init hook eval when .envrc from direnv

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -36,6 +36,7 @@ users)
   * ◈ `tree` subcommand now supports `--json` option [#5303 @cannorin - fix #5298]
   * ◈ Add `why` subcommand to examine how the versions of currently installed packages get constrained (alias to `tree --rev-deps`) [#5171 @cannorin - fix #3775]
   * Make the plugin lookup faster when mistyping a subcommand [#5297 @kit-ty-kate]
+  * Do not evaluate opam hooks when .envrc from direnv present [#5486 @jonahbeckford]
 
 ## Plugins
   *

--- a/src/state/shellscripts/env_hook.csh
+++ b/src/state/shellscripts/env_hook.csh
@@ -1,1 +1,1 @@
-alias precmd 'eval `opam env --shell=csh --readonly`'
+alias precmd 'if (! -e .envrc) eval `opam env --shell=csh --readonly`'

--- a/src/state/shellscripts/env_hook.fish
+++ b/src/state/shellscripts/env_hook.fish
@@ -1,3 +1,3 @@
 function __opam_env_export_eval --on-event fish_prompt;
-    eval (opam env --shell=fish --readonly 2> /dev/null);
+    test -e .envrc; or eval (opam env --shell=fish --readonly 2> /dev/null);
 end

--- a/src/state/shellscripts/env_hook.sh
+++ b/src/state/shellscripts/env_hook.sh
@@ -1,6 +1,6 @@
 _opam_env_hook() {
  local previous_exit_status=$?;
- eval $(opam env --shell=bash --readonly 2> /dev/null <&- );
+ if [ ! -e .envrc ]; then eval $(opam env --shell=bash --readonly 2> /dev/null <&- ); fi;
  return $previous_exit_status;
 };
 if ! [[ "$PROMPT_COMMAND" =~ _opam_env_hook ]]; then

--- a/src/state/shellscripts/env_hook.zsh
+++ b/src/state/shellscripts/env_hook.zsh
@@ -1,5 +1,5 @@
 _opam_env_hook() {
-    eval $(opam env --shell=zsh --readonly 2> /dev/null <&-);
+    if [ ! -e .envrc ]; then eval $(opam env --shell=zsh --readonly 2> /dev/null <&-); fi;
 }
 typeset -ag precmd_functions;
 if [[ -z ${precmd_functions[(r)_opam_env_hook]} ]]; then


### PR DESCRIPTION
Stops https://direnv.net/ and opam init hooks from conflicting. With this commit, either direnv runs, or opam init hooks run. Explicit .envrc in a directory (aka. direnv is present) has higher precedence.

Tested:
* fish
* zsh
* sh (bash)
* csh - *Only partial testing. I tested the expression within the csh `precmd` for correctness in an Ubuntu container, but I don't know how to get precmds to work. Would appreciate if someone with a working `csh` can test*
