### PR TITLE
doc: `?` evaluates to `true` if defined

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -571,8 +571,9 @@ The following are allowed in filters:
 - Idents
 - Parentheses
 - Logical operators (binary AND `&`, binary OR `|`, prefix, unary NOT `!`)
-- The unary operator `?` for detecting whether an expression contains undefined
-  variables
+- The unary operator `?` for detecting whether a value is defined. `?expr`
+  evaluates to `true` if `expr` evaluates to a defined value, and `false` if it
+  evaluates to an undefined value.
 - Binary relational operators (`=`, `!=`, `<`, `<=`, `>`, `>=`)
 
 The comparisons are done using [Version Order](#version-ordering), including for

--- a/master_changes.md
+++ b/master_changes.md
@@ -536,6 +536,7 @@ users)
   * Up-to-date synchronisation with shell session in switch man page: mention shell hooks [#5311 @rjbou - fix #5307]
   * Fix info for IRC channels in README.md and FAQ.md [#5340 @purplearmadillo77]
   * Update `--cudf` manpage description to specify what is the `<n>` (n(the solver-cal) [#5343 @kit-ty-kate]
+  * Improve the documentation of the `?expr` filter [#5512 @emillon]
 
 ## Security fixes
   *


### PR DESCRIPTION
The existing sentence seems to indicate that it evaluates to `true` when it contains undefined variables.
