### PR TITLE
depexts: reword message

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -25,6 +25,7 @@ users)
   * Refactored depext-related questions, with a flat menu instead of nested y/n questions [#5053 @AltGr - fix #5026]
     * Fix removal of interactive special characters is output is not tty [#5155 @rjbou]
     * Fix behaviour of menu and depexts in non-interactive environments [#5295 @AltGr]
+    * Reword message for the ignore path to avoid ambiguity [#5499 @AltGr]
   * [BUG] Fix default cli handling for simple flags [#5099 @rjbou]
   * Add `experimental` flags handling [#5099 @rjbou]
   * [BUG] Fix `OPAMCURL` and `OPAMFETCH` value setting [#5111 @rjbou - fix #5108]

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1188,8 +1188,9 @@ let install_depexts ?(force_depext=false) ?(confirm=true) t packages =
           `No, Printf.sprintf
             "Display the recommended %s command and wait while you run it \
              manually (e.g. in another terminal)" pkgman;
-          `Ignore, "Attempt installation anyway, and permanently register that \
-                    this external dependency is present, but not detectable";
+          `Ignore, "Continue anyway, and, upon success, permanently register \
+                    that this external dependency is present, but not \
+                    detectable";
           `Quit, "Abort the installation";
         ]
     in
@@ -1224,8 +1225,9 @@ let install_depexts ?(force_depext=false) ?(confirm=true) t packages =
       OpamConsole.menu ~default:`Continue ~no:`Quit "Would you like opam to:"
         ~options:[
           `Continue, "Check again, as the package is now installed";
-          `Ignore, "Attempt installation anyway, and permanently register that \
-                    this external dependency is present, but not detectable";
+          `Ignore, "Continue anyway, and, upon success, permanently register \
+                    that this external dependency is present, but not \
+                    detectable";
           `Quit, "Abort the installation";
         ]
     in

--- a/tests/reftests/autopin.test
+++ b/tests/reftests/autopin.test
@@ -60,7 +60,7 @@ The following system packages will first need to be installed:
 opam believes some required external dependencies are missing. opam can:
 > 1. Run echo to install them (may need root/sudo access)
   2. Display the recommended echo command and wait while you run it manually (e.g. in another terminal)
-  3. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
+  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
   4. Abort the installation
 
 [1/2/3/4] 1
@@ -107,7 +107,7 @@ The following system packages will first need to be installed:
 opam believes some required external dependencies are missing. opam can:
 > 1. Run echo to install them (may need root/sudo access)
   2. Display the recommended echo command and wait while you run it manually (e.g. in another terminal)
-  3. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
+  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
   4. Abort the installation
 
 [1/2/3/4] 1
@@ -151,7 +151,7 @@ The following system packages will first need to be installed:
 opam believes some required external dependencies are missing. opam can:
 > 1. Run echo to install them (may need root/sudo access)
   2. Display the recommended echo command and wait while you run it manually (e.g. in another terminal)
-  3. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
+  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
   4. Abort the installation
 
 [1/2/3/4] 1
@@ -203,7 +203,7 @@ The following system packages will first need to be installed:
 opam believes some required external dependencies are missing. opam can:
 > 1. Run echo to install them (may need root/sudo access)
   2. Display the recommended echo command and wait while you run it manually (e.g. in another terminal)
-  3. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
+  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
   4. Abort the installation
 
 [1/2/3/4] 1
@@ -279,7 +279,7 @@ The following system packages will first need to be installed:
 opam believes some required external dependencies are missing. opam can:
 > 1. Run echo to install them (may need root/sudo access)
   2. Display the recommended echo command and wait while you run it manually (e.g. in another terminal)
-  3. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
+  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
   4. Abort the installation
 
 [1/2/3/4] 1
@@ -312,7 +312,7 @@ The following system packages will first need to be installed:
 opam believes some required external dependencies are missing. opam can:
 > 1. Run echo to install them (may need root/sudo access)
   2. Display the recommended echo command and wait while you run it manually (e.g. in another terminal)
-  3. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
+  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
   4. Abort the installation
 
 [1/2/3/4] 1

--- a/tests/reftests/depexts.test
+++ b/tests/reftests/depexts.test
@@ -20,7 +20,7 @@ The following system packages will first need to be installed:
 opam believes some required external dependencies are missing. opam can:
 > 1. Run false to install them (may need root/sudo access)
   2. Display the recommended false command and wait while you run it manually (e.g. in another terminal)
-  3. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
+  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
   4. Abort the installation
 
 [1/2/3/4] 1

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -112,7 +112,7 @@ The following system packages will first need to be installed:
 opam believes some required external dependencies are missing. opam can:
 > 1. Run echo to install them (may need root/sudo access)
   2. Display the recommended echo command and wait while you run it manually (e.g. in another terminal)
-  3. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
+  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
   4. Abort the installation
 
 [1/2/3/4] 1
@@ -161,7 +161,7 @@ The following system packages will first need to be installed:
 opam believes some required external dependencies are missing. opam can:
 > 1. Run echo to install them (may need root/sudo access)
   2. Display the recommended echo command and wait while you run it manually (e.g. in another terminal)
-  3. Attempt installation anyway, and permanently register that this external dependency is present, but not detectable
+  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
   4. Abort the installation
 
 [1/2/3/4] 1


### PR DESCRIPTION
I just noticed that "attempt installation anyway" could be misleading because of
the ambiguity between "system installation" and "opam installation".

"Continue anyway" is much more obvious, esp. if you read quickly.