### PR TITLE
Do not silently disable mccs if a C++ compiler is not present

### DIFF
--- a/configure
+++ b/configure
@@ -1421,6 +1421,7 @@ Optional Packages:
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --without-mccs          Compile without a built-in Cudf solver (only works
                           if 'mccs' is not otherwise installed)
+
   --without-0install-solver
                           Legacy option (does nothing)
 
@@ -4000,9 +4001,6 @@ fi
 if test ${with_mccs+y}
 then :
   withval=$with_mccs;
-else $as_nop
-  MCCS_DEFAULT=yes
-
 fi
 
 
@@ -7305,20 +7303,10 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
   if test -z "$CXX"
 then :
 
-    if test "x$MCCS_DEFAULT" = "xyes"
+    if test "x${enable_checks}" != "xno"
 then :
 
-      MCCS_ENABLED=false
-
-
-else $as_nop
-
-      if test "x${enable_checks}" != "xno"
-then :
-
-        as_fn_error $? "A C++ compiler is required to build mccs" "$LINENO" 5
-
-fi
+      as_fn_error $? "A C++ compiler is required to build mccs" "$LINENO" 5
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -61,7 +61,7 @@ AC_ARG_ENABLE([developer_mode],
 
 AC_ARG_WITH([mccs],
   AC_HELP_STRING([--without-mccs],
-                 [Compile without a built-in Cudf solver (only works if 'mccs' is not otherwise installed)]),[],[MCCS_DEFAULT=yes]
+                 [Compile without a built-in Cudf solver (only works if 'mccs' is not otherwise installed)])
 )
 AC_ARG_WITH([0install-solver],
   AC_HELP_STRING([--without-0install-solver],
@@ -372,12 +372,8 @@ AS_IF([test "x$MCCS_ENABLED" = "xtrue"],[
 AS_IF([test -n "$CXX"],[
   CHECK_CXX_WORKS
   AS_IF([test -z "$CXX"],[
-    AS_IF([test "x$MCCS_DEFAULT" = "xyes"],[
-      AC_SUBST(MCCS_ENABLED,false)
-    ],[
-      AS_IF([test "x${enable_checks}" != "xno"],[
-        AC_MSG_ERROR([A C++ compiler is required to build mccs])
-      ])
+    AS_IF([test "x${enable_checks}" != "xno"],[
+      AC_MSG_ERROR([A C++ compiler is required to build mccs])
     ])
   ])
 ])

--- a/master_changes.md
+++ b/master_changes.md
@@ -292,6 +292,7 @@ users)
   * Replace CPPO dependency with simple conditional compilation helper [#5498 @Leonidas-from-XIV]
   * Remove conditional compilation [#5508 @Leonidas-from-XIV]
   * Update msvs-detect [#5514 @MisterDA]
+  * Do not silently disable mccs if a C++ compiler is not present [#5527 @kit-ty-kate - fix #4452]
 
 ## Infrastructure
   * Fix caching of Cygwin compiler on AppVeyor [#4988 @dra27]


### PR DESCRIPTION
Fixes #4452
Fixes #5523
Extracted from #5525 