### PR TITLE
init: install cygwin internally

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -20,6 +20,8 @@ users)
 ## Plugins
 
 ## Init
+  * Permit internal Cygwin install on Windows [#5545 @rjbou @dra27]
+  * Add `--no-cygwin-setup`, `--cygwin-internal-install`, `--cygwin-local-install` and `--cygwin-location <path>` experimental flags available only on Windows to permit non-interactive Cygwin configuration [#5545 @rjbou]
 
 ## Config report
 
@@ -116,10 +118,18 @@ users)
 
 # API updates
 ## opam-client
+  * `OpaminitDefault`: add `required_packages_for_cygwin` packages tool list [#5545 @rjbou]
+  * `OpamClient.init`: now propose to install internal Cygwin install [#5545 @rjbou]
+  * `OpamSolution.get_depext`: do not confirm in case of internal Cygwin install [#5545 @rjbou]
+  * `OpamClient.init`: add optional `cygwin_setup` argument to permit non interactive setup [#5545 @rjbou]
+  * `OpamCommands.init`: add cygwin setup flags [#5545 @rjbou]
 
 ## opam-repository
 
 ## opam-state
+  * `OpamSysinteract.Cygwin`: add `install` that performs a Cygwin install in opam internals [#5545 @rjbou @dra27]
+  * `OpamSysInteract.Cygwin`: add `is_internal` [#5545 @rjbou]
+  * `OpamSysInteract.install`: on Cygwin, upgrade automatically packages, and select local cache [#5545 @rjbou]
 
 ## opam-solver
 

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -717,13 +717,13 @@ let windows_checks config =
                 let options = [
                   `manual,
                   "Manually enter prefix of an existing Cygwin installation \
-                   (e.g. C:\\cygwin64)";
+                   (e.g. D:\\cygwin64)";
                   `default,
                   (Printf.sprintf "Use default Cygwin installation at %s"
                      OpamSysInteract.Cygwin.default_cygroot);
                   `abort, "Abort initialisation";
                 ] in
-                OpamConsole.menu "Opam needs pre-existent Cygwin installation"
+                OpamConsole.menu "Cygwin location"
                   ~default:`default ~no:`default ~options
               in
               (match prompt_cygroot () with
@@ -756,16 +756,37 @@ let windows_checks config =
             Some (success cygcheck)
           | None -> None
         in
-        match enter_paths () with
-        | Some config -> config
-        | None -> menu ()
+        let prompt () =
+          let options = [
+            `Internal,
+            "Automatically create an internal Cygwin installation \
+             that will be managed by opam";
+            `Specify, "Enter the location of an existing Cygwin installation";
+            `Abort, "Abort initialisation";
+          ] in
+          OpamConsole.menu "How should opam handle Cygwin?"
+            ~no:`Internal ~options
+        in
+        match prompt () with
+        | `Abort -> OpamStd.Sys.exit_because `Aborted
+        | `Internal ->
+          let cygcheck =
+            OpamSysInteract.Cygwin.install
+              ~packages:OpamInitDefaults.required_packages_for_cygwin
+          in
+          let config = success cygcheck in
+          config
+        | `Specify ->
+          match enter_paths () with
+          | Some config -> config
+          | None -> menu ()
       in
       OpamConsole.header_msg "Unix support infrastructure";
       OpamConsole.msg
         "\n\
-         opam and the OCaml ecosystem in general depend on various Unix tools \
-         in order to operate correctly. At present, this requires \
-         a pre-existing Cygwin installation.\n\n";
+         opam and the OCaml ecosystem in general require various Unix tools \
+         in order to operate correctly. At present, this requires the \
+         installation of Cygwin to provide these tools.\n\n";
       menu ()
   in
   let config =

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -28,6 +28,7 @@ val init:
   ?env_hook:bool ->
   ?completion:bool ->
   ?check_sandbox:bool ->
+  ?cygwin_setup: [ `internal | `default_location | `location of dirname | `no ] ->
   shell ->
   rw global_state * unlocked repos_state * atom list
 
@@ -44,6 +45,7 @@ val reinit:
   ?init_config:OpamFile.InitConfig.t -> interactive:bool -> ?dot_profile:filename ->
   ?update_config:bool -> ?env_hook:bool -> ?completion:bool -> ?inplace:bool ->
   ?check_sandbox:bool -> ?bypass_checks:bool ->
+  ?cygwin_setup: [ `internal | `default_location | `location of dirname | `no ] ->
   OpamFile.Config.t -> shell -> unit
 
 (** Install the given list of packages. [add_to_roots], if given, specifies that

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -146,6 +146,16 @@ let required_tools ~sandboxing () =
     ["sandbox-exec"], None, Some macos_filter;
   ] else []
 
+let required_packages_for_cygwin =
+  [
+    "diffutils";
+    "git"; (* XXX hg & mercurial ? *)
+    "make";
+    "patch";
+    "tar";
+    "unzip";
+  ] |> List.map OpamSysPkg.of_string
+
 let init_scripts () = [
   ("sandbox.sh", OpamScript.bwrap), Some bwrap_filter;
   ("sandbox.sh", OpamScript.sandbox_exec), Some macos_filter;

--- a/src/client/opamInitDefaults.mli
+++ b/src/client/opamInitDefaults.mli
@@ -29,3 +29,5 @@ val sandbox_wrappers:
 (** Default initial configuration file for use by [opam init] if nothing is
     supplied. *)
 val init_config: ?sandboxing:bool -> unit -> OpamFile.InitConfig.t
+
+val required_packages_for_cygwin: sys_package list

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1147,6 +1147,9 @@ let get_depexts ?(force=false) ?(recover=false) t packages =
   avail
 
 let install_depexts ?(force_depext=false) ?(confirm=true) t packages =
+  let confirm =
+    confirm && not (OpamSysInteract.Cygwin.is_internal t.switch_global.config)
+  in
   let sys_packages =
     get_depexts ~force:force_depext ~recover:force_depext t packages
   in

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -935,15 +935,22 @@ let install_packages_commands_t ?(env=OpamVariable.Map.empty) config sys_package
     (* We use setp_x86_64 to install package instead of `cygcheck` that is
        stored in `sys-pkg-manager-cmd` field *)
     [`AsUser (OpamFilename.to_string (Cygwin.cygsetup ())),
-      [ "--root"; (OpamFilename.Dir.to_string (Cygwin.cygroot config));
-        "--quiet-mode";
-        "--no-shortcuts";
-        "--no-startmenu";
-        "--no-desktop";
-        "--no-admin";
-        "--packages";
-        String.concat "," packages
-      ]],
+     [ "--root"; (OpamFilename.Dir.to_string (Cygwin.cygroot config));
+       "--quiet-mode";
+       "--no-shortcuts";
+       "--no-startmenu";
+       "--no-desktop";
+       "--no-admin";
+       "--packages";
+       String.concat "," packages;
+     ] @ (if Cygwin.is_internal config then
+            [ "--upgrade-also";
+              "--only-site";
+              "--site"; Cygwin.mirror;
+              "--local-package-dir";
+              OpamFilename.Dir.to_string (Cygwin.internal_cygcache ());
+            ] else [])
+    ],
     None
   | Debian ->
     [`AsAdmin "apt-get", "install"::yes ["-qq"; "-yy"] packages],

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -247,6 +247,10 @@ module Cygwin = struct
   let internal_cygroot () = internal_cygwin () / "root"
   let internal_cygcache () = internal_cygwin () / "cache"
   let cygsetup () = internal_cygwin () // setupexe
+  let is_internal config =
+    OpamStd.Option.equal OpamFilename.Dir.equal
+      (cygroot_opt config)
+      (Some (internal_cygroot ()))
 
   let download_setupexe dst =
     let overwrite = true in

--- a/src/state/opamSysInteract.mli
+++ b/src/state/opamSysInteract.mli
@@ -54,6 +54,9 @@ module Cygwin : sig
   val check_install:
     string -> (OpamFilename.t, string) result
 
+  (* Returns true if Cygwin install is internal *)
+  val is_internal: OpamFile.Config.t -> bool
+
   (* [check_setup path] checks and store Cygwin setup executable. Is [path] is
      [None], it downloads it, otherwise it copies it to
      <opamroot>/.cygwin/setup-x86_64.exe. If the file is already existent, it

--- a/src/state/opamSysInteract.mli
+++ b/src/state/opamSysInteract.mli
@@ -46,6 +46,9 @@ module Cygwin : sig
   (* Default Cygwin installation prefix C:\cygwin64 *)
   val default_cygroot: string
 
+  (* Install an internal Cygwin install, in <root>/.cygwin *)
+  val install: packages:OpamSysPkg.t list -> OpamFilename.t
+
   (* [check_install path] checks a Cygwin installation at [path]. It checks
      that 'path\cygcheck.exe' or 'path\bin\cygcheck.exe' exists. *)
   val check_install:


### PR DESCRIPTION
At init, add an item in the cygwin menu to propose to have a cygwin install internal to opam. It is handled by opam itself (prefix stored in `<opamroot>/.cygwin/root`), when depext are requested, there is no confirmation requested.
It also adds some flags to `init`, to have a cywgin configuration non interactively: `--no-cygwin-setup`|`--cygwin-internal-install`|`--cygwin-local-install` and `--cygwin-location <path>`.
These are experimental as they can change name from the finale release.

#### TODO
* [x] queued on #5544
* [x] queued on #5543
* [x] queued on #5542