### PR TITLE
init: detect local cygwin installation

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -202,6 +202,7 @@ users)
 
 ## External dependencies
   * Depexts support Cygwin on Windows [#5542 @rjbou]
+    * Default location of setup.exe is now `<opamroot>/.cygwin/setup-x86_64.exe` [#5544 @rjbou]
   * Support MSYS2 on Windows for depexts [#5348 @jonahbeckford #5433 @rjbou]
   * Set `DEBIAN_FRONTEND=noninteractive` for unsafe-yes confirmation level [#4735 @dra27 - partially fix #4731] [2.1.0~rc2 #4739]
   * Fix depext alpine tagged repositories handling [#4763 @rjbou] [2.1.0~rc2 #4758]

--- a/master_changes.md
+++ b/master_changes.md
@@ -752,4 +752,4 @@ users)
   * `OpamStd.Sys.is_cygwin_variant`: returns a boolean [#5543 @rjbou]
   * `OpamStd.Sys`: add `is_cygwin_cygcheck` anf `get_cygwin_variant` [#5543 @rjbou]
   * `OpamProcess`: add `default_env` to retrieve environment, if cygwin is set, adds cygwin binary path to environment ; and use it instead of `Unix.environment` [#5543 @rjbou]
-
+  * `OpamProcess.apply_cygpath`: fix empty output [#5543 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -746,3 +746,6 @@ users)
   * `OpamCoreConfig`: add `cygbin`, the cygwin install binary path [#5543 @rjbou]
   * `OpamStd.Env`: add `cyg_env` that returns the environment with PATH containing cygwin binary path [#5543 @rjbou]
   * `OpamCompat`: add `Filename.quote_command` [#5543 @rjbou]
+  * `OpamStd.Sys.get_windows_executable`: Add `cygbin` argument to pass cygwin binary path [#5543 @rjbou]
+  * `OpamStd.Sys.is_cygwin_variant`: returns a boolean [#5543 @rjbou]
+  * `OpamStd.Sys`: add `is_cygwin_cygcheck` anf `get_cygwin_variant` [#5543 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -749,3 +749,5 @@ users)
   * `OpamStd.Sys.get_windows_executable`: Add `cygbin` argument to pass cygwin binary path [#5543 @rjbou]
   * `OpamStd.Sys.is_cygwin_variant`: returns a boolean [#5543 @rjbou]
   * `OpamStd.Sys`: add `is_cygwin_cygcheck` anf `get_cygwin_variant` [#5543 @rjbou]
+  * `OpamProcess`: add `default_env` to retrieve environment, if cygwin is set, adds cygwin binary path to environment ; and use it instead of `Unix.environment` [#5543 @rjbou]
+

--- a/master_changes.md
+++ b/master_changes.md
@@ -741,3 +741,4 @@ users)
   * `OpamStd.Sys`: add `SH_pwsh`, `SH_win_cmd` and `SH_win_powershell` to `shell` type [#4816 @jonahbeckford]
     * unify powershell variant: `SH_win_powershell` and `SH_pwsh` to `SH_pwsh of powershell_host` [#5203 @dra27]
     * change `SH_win_cmd` into `SH_cmd` [#5541 @dra27]
+  * `OpamCoreConfig`: add `cygbin`, the cygwin install binary path [#5543 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -651,6 +651,9 @@ users)
   * `OpamEnv`: add handling of `SH_pwsh` and `SH_cmd` in shell lists [#5541 @dra27]
   * `OpamSysInteract.Cygwin`: add `cygbin_opt` to retrieve cygwin binary path from config file [#5543 @rjbou]
   * `OpamGlobalState.load`: Retrieve cygwin binary path from config to add it to opamCoreConfig.r.cygbin [#5543 @rjbou]
+  * `OpamSysInteract.Cygwin`: add `check_install` to check that a given path is a cygwin installation, regarding presence of `cygcheck.exe` [#5544 @rjbou @dra27]
+  * `OpamSysInteract.Cygwin`: add `check_setup` to check, copy or download a cygwin setup.exe [#5544 @rjbou]
+
 
 ## opam-solver
   * `OpamCudf`: Change type of `conflict_case.Conflict_cycle` (`string list list` to `Cudf.package action list list`) and `cycle_conflict`, `string_of_explanations`, `conflict_explanations_raw` types accordingly [#4039 @gasche]

--- a/master_changes.md
+++ b/master_changes.md
@@ -745,3 +745,4 @@ users)
     * change `SH_win_cmd` into `SH_cmd` [#5541 @dra27]
   * `OpamCoreConfig`: add `cygbin`, the cygwin install binary path [#5543 @rjbou]
   * `OpamStd.Env`: add `cyg_env` that returns the environment with PATH containing cygwin binary path [#5543 @rjbou]
+  * `OpamCompat`: add `Filename.quote_command` [#5543 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -50,6 +50,7 @@ users)
   * Surround and add a comment describing the role of the lines added to the ~/.profile or equivalent [#5456 @kit-ty-kate]
   * Don't require cc on Windows [#5541 @dra27]
   * Generate init and variables for Windows [#5541 @dra27]
+  * On Windows, ask for pre-existent Cygwin installation, check it, and configure opam with it [#5544 @dra27 @rjbou]
 
 ## Config report
   * [BUG] Don't fail is no switch is set [#5198 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -597,6 +597,7 @@ users)
   * `OpamListCommand`: add `swhid` in `info` printable fields and its handling in `details_printer`
   * ✘ `OpamListCommand.apply_selector`, `string_of_selector`: change column name base to invariant, and the content is invariant formula installed dependencies [#5208 @rjbou]
   * `OpamSwitchCommand.install_compiler`: fill empty switch synopsis with invariant formula instead of compiler package name [#5208 @rjbou]
+  * `OpamArg.opam_init`: retrieve cygwin binary path from config (low level reading) to add it to opamCoreConfig.r.cygbin [#5543 @rjbou]
 
 ## opam-repository
   * `OpamRepositoryConfig`: add in config record `repo_tarring` field and as an argument to config functions, and a new constructor `REPOSITORYTARRING` in `E` environment module and its access function [#5015 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -646,6 +646,7 @@ users)
   * `OpamEnv`: generalise splitting of environment variables [#5541 @dra27]
   * `OpamEnv`: add handling of `SH_pwsh` and `SH_cmd` in shell lists [#5541 @dra27]
   * `OpamSysInteract.Cygwin`: add `cygbin_opt` to retrieve cygwin binary path from config file [#5543 @rjbou]
+  * `OpamGlobalState.load`: Retrieve cygwin binary path from config to add it to opamCoreConfig.r.cygbin [#5543 @rjbou]
 
 ## opam-solver
   * `OpamCudf`: Change type of `conflict_case.Conflict_cycle` (`string list list` to `Cudf.package action list list`) and `cycle_conflict`, `string_of_explanations`, `conflict_explanations_raw` types accordingly [#4039 @gasche]

--- a/master_changes.md
+++ b/master_changes.md
@@ -631,7 +631,6 @@ users)
   * `OpamUpdate`: change `repository` output to update function option, to not write cache and new repo config if nothing changed in `repositories` [#5146 @rjbou]
   * Add `OpamPinned.version_opt` [#5325 @kit-ty-kate]
   * `OpamUpdate.download_package_source`: add SWH fallback when archive remain not found [#4859 @rjbou]
-
   * Add optional argument `?env:(variable_contents option Lazy.t * string) OpamVariable.Map.t` to `OpamSysPoll` and `OpamSysInteract` functions. It is used to get syspolling variables from the environment first. [#4892 @rjbou]
   * `OpamSwitchState`: move and reimplement `opam-solver` `dependencies` and `reverse_dependencies` [#5337 @rjbou]
   * `OpamEnv`: add `env_expansion` [#5352 @dra27]
@@ -646,6 +645,7 @@ users)
   * `OpamSwitchState`: add `compiler_packages` that returns set of installed compilers, with their dependencies including only build & depopt [#5480 @rjbou]
   * `OpamEnv`: generalise splitting of environment variables [#5541 @dra27]
   * `OpamEnv`: add handling of `SH_pwsh` and `SH_cmd` in shell lists [#5541 @dra27]
+  * `OpamSysInteract.Cygwin`: add `cygbin_opt` to retrieve cygwin binary path from config file [#5543 @rjbou]
 
 ## opam-solver
   * `OpamCudf`: Change type of `conflict_case.Conflict_cycle` (`string list list` to `Cudf.package action list list`) and `cycle_conflict`, `string_of_explanations`, `conflict_explanations_raw` types accordingly [#4039 @gasche]

--- a/master_changes.md
+++ b/master_changes.md
@@ -744,3 +744,4 @@ users)
     * unify powershell variant: `SH_win_powershell` and `SH_pwsh` to `SH_pwsh of powershell_host` [#5203 @dra27]
     * change `SH_win_cmd` into `SH_cmd` [#5541 @dra27]
   * `OpamCoreConfig`: add `cygbin`, the cygwin install binary path [#5543 @rjbou]
+  * `OpamStd.Env`: add `cyg_env` that returns the environment with PATH containing cygwin binary path [#5543 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -74,6 +74,7 @@ users)
     * ◈ Rename --with-tools` to `--with-dev-setup` [#5214 @rjbou - fix #4959]
   * Use the default criteria during reinstall/upgrade when requesting at least one non-installed package [#5228 @kit-ty-kate]
   * Show the reason for installing packages when using opam reinstall [#5229 @kit-ty-kate]
+  * When defined, add cygwin binary path to build environment [#5543 @rjbou]
 
 ## Remove
   *
@@ -598,6 +599,7 @@ users)
   * ✘ `OpamListCommand.apply_selector`, `string_of_selector`: change column name base to invariant, and the content is invariant formula installed dependencies [#5208 @rjbou]
   * `OpamSwitchCommand.install_compiler`: fill empty switch synopsis with invariant formula instead of compiler package name [#5208 @rjbou]
   * `OpamArg.opam_init`: retrieve cygwin binary path from config (low level reading) to add it to opamCoreConfig.r.cygbin [#5543 @rjbou]
+  * `OpamAction`: when defined, add cygwin binary path to build environment [#5543 @rjbou]
 
 ## opam-repository
   * `OpamRepositoryConfig`: add in config record `repo_tarring` field and as an argument to config functions, and a new constructor `REPOSITORYTARRING` in `E` environment module and its access function [#5015 @rjbou]

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -524,6 +524,12 @@ let compilation_env t opam =
   let build_env =
     List.map (OpamEnv.env_expansion ~opam t) (OpamFile.OPAM.build_env opam)
   in
+  let cygwin_env =
+    match OpamSysInteract.Cygwin.cygbin_opt t.switch_global.config with
+    | Some cygbin ->
+      [ "PATH", EqPlus, OpamFilename.Dir.to_string cygbin, Some "Cygwin path" ]
+    | None -> []
+  in
   let scrub = OpamClientConfig.(!r.scrubbed_environment_variables) in
   OpamEnv.get_full ~scrub ~set_opamroot:true ~set_opamswitch:true
     ~force_path:true t ~updates:([
@@ -538,7 +544,8 @@ let compilation_env t opam =
       Some "build environment definition";
       "OPAMCLI", Eq, "2.0", Some "opam CLI version";
     ] @
-      build_env)
+      build_env
+      @ cygwin_env)
 
 let installed_opam_opt st nv =
   OpamStd.Option.Op.(

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -523,6 +523,7 @@ let apply_global_options cli o =
     ?confirm_level:o.confirm_level
     ?yes
     ?safe_mode:(flag o.safe_mode)
+    (* ?cygbin:string option *)
     (* ?lock_retries:int *)
     (* ?log_dir:OpamTypes.dirname *)
     (* ?keep_log_dir:bool *)

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -164,4 +164,5 @@ val opam_init:
   ?errlog_length:int ->
   ?merged_output:bool ->
   ?precise_tracking:bool ->
+  ?cygbin:string ->
   unit -> unit

--- a/src/core/opamCompat.ml
+++ b/src/core/opamCompat.ml
@@ -57,3 +57,93 @@ module Lazy = struct
 
   include Stdlib.Lazy
 end
+
+module Filename = struct
+  [@@@warning "-32"]
+
+  let quote s =
+    let l = String.length s in
+    let b = Buffer.create (l + 20) in
+    Buffer.add_char b '\"';
+    let rec loop i =
+      if i = l then Buffer.add_char b '\"' else
+      match s.[i] with
+      | '\"' -> loop_bs 0 i;
+      | '\\' -> loop_bs 0 i;
+      | c    -> Buffer.add_char b c; loop (i+1);
+    and loop_bs n i =
+      if i = l then begin
+        Buffer.add_char b '\"';
+        add_bs n;
+      end else begin
+        match s.[i] with
+        | '\"' -> add_bs (2*n+1); Buffer.add_char b '\"'; loop (i+1);
+        | '\\' -> loop_bs (n+1) (i+1);
+        | _    -> add_bs n; loop i
+      end
+    and add_bs n = for _j = 1 to n do Buffer.add_char b '\\'; done
+    in
+    loop 0;
+    Buffer.contents b
+
+(*
+Quoting commands for execution by cmd.exe is difficult.
+1- Each argument is first quoted using the "quote" function above, to
+   protect it against the processing performed by the C runtime system,
+   then cmd.exe's special characters are escaped with '^', using
+   the "quote_cmd" function below.  For more details, see
+   https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23
+2- The command and the redirection files, if any, must be double-quoted
+   in case they contain spaces.  This quoting is interpreted by cmd.exe,
+   not by the C runtime system, hence the "quote" function above
+   cannot be used.  The two characters we don't know how to quote
+   inside a double-quoted cmd.exe string are double-quote and percent.
+   We just fail if the command name or the redirection file names
+   contain a double quote (not allowed in Windows file names, anyway)
+   or a percent.  See function "quote_cmd_filename" below.
+3- The whole string passed to Sys.command is then enclosed in double
+   quotes, which are immediately stripped by cmd.exe.  Otherwise,
+   some of the double quotes from step 2 above can be misparsed.
+   See e.g. https://stackoverflow.com/a/9965141
+*)
+  let quote_cmd s =
+    let b = Buffer.create (String.length s + 20) in
+    String.iter
+      (fun c ->
+         match c with
+         | '(' | ')' | '!' | '^' | '%' | '\"' | '<' | '>' | '&' | '|' ->
+           Buffer.add_char b '^'; Buffer.add_char b c
+         | _ ->
+           Buffer.add_char b c)
+      s;
+    Buffer.contents b
+
+  let quote_cmd_filename f =
+    if String.contains f '\"' || String.contains f '%' then
+      failwith ("Filename.quote_command: bad file name " ^ f)
+    else if String.contains f ' ' then
+      "\"" ^ f ^ "\""
+    else
+      f
+  (* Redirections in cmd.exe: see https://ss64.com/nt/syntax-redirection.html
+     and https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-xp/bb490982(v=technet.10)
+  *)
+
+  (** NOTE: OCaml >= 4.10 *)
+  let quote_command cmd ?stdin ?stdout ?stderr args =
+    String.concat "" [
+      "\"";
+      quote_cmd_filename cmd;
+      " ";
+      quote_cmd (String.concat " " (List.map quote args));
+      (match stdin  with None -> "" | Some f -> " <" ^ quote_cmd_filename f);
+      (match stdout with None -> "" | Some f -> " >" ^ quote_cmd_filename f);
+      (match stderr with None -> "" | Some f ->
+          if stderr = stdout
+          then " 2>&1"
+          else " 2>" ^ quote_cmd_filename f);
+      "\""
+    ]
+
+  include Stdlib.Filename
+end

--- a/src/core/opamCompat.mli
+++ b/src/core/opamCompat.mli
@@ -30,3 +30,11 @@ module Unix : sig
      implementation with double chdir otherwise *)
   val realpath: string -> string
 end
+
+module Filename: sig
+  (** NOTE: OCaml >= 4.10 *)
+
+  val quote_command :
+    string -> ?stdin:string -> ?stdout:string -> ?stderr:string
+    -> string list -> string
+end

--- a/src/core/opamCoreConfig.ml
+++ b/src/core/opamCoreConfig.ml
@@ -63,6 +63,7 @@ type t = {
   errlog_length: int;
   merged_output: bool;
   precise_tracking: bool;
+  cygbin: string option;
   set: bool;
 }
 
@@ -81,6 +82,7 @@ type 'a options_fun =
   ?errlog_length:int ->
   ?merged_output:bool ->
   ?precise_tracking:bool ->
+  ?cygbin:string ->
   'a
 
 let default = {
@@ -101,6 +103,7 @@ let default = {
   errlog_length = 12;
   merged_output = true;
   precise_tracking = false;
+  cygbin = None;
   set = false;
 }
 
@@ -119,6 +122,7 @@ let setk k t
     ?errlog_length
     ?merged_output
     ?precise_tracking
+    ?cygbin
   =
   let (+) x opt = match opt with Some x -> x | None -> x in
   k {
@@ -139,6 +143,7 @@ let setk k t
     errlog_length = t.errlog_length + errlog_length;
     merged_output = t.merged_output + merged_output;
     precise_tracking = t.precise_tracking + precise_tracking;
+    cygbin = (match cygbin with Some _ -> cygbin | None -> t.cygbin);
     set = true;
   }
 
@@ -179,6 +184,7 @@ let initk k =
     ?errlog_length:(E.errloglen ())
     ?merged_output:(E.mergeout ())
     ?precise_tracking:(E.precisetracking ())
+    ?cygbin:None
 
 let init ?noop:_ = initk (fun () -> ())
 

--- a/src/core/opamCoreConfig.mli
+++ b/src/core/opamCoreConfig.mli
@@ -71,6 +71,7 @@ type t = private {
   precise_tracking : bool;
   (** If set, will take full md5 of all files when checking diffs (to track
       installations), rather than rely on just file size and mtime *)
+  cygbin: string option;
   set : bool;
   (** Options have not yet been initialised (i.e. defaults are active) *)
 }
@@ -90,6 +91,7 @@ type 'a options_fun =
   ?errlog_length:int ->
   ?merged_output:bool ->
   ?precise_tracking:bool ->
+  ?cygbin:string ->
   'a
 
 val default : t

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -180,8 +180,7 @@ let cygwin_create_process_env prog args env fd1 fd2 fd3 =
                 List.rev_append prefix (dir::(List.rev_append suffix dirs))
               end else
                 f prefix (dir::suffix) dirs
-        | [] ->
-            assert false
+        | [] -> []
         in
         Some (key ^ "=" ^ String.concat ";" (f [] [] path_dirs))
     | _ ->

--- a/src/core/opamProcess.mli
+++ b/src/core/opamProcess.mli
@@ -232,3 +232,5 @@ val create_process_env :
   string -> string array -> string array ->
   Unix.file_descr -> Unix.file_descr -> Unix.file_descr ->
   int
+
+val default_env : unit -> string array

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -455,6 +455,8 @@ module Env : sig
   val getopt_full: Name.t -> Name.t * string option
 
   val list: unit -> (Name.t * string) list
+  val raw_env: unit -> string Array.t
+  val cyg_env: string -> string Array.t
 end
 
 (** {2 System query and exit handling} *)

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -536,10 +536,15 @@ module Sys : sig
 
       Note that this returns [`Native] on a Cygwin-build of opam!
 
-      Both cygcheck and an unqualified command will be resolved using the
-      current PATH. *)
-  val get_windows_executable_variant:
+      Both cygcheck and an unqualified command will be resolved if necessary
+      using the current PATH. *)
+  val get_windows_executable_variant: cygbin:string option ->
     string -> [ `Native | `Cygwin | `Tainted of [ `Msys2 | `Cygwin] | `Msys2 ]
+
+  (** Determines if cygcheck in given cygwin binary directory comes from a
+      Cygwin or MSYS2 installation. Determined by analysing the cygpath command
+      found with it. *)
+  val is_cygwin_cygcheck : cygbin:string option -> bool
 
   (** For native Windows builds, returns [`Cygwin] if the command is a Cygwin-
       or Msys2- compiled executable, and [`CygLinked] if the command links to a
@@ -549,7 +554,10 @@ module Sys : sig
 
       Both cygcheck and an unqualified command will be resolved using the
       current PATH. *)
-  val is_cygwin_variant: string -> [ `Native | `Cygwin | `CygLinked ]
+  val get_cygwin_variant: cygbin:string option -> string -> [ `Native | `Cygwin | `CygLinked ]
+
+  (** Returns true if [get_cygwin_variant] is [`Cygwin] *)
+  val is_cygwin_variant: cygbin:string option -> string -> bool
 
   (** {3 Exit handling} *)
 

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -401,11 +401,6 @@ let real_path p =
 
 type command = string list
 
-let default_env () =
-  (OpamStd.Env.list () :> (string * string) list)
-    |> List.map (fun (var, v) -> var^"="^v)
-    |> Array.of_list
-
 let env_var env var =
   let len = Array.length env in
   let f = if Sys.win32 then String.uppercase_ascii else fun x -> x in
@@ -506,7 +501,7 @@ let t_resolve_command =
         `Denied
   in
   fun ?env ?dir name ->
-    let env = match env with None -> default_env () | Some e -> e in
+    let env = match env with None -> OpamProcess.default_env () | Some e -> e in
     resolve env ?dir name
 
 let resolve_command ?env ?dir name =
@@ -577,7 +572,7 @@ let make_command
     ?verbose ?env ?name ?text ?metadata ?allow_stdin ?stdout
     ?dir ?(resolve_path=true)
     cmd args =
-  let env = match env with None -> default_env () | Some e -> e in
+  let env = match env with None -> OpamProcess.default_env () | Some e -> e in
   let name = log_file name in
   let verbose =
     OpamStd.Option.default OpamCoreConfig.(!r.verbose_level >= 2) verbose
@@ -599,7 +594,7 @@ let make_command
 
 let run_process
     ?verbose ?env ~name ?metadata ?stdout ?allow_stdin command =
-  let env = match env with None -> default_env () | Some e -> e in
+  let env = match env with None -> OpamProcess.default_env () | Some e -> e in
   let chrono = OpamConsole.timer () in
   runs := command :: !runs;
   match command with

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -38,6 +38,10 @@ let load_config lock_kind global_lock root =
   let config =
     OpamFormatUpgrade.as_necessary lock_kind global_lock root config
   in
+  OpamStd.Option.iter
+    (fun cygbin ->
+       OpamCoreConfig.update ~cygbin:(OpamFilename.Dir.to_string cygbin) ())
+    (OpamSysInteract.Cygwin.cygbin_opt (fst config));
   config
 
 let inferred_from_system = "Inferred from system"

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -217,6 +217,9 @@ let family ~env () =
 
 module Cygwin = struct
 
+  let url_setupexe = OpamUrl.of_string "https://cygwin.com/setup-x86_64.exe"
+  let url_setupexe_sha512 = OpamUrl.of_string "https://cygwin.com/sha512.sum"
+
   (* Cygwin setup exe must be stored at Cygwin installation root *)
   let setupexe = "setup-x86_64.exe"
   let cygcheck_opt = Commands.cygcheck_opt
@@ -234,6 +237,76 @@ module Cygwin = struct
   let cygsetup () =
     OpamFilename.Op.(OpamStateConfig.(!r.root_dir) / ".cygwin" // setupexe)
 
+  let download_setupexe dst =
+    let overwrite = true in
+    let open OpamProcess.Job.Op in
+    OpamFilename.with_tmp_dir_job @@ fun dir ->
+    OpamDownload.download ~overwrite url_setupexe_sha512 dir @@+ fun file ->
+    let checksum =
+      let content = OpamFilename.read file in
+      let re =
+        (* File content:
+           >SHA512  setup-x86.exe
+           >SHA512  setup-x86_64.exe
+        *)
+        Re.(compile @@ seq [
+            group @@ repn
+              (alt [ digit ; rg 'A' 'F'; rg 'a' 'f' ]) 128 (Some 128);
+            rep space;
+            str "setup-x86_64.exe"
+          ])
+      in
+      try Some (OpamHash.sha512 Re.(Group.get (exec re content) 1))
+      with Not_found -> None
+    in
+    OpamDownload.download_as ~overwrite ?checksum url_setupexe dst
+
+  let default_cygroot = "C:\\cygwin64"
+
+  let check_install path =
+    if not (Sys.file_exists path) then
+      Error (Printf.sprintf "%s not found!" path)
+    else if Filename.basename path = "cygcheck.exe" then
+      (* We have cygcheck.exe path *)
+      let cygbin = Some (Filename.dirname path) in
+      if OpamStd.Sys.is_cygwin_cygcheck ~cygbin then
+        Ok (OpamFilename.of_string path)
+      else
+        Error
+          (Printf.sprintf
+             "%s found, but it is not from a Cygwin installation"
+             path)
+    else if not (Sys.is_directory path) then
+      Error (Printf.sprintf "%s is not a directory" path)
+    else
+    let cygbin = Filename.concat path "bin" in
+    (* We have cygroot path *)
+    if Sys.file_exists cygbin then
+      if OpamStd.Sys.is_cygwin_cygcheck ~cygbin:(Some cygbin) then
+        Ok (OpamFilename.of_string (Filename.concat cygbin "cygcheck.exe"))
+      else
+        Error
+          (Printf.sprintf
+             "%s found, but it does not appear to be a Cygwin installation"
+             path)
+    else
+      Error
+        (Printf.sprintf "bin\\cygcheck.exe not found in %s"
+           path)
+
+  (* Set setup.exe in the good place, ie in .opam/.cygwin/ *)
+  let check_setup setup =
+    let dst = cygsetup () in
+    if OpamFilename.exists dst then () else
+      (match setup with
+       | Some setup ->
+         log "Copying %s into %s"
+           (OpamFilename.to_string setup)
+           (OpamFilename.to_string dst);
+         OpamFilename.copy ~src:setup ~dst
+       | None ->
+         log "Donwloading setup exe";
+         OpamProcess.Job.run @@ download_setupexe dst)
 end
 
 let yum_cmd = lazy begin

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -227,15 +227,12 @@ module Cygwin = struct
   let cygroot_opt config =
     cygbin_opt config
     >>| OpamFilename.dirname_dir
-  let cygsetup_raw cygroot = OpamFilename.Op.(cygroot // setupexe)
-  let cygsetup_opt config =
-    cygroot_opt config
-    >>| cygsetup_raw
   let get_opt = function
     | Some c -> c
     | None -> failwith "Cygwin install not found"
   let cygroot config = get_opt (cygroot_opt config)
-  let cygsetup config = get_opt (cygsetup_opt config)
+  let cygsetup () =
+    OpamFilename.Op.(OpamStateConfig.(!r.root_dir) / ".cygwin" // setupexe)
 
 end
 
@@ -805,7 +802,7 @@ let install_packages_commands_t ?(env=OpamVariable.Map.empty) config sys_package
   | Cygwin ->
     (* We use setp_x86_64 to install package instead of `cygcheck` that is
        stored in `sys-pkg-manager-cmd` field *)
-    [`AsUser (OpamFilename.to_string (Cygwin.cygsetup config)),
+    [`AsUser (OpamFilename.to_string (Cygwin.cygsetup ())),
       [ "--root"; (OpamFilename.Dir.to_string (Cygwin.cygroot config));
         "--quiet-mode";
         "--no-shortcuts";

--- a/src/state/opamSysInteract.mli
+++ b/src/state/opamSysInteract.mli
@@ -39,3 +39,11 @@ val package_manager_name: ?env:gt_variables -> OpamFile.Config.t -> string
    Presently used to check for epel-release on CentOS and RHEL.
    [env] is used to determine host specification. *)
 val repo_enablers: ?env:gt_variables -> OpamFile.Config.t -> string option
+
+
+module Cygwin : sig
+
+  (* Return Cygwin binary path *)
+  val cygbin_opt: OpamFile.Config.t -> OpamFilename.Dir.t option
+
+end

--- a/src/state/opamSysInteract.mli
+++ b/src/state/opamSysInteract.mli
@@ -43,6 +43,20 @@ val repo_enablers: ?env:gt_variables -> OpamFile.Config.t -> string option
 
 module Cygwin : sig
 
+  (* Default Cygwin installation prefix C:\cygwin64 *)
+  val default_cygroot: string
+
+  (* [check_install path] checks a Cygwin installation at [path]. It checks
+     that 'path\cygcheck.exe' or 'path\bin\cygcheck.exe' exists. *)
+  val check_install:
+    string -> (OpamFilename.t, string) result
+
+  (* [check_setup path] checks and store Cygwin setup executable. Is [path] is
+     [None], it downloads it, otherwise it copies it to
+     <opamroot>/.cygwin/setup-x86_64.exe. If the file is already existent, it
+     is a no-op. *)
+  val check_setup: OpamFilename.t option -> unit
+
   (* Return Cygwin binary path *)
   val cygbin_opt: OpamFile.Config.t -> OpamFilename.Dir.t option
 

--- a/src/state/opamSysInteract.mli
+++ b/src/state/opamSysInteract.mli
@@ -60,4 +60,10 @@ module Cygwin : sig
   (* Return Cygwin binary path *)
   val cygbin_opt: OpamFile.Config.t -> OpamFilename.Dir.t option
 
+  (* Return Cygwin cygcheck.exe path *)
+  val cygcheck_opt: OpamFile.Config.t -> OpamFilename.t option
+
+  (* Return Cygwin installation prefix *)
+  val cygroot_opt: OpamFile.Config.t -> OpamFilename.Dir.t option
+
 end

--- a/src/state/opamSysPoll.ml
+++ b/src/state/opamSysPoll.ml
@@ -113,6 +113,15 @@ let poll_os_distribution () =
      | Some (s::_) ->
        try Scanf.sscanf s " %s " norm
        with Scanf.Scan_failure _ -> linux)
+  | Some "win32" ->
+    (* If the user provides a Cygwin installation in PATH, by default we'll use
+       it. Note that this is _not_ done for MSYS2. *)
+    let cygwin =
+      OpamSystem.resolve_command "cygcheck"
+      >>| Filename.dirname
+      |> (fun cygbin -> OpamStd.Sys.is_cygwin_cygcheck ~cygbin)
+    in
+    if cygwin then Some "cygwin" else os
   | os -> os
 let os_distribution = Lazy.from_fun poll_os_distribution
 

--- a/tests/reftests/env.test
+++ b/tests/reftests/env.test
@@ -144,7 +144,7 @@ FOO=''; export FOO;
 ### RT="$BASEDIR/root 2"
 ### SW="switch w spaces"
 ### OPAMNOENVNOTICE=0
-### opam init -na --bare --bypass-check --disable-sandbox --root "$RT" defaut ./REPO
+### opam init -na --bare --bypass-check --disable-sandbox --root "$RT" defaut ./REPO | grep -v Cygwin
 No configuration file found, using built-in defaults.
 
 <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -5,7 +5,7 @@
 ### rm -rf ${OPAMROOT}
 ### <opamrc>
 eval-variables: [ sys-ocaml-version ["false"] "no system compiler" ]
-### opam init --no-setup --bypass-checks default default/ --fake --config opamrc
+### opam init --no-setup --bypass-checks default default/ --fake --config opamrc | grep -v Cygwin
 Configuring from ${BASEDIR}/opamrc and then from built-in defaults.
 
 <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
@@ -29,7 +29,7 @@ Done.
 ### rm -rf ${OPAMROOT}
 ### <opamrc>
 eval-variables: [ sys-ocaml-version ["echo" "4.02.3"] "old system compiler" ]
-### opam init --no-setup --bypass-checks default default/ --fake --config opamrc
+### opam init --no-setup --bypass-checks default default/ --fake --config opamrc | grep -v Cygwin
 Configuring from ${BASEDIR}/opamrc and then from built-in defaults.
 
 <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
@@ -53,7 +53,7 @@ Done.
 ### rm -rf ${OPAMROOT}
 ### <opamrc>
 eval-variables: [ sys-ocaml-version ["echo" "4.07.0"] "new system compiler" ]
-### opam init --no-setup --bypass-checks default default/ --fake --config opamrc
+### opam init --no-setup --bypass-checks default default/ --fake --config opamrc | grep -v Cygwin
 Configuring from ${BASEDIR}/opamrc and then from built-in defaults.
 
 <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
@@ -101,12 +101,12 @@ opam-version: "2.0"
 opam-version: "2.0"
 ### :: default setup ::
 ### rm -rf $OPAMROOT
-### opam init --bypass-checks --bare --no-setup default REPO/
+### opam init --bypass-checks --bare --no-setup default REPO/ | grep -v Cygwin
 No configuration file found, using built-in defaults.
 
 <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
 [default] Initialised
-### opam-cat $OPAMROOT/config | 'opam-root-version: "${OPAMROOTVERSION}"' -> 'opam-root-version: current'
+### opam-cat $OPAMROOT/config | 'opam-root-version: "${OPAMROOTVERSION}"' -> 'opam-root-version: current' | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["ocaml-system" "ocaml-base-compiler"]
 default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
@@ -157,12 +157,12 @@ post-build-commands: ["%{hooks}%/a-script.sh" "post-build" ]
 post-install-commands: ["%{hooks}%/a-script.sh" "post-install" ]
 post-remove-commands: ["%{hooks}%/a-script.sh" "post-remove" ]
 post-session-commands: ["%{hooks}%/a-script.sh" "post-session" ]
-### opam init --bypass-checks --bare --no-setup --config opamrc
+### opam init --bypass-checks --bare --no-setup --config opamrc | grep -v Cygwin
 Configuring from ${BASEDIR}/opamrc and then from built-in defaults.
 
 <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
 [norepo] Initialised
-### opam-cat $OPAMROOT/config | 'opam-root-version: "${OPAMROOTVERSION}"' -> 'opam-root-version: current'
+### opam-cat $OPAMROOT/config | 'opam-root-version: "${OPAMROOTVERSION}"' -> 'opam-root-version: current' | grep -v sys-pkg-manager-cmd | '\[\[os-distribution "cygwin" "Set by opam init"] ' -> '' | ']]' -> ']'
 archive-mirrors: "file://${BASEDIR}/REPO/cache"
 default-compiler: ["comp"]
 default-invariant: ["comp" {= "1"}]
@@ -224,12 +224,12 @@ echo "SUCCESS"
 pre-build-commands: ["%{hooks}%/a-script.sh" "pre-build" ]
 wrap-install-commands: ["%{hooks}%/a-script.sh" "wrap-install" ]
 post-session-commands: ["%{hooks}%/a-script.sh" "post-session" ]
-### opam init --bypass-checks --bare --no-setup --config opamrc
+### opam init --bypass-checks --bare --no-setup --config opamrc | grep -v Cygwin
 Configuring from ${BASEDIR}/opamrc and then from built-in defaults.
 
 <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
 [norepo] Initialised
-### opam-cat $OPAMROOT/config | 'opam-root-version: "${OPAMROOTVERSION}"' -> 'opam-root-version: current'
+### opam-cat $OPAMROOT/config | 'opam-root-version: "${OPAMROOTVERSION}"' -> 'opam-root-version: current' | grep -v sys-pkg-manager-cmd | grep -v global-variables
 archive-mirrors: "file://${BASEDIR}/REPO/cache"
 default-compiler: ["comp"]
 default-invariant: ["ocaml" {>= "4.05.0"}]

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -671,7 +671,7 @@ let _ =
   | _ -> ()
 ### rm -rf $OPAMROOT
 ### OPAMSYSCOMP=2
-### opam init -na default ./default --bare --bypass-checks --no-opamrc --debug-level=0
+### opam init -na default ./default --bare --bypass-checks --no-opamrc --debug-level=0 | grep -v Cygwin
 No configuration file found, using built-in defaults.
 
 <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
@@ -736,7 +736,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ sw-comp
 STATE                           Switch state loaded in 0.000s
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 depext: true
 depext-cannot-install: false
@@ -815,7 +815,7 @@ Continue? [y/n] y
            opam option jobs=1 --global
 Format upgrade done.
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 depext: true
 depext-cannot-install: false
@@ -896,7 +896,7 @@ Continue? [y/n] y
            opam option jobs=1 --global
 Format upgrade done.
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 depext: true
 depext-cannot-install: false
@@ -962,7 +962,7 @@ Done.
 ### opam option jobs=4
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -996,7 +996,7 @@ opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:1:e: reinit from 2.0
 ### ocaml generate.ml 2.0
-### opam init --reinit --bypass-checks --no-setup | "${OPAMROOTVERSION}($|,)" -> "current"
+### opam init --reinit --bypass-checks --no-setup | "${OPAMROOTVERSION}($|,)" -> "current" | grep -v Cygwin
 No configuration file found, using built-in defaults.
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
@@ -1030,7 +1030,7 @@ STATE                           Switch state loaded in 0.000s
 # Name            # Installed # Synopsis
 i-am-package      2           One-line description
 i-am-sys-compiler 2           One-line description
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
@@ -1050,7 +1050,7 @@ wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "ma
 ### rm -rf _opam
 ### :V:2:a: From 2.1~alpha root, global
 ### ocaml generate.ml 2.1~alpha
-### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
+### opam list | "${OPAMROOTVERSION}($|,)" -> "current" | grep -v Cygwin
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Hard config upgrade, from 2.1~alpha to current
@@ -1105,7 +1105,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ sw-comp
 STATE                           Switch state loaded in 0.000s
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
@@ -1140,7 +1140,7 @@ opam-version: "2.0"
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### :V:2:b: From 2.1~alpha root, local
 ### ocaml generate.ml 2.1~alpha local
-### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
+### opam list | "${OPAMROOTVERSION}($|,)" -> "current" | grep -v Cygwin
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Hard config upgrade, from 2.1~alpha to current
@@ -1177,7 +1177,7 @@ The following actions will be performed:
 -> installed i-am-package.2
 STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
@@ -1214,7 +1214,7 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:2:c: From 2.1~alpha root, local unknown from config
 ### ocaml generate.ml 2.1~alpha orphaned
-### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
+### opam list | "${OPAMROOTVERSION}($|,)" -> "current" | grep -v Cygwin
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Hard config upgrade, from 2.1~alpha to current
@@ -1252,7 +1252,7 @@ The following actions will be performed:
 -> installed i-am-package.2
 STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
@@ -1320,7 +1320,7 @@ Done.
 ### opam option jobs=4
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -1354,7 +1354,7 @@ opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:2:e: reinit from 2.1~alpha
 ### ocaml generate.ml 2.1~alpha
-### opam init --reinit --bypass-checks --no-setup | "${OPAMROOTVERSION}($|,)" -> "current"
+### opam init --reinit --bypass-checks --no-setup | "${OPAMROOTVERSION}($|,)" -> "current" | grep -v Cygwin
 No configuration file found, using built-in defaults.
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
@@ -1391,7 +1391,7 @@ STATE                           Switch state loaded in 0.000s
 # Name            # Installed # Synopsis
 i-am-package      2           One-line description
 i-am-sys-compiler 2           One-line description
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
@@ -1412,7 +1412,7 @@ wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "ma
 ### :V:3:a: From 2.1~alpha2 root, global
 ### ocaml generate.ml 2.1~alpha2
 ### # ro global state
-### opam option jobs | "${OPAMROOTVERSION}($|,)" -> "current"
+### opam option jobs | "${OPAMROOTVERSION}($|,)" -> "current" | grep -v Cygwin
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         Intermediate opam root detected, launch hard upgrade
 FMT_UPG                         Downgrade config opam-version to fix up
@@ -1469,7 +1469,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 STATE                           LOAD-SWITCH-STATE @ sw-comp
 STATE                           Switch state loaded in 0.000s
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
@@ -1504,7 +1504,7 @@ opam-version: "2.0"
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### :V:3:b: From 2.1~alpha2 root, local
 ### ocaml generate.ml 2.1~alpha2 local
-### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
+### opam list | "${OPAMROOTVERSION}($|,)" -> "current" | grep -v Cygwin
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         Intermediate opam root detected, launch hard upgrade
 FMT_UPG                         Downgrade config opam-version to fix up
@@ -1543,7 +1543,7 @@ The following actions will be performed:
 -> installed i-am-package.2
 STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
@@ -1580,7 +1580,7 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
 ### :V:3:c: From 2.1~alpha2 root, local unknown from config
 ### ocaml generate.ml 2.1~alpha2 orphaned
-### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
+### opam list | "${OPAMROOTVERSION}($|,)" -> "current" | grep -v Cygwin
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         Intermediate opam root detected, launch hard upgrade
 FMT_UPG                         Downgrade config opam-version to fix up
@@ -1620,7 +1620,7 @@ The following actions will be performed:
 -> installed i-am-package.2
 STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
@@ -1688,7 +1688,7 @@ Done.
 ### opam option jobs=4
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -1722,7 +1722,7 @@ opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:3:e: reinit from 2.1~alpha2
 ### ocaml generate.ml 2.1~alpha2
-### opam init --reinit --bypass-checks --no-setup | "${OPAMROOTVERSION}($|,)" -> "current"
+### opam init --reinit --bypass-checks --no-setup | "${OPAMROOTVERSION}($|,)" -> "current" | grep -v Cygwin
 No configuration file found, using built-in defaults.
 FMT_UPG                         Intermediate opam root detected, launch hard upgrade
 FMT_UPG                         Downgrade config opam-version to fix up
@@ -1759,7 +1759,7 @@ STATE                           Switch state loaded in 0.000s
 # Name            # Installed # Synopsis
 i-am-package      2           One-line description
 i-am-sys-compiler 2           One-line description
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
@@ -1828,7 +1828,7 @@ You may want to back it up before going further.
 Continue? [y/n] y
 Format upgrade done.
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -1899,7 +1899,7 @@ You may want to back it up before going further.
 Continue? [y/n] y
 Format upgrade done.
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -1972,7 +1972,7 @@ You may want to back it up before going further.
 Continue? [y/n] y
 Format upgrade done.
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -2033,7 +2033,7 @@ Done.
 ### opam option jobs=4
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -2063,7 +2063,7 @@ opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:4:e: reinit from 2.1~rc
 ### ocaml generate.ml 2.1~rc
-### opam init --reinit --bypass-checks --no-setup | "${OPAMROOTVERSION}($|,)" -> "current"
+### opam init --reinit --bypass-checks --no-setup | "${OPAMROOTVERSION}($|,)" -> "current" | grep -v Cygwin
 No configuration file found, using built-in defaults.
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
@@ -2095,7 +2095,7 @@ STATE                           Switch state loaded in 0.000s
 # Name            # Installed # Synopsis
 i-am-package      2           One-line description
 i-am-sys-compiler 2           One-line description
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -2175,7 +2175,7 @@ You may want to back it up before going further.
 Continue? [y/n] y
 Format upgrade done.
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -2245,7 +2245,7 @@ You may want to back it up before going further.
 Continue? [y/n] y
 Format upgrade done.
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -2317,7 +2317,7 @@ You may want to back it up before going further.
 Continue? [y/n] y
 Format upgrade done.
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -2389,7 +2389,7 @@ You may want to back it up before going further.
 Continue? [y/n] y
 Format upgrade done.
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -2419,7 +2419,7 @@ opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:5:e: reinit from 2.1
 ### ocaml generate.ml 2.1
-### opam init --reinit --bypass-checks --no-setup | "${OPAMROOTVERSION}($|,)" -> "current"
+### opam init --reinit --bypass-checks --no-setup | "${OPAMROOTVERSION}($|,)" -> "current" | grep -v Cygwin
 No configuration file found, using built-in defaults.
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
@@ -2435,7 +2435,7 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -2516,7 +2516,7 @@ RSTATE                          Cache found
 ### opam option jobs=4
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -2576,7 +2576,7 @@ Done.
 ### opam option jobs=4
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -2636,7 +2636,7 @@ Done.
 ### opam option jobs=4
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -2697,7 +2697,7 @@ Done.
 ### opam option jobs=4
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 Set to '4' the field jobs in global configuration
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true
@@ -2727,7 +2727,7 @@ opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:6:e: reinit from 2.2~alpha
 ### ocaml generate.ml 2.2~alpha
-### opam init --reinit --bypass-checks --no-setup
+### opam init --reinit --bypass-checks --no-setup | grep -v Cygwin
 No configuration file found, using built-in defaults.
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
@@ -2736,7 +2736,7 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
-### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current"
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
 depext: true

--- a/tests/reftests/var-option.test
+++ b/tests/reftests/var-option.test
@@ -14,6 +14,7 @@ opam-version: "2.0"
 Removed variable user in switch var-option
 ### opam var group= --switch var-option
 Removed variable group in switch var-option
+### opam option sys-pkg-manager-cmd= --global | grep -v configuration
 ### opam var arch=x86_64 --global
 Added '[arch "x86_64" "Set through 'opam var'"]' to field global-variables in global configuration
 ### opam var jobs=7 --global


### PR DESCRIPTION
At init && reinit, add detection and setup of a pre-existent cygwin installation.

It contains commit of #5543 (see https://github.com/ocaml/opam/pull/5543#issuecomment-1589723915)

#### TODO
* [x] queued on #5543
* [x] queued on #5542