### PR TITLE
Ensure all make targets are run serially

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,3 +286,7 @@ cold: compiler
 
 cold-%:
 	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" CAML_LD_LIBRARY_PATH= $(MAKE) $*
+
+# Temorary fix to make sure all rules are run serially as in its current state
+# this Makefile does not support it
+.NOTPARALLEL:

--- a/master_changes.md
+++ b/master_changes.md
@@ -293,6 +293,7 @@ users)
   * Remove conditional compilation [#5508 @Leonidas-from-XIV]
   * Update msvs-detect [#5514 @MisterDA]
   * Do not silently disable mccs if a C++ compiler is not present [#5527 @kit-ty-kate - fix #4452]
+  * Ensure all make targets are run serially [#5532 @kit-ty-kate]
 
 ## Infrastructure
   * Fix caching of Cygwin compiler on AppVeyor [#4988 @dra27]


### PR DESCRIPTION
Having things like `MAKEFLAGS=-j8` in your environment makes most targets of the main makefile fail.

Failure encountered by @MisterDA 