### PR TITLE
Unset OPAM_SWITCH_PREFIX when using make cold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,8 +273,8 @@ src_ext/secondary/ocaml/bin/ocaml:
 	env MAKE=$(MAKE) BOOTSTRAP_EXTRA_OPTS="--disable-ocamldoc --disable-debug-runtime --disable-debugger" BOOTSTRAP_TARGETS="world opt" BOOTSTRAP_ROOT=../.. BOOTSTRAP_DIR=src_ext/secondary ./shell/bootstrap-ocaml.sh $(OCAML_PORT)
 
 cold: compiler
-	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" CAML_LD_LIBRARY_PATH= ./configure --with-vendored-deps --without-dune --enable-cold-check $(CONFIGURE_ARGS)
-	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" CAML_LD_LIBRARY_PATH= $(MAKE)
+	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" CAML_LD_LIBRARY_PATH= OPAM_SWITCH_PREFIX= ./configure --with-vendored-deps --without-dune --enable-cold-check $(CONFIGURE_ARGS)
+	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" CAML_LD_LIBRARY_PATH= OPAM_SWITCH_PREFIX= $(MAKE)
 
 cold-%:
 	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" CAML_LD_LIBRARY_PATH= $(MAKE) $*

--- a/master_changes.md
+++ b/master_changes.md
@@ -78,6 +78,7 @@ users)
 
 ## Build
  * Synchronise opam-core.opam with opam-repository changes [#6043 @dra27]
+  * Unset OPAM_SWITCH_PREFIX when using make cold [#5534 @kit-ty-kate]
 
 ## Infrastructure
 


### PR DESCRIPTION
Otherwise if for example `z3` is installed in your local switch `make cold` fails with:
```
Downloading vendored source dependencies...
done
Extracting vendored source dependencies in src_ext/... done
env PATH="`pwd`/bootstrap/ocaml/bin:$PATH" CAML_LD_LIBRARY_PATH= OCAML_TOPLEVEL_PATH= make
make[1]: Entering directory '/home/kit_ty_kate/work/opam'
src_ext/dune-local/dune.exe build --profile=release --root .  --promote-install-files -- opam-installer.install opam.install
File "src/solver/opamBuiltinZ3.ml", line 1:
Error: /home/kit_ty_kate/.opam/default/lib/z3/z3.cmi
       is not a compiled interface for this version of OCaml.
It seems to be for a newer version of OCaml.
make[1]: *** [Makefile:146: build-opam] Error 1
make[1]: Leaving directory '/home/kit_ty_kate/work/opam'
make: *** [Makefile:287: cold] Error 2
```