### PR TITLE
Setup benchmarking using current-bench

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,10 @@ uninstall: opam.install
 .PHONY: test
 test: tests
 
+.PHONY: bench
+bench:
+	@$(DUNE) exec --display=quiet $(DUNE_PROFILE_ARG) --root . $(DUNE_ARGS) -- ./tests/bench/bench.exe
+
 .PHONY: tests
 tests: $(DUNE_DEP) src/client/no-git-version
 	@$(DUNE) runtest $(DUNE_PROFILE_ARG) --root . $(DUNE_ARGS) src/ tests/ --no-buffer; \

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,0 +1,11 @@
+FROM debian
+RUN apt-get update -qq && apt-get install -qq -yy make curl gcc g++ patch bzip2 git unzip
+RUN adduser --disabled-password --gecos '' --shell /bin/bash opam
+USER opam
+COPY --chown=opam:opam . /src
+WORKDIR /src
+RUN make cold
+USER root
+RUN install ./opam /usr/local/bin/
+USER opam
+RUN opam init -n --disable-sandboxing git+https://github.com/ocaml/opam-repository#26770281fa1ea8b13aab979c1dfbd326e9ab512c

--- a/master_changes.md
+++ b/master_changes.md
@@ -389,6 +389,7 @@ users)
 ## Test
   * Update crowbar with compare functions [#4918 @rjbou]
   * No more mute test debug output (level < 0) if `--readonly` is given with `--debug-level` [#5476 @rjbou]
+  * Setup benchmarking using current-bench [#5525 @kit-ty-kate]
 
 ## Reftests
 ### Tests

--- a/tests/bench/bench.ml
+++ b/tests/bench/bench.ml
@@ -1,0 +1,45 @@
+let fmt = Printf.sprintf
+
+let time_cmd ~exit cmd =
+  let cmd = cmd ^ " 2> /dev/null > /dev/null" in
+  let before = Unix.gettimeofday () in
+  let code = Sys.command cmd in
+  let timer = Unix.gettimeofday () -. before in
+  if Int.equal code exit then
+    timer
+  else
+    failwith (fmt "Command %S exited with error code %d" cmd code)
+
+let () =
+  let bin = "./opam" in
+  let bin_size = (Unix.stat bin).st_size in
+  let time_misspelled_cmd =
+    (* NOTE: https://github.com/ocaml/opam/issues/5479 *)
+    time_cmd ~exit:2 (fmt "%s sitch" bin)
+  in
+  let json = fmt {|{
+  "results": [
+    {
+      "name": "Timings",
+      "metrics": [
+        {
+          "name": "Misspelled command",
+          "value": %f,
+          "units": "secs"
+        }
+      ]
+    },
+    {
+      "name": "Misc",
+      "metrics": [
+        {
+          "name": "Size of opam.exe",
+          "value": %d,
+          "units": "bytes"
+        }
+      ]
+    }
+  ]
+}|} time_misspelled_cmd bin_size
+  in
+  print_endline json

--- a/tests/bench/dune
+++ b/tests/bench/dune
@@ -1,0 +1,3 @@
+(executable
+ (name bench)
+ (libraries unix))


### PR DESCRIPTION
Just a small simple benchmark inspired by https://github.com/ocaml/dune/pull/4507 and https://github.com/ocaml/dune/pull/5034 to test part of https://github.com/ocaml/opam/pull/5518

For now it only shows:
* The time that `opam sitch` (misspelled command) takes (see https://github.com/ocaml/opam/issues/5479)
* The size of the resulting opam binary

More benchmarks will be added later. This is the minimum required for other PRs to be merged as current-bench is currently failing without it.