### PR TITLE
configure: Ensure a complementary (32bit on 64bit platforms and 64bit on 32bit platforms) C compiler is installed on Windows

### DIFF
--- a/configure
+++ b/configure
@@ -5315,8 +5315,7 @@ fi
   if  test "x${CC64}" = "xno"
 then :
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Complementary C compiler not found - opam-putenv will not be built" >&5
-printf "%s\n" "$as_me: WARNING: Complementary C compiler not found - opam-putenv will not be built" >&2;}
+    as_fn_error $? "${ARCH} C compiler not found - opam-putenv cannot be built" "$LINENO" 5
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -243,7 +243,7 @@ AS_IF([ test ${WIN32} -eq 1 ],[
     ])
   ])
   AS_IF([ test "x${CC64}" = "xno" ],[
-    AC_MSG_WARN([Complementary C compiler not found - opam-putenv will not be built])
+    AC_MSG_ERROR([${ARCH} C compiler not found - opam-putenv cannot be built])
   ])
 ])
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -66,6 +66,7 @@ users)
 ## Build
   * Run autoupdate to silence autogen warnings [#5555 @MisterDA]
   * Update bootstrap to use FlexDLL 0.43 from ocaml/flexdll [#5579 @MisterDA]
+  * configure: Ensure a complementary (32bit on 64bit platforms and 64bit on 32bit platforms) C compiler is installed on Windows [#5522 @kit-ty-kate]
 
 ## Infrastructure
 


### PR DESCRIPTION
~`src/stubs/win32/cc64` was never written before because the C compiler was always the wrong one (x86_32 when only the x86_64 is available and x86_64 when only the x86_32 one is available)~

~I'm not sure how it ever worked before. Maybe the typical setup always has both x86_64 and x86_32 so it somehow worked out.~

A complementary C compiler (32bit on 64bit platforms and 64bit on 32bit platforms) is required to build opam-putenv on Windows, but the check for those compilers only output a warning instead of an error. Said warning made it seem like it way an optional binary, however this is not the case and is always required on Windows AFAIK.

cc @MisterDA