### PR TITLE
Add the OPAMSOLVERTOLERANCE environment variable to allow users to fix solver timeouts for good

### DIFF
--- a/doc/pages/Tricks.md
+++ b/doc/pages/Tricks.md
@@ -150,6 +150,7 @@ The following sequence of commands tries to install as much packages as possible
 opam update
 opam switch create . ocaml-base-compiler.$(VERSION)
 export OPAMSOLVERTIMEOUT=3600
+export OPAMSOLVERTOLERANCE=1.0
 opam list --available -s | xargs opam install --best-effort --yes
 # Be patient
 ```

--- a/master_changes.md
+++ b/master_changes.md
@@ -79,6 +79,7 @@ users)
 ## Clean
 
 ## Env
+  * Add the `OPAMSOLVERTOLERANCE` environment variable to allow users to fix solver timeouts for good [#5510 @kit-ty-kate - fix #3230]
 
 ## Opamfile
 

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -186,6 +186,16 @@ let environment_variables =
          "change the time allowance of the solver. Default is %.1f, set to 0 \
           for unlimited. Note that all solvers may not support this option."
          (OpamStd.Option.default 0. OpamSolverConfig.(default.solver_timeout)));
+      "SOLVERTOLERANCE", cli_from cli2_4, (fun v -> SOLVERTOLERANCE (env_float v)),
+      (Printf.sprintf
+         "changes the tolerance towards the solver choosing an unoptimized \
+          solution (i.e. might pull outdated packages). Typical values range \
+          from 0.0 (best solution known to the solver) to 1.0 (unoptimized \
+          solution). Default is %.1f. This option is useful in case the solver \
+          can't find a solution in a reasonable time \
+          (see $(b,\\$OPAMSOLVERTIMEOUT)). Note that all solvers may not \
+          support this option."
+         (OpamStd.Option.default 0. OpamSolverConfig.default.solver_tolerance));
       "UPGRADECRITERIA", cli_original,
       (fun v -> UPGRADECRITERIA (env_string v)),
       "specifies user $(i,preferences) for dependency solving when performing \

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -146,6 +146,7 @@ val opam_init:
   ?solver_preferences_fixup:string option Lazy.t ->
   ?solver_preferences_best_effort_prefix: string option Lazy.t ->
   ?solver_timeout:float option ->
+  ?solver_tolerance:float option ->
   ?solver_allow_suboptimal:bool ->
   ?cudf_trim:string option ->
   ?dig_depth:int ->

--- a/src/solver/opamBuiltin0install.ml
+++ b/src/solver/opamBuiltin0install.ml
@@ -123,7 +123,7 @@ let parse_criteria criteria =
   in
   parse default (OpamCudfCriteria.of_string criteria)
 
-let call ~criteria ?timeout:_ (preamble, universe, request) =
+let call ~criteria ?timeout:_ ?tolerance:_ (preamble, universe, request) =
   let {
     drop_installed_packages;
     prefer_oldest;

--- a/src/solver/opamBuiltinMccs.dummy.ml
+++ b/src/solver/opamBuiltinMccs.dummy.ml
@@ -28,7 +28,7 @@ module S = struct
     crit_best_effort_prefix = None;
   }
 
-  let call ~criteria:_ ?timeout:_ _cudf =
+  let call ~criteria:_ ?timeout:_ ?tolerance:_ _cudf =
     failwith "This opam was compiled without a solver built in"
 end
 

--- a/src/solver/opamBuiltinMccs.real.ml
+++ b/src/solver/opamBuiltinMccs.real.ml
@@ -31,7 +31,7 @@ let default_criteria = {
   crit_best_effort_prefix = Some "+count[opam-query:,false],";
 }
 
-let call solver_backend ext ~criteria ?timeout cudf =
+let call solver_backend ext ~criteria ?timeout ?tolerance cudf =
   let solver = match solver_backend, ext with
     | `LP _, Some ext -> `LP ext
     | _ -> solver_backend
@@ -39,7 +39,8 @@ let call solver_backend ext ~criteria ?timeout cudf =
   match
     Mccs.resolve_cudf
       ~solver
-      ~verbose:OpamCoreConfig.(abs !r.debug_level >= 2)
+      ?mip_gap:tolerance
+      ~verbosity:(!OpamCoreConfig.r.debug_level - 1) (*  *)
       ?timeout criteria cudf
   with
   | None -> raise Dose_common.CudfSolver.Unsat

--- a/src/solver/opamBuiltinZ3.dummy.ml
+++ b/src/solver/opamBuiltinZ3.dummy.ml
@@ -27,5 +27,5 @@ let default_criteria = {
   crit_best_effort_prefix = None;
 }
 
-let call ~criteria:_ ?timeout:_ _cudf =
+let call ~criteria:_ ?timeout:_ ?tolerance:_ _cudf =
   failwith "This opam was compiled without the Z3 solver built in"

--- a/src/solver/opamBuiltinZ3.real.ml
+++ b/src/solver/opamBuiltinZ3.real.ml
@@ -382,13 +382,14 @@ let extract_solution_packages universe opt =
       []
   | None -> failwith "no model ??"
 
-let call ~criteria ?timeout (preamble, universe, _ as cudf) =
+let call ~criteria ?timeout ?tolerance:_ (preamble, universe, _ as cudf) =
   (* try *)
   log "Generating problem...";
   let cfg = match timeout with
     | None -> []
     | Some secs -> ["timeout", string_of_int (int_of_float (1000. *. secs))]
   in
+  (* TODO: use tolerance. Maybe the rlimit cfg option + intermediate solution could be used *)
   let ctx = {
     z3 = Z3.mk_context cfg;
     pkgs = Hashtbl.create 2731;

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -1595,9 +1595,12 @@ let call_external_solver ~version_map univ req =
       let msg =
         Printf.sprintf
           "Sorry, resolution of the request timed out.\n\
-           Try to specify a more precise request, use a different solver, or \
-           increase the allowed time by setting OPAMSOLVERTIMEOUT to a bigger \
+           Try to specify a more precise request, use a different solver, \
+           increase the tolerance for unoptimized solutions by setting \
+           OPAMSOLVERTOLERANCE to a bigger value (currently, it is set to %.1f) \
+           or increase the allowed time by setting OPAMSOLVERTIMEOUT to a bigger \
            value (currently, it is set to %.1f seconds)."
+          OpamSolverConfig.(OpamStd.Option.default 0. !r.solver_tolerance)
           OpamSolverConfig.(OpamStd.Option.default 0. !r.solver_timeout)
       in
       raise (Solver_failure msg)

--- a/src/solver/opamCudfSolver.ml
+++ b/src/solver/opamCudfSolver.ml
@@ -27,7 +27,7 @@ module type ExternalArg = sig
   val default_criteria: criteria_def
 end
 
-let call_external_solver command ~criteria ?timeout (_, universe,_ as cudf) =
+let call_external_solver command ~criteria ?timeout ?tolerance:_ (_, universe,_ as cudf) =
   let solver_in =
     OpamFilename.of_string (OpamSystem.temp_file "solver-in") in
   let solver_out =

--- a/src/solver/opamCudfSolverSig.ml
+++ b/src/solver/opamCudfSolverSig.ml
@@ -38,7 +38,7 @@ module type S = sig
       it's only run if the solver returns unsat, to extract the explanations. *)
 
   val call:
-    criteria:string -> ?timeout:float -> Cudf.cudf ->
+    criteria:string -> ?timeout:float -> ?tolerance:float -> Cudf.cudf ->
     Cudf.preamble option * Cudf.universe
 
 end

--- a/src/solver/opamSolverConfig.mli
+++ b/src/solver/opamSolverConfig.mli
@@ -25,6 +25,7 @@ module E : sig
     | PREPRO of bool option
     | SOLVERALLOWSUBOPTIMAL of bool option
     | SOLVERTIMEOUT of float option
+    | SOLVERTOLERANCE of float option
     | UPGRADECRITERIA of string option
     | USEINTERNALSOLVER of bool option
     | VERSIONLAGPOWER of int option
@@ -40,6 +41,7 @@ type t = private {
   solver_preferences_fixup: string option Lazy.t;
   solver_preferences_best_effort_prefix: string option Lazy.t;
   solver_timeout: float option;
+  solver_tolerance: float option;
   solver_allow_suboptimal: bool;
   cudf_trim: string option;
   dig_depth: int;
@@ -56,6 +58,7 @@ type 'a options_fun =
   ?solver_preferences_fixup:string option Lazy.t ->
   ?solver_preferences_best_effort_prefix:string option Lazy.t ->
   ?solver_timeout:float option ->
+  ?solver_tolerance:float option ->
   ?solver_allow_suboptimal:bool ->
   ?cudf_trim:string option ->
   ?dig_depth:int ->


### PR DESCRIPTION
Partially fixes https://github.com/ocaml/opam/issues/5504
Partially fixes https://github.com/ocaml/opam/issues/3447
Partially fixes https://github.com/ocaml/opam/issues/5353
Partially fixes https://github.com/ocaml/opam/issues/4794
Fixes https://github.com/ocaml/opam/issues/3230
Requires https://github.com/AltGr/ocaml-mccs/pull/40

Optimizing solvers can be an annoying breed, sometimes a problem is just too complex for solver A but easy for solver B, and on some other problem solver B might take too long where solver A takes no time at all.

To partly solve the numerous timeout issues that have been plagued opam, I introduce this new environment variable that allows `builtin-mccs+glpk` (default solver) to not wait around for too long when it found a solution but the solution is not the optimum solution.

The downside of having unoptimized solutions is that opam might install out-of-date packages so it is to be used parsimoniously.

~TODO: add tests~ too complicated to do reliably