### PR TITLE
Better cygwin support in core 

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -621,7 +621,6 @@ users)
   * `OpamUpdate`: change `repository` output to update function option, to not write cache and new repo config if nothing changed in `repositories` [#5146 @rjbou]
   * Add `OpamPinned.version_opt` [#5325 @kit-ty-kate]
   * `OpamUpdate.download_package_source`: add SWH fallback when archive remain not found [#4859 @rjbou]
-
   * Add optional argument `?env:(variable_contents option Lazy.t * string) OpamVariable.Map.t` to `OpamSysPoll` and `OpamSysInteract` functions. It is used to get syspolling variables from the environment first. [#4892 @rjbou]
   * `OpamSwitchState`: move and reimplement `opam-solver` `dependencies` and `reverse_dependencies` [#5337 @rjbou]
   * `OpamEnv`: add `env_expansion` [#5352 @dra27]
@@ -634,6 +633,7 @@ users)
   * `OpamSysInteract`: add global config argument to function, in order to be able to retrieve system package manager path for MSYS2, and in the future Cygwin, etc. [#5433 @rjbou]
   * `OpamSwitchState.load`: fill empty switch synopsis with invariant formula instead of compiler package name [#5208 @rjbou]
   * `OpamSwitchState`: add `compiler_packages` that returns set of installed compilers, with their dependencies including only build & depopt [#5480 @rjbou]
+  * `OpamSysInteract.Cygwin`: add `cygbin_opt` to retrieve cygwin binary path from config file [#5543 @rjbou]
 
 ## opam-solver
   * `OpamCudf`: Change type of `conflict_case.Conflict_cycle` (`string list list` to `Cudf.package action list list`) and `cycle_conflict`, `string_of_explanations`, `conflict_explanations_raw` types accordingly [#4039 @gasche]

--- a/master_changes.md
+++ b/master_changes.md
@@ -731,3 +731,6 @@ users)
   * `OpamCoreConfig`: add `cygbin`, the cygwin install binary path [#5543 @rjbou]
   * `OpamStd.Env`: add `cyg_env` that returns the environment with PATH containing cygwin binary path [#5543 @rjbou]
   * `OpamCompat`: add `Filename.quote_command` [#5543 @rjbou]
+  * `OpamStd.Sys.get_windows_executable`: Add `cygbin` argument to pass cygwin binary path [#5543 @rjbou]
+  * `OpamStd.Sys.is_cygwin_variant`: returns a boolean [#5543 @rjbou]
+  * `OpamStd.Sys`: add `is_cygwin_cygcheck` anf `get_cygwin_variant` [#5543 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -634,6 +634,7 @@ users)
   * `OpamSwitchState.load`: fill empty switch synopsis with invariant formula instead of compiler package name [#5208 @rjbou]
   * `OpamSwitchState`: add `compiler_packages` that returns set of installed compilers, with their dependencies including only build & depopt [#5480 @rjbou]
   * `OpamSysInteract.Cygwin`: add `cygbin_opt` to retrieve cygwin binary path from config file [#5543 @rjbou]
+  * `OpamGlobalState.load`: Retrieve cygwin binary path from config to add it to opamCoreConfig.r.cygbin [#5543 @rjbou]
 
 ## opam-solver
   * `OpamCudf`: Change type of `conflict_case.Conflict_cycle` (`string list list` to `Cudf.package action list list`) and `cycle_conflict`, `string_of_explanations`, `conflict_explanations_raw` types accordingly [#4039 @gasche]

--- a/master_changes.md
+++ b/master_changes.md
@@ -734,3 +734,5 @@ users)
   * `OpamStd.Sys.get_windows_executable`: Add `cygbin` argument to pass cygwin binary path [#5543 @rjbou]
   * `OpamStd.Sys.is_cygwin_variant`: returns a boolean [#5543 @rjbou]
   * `OpamStd.Sys`: add `is_cygwin_cygcheck` anf `get_cygwin_variant` [#5543 @rjbou]
+  * `OpamProcess`: add `default_env` to retrieve environment, if cygwin is set, adds cygwin binary path to environment ; and use it instead of `Unix.environment` [#5543 @rjbou]
+

--- a/master_changes.md
+++ b/master_changes.md
@@ -730,3 +730,4 @@ users)
   * `OpamFilename`: add `with_open_out_bin` and `with_open_out_bin_atomic` [#5476 @dra27]
   * `OpamCoreConfig`: add `cygbin`, the cygwin install binary path [#5543 @rjbou]
   * `OpamStd.Env`: add `cyg_env` that returns the environment with PATH containing cygwin binary path [#5543 @rjbou]
+  * `OpamCompat`: add `Filename.quote_command` [#5543 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -726,3 +726,4 @@ users)
   * `OpamSWHID`: add module to handle swhid [#4859 @rjbou]
   * `OpamProcess`: expose the `command` type as a private type [#5452 @Leonidas-from-XIV]
   * `OpamFilename`: add `with_open_out_bin` and `with_open_out_bin_atomic` [#5476 @dra27]
+  * `OpamCoreConfig`: add `cygbin`, the cygwin install binary path [#5543 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -72,6 +72,7 @@ users)
     * ◈ Rename --with-tools` to `--with-dev-setup` [#5214 @rjbou - fix #4959]
   * Use the default criteria during reinstall/upgrade when requesting at least one non-installed package [#5228 @kit-ty-kate]
   * Show the reason for installing packages when using opam reinstall [#5229 @kit-ty-kate]
+  * When defined, add cygwin binary path to build environment [#5543 @rjbou]
 
 ## Remove
   *
@@ -589,6 +590,7 @@ users)
   * ✘ `OpamListCommand.apply_selector`, `string_of_selector`: change column name base to invariant, and the content is invariant formula installed dependencies [#5208 @rjbou]
   * `OpamSwitchCommand.install_compiler`: fill empty switch synopsis with invariant formula instead of compiler package name [#5208 @rjbou]
   * `OpamArg.opam_init`: retrieve cygwin binary path from config (low level reading) to add it to opamCoreConfig.r.cygbin [#5543 @rjbou]
+  * `OpamAction`: when defined, add cygwin binary path to build environment [#5543 @rjbou]
 
 ## opam-repository
   * `OpamRepositoryConfig`: add in config record `repo_tarring` field and as an argument to config functions, and a new constructor `REPOSITORYTARRING` in `E` environment module and its access function [#5015 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -729,3 +729,4 @@ users)
   * `OpamProcess`: expose the `command` type as a private type [#5452 @Leonidas-from-XIV]
   * `OpamFilename`: add `with_open_out_bin` and `with_open_out_bin_atomic` [#5476 @dra27]
   * `OpamCoreConfig`: add `cygbin`, the cygwin install binary path [#5543 @rjbou]
+  * `OpamStd.Env`: add `cyg_env` that returns the environment with PATH containing cygwin binary path [#5543 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -588,6 +588,7 @@ users)
   * `OpamListCommand`: add `swhid` in `info` printable fields and its handling in `details_printer`
   * ✘ `OpamListCommand.apply_selector`, `string_of_selector`: change column name base to invariant, and the content is invariant formula installed dependencies [#5208 @rjbou]
   * `OpamSwitchCommand.install_compiler`: fill empty switch synopsis with invariant formula instead of compiler package name [#5208 @rjbou]
+  * `OpamArg.opam_init`: retrieve cygwin binary path from config (low level reading) to add it to opamCoreConfig.r.cygbin [#5543 @rjbou]
 
 ## opam-repository
   * `OpamRepositoryConfig`: add in config record `repo_tarring` field and as an argument to config functions, and a new constructor `REPOSITORYTARRING` in `E` environment module and its access function [#5015 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -737,4 +737,4 @@ users)
   * `OpamStd.Sys.is_cygwin_variant`: returns a boolean [#5543 @rjbou]
   * `OpamStd.Sys`: add `is_cygwin_cygcheck` anf `get_cygwin_variant` [#5543 @rjbou]
   * `OpamProcess`: add `default_env` to retrieve environment, if cygwin is set, adds cygwin binary path to environment ; and use it instead of `Unix.environment` [#5543 @rjbou]
-
+  * `OpamProcess.apply_cygpath`: fix empty output [#5543 @rjbou]

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -524,6 +524,12 @@ let compilation_env t opam =
   let build_env =
     List.map (OpamEnv.env_expansion ~opam t) (OpamFile.OPAM.build_env opam)
   in
+  let cygwin_env =
+    match OpamSysInteract.Cygwin.cygbin_opt t.switch_global.config with
+    | Some cygbin ->
+      [ "PATH", EqPlus, OpamFilename.Dir.to_string cygbin, Some "Cygwin path" ]
+    | None -> []
+  in
   let scrub = OpamClientConfig.(!r.scrubbed_environment_variables) in
   OpamEnv.get_full ~scrub ~set_opamroot:true ~set_opamswitch:true
     ~force_path:true t ~updates:([
@@ -538,7 +544,8 @@ let compilation_env t opam =
       Some "build environment definition";
       "OPAMCLI", Eq, "2.0", Some "opam CLI version";
     ] @
-      build_env)
+      build_env
+      @ cygwin_env)
 
 let installed_opam_opt st nv =
   OpamStd.Option.Op.(

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -523,6 +523,7 @@ let apply_global_options cli o =
     ?confirm_level:o.confirm_level
     ?yes
     ?safe_mode:(flag o.safe_mode)
+    (* ?cygbin:string option *)
     (* ?lock_retries:int *)
     (* ?log_dir:OpamTypes.dirname *)
     (* ?keep_log_dir:bool *)

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -164,4 +164,5 @@ val opam_init:
   ?errlog_length:int ->
   ?merged_output:bool ->
   ?precise_tracking:bool ->
+  ?cygbin:string ->
   unit -> unit

--- a/src/core/opamCompat.ml
+++ b/src/core/opamCompat.ml
@@ -57,3 +57,93 @@ module Lazy = struct
 
   include Stdlib.Lazy
 end
+
+module Filename = struct
+  [@@@warning "-32"]
+
+  let quote s =
+    let l = String.length s in
+    let b = Buffer.create (l + 20) in
+    Buffer.add_char b '\"';
+    let rec loop i =
+      if i = l then Buffer.add_char b '\"' else
+      match s.[i] with
+      | '\"' -> loop_bs 0 i;
+      | '\\' -> loop_bs 0 i;
+      | c    -> Buffer.add_char b c; loop (i+1);
+    and loop_bs n i =
+      if i = l then begin
+        Buffer.add_char b '\"';
+        add_bs n;
+      end else begin
+        match s.[i] with
+        | '\"' -> add_bs (2*n+1); Buffer.add_char b '\"'; loop (i+1);
+        | '\\' -> loop_bs (n+1) (i+1);
+        | _    -> add_bs n; loop i
+      end
+    and add_bs n = for _j = 1 to n do Buffer.add_char b '\\'; done
+    in
+    loop 0;
+    Buffer.contents b
+
+(*
+Quoting commands for execution by cmd.exe is difficult.
+1- Each argument is first quoted using the "quote" function above, to
+   protect it against the processing performed by the C runtime system,
+   then cmd.exe's special characters are escaped with '^', using
+   the "quote_cmd" function below.  For more details, see
+   https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23
+2- The command and the redirection files, if any, must be double-quoted
+   in case they contain spaces.  This quoting is interpreted by cmd.exe,
+   not by the C runtime system, hence the "quote" function above
+   cannot be used.  The two characters we don't know how to quote
+   inside a double-quoted cmd.exe string are double-quote and percent.
+   We just fail if the command name or the redirection file names
+   contain a double quote (not allowed in Windows file names, anyway)
+   or a percent.  See function "quote_cmd_filename" below.
+3- The whole string passed to Sys.command is then enclosed in double
+   quotes, which are immediately stripped by cmd.exe.  Otherwise,
+   some of the double quotes from step 2 above can be misparsed.
+   See e.g. https://stackoverflow.com/a/9965141
+*)
+  let quote_cmd s =
+    let b = Buffer.create (String.length s + 20) in
+    String.iter
+      (fun c ->
+         match c with
+         | '(' | ')' | '!' | '^' | '%' | '\"' | '<' | '>' | '&' | '|' ->
+           Buffer.add_char b '^'; Buffer.add_char b c
+         | _ ->
+           Buffer.add_char b c)
+      s;
+    Buffer.contents b
+
+  let quote_cmd_filename f =
+    if String.contains f '\"' || String.contains f '%' then
+      failwith ("Filename.quote_command: bad file name " ^ f)
+    else if String.contains f ' ' then
+      "\"" ^ f ^ "\""
+    else
+      f
+  (* Redirections in cmd.exe: see https://ss64.com/nt/syntax-redirection.html
+     and https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-xp/bb490982(v=technet.10)
+  *)
+
+  (** NOTE: OCaml >= 4.10 *)
+  let quote_command cmd ?stdin ?stdout ?stderr args =
+    String.concat "" [
+      "\"";
+      quote_cmd_filename cmd;
+      " ";
+      quote_cmd (String.concat " " (List.map quote args));
+      (match stdin  with None -> "" | Some f -> " <" ^ quote_cmd_filename f);
+      (match stdout with None -> "" | Some f -> " >" ^ quote_cmd_filename f);
+      (match stderr with None -> "" | Some f ->
+          if stderr = stdout
+          then " 2>&1"
+          else " 2>" ^ quote_cmd_filename f);
+      "\""
+    ]
+
+  include Stdlib.Filename
+end

--- a/src/core/opamCompat.mli
+++ b/src/core/opamCompat.mli
@@ -30,3 +30,11 @@ module Unix : sig
      implementation with double chdir otherwise *)
   val realpath: string -> string
 end
+
+module Filename: sig
+  (** NOTE: OCaml >= 4.10 *)
+
+  val quote_command :
+    string -> ?stdin:string -> ?stdout:string -> ?stderr:string
+    -> string list -> string
+end

--- a/src/core/opamCoreConfig.ml
+++ b/src/core/opamCoreConfig.ml
@@ -63,6 +63,7 @@ type t = {
   errlog_length: int;
   merged_output: bool;
   precise_tracking: bool;
+  cygbin: string option;
   set: bool;
 }
 
@@ -81,6 +82,7 @@ type 'a options_fun =
   ?errlog_length:int ->
   ?merged_output:bool ->
   ?precise_tracking:bool ->
+  ?cygbin:string ->
   'a
 
 let default = {
@@ -101,6 +103,7 @@ let default = {
   errlog_length = 12;
   merged_output = true;
   precise_tracking = false;
+  cygbin = None;
   set = false;
 }
 
@@ -119,6 +122,7 @@ let setk k t
     ?errlog_length
     ?merged_output
     ?precise_tracking
+    ?cygbin
   =
   let (+) x opt = match opt with Some x -> x | None -> x in
   k {
@@ -139,6 +143,7 @@ let setk k t
     errlog_length = t.errlog_length + errlog_length;
     merged_output = t.merged_output + merged_output;
     precise_tracking = t.precise_tracking + precise_tracking;
+    cygbin = (match cygbin with Some _ -> cygbin | None -> t.cygbin);
     set = true;
   }
 
@@ -179,6 +184,7 @@ let initk k =
     ?errlog_length:(E.errloglen ())
     ?merged_output:(E.mergeout ())
     ?precise_tracking:(E.precisetracking ())
+    ?cygbin:None
 
 let init ?noop:_ = initk (fun () -> ())
 

--- a/src/core/opamCoreConfig.mli
+++ b/src/core/opamCoreConfig.mli
@@ -71,6 +71,7 @@ type t = private {
   precise_tracking : bool;
   (** If set, will take full md5 of all files when checking diffs (to track
       installations), rather than rely on just file size and mtime *)
+  cygbin: string option;
   set : bool;
   (** Options have not yet been initialised (i.e. defaults are active) *)
 }
@@ -90,6 +91,7 @@ type 'a options_fun =
   ?errlog_length:int ->
   ?merged_output:bool ->
   ?precise_tracking:bool ->
+  ?cygbin:string ->
   'a
 
 val default : t

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -180,8 +180,7 @@ let cygwin_create_process_env prog args env fd1 fd2 fd3 =
                 List.rev_append prefix (dir::(List.rev_append suffix dirs))
               end else
                 f prefix (dir::suffix) dirs
-        | [] ->
-            assert false
+        | [] -> []
         in
         Some (key ^ "=" ^ String.concat ";" (f [] [] path_dirs))
     | _ ->

--- a/src/core/opamProcess.mli
+++ b/src/core/opamProcess.mli
@@ -232,3 +232,5 @@ val create_process_env :
   string -> string array -> string array ->
   Unix.file_descr -> Unix.file_descr -> Unix.file_descr ->
   int
+
+val default_env : unit -> string array

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1228,58 +1228,72 @@ module OpamSys = struct
   let get_windows_executable_variant =
     if Sys.win32 then
       let results = Hashtbl.create 17 in
-      let requires_cygwin name =
-        let cmd = Printf.sprintf "cygcheck \"%s\"" name in
-        let ((c, _, _) as process) = Unix.open_process_full cmd (Unix.environment ()) in
-        let rec f a =
+      let requires_cygwin cygcheck name =
+        let env = Env.cyg_env (Filename.dirname cygcheck) in
+        let cmd = OpamCompat.Filename.quote_command cygcheck [name] in
+        let ((c, _, _) as process) = Unix.open_process_full cmd env in
+        let rec check_dll platform =
           match input_line c with
-          | x ->
-            let tx = String.trim x in
-            if OpamString.ends_with ~suffix:"cygwin1.dll" tx then
-              if OpamString.starts_with ~prefix:"  " x then
-                f `Cygwin
-              else if a = `Native then
-                f (`Tainted `Cygwin)
+          | dll ->
+            let tdll = (*String.trim*) dll in
+            if OpamString.ends_with ~suffix:"cygwin1.dll" tdll then
+              if OpamString.starts_with ~prefix:"  " dll then
+                check_dll `Cygwin
+              else if platform = `Native then
+                check_dll (`Tainted `Cygwin)
               else
-                f a
-            else if OpamString.ends_with ~suffix:"msys-2.0.dll" tx then
-              if OpamString.starts_with ~prefix:"  " x then
-                f `Msys2
-              else if a = `Native then
-                f (`Tainted `Msys2)
+                check_dll platform
+            else if OpamString.ends_with ~suffix:"msys-2.0.dll" tdll then
+              if OpamString.starts_with ~prefix:"  " dll then
+                check_dll `Msys2
+              else if platform = `Native then
+                check_dll (`Tainted `Msys2)
               else
-                f a
+                check_dll platform
             else
-              f a
+              check_dll platform
           | exception e ->
-              Unix.close_process_full process |> ignore;
-              fatal e;
-              a
+            Unix.close_process_full process |> ignore;
+            fatal e;
+            platform
         in
-        f `Native
+        check_dll `Native
       in
-      fun name ->
-        if Filename.is_relative name then
-          requires_cygwin name
-        else
-          try
-            Hashtbl.find results name
-          with Not_found ->
-            let result = requires_cygwin name
-            in
-              Hashtbl.add results name result;
-              result
+      fun ~cygbin name ->
+        match cygbin with
+        | Some cygbin ->
+          (let cygcheck = Filename.concat cygbin "cygcheck.exe" in
+           if Filename.is_relative name then
+             requires_cygwin cygcheck name
+           else
+           try Hashtbl.find results (cygcheck, name)
+           with Not_found ->
+             let result = requires_cygwin cygcheck name in
+             Hashtbl.add results (cygcheck, name) result;
+             result)
+        | None -> `Native
     else
-      fun _ -> `Native
+    fun ~cygbin:_ _ -> `Native
 
-  let is_cygwin_variant cmd =
+  let is_cygwin_cygcheck ~cygbin =
+    match cygbin with
+    | Some cygbin ->
+      let cygpath = Filename.concat cygbin "cygpath.exe" in
+      Sys.file_exists cygpath
+      && (get_windows_executable_variant ~cygbin:(Some cygbin) cygpath = `Cygwin)
+    | None -> false
+
+  let get_cygwin_variant ~cygbin cmd =
     (* Treat MSYS2's variant of `cygwin1.dll` called `msys-2.0.dll` equivalently.
        Confer https://www.msys2.org/wiki/How-does-MSYS2-differ-from-Cygwin/ *)
-    match get_windows_executable_variant cmd with
+    match get_windows_executable_variant ~cygbin cmd with
     | `Native -> `Native
     | `Cygwin
     | `Msys2 -> `Cygwin
     | `Tainted _ -> `CygLinked
+
+  let is_cygwin_variant ~cygbin cmd =
+    get_cygwin_variant ~cygbin cmd = `Cygwin
 
   exception Exit of int
   exception Exec of string * string array * string array

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -455,6 +455,8 @@ module Env : sig
   val getopt_full: Name.t -> Name.t * string option
 
   val list: unit -> (Name.t * string) list
+  val raw_env: unit -> string Array.t
+  val cyg_env: string -> string Array.t
 end
 
 (** {2 System query and exit handling} *)

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -535,10 +535,15 @@ module Sys : sig
 
       Note that this returns [`Native] on a Cygwin-build of opam!
 
-      Both cygcheck and an unqualified command will be resolved using the
-      current PATH. *)
-  val get_windows_executable_variant:
+      Both cygcheck and an unqualified command will be resolved if necessary
+      using the current PATH. *)
+  val get_windows_executable_variant: cygbin:string option ->
     string -> [ `Native | `Cygwin | `Tainted of [ `Msys2 | `Cygwin] | `Msys2 ]
+
+  (** Determines if cygcheck in given cygwin binary directory comes from a
+      Cygwin or MSYS2 installation. Determined by analysing the cygpath command
+      found with it. *)
+  val is_cygwin_cygcheck : cygbin:string option -> bool
 
   (** For native Windows builds, returns [`Cygwin] if the command is a Cygwin-
       or Msys2- compiled executable, and [`CygLinked] if the command links to a
@@ -548,7 +553,10 @@ module Sys : sig
 
       Both cygcheck and an unqualified command will be resolved using the
       current PATH. *)
-  val is_cygwin_variant: string -> [ `Native | `Cygwin | `CygLinked ]
+  val get_cygwin_variant: cygbin:string option -> string -> [ `Native | `Cygwin | `CygLinked ]
+
+  (** Returns true if [get_cygwin_variant] is [`Cygwin] *)
+  val is_cygwin_variant: cygbin:string option -> string -> bool
 
   (** {3 Exit handling} *)
 

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -401,11 +401,6 @@ let real_path p =
 
 type command = string list
 
-let default_env () =
-  (OpamStd.Env.list () :> (string * string) list)
-    |> List.map (fun (var, v) -> var^"="^v)
-    |> Array.of_list
-
 let env_var env var =
   let len = Array.length env in
   let f = if Sys.win32 then String.uppercase_ascii else fun x -> x in
@@ -506,7 +501,7 @@ let t_resolve_command =
         `Denied
   in
   fun ?env ?dir name ->
-    let env = match env with None -> default_env () | Some e -> e in
+    let env = match env with None -> OpamProcess.default_env () | Some e -> e in
     resolve env ?dir name
 
 let resolve_command ?env ?dir name =
@@ -577,7 +572,7 @@ let make_command
     ?verbose ?env ?name ?text ?metadata ?allow_stdin ?stdout
     ?dir ?(resolve_path=true)
     cmd args =
-  let env = match env with None -> default_env () | Some e -> e in
+  let env = match env with None -> OpamProcess.default_env () | Some e -> e in
   let name = log_file name in
   let verbose =
     OpamStd.Option.default OpamCoreConfig.(!r.verbose_level >= 2) verbose
@@ -599,7 +594,7 @@ let make_command
 
 let run_process
     ?verbose ?env ~name ?metadata ?stdout ?allow_stdin command =
-  let env = match env with None -> default_env () | Some e -> e in
+  let env = match env with None -> OpamProcess.default_env () | Some e -> e in
   let chrono = OpamConsole.timer () in
   runs := command :: !runs;
   match command with

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -38,6 +38,10 @@ let load_config lock_kind global_lock root =
   let config =
     OpamFormatUpgrade.as_necessary lock_kind global_lock root config
   in
+  OpamStd.Option.iter
+    (fun cygbin ->
+       OpamCoreConfig.update ~cygbin:(OpamFilename.Dir.to_string cygbin) ())
+    (OpamSysInteract.Cygwin.cygbin_opt (fst config));
   config
 
 let inferred_from_system = "Inferred from system"

--- a/src/state/opamSysInteract.mli
+++ b/src/state/opamSysInteract.mli
@@ -39,3 +39,11 @@ val package_manager_name: ?env:gt_variables -> OpamFile.Config.t -> string
    Presently used to check for epel-release on CentOS and RHEL.
    [env] is used to determine host specification. *)
 val repo_enablers: ?env:gt_variables -> OpamFile.Config.t -> string option
+
+
+module Cygwin : sig
+
+  (* Return Cygwin binary path *)
+  val cygbin_opt: OpamFile.Config.t -> OpamFilename.Dir.t option
+
+end


### PR DESCRIPTION
* At `opam_init` and global state loading, update internal configuration to retrieve cygwin binary path and store it in configuration (`OpamCoreConfig`)
* When defined, add cygwin binary path to build environment

### TODO
* [x] queued on #5542