### PR TITLE
Add `package` stanza on all rules that depend on opamMain.exe.exe

### DIFF
--- a/doc/man/dune
+++ b/doc/man/dune
@@ -28,13 +28,15 @@
   (targets opam-topics.inc)
   (deps %{bin:opam} using-built-opam)
   (mode promote)
-  (action (with-stdout-to %{targets} (run %{exe:dune_man.exe} opam))))
+  (action (with-stdout-to %{targets} (run %{exe:dune_man.exe} opam)))
+  (package opam))
 
 (rule
   (targets opam-admin-topics.inc)
   (deps %{bin:opam} using-built-opam)
   (mode promote)
-  (action (with-stdout-to %{targets} (run %{exe:dune_man.exe} opam admin))))
+  (action (with-stdout-to %{targets} (run %{exe:dune_man.exe} opam admin)))
+  (package opam))
 
 (include opam-topics.inc)
 
@@ -50,5 +52,6 @@
     (echo "let s = Sys.argv.(1) in exit (if not (Filename.is_implicit s) && Filename.is_relative s then 0 else 1)")))
 
 (rule
-  (with-stdout-to using-built-opam (run ocaml %{dep:check_local_build.ml} %{bin:opam})))
-
+  (action
+    (with-stdout-to using-built-opam (run ocaml %{dep:check_local_build.ml} %{bin:opam})))
+  (package opam))

--- a/doc/man/dune_man.ml
+++ b/doc/man/dune_man.ml
@@ -7,7 +7,8 @@ let gen_topic target_basename dline t =
                 \  (deps using-built-opam)\n\
                 \  (action (progn (with-stderr-to %s-%s.err\n\
                 \                   (with-stdout-to %s-%s.1 (run %s %s --help=groff)))\n\
-                \                 (diff %s-%s.err %%{dep:%s-%s.0}))))\n\
+                \                 (diff %s-%s.err %%{dep:%s-%s.0})))\n\
+                \  (package opam))\n\
                 "
     target_basename t target_basename t target_basename t target_basename t target_basename t dline t target_basename t target_basename t
 

--- a/doc/man/opam-admin-topics.inc
+++ b/doc/man/opam-admin-topics.inc
@@ -7,7 +7,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-help.err
                    (with-stdout-to opam-admin-help.1 (run %{bin:opam} admin help --help=groff)))
-                 (diff opam-admin-help.err %{dep:opam-admin-help.0}))))
+                 (diff opam-admin-help.err %{dep:opam-admin-help.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-admin-add-hashes.0 (echo "")))
@@ -16,7 +17,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-add-hashes.err
                    (with-stdout-to opam-admin-add-hashes.1 (run %{bin:opam} admin add-hashes --help=groff)))
-                 (diff opam-admin-add-hashes.err %{dep:opam-admin-add-hashes.0}))))
+                 (diff opam-admin-add-hashes.err %{dep:opam-admin-add-hashes.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-admin-add-constraint.0 (echo "")))
@@ -25,7 +27,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-add-constraint.err
                    (with-stdout-to opam-admin-add-constraint.1 (run %{bin:opam} admin add-constraint --help=groff)))
-                 (diff opam-admin-add-constraint.err %{dep:opam-admin-add-constraint.0}))))
+                 (diff opam-admin-add-constraint.err %{dep:opam-admin-add-constraint.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-admin-filter.0 (echo "")))
@@ -34,7 +37,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-filter.err
                    (with-stdout-to opam-admin-filter.1 (run %{bin:opam} admin filter --help=groff)))
-                 (diff opam-admin-filter.err %{dep:opam-admin-filter.0}))))
+                 (diff opam-admin-filter.err %{dep:opam-admin-filter.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-admin-list.0 (echo "")))
@@ -43,7 +47,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-list.err
                    (with-stdout-to opam-admin-list.1 (run %{bin:opam} admin list --help=groff)))
-                 (diff opam-admin-list.err %{dep:opam-admin-list.0}))))
+                 (diff opam-admin-list.err %{dep:opam-admin-list.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-admin-check.0 (echo "")))
@@ -52,7 +57,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-check.err
                    (with-stdout-to opam-admin-check.1 (run %{bin:opam} admin check --help=groff)))
-                 (diff opam-admin-check.err %{dep:opam-admin-check.0}))))
+                 (diff opam-admin-check.err %{dep:opam-admin-check.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-admin-lint.0 (echo "")))
@@ -61,7 +67,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-lint.err
                    (with-stdout-to opam-admin-lint.1 (run %{bin:opam} admin lint --help=groff)))
-                 (diff opam-admin-lint.err %{dep:opam-admin-lint.0}))))
+                 (diff opam-admin-lint.err %{dep:opam-admin-lint.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-admin-upgrade.0 (echo "")))
@@ -70,7 +77,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-upgrade.err
                    (with-stdout-to opam-admin-upgrade.1 (run %{bin:opam} admin upgrade --help=groff)))
-                 (diff opam-admin-upgrade.err %{dep:opam-admin-upgrade.0}))))
+                 (diff opam-admin-upgrade.err %{dep:opam-admin-upgrade.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-admin-cache.0 (echo "")))
@@ -79,7 +87,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-cache.err
                    (with-stdout-to opam-admin-cache.1 (run %{bin:opam} admin cache --help=groff)))
-                 (diff opam-admin-cache.err %{dep:opam-admin-cache.0}))))
+                 (diff opam-admin-cache.err %{dep:opam-admin-cache.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-admin-make.0 (echo "")))
@@ -88,7 +97,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-make.err
                    (with-stdout-to opam-admin-make.1 (run %{bin:opam} admin make --help=groff)))
-                 (diff opam-admin-make.err %{dep:opam-admin-make.0}))))
+                 (diff opam-admin-make.err %{dep:opam-admin-make.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-admin-index.0 (echo "")))
@@ -97,7 +107,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin-index.err
                    (with-stdout-to opam-admin-index.1 (run %{bin:opam} admin index --help=groff)))
-                 (diff opam-admin-index.err %{dep:opam-admin-index.0}))))
+                 (diff opam-admin-index.err %{dep:opam-admin-index.0})))
+  (package opam))
 
 (install
   (section man)

--- a/doc/man/opam-topics.inc
+++ b/doc/man/opam-topics.inc
@@ -7,7 +7,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-help.err
                    (with-stdout-to opam-help.1 (run %{bin:opam} help --help=groff)))
-                 (diff opam-help.err %{dep:opam-help.0}))))
+                 (diff opam-help.err %{dep:opam-help.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-admin.0 (echo "")))
@@ -16,7 +17,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-admin.err
                    (with-stdout-to opam-admin.1 (run %{bin:opam} admin --help=groff)))
-                 (diff opam-admin.err %{dep:opam-admin.0}))))
+                 (diff opam-admin.err %{dep:opam-admin.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-lock.0 (echo "")))
@@ -25,7 +27,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-lock.err
                    (with-stdout-to opam-lock.1 (run %{bin:opam} lock --help=groff)))
-                 (diff opam-lock.err %{dep:opam-lock.0}))))
+                 (diff opam-lock.err %{dep:opam-lock.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-clean.0 (echo "")))
@@ -34,7 +37,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-clean.err
                    (with-stdout-to opam-clean.1 (run %{bin:opam} clean --help=groff)))
-                 (diff opam-clean.err %{dep:opam-clean.0}))))
+                 (diff opam-clean.err %{dep:opam-clean.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-lint.0 (echo "")))
@@ -43,7 +47,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-lint.err
                    (with-stdout-to opam-lint.1 (run %{bin:opam} lint --help=groff)))
-                 (diff opam-lint.err %{dep:opam-lint.0}))))
+                 (diff opam-lint.err %{dep:opam-lint.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-source.0 (echo "")))
@@ -52,7 +57,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-source.err
                    (with-stdout-to opam-source.1 (run %{bin:opam} source --help=groff)))
-                 (diff opam-source.err %{dep:opam-source.0}))))
+                 (diff opam-source.err %{dep:opam-source.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-unpin.0 (echo "")))
@@ -61,7 +67,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-unpin.err
                    (with-stdout-to opam-unpin.1 (run %{bin:opam} unpin --help=groff)))
-                 (diff opam-unpin.err %{dep:opam-unpin.0}))))
+                 (diff opam-unpin.err %{dep:opam-unpin.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-pin.0 (echo "")))
@@ -70,7 +77,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-pin.err
                    (with-stdout-to opam-pin.1 (run %{bin:opam} pin --help=groff)))
-                 (diff opam-pin.err %{dep:opam-pin.0}))))
+                 (diff opam-pin.err %{dep:opam-pin.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-switch.0 (echo "")))
@@ -79,7 +87,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-switch.err
                    (with-stdout-to opam-switch.1 (run %{bin:opam} switch --help=groff)))
-                 (diff opam-switch.err %{dep:opam-switch.0}))))
+                 (diff opam-switch.err %{dep:opam-switch.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-remote.0 (echo "")))
@@ -88,7 +97,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-remote.err
                    (with-stdout-to opam-remote.1 (run %{bin:opam} remote --help=groff)))
-                 (diff opam-remote.err %{dep:opam-remote.0}))))
+                 (diff opam-remote.err %{dep:opam-remote.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-repository.0 (echo "")))
@@ -97,7 +107,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-repository.err
                    (with-stdout-to opam-repository.1 (run %{bin:opam} repository --help=groff)))
-                 (diff opam-repository.err %{dep:opam-repository.0}))))
+                 (diff opam-repository.err %{dep:opam-repository.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-env.0 (echo "")))
@@ -106,7 +117,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-env.err
                    (with-stdout-to opam-env.1 (run %{bin:opam} env --help=groff)))
-                 (diff opam-env.err %{dep:opam-env.0}))))
+                 (diff opam-env.err %{dep:opam-env.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-exec.0 (echo "")))
@@ -115,7 +127,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-exec.err
                    (with-stdout-to opam-exec.1 (run %{bin:opam} exec --help=groff)))
-                 (diff opam-exec.err %{dep:opam-exec.0}))))
+                 (diff opam-exec.err %{dep:opam-exec.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-config.0 (echo "")))
@@ -124,7 +137,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-config.err
                    (with-stdout-to opam-config.1 (run %{bin:opam} config --help=groff)))
-                 (diff opam-config.err %{dep:opam-config.0}))))
+                 (diff opam-config.err %{dep:opam-config.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-option.0 (echo "")))
@@ -133,7 +147,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-option.err
                    (with-stdout-to opam-option.1 (run %{bin:opam} option --help=groff)))
-                 (diff opam-option.err %{dep:opam-option.0}))))
+                 (diff opam-option.err %{dep:opam-option.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-var.0 (echo "")))
@@ -142,7 +157,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-var.err
                    (with-stdout-to opam-var.1 (run %{bin:opam} var --help=groff)))
-                 (diff opam-var.err %{dep:opam-var.0}))))
+                 (diff opam-var.err %{dep:opam-var.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-upgrade.0 (echo "")))
@@ -151,7 +167,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-upgrade.err
                    (with-stdout-to opam-upgrade.1 (run %{bin:opam} upgrade --help=groff)))
-                 (diff opam-upgrade.err %{dep:opam-upgrade.0}))))
+                 (diff opam-upgrade.err %{dep:opam-upgrade.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-update.0 (echo "")))
@@ -160,7 +177,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-update.err
                    (with-stdout-to opam-update.1 (run %{bin:opam} update --help=groff)))
-                 (diff opam-update.err %{dep:opam-update.0}))))
+                 (diff opam-update.err %{dep:opam-update.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-reinstall.0 (echo "")))
@@ -169,7 +187,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-reinstall.err
                    (with-stdout-to opam-reinstall.1 (run %{bin:opam} reinstall --help=groff)))
-                 (diff opam-reinstall.err %{dep:opam-reinstall.0}))))
+                 (diff opam-reinstall.err %{dep:opam-reinstall.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-uninstall.0 (echo "")))
@@ -178,7 +197,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-uninstall.err
                    (with-stdout-to opam-uninstall.1 (run %{bin:opam} uninstall --help=groff)))
-                 (diff opam-uninstall.err %{dep:opam-uninstall.0}))))
+                 (diff opam-uninstall.err %{dep:opam-uninstall.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-remove.0 (echo "")))
@@ -187,7 +207,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-remove.err
                    (with-stdout-to opam-remove.1 (run %{bin:opam} remove --help=groff)))
-                 (diff opam-remove.err %{dep:opam-remove.0}))))
+                 (diff opam-remove.err %{dep:opam-remove.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-install.0 (echo "")))
@@ -196,7 +217,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-install.err
                    (with-stdout-to opam-install.1 (run %{bin:opam} install --help=groff)))
-                 (diff opam-install.err %{dep:opam-install.0}))))
+                 (diff opam-install.err %{dep:opam-install.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-info.0 (echo "")))
@@ -205,7 +227,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-info.err
                    (with-stdout-to opam-info.1 (run %{bin:opam} info --help=groff)))
-                 (diff opam-info.err %{dep:opam-info.0}))))
+                 (diff opam-info.err %{dep:opam-info.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-show.0 (echo "")))
@@ -214,7 +237,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-show.err
                    (with-stdout-to opam-show.1 (run %{bin:opam} show --help=groff)))
-                 (diff opam-show.err %{dep:opam-show.0}))))
+                 (diff opam-show.err %{dep:opam-show.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-why.0 (echo "")))
@@ -223,7 +247,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-why.err
                    (with-stdout-to opam-why.1 (run %{bin:opam} why --help=groff)))
-                 (diff opam-why.err %{dep:opam-why.0}))))
+                 (diff opam-why.err %{dep:opam-why.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-tree.0 (echo "")))
@@ -232,7 +257,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-tree.err
                    (with-stdout-to opam-tree.1 (run %{bin:opam} tree --help=groff)))
-                 (diff opam-tree.err %{dep:opam-tree.0}))))
+                 (diff opam-tree.err %{dep:opam-tree.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-search.0 (echo "")))
@@ -241,7 +267,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-search.err
                    (with-stdout-to opam-search.1 (run %{bin:opam} search --help=groff)))
-                 (diff opam-search.err %{dep:opam-search.0}))))
+                 (diff opam-search.err %{dep:opam-search.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-list.0 (echo "")))
@@ -250,7 +277,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-list.err
                    (with-stdout-to opam-list.1 (run %{bin:opam} list --help=groff)))
-                 (diff opam-list.err %{dep:opam-list.0}))))
+                 (diff opam-list.err %{dep:opam-list.0})))
+  (package opam))
 
 (rule
   (with-stdout-to opam-init.0 (echo "")))
@@ -259,7 +287,8 @@
   (deps using-built-opam)
   (action (progn (with-stderr-to opam-init.err
                    (with-stdout-to opam-init.1 (run %{bin:opam} init --help=groff)))
-                 (diff opam-init.err %{dep:opam-init.0}))))
+                 (diff opam-init.err %{dep:opam-init.0})))
+  (package opam))
 
 (install
   (section man)

--- a/master_changes.md
+++ b/master_changes.md
@@ -281,6 +281,7 @@ users)
   * Add `swhid_core` dependency [#4859 @rjbou]
   * Remove unused vendored dependency: result [#5465 @kit-ty-kate]
   * `opam-state` depends on `opam-solver` [#5208 @rjbou]
+  * Specify the `opam` package for all rules that need `opamMain.exe.exe` [#5496 @Leonidas-from-XIV]
 
 ## Infrastructure
   * Fix caching of Cygwin compiler on AppVeyor [#4988 @dra27]

--- a/src/client/dune
+++ b/src/client/dune
@@ -31,6 +31,7 @@
 ; Hack to make the tests work on Cygwin
 (rule
  (targets opamMain.exe.exe)
+ (package opam)
  (action (copy opamMain.exe %{targets})))
 
 (rule

--- a/src/dune
+++ b/src/dune
@@ -5,3 +5,5 @@
 
 (rule
   (with-stdout-to ocaml-context-flags.sexp (run ocaml %{dep:../shell/context_flags.ml} flags)))
+
+(vendored_dirs crowbar)

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -11,6 +11,7 @@
 (rule
  (targets admin-add-constraint.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -28,6 +29,7 @@
 (rule
  (targets assume-built.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -45,6 +47,7 @@
 (rule
  (targets autopin.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -62,6 +65,7 @@
 (rule
  (targets avoid-version.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -79,6 +83,7 @@
 (rule
  (targets best-effort.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -96,6 +101,7 @@
 (rule
  (targets clean.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -113,6 +119,7 @@
 (rule
  (targets cli-versioning.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -130,6 +137,7 @@
 (rule
  (targets config.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -147,6 +155,7 @@
 (rule
  (targets conflict-4373.out)
  (deps root-c1d23f0e)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -164,6 +173,7 @@
 (rule
  (targets conflict-badversion.out)
  (deps root-f372039d)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -181,6 +191,7 @@
 (rule
  (targets conflict-camlp4.out)
  (deps root-f372039d)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -198,6 +209,7 @@
 (rule
  (targets conflict-core.out)
  (deps root-f372039d)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -215,6 +227,7 @@
 (rule
  (targets conflict-resto.out)
  (deps root-a5d7cdc0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -232,6 +245,7 @@
 (rule
  (targets conflict-solo5.out)
  (deps root-f372039d)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -249,6 +263,7 @@
 (rule
  (targets cudf-preprocess.out)
  (deps root-ad4dd344)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -266,6 +281,7 @@
 (rule
  (targets depexts.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -283,6 +299,7 @@
 (rule
  (targets deprecated.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -300,6 +317,7 @@
 (rule
  (targets deps-only.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -317,6 +335,7 @@
 (rule
  (targets dot-install.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -334,6 +353,7 @@
 (rule
  (targets empty-conflicts-001.out)
  (deps root-297366c)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -351,6 +371,7 @@
 (rule
  (targets empty-conflicts-002.out)
  (deps root-11ea1cb)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -368,6 +389,7 @@
 (rule
  (targets empty-conflicts-003.out)
  (deps root-3235916)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -385,6 +407,7 @@
 (rule
  (targets empty-conflicts-004.out)
  (deps root-0070613707)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -402,6 +425,7 @@
 (rule
  (targets empty-conflicts-005.out)
  (deps root-de897adf36c4230dfea812f40c98223b31c4521a)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -419,6 +443,7 @@
 (rule
  (targets empty-conflicts-006.out)
  (deps root-c1842d168d)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -436,6 +461,7 @@
 (rule
  (targets env.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -456,6 +482,7 @@
  (targets env.win32.out)
  (deps root-N0REP0)
  (enabled_if (= %{os_type} "Win32"))
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -473,6 +500,7 @@
 (rule
  (targets init.out)
  (deps root-009e00fa)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -490,6 +518,7 @@
 (rule
  (targets inplace.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -507,6 +536,7 @@
 (rule
  (targets install-formula.out)
  (deps root-f372039d)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -524,6 +554,7 @@
 (rule
  (targets install-pgocaml.out)
  (deps root-f372039d)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -544,6 +575,7 @@
  (targets json.unix.out)
  (deps root-N0REP0)
  (enabled_if (= %{os_type} "Unix"))
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -561,6 +593,7 @@
 (rule
  (targets legacy-git.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -578,6 +611,7 @@
 (rule
  (targets legacy-local.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -595,6 +629,7 @@
 (rule
  (targets lint.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -612,6 +647,7 @@
 (rule
  (targets list-coinstallable.out)
  (deps root-7371c1d9)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -629,6 +665,7 @@
 (rule
  (targets list.out)
  (deps root-7371c1d9)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -649,6 +686,7 @@
  (targets list.unix.out)
  (deps root-f372039d)
  (enabled_if (= %{os_type} "Unix"))
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -666,6 +704,7 @@
 (rule
  (targets lock.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -683,6 +722,7 @@
 (rule
  (targets opamroot-versions.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -700,6 +740,7 @@
 (rule
  (targets opamrt-big-upgrade.out)
  (deps root-7090735c)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -717,6 +758,7 @@
 (rule
  (targets opamrt-dep-cycle.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -734,6 +776,7 @@
 (rule
  (targets opamrt-reinstall.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -751,6 +794,7 @@
 (rule
  (targets orphans.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -768,6 +812,7 @@
 (rule
  (targets parallel.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -785,6 +830,7 @@
 (rule
  (targets pat-sub.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -802,6 +848,7 @@
 (rule
  (targets pin.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -819,6 +866,7 @@
 (rule
  (targets rebuild.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -836,6 +884,7 @@
 (rule
  (targets rec-pin.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -853,6 +902,7 @@
 (rule
  (targets reinstall.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -870,6 +920,7 @@
 (rule
  (targets remove.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -887,6 +938,7 @@
 (rule
  (targets repository.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -904,6 +956,7 @@
 (rule
  (targets resolve-variables.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -921,6 +974,7 @@
 (rule
  (targets shared-fetch.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -938,6 +992,7 @@
 (rule
  (targets show.out)
  (deps root-009e00fa)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -955,6 +1010,7 @@
 (rule
  (targets source.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -975,6 +1031,7 @@
  (targets swhid.unix.out)
  (deps root-N0REP0)
  (enabled_if (= %{os_type} "Unix"))
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -992,6 +1049,7 @@
 (rule
  (targets switch-creation.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -1009,6 +1067,7 @@
 (rule
  (targets switch-import.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -1026,6 +1085,7 @@
 (rule
  (targets switch-invariant.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -1043,6 +1103,7 @@
 (rule
  (targets switch-list.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -1060,6 +1121,7 @@
 (rule
  (targets switch-set.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -1077,6 +1139,7 @@
 (rule
  (targets tree.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -1094,6 +1157,7 @@
 (rule
  (targets unhelpful-conflicts-001.out)
  (deps root-c1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -1111,6 +1175,7 @@
 (rule
  (targets update-upgrade.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -1128,6 +1193,7 @@
 (rule
  (targets upgrade-format.out)
  (deps root-009e00fa)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -1145,6 +1211,7 @@
 (rule
  (targets upgrade-two-point-o.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -1162,6 +1229,7 @@
 (rule
  (targets upgrade.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -1179,6 +1247,7 @@
 (rule
  (targets var-option.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -1196,6 +1265,7 @@
 (rule
  (targets with-dev-setup.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}
@@ -1213,6 +1283,7 @@
 (rule
  (targets working-dir.out)
  (deps root-N0REP0)
+ (package opam)
  (action
   (with-stdout-to
    %{targets}

--- a/tests/reftests/gen.ml
+++ b/tests/reftests/gen.ml
@@ -35,6 +35,7 @@ let run_rule ~base_name ~archive_hash ~condition =
 (rule
  (targets %s)
  (deps %s)%s
+ (package opam)
  (action
   (with-stdout-to
    %%{targets}


### PR DESCRIPTION
The compilation fails if

```sh
$ dune build --only-packages opam-core,opam-format,opam-repository
```

As it tries to build the binary, but can't due to the opam package not being compiled. This adds the `package` stanza to the associated rules to avoid the rules being triggered when the `opam` package is not selected.