### PR TITLE
[API] Make the ?lock_kind parameters non-optional to avoid breaking the library users after they upgrade their opam root

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -225,6 +225,8 @@ users)
   * `OpamDownload.download`: more fine grained HTTP request error code detection for curl [#6036 @rjbou]
 
 ## opam-state
+  * `OpamStateConfig`: Make the `?lock_kind` parameters non-optional to avoid breaking the library users after they upgrade their opam root [#5488 @kit-ty-kate]
+  * `OpamSwitchState.load_selections`: Make the `?lock_kind` parameter non-optional to avoid breaking the library users after they upgrade their opam root [#5488 @kit-ty-kate]
 
 ## opam-solver
 

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -389,7 +389,9 @@ let apply_selector ~base st = function
        in
        let selections =
          if switch = st.switch then OpamSwitchState.selections st
-         else OpamSwitchState.load_selections st.switch_global switch
+         else
+           OpamSwitchState.load_selections ~lock_kind:`Lock_none
+             st.switch_global switch
        in
        List.fold_left (fun acc f ->
            let name =

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -528,7 +528,10 @@ let import_t ?ask ?(deps_only=false) importfile t =
             opam)
       pinned;
     (* Save new pinnings *)
-    let sel = OpamSwitchState.load_selections t.switch_global t.switch in
+    let sel =
+      OpamSwitchState.load_selections ~lock_kind:`Lock_write
+        t.switch_global t.switch
+    in
     S.write
       (OpamPath.Switch.selections t.switch_global.root t.switch)
       { sel with sel_pinned = pinned }

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -190,7 +190,7 @@ let drop gt =
   let _ = unlock gt in ()
 
 let with_write_lock ?dontblock gt f =
-  if OpamStateConfig.is_newer_than_self gt then
+  if OpamStateConfig.is_newer_than_self ~lock_kind:`Lock_write gt then
     OpamConsole.error_and_exit `Locked
       "The opam root has been upgraded by a newer version of opam-state \
        and cannot be written to";

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -159,7 +159,7 @@ let load lock_kind gt =
   log "LOAD-REPOSITORY-STATE %@ %a" (slog OpamFilename.Dir.to_string) gt.root;
   let lock = OpamFilename.flock lock_kind (OpamPath.repos_lock gt.root) in
   let repos_map = OpamStateConfig.Repos.safe_read ~lock_kind gt in
-  if OpamStateConfig.is_newer_than_self gt then
+  if OpamStateConfig.is_newer_than_self ~lock_kind gt then
     log "root version (%s) is greater than running binary's (%s); \
          load with best-effort (read-only)"
       (OpamVersion.to_string (OpamFile.Config.opam_root_version gt.config))
@@ -260,7 +260,8 @@ let drop ?cleanup rt =
   let _ = unlock ?cleanup rt in ()
 
 let with_write_lock ?dontblock rt f =
-  if OpamStateConfig.is_newer_than_self rt.repos_global then
+  if OpamStateConfig.is_newer_than_self ~lock_kind:`Lock_write rt.repos_global
+  then
     OpamConsole.error_and_exit `Locked
       "The opam root has been upgraded by a newer version of opam-state \
        and cannot be written to";

--- a/src/state/opamStateConfig.mli
+++ b/src/state/opamStateConfig.mli
@@ -92,8 +92,8 @@ val opamroot_with_provenance: ?root_dir:dirname -> unit -> provenance * dirname
 val opamroot: ?root_dir:dirname -> unit -> dirname
 
 (** Loads the global configuration file, protecting against concurrent writes *)
-val load: ?lock_kind: 'a lock -> dirname -> OpamFile.Config.t option
-val safe_load: ?lock_kind: 'a lock -> dirname -> OpamFile.Config.t
+val load: lock_kind: 'a lock -> dirname -> OpamFile.Config.t option
+val safe_load: lock_kind: 'a lock -> dirname -> OpamFile.Config.t
 
 (** Loads the config file from the OPAM root and updates default values for all
     related OpamXxxConfig modules. Doesn't read the env yet, the {!init}
@@ -102,7 +102,7 @@ val safe_load: ?lock_kind: 'a lock -> dirname -> OpamFile.Config.t
 
     Returns the config file that was found, if any *)
 val load_defaults:
-  ?lock_kind:'a lock -> OpamFilename.Dir.t -> OpamFile.Config.t option
+  lock_kind:'a lock -> OpamFilename.Dir.t -> OpamFile.Config.t option
 
 (** Returns the current switch, failing with an error message is none is set. *)
 val get_switch: unit -> switch
@@ -124,31 +124,31 @@ val resolve_local_switch: OpamFilename.Dir.t -> switch -> switch
 
 (** Given the required lock, returns [true] if the opam root is newer than the
     binary, so that it can only be loaded read-only by the current binary. *)
-val is_newer_than_self: ?lock_kind:'a lock -> 'b global_state -> bool
+val is_newer_than_self: lock_kind:'a lock -> 'b global_state -> bool
 
 (** Check config root version regarding self-defined one *)
 val is_newer: OpamFile.Config.t ->  bool
 
 val load_config_root:
-  ?lock_kind:'a lock ->
+  lock_kind:'a lock ->
   ((OpamFile.Config.t OpamFile.t -> 'b) * (OpamFile.Config.t OpamFile.t -> 'b)) ->
   dirname -> 'b
 
 module Switch : sig
   val safe_load_t:
-    ?lock_kind: 'a lock -> dirname -> switch -> OpamFile.Switch_config.t
+    lock_kind: 'a lock -> dirname -> switch -> OpamFile.Switch_config.t
   val safe_load:
-    ?lock_kind: 'a lock -> 'b global_state -> switch -> OpamFile.Switch_config.t
+    lock_kind: 'a lock -> 'b global_state -> switch -> OpamFile.Switch_config.t
   val safe_read_selections:
-    ?lock_kind: 'a lock -> 'b global_state -> switch -> switch_selections
+    lock_kind: 'a lock -> 'b global_state -> switch -> switch_selections
   val read_opt:
-    ?lock_kind: 'a lock -> 'b global_state -> switch ->
+    lock_kind: 'a lock -> 'b global_state -> switch ->
     OpamFile.Switch_config.t option
 end
 
 module Repos : sig
   val safe_read:
-    ?lock_kind: 'a lock -> 'b global_state -> OpamFile.Repos_config.t
+    lock_kind: 'a lock -> 'b global_state -> OpamFile.Repos_config.t
 end
 
 (* Raw read an switch config to downgrade its [opam-version] from 2.1 to 2.0.

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -18,11 +18,11 @@ let slog = OpamConsole.slog
 
 open OpamStateTypes
 
-let load_selections ?lock_kind gt switch =
-  OpamStateConfig.Switch.safe_read_selections ?lock_kind gt switch
+let load_selections ~lock_kind gt switch =
+  OpamStateConfig.Switch.safe_read_selections ~lock_kind gt switch
 
-let load_switch_config ?lock_kind gt switch =
-  match OpamStateConfig.Switch.read_opt ?lock_kind gt switch with
+let load_switch_config ~lock_kind gt switch =
+  match OpamStateConfig.Switch.read_opt ~lock_kind gt switch with
   | Some c -> c
   | exception (OpamPp.Bad_version _ as e) ->
     OpamFormatUpgrade.hard_upgrade_from_2_1_intermediates
@@ -257,7 +257,7 @@ let load lock_kind gt rt switch =
     OpamFilename.flock lock_kind (OpamPath.Switch.lock gt.root switch)
   in
   let switch_config = load_switch_config ~lock_kind gt switch in
-  if OpamStateConfig.is_newer_than_self gt then
+  if OpamStateConfig.is_newer_than_self ~lock_kind gt then
     log "root version (%s) is greater than running binary's (%s); \
          load with best-effort (read-only)"
       (OpamVersion.to_string (OpamFile.Config.opam_root_version gt.config))
@@ -672,7 +672,8 @@ let drop st =
   let _ = unlock st in ()
 
 let with_write_lock ?dontblock st f =
-  if OpamStateConfig.is_newer_than_self st.switch_global then
+  if OpamStateConfig.is_newer_than_self ~lock_kind:`Lock_write st.switch_global
+  then
     OpamConsole.error_and_exit `Locked
       "The opam root has been upgraded by a newer version of opam-state \
        and cannot be written to";

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -45,7 +45,7 @@ val load_virtual:
 (** Load the switch's state file, without constructing the package maps: much
     faster than loading the full switch state *)
 val load_selections:
-  ?lock_kind: 'a lock -> 'b global_state -> switch -> switch_selections
+  lock_kind: 'a lock -> 'b global_state -> switch -> switch_selections
 
 (** Raw function to compute the availability of all packages, in [opams], given
     the switch configuration and the set of pinned packages. (The result is


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/5487

The current code shows issues with our internal uses of such functions, opening as a draft for now and I will point out where the issues are.