### PR TITLE
Stop the configure script from downloading and vendoring dependencies by default

### DIFF
--- a/.github/scripts/main/main.sh
+++ b/.github/scripts/main/main.sh
@@ -32,7 +32,7 @@ if [ -e "$OCAML_LOCAL/_build" ]; then
   cp -a "$OCAML_LOCAL/_build" .
 fi
 
-./configure --prefix $CONFIGURE_PREFIX --with-mccs
+./configure --prefix $CONFIGURE_PREFIX --with-vendored-deps --with-mccs
 if [ "$OPAM_TEST" != "1" ]; then
   echo 'DUNE_PROFILE=dev' >> Makefile.config
 fi

--- a/configure
+++ b/configure
@@ -7348,41 +7348,25 @@ if test "x${enable_checks}" != "xno" && {
        test "x$OCAML_PKG_mccs$MCCS_ENABLED" = "xnotrue";}
 then :
 
-  if test "x${with_vendored_deps}" = "xno"
+  if test "x${with_vendored_deps}" != "xyes"
 then :
 
-    as_fn_error $? "Dependencies missing and --without-vendored-deps given; override with --disable-checks" "$LINENO" 5
-
-else $as_nop
-
-    if test "x${with_vendored_deps}" != "xyes"
-then :
-
-      echo "============================================================================"
-      echo "Some dependencies are missing. Vendored mode has been automatically enabled."
-      echo "The sources for opam's dependencies will be extracted in src_ext and built."
-      echo "============================================================================"
-
-fi
-    VENDORED="true"
-
+    as_fn_error $? "Dependencies missing. Use --with-vendored-deps or --disable-checks" "$LINENO" 5
 
 fi
 
-else $as_nop
+fi
 
-  if test "x${with_vendored_deps}" = "xyes"
+if test "x${with_vendored_deps}" = "xyes"
 then :
 
-    VENDORED="true"
+  VENDORED="true"
 
 
 else $as_nop
 
-    VENDORED="false"
+  VENDORED="false"
 
-
-fi
 
 fi
 
@@ -8618,22 +8602,6 @@ then :
   printf %s "Extracting vendored source dependencies in src_ext/... "
   ${MAKE} --no-print-directory -C src_ext SILENT=@ clone
   printf "%s\n" done
-
-else $as_nop
-
-  ${MAKE} --no-print-directory -C src_ext def-ignore
-  if test -z "${DUNE}"
-then :
-
-    echo
-    printf %s "Downloading dune sources... "
-    ${MAKE} --no-print-directory -C src_ext SILENT=@ dune-local.download
-    printf "%s\n" done
-    printf %s "Extracting dune sources to src_ext/dune-local/... "
-    ${MAKE} --no-print-directory -C src_ext SILENT=@ dune-local.stamp
-    printf "%s\n" done
-
-fi
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -402,23 +402,15 @@ AS_IF([test "x${enable_checks}" != "xno" && {
        test "x$OCAML_PKG_swhid_core" = "xno" ||
        test "x$CPPO" = "x" ||
        test "x$OCAML_PKG_mccs$MCCS_ENABLED" = "xnotrue";}],[
-  AS_IF([test "x${with_vendored_deps}" = "xno"],[
-    AC_MSG_ERROR([Dependencies missing and --without-vendored-deps given; override with --disable-checks])
-  ],[
-    AS_IF([test "x${with_vendored_deps}" != "xyes"],[
-      echo "============================================================================"
-      echo "Some dependencies are missing. Vendored mode has been automatically enabled."
-      echo "The sources for opam's dependencies will be extracted in src_ext and built."
-      echo "============================================================================"
-    ])
-    AC_SUBST(VENDORED,"true")
+  AS_IF([test "x${with_vendored_deps}" != "xyes"],[
+    AC_MSG_ERROR([Dependencies missing. Use --with-vendored-deps or --disable-checks])
   ])
+])
+
+AS_IF([test "x${with_vendored_deps}" = "xyes"],[
+  AC_SUBST(VENDORED,"true")
 ],[
-  AS_IF([test "x${with_vendored_deps}" = "xyes"],[
-    AC_SUBST(VENDORED,"true")
-  ],[
-    AC_SUBST(VENDORED,"false")
-  ])
+  AC_SUBST(VENDORED,"false")
 ])
 
 if test "x$prefix" = "xNONE"; then
@@ -482,15 +474,4 @@ AS_IF([test "x${VENDORED}" = "xtrue"],[
   AS_ECHO_N(["Extracting vendored source dependencies in src_ext/... "])
   ${MAKE} --no-print-directory -C src_ext SILENT=@ clone
   AS_ECHO([done])
-],[
-  ${MAKE} --no-print-directory -C src_ext def-ignore
-  AS_IF([test -z "${DUNE}"],[
-    echo
-    AS_ECHO_N(["Downloading dune sources... "])
-    ${MAKE} --no-print-directory -C src_ext SILENT=@ dune-local.download
-    AS_ECHO([done])
-    AS_ECHO_N(["Extracting dune sources to src_ext/dune-local/... "])
-    ${MAKE} --no-print-directory -C src_ext SILENT=@ dune-local.stamp
-    AS_ECHO([done])
-  ])
 ])

--- a/master_changes.md
+++ b/master_changes.md
@@ -246,6 +246,7 @@ users)
   * Add `--without-dune` to configure to force compiling vendored Dune [#4776 @dra27]
   * Use `--without-dune` in `make cold` to avoid picking up external Dune [#4776 @dra27 - fix #3987]
   * Add `--with-vendored-deps` to replace `make lib-ext` instruction [#4776 @dra27 - fix #4772]
+    * Stop the configure script from downloading and vendoring dependencies by default [#5511 @kit-ty-kate]
   * Fix vendored build on mingw-w64 with g++ 11.2 [#4835 @dra27]
   * Switch to vendored build if spdx_licenses is missing [#4842 @dra27]
   * Check versions of findlib packages in configure [#4842 @dra27]

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -25,8 +25,8 @@ WORKDIR /home/opam/
 CMD tar xz >&2 && \
     cd opam-full-${VERSION} >&2 && \
     echo "(${LINKING})" > src/client/linking.sexp && \
-    ./configure --with-mccs >&2 && \
-    { make lib-ext >&2 || ./configure --with-vendored-deps >&2 ; } && \
+    { { ./configure --with-mccs >&2 && make lib-ext >&2 ; } || \
+      ./configure --with-vendored-deps >&2 ; } && \
     make opam >&2 && \
     strip opam >&2 && \
     cat opam


### PR DESCRIPTION
Currently if dune is not detected, or a dependency is not detected by the configure script (said configure script can well be outdated, e.g. https://github.com/ocaml/opam/pull/5497), the vendoring mode is enabled by default without asking the user.

I think this is not a good default and if it were to be released now i would probably weigh against merging it in this state in opam-repository as the sandbox does not allow network access and the the general behaviour can become non-deterministic very easily. Other system package managers maintainers would probably also get upset by this behaviour.

I thus propose to simply switch the behaviour to "vendor only when `--with-vendored-deps` is given"