### PR TITLE
Allow passing in a custom runner to `OpamStd.Sys`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -717,3 +717,4 @@ users)
   * `OpamSWHID`: add module to handle swhid [#4859 @rjbou]
   * `OpamProcess`: expose the `command` type as a private type [#5452 @Leonidas-from-XIV]
   * `OpamFilename`: add `with_open_out_bin` and `with_open_out_bin_atomic` [#5476 @dra27]
+  * `OpamStd.OpamSysRunner`: Allow plugging in custom runners [#5549 @Leonidas-from-XIV]

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -917,8 +917,7 @@ module UnitRunner : Runner = struct
     let stdio = Unix.open_process_full cmd argv in
     let (stdout, _, _) = stdio in
     Fun.protect
-      (fun () ->
-        return (input_line stdout))
+      (fun () -> return (input_line stdout))
       ~finally:(fun () ->
         let _ : Unix.process_status = Unix.close_process_full stdio in
         ())

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1362,7 +1362,157 @@ module OpamSysRunnable(R : Runner) = struct
       console := printer
 end
 
-module OpamSysUnit = OpamSysRunnable(UnitRunner)
+module type OpamSysRunnableT = functor (R : Runner) -> sig 
+  val tty_out : bool
+
+  val tty_in : bool
+
+  val terminal_columns : unit -> int R.t
+
+  val home: unit -> string
+
+  val etc: unit -> string
+
+  val system: unit -> string
+
+  type os = Darwin
+          | Linux
+          | FreeBSD
+          | OpenBSD
+          | NetBSD
+          | DragonFly
+          | Cygwin
+          | Win32
+          | Unix
+          | Other of string
+
+  val os: unit -> os R.t
+
+  val uname: string list -> string option R.t
+
+  val executable_name : string -> string
+
+  type powershell_host = Powershell_pwsh | Powershell
+  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish
+    | SH_pwsh of powershell_host | SH_win_cmd
+
+  val all_shells : shell list
+
+  val guess_shell_compat: unit -> shell R.t
+
+  val guess_dot_profile: shell -> string
+
+  val path_sep: char
+
+  val split_path_variable: ?clean:bool -> string -> string list
+
+  val get_windows_executable_variant:
+    string -> [ `Native | `Cygwin | `Tainted of [ `Msys2 | `Cygwin] | `Msys2 ]
+
+  val is_cygwin_variant: string -> [ `Native | `Cygwin | `CygLinked ]
+
+  val at_exit: (unit -> unit) -> unit
+
+  val exec_at_exit: unit -> unit
+
+  exception Exit of int
+
+  exception Exec of string * string array * string array
+
+  type exit_reason =
+    [ `Success | `False | `Bad_arguments | `Not_found | `Aborted | `Locked
+    | `No_solution | `File_error | `Package_operation_error | `Sync_error
+    | `Configuration_error | `Solver_failure | `Internal_error
+    | `User_interrupt ]
+
+  val exit_codes : (exit_reason * int) list
+
+  val get_exit_code : exit_reason -> int
+
+  val exit_because: exit_reason -> 'a
+
+  type warning_printer =
+    {mutable warning : 'a . ('a, unit, string, unit) format4 -> 'a}
+  val set_warning_printer : warning_printer -> unit
+end
+
+module OpamSysRunnable' = (OpamSysRunnable : OpamSysRunnableT)
+module OpamSysUnit = OpamSysRunnable'(UnitRunner)
+(* module OpamSysUnit = OpamSysRunnable(UnitRunner) *)
+
+module type Sys = sig
+  val tty_out : bool
+
+  val tty_in : bool
+
+  val terminal_columns : unit -> int
+
+  val home: unit -> string
+
+  val etc: unit -> string
+
+  val system: unit -> string
+
+  type os = Darwin
+          | Linux
+          | FreeBSD
+          | OpenBSD
+          | NetBSD
+          | DragonFly
+          | Cygwin
+          | Win32
+          | Unix
+          | Other of string
+
+  val os: unit -> os
+
+  val uname: string -> string option
+
+  val executable_name : string -> string
+
+  type powershell_host = Powershell_pwsh | Powershell
+  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish
+    | SH_pwsh of powershell_host | SH_win_cmd
+
+  val all_shells : shell list
+
+  val guess_shell_compat: unit -> shell
+
+  val guess_dot_profile: shell -> string
+
+  val path_sep: char
+
+  val split_path_variable: ?clean:bool -> string -> string list
+
+  val get_windows_executable_variant:
+    string -> [ `Native | `Cygwin | `Tainted of [ `Msys2 | `Cygwin] | `Msys2 ]
+
+  val is_cygwin_variant: string -> [ `Native | `Cygwin | `CygLinked ]
+
+  val at_exit: (unit -> unit) -> unit
+
+  val exec_at_exit: unit -> unit
+
+  exception Exit of int
+
+  exception Exec of string * string array * string array
+
+  type exit_reason =
+    [ `Success | `False | `Bad_arguments | `Not_found | `Aborted | `Locked
+    | `No_solution | `File_error | `Package_operation_error | `Sync_error
+    | `Configuration_error | `Solver_failure | `Internal_error
+    | `User_interrupt ]
+
+  val exit_codes : (exit_reason * int) list
+
+  val get_exit_code : exit_reason -> int
+
+  val exit_because: exit_reason -> 'a
+
+  type warning_printer =
+    {mutable warning : 'a . ('a, unit, string, unit) format4 -> 'a}
+  val set_warning_printer : warning_printer -> unit
+end
 
 module OpamSys = struct
   include OpamSysUnit

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -926,7 +926,9 @@ module UnitRunner : Runner = struct
     try
       let line = with_process_in ~prog ~argv in
       map line @@ fun line -> Some (OpamString.strip line)
-    with Unix.Unix_error _ | Sys_error _ | Not_found -> return None
+    with
+    | Unix.Unix_error _ | Sys_error _ | Not_found | End_of_file ->
+      return None
 
   let escape v = v ()
 end

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1360,6 +1360,8 @@ module OpamSysRunnable(R : Runner) = struct
       if !called then invalid_arg "Just what do you think you're doing, Dave?";
       called := true;
       console := printer
+
+  module R = R
 end
 
 module type OpamSysRunnableT = functor (R : Runner) -> sig 
@@ -1434,11 +1436,12 @@ module type OpamSysRunnableT = functor (R : Runner) -> sig
   type warning_printer =
     {mutable warning : 'a . ('a, unit, string, unit) format4 -> 'a}
   val set_warning_printer : warning_printer -> unit
+
+  module R : Runner with type 'a t = 'a R.t
 end
 
 module OpamSysRunnable' = (OpamSysRunnable : OpamSysRunnableT)
 module OpamSysUnit = OpamSysRunnable'(UnitRunner)
-(* module OpamSysUnit = OpamSysRunnable(UnitRunner) *)
 
 module type Sys = sig
   val tty_out : bool

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -918,8 +918,7 @@ module UnitRunner : Runner = struct
     let (stdout, _, _) = stdio in
     Fun.protect
       (fun () ->
-        let line = input_line stdout in
-        return line)
+        return (input_line stdout))
       ~finally:(fun () ->
         let _ : Unix.process_status = Unix.close_process_full stdio in
         ())

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -476,7 +476,7 @@ module type Runner = sig
   val escape : 'a t -> 'a
 end
 
-module OpamSysRunnable (R : Runner) : sig
+module type OpamSysRunnableT = functor (R : Runner) -> sig
   val tty_out : bool
 
   val tty_in : bool
@@ -548,10 +548,15 @@ module OpamSysRunnable (R : Runner) : sig
   type warning_printer =
     {mutable warning : 'a . ('a, unit, string, unit) format4 -> 'a}
   val set_warning_printer : warning_printer -> unit
+
 end
+
+(* module Hest = (Set : OpamSysRunnableT) *)
+(* module OpamSysRunnable = functor (R : Runner) : OpamSysRunnable(R : Runner) *)
+
 (**/**)
 
-module Sys : sig
+module type Sys = sig
 
   (** {3 Querying} *)
 
@@ -680,6 +685,8 @@ module Sys : sig
     {mutable warning : 'a . ('a, unit, string, unit) format4 -> 'a}
   val set_warning_printer : warning_printer -> unit
 end
+
+module Sys : Sys
 
 (** {2 Windows-specific functions} *)
 module Win32 : sig

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -469,8 +469,6 @@ module type Runner = sig
 
   val return : 'a -> 'a t
 
-  val with_process_in : prog:string -> argv:string list -> string t
-
   val run : prog:string -> argv:string list -> string option t
 
   val escape : 'a t -> 'a

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -549,10 +549,12 @@ module type OpamSysRunnableT = functor (R : Runner) -> sig
     {mutable warning : 'a . ('a, unit, string, unit) format4 -> 'a}
   val set_warning_printer : warning_printer -> unit
 
+  module R : Runner with type 'a t = 'a R.t
 end
 
-(* module Hest = (Set : OpamSysRunnableT) *)
-(* module OpamSysRunnable = functor (R : Runner) : OpamSysRunnable(R : Runner) *)
+module OpamSysRunnable' : OpamSysRunnableT
+
+module UnitRunner : Runner
 
 (**/**)
 

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -469,9 +469,9 @@ module type Runner = sig
 
   val return : 'a -> 'a t
 
-  val with_process_in : string -> string -> string t
+  val with_process_in : prog:string -> argv:string list -> string t
 
-  val run : string -> string -> string option t
+  val run : prog:string -> argv:string list -> string option t
 
   val escape : 'a t -> 'a
 end
@@ -502,7 +502,7 @@ module OpamSysRunnable (R : Runner) : sig
 
   val os: unit -> os R.t
 
-  val uname: string -> string option R.t
+  val uname: string list -> string option R.t
 
   val executable_name : string -> string
 

--- a/src/state/opamSysPoll.ml
+++ b/src/state/opamSysPoll.ml
@@ -10,15 +10,6 @@
 
 open OpamStd.Option.Op
 
-let command_output c =
-  match List.filter (fun s -> String.trim s <> "")
-          (OpamSystem.read_command_output c)
-  with
-  | [""] -> None
-  | [s] -> Some s
-  | _ -> None
-  | exception (OpamSystem.Process_error _ | OpamSystem.Command_not_found _) ->
-    None
 
 let norm s = if s = "" then None else Some (String.lowercase_ascii s)
 
@@ -33,115 +24,129 @@ let normalise_arch raw =
         ["armv5"; "armv6"; "earmv6"; "armv7"; "earmv7"] -> "arm32"
   | s -> s
 
-let poll_arch () =
-  let raw = match Sys.os_type with
-    | "Unix" | "Cygwin" -> OpamStd.Sys.uname "-m"
-    | "Win32" ->
-      if Sys.word_size = 32 && not (OpamStubs.isWoW64 ()) then
-        Some "i686"
-      else
-        Some "x86_64"
-    | _ -> None
-  in
-  match raw with
-  | None | Some "" -> None
-  | Some a -> Some (normalise_arch a)
-let arch = Lazy.from_fun poll_arch
-
 let normalise_os raw =
   match String.lowercase_ascii raw with
   | "darwin" | "osx" -> "macos"
   | s -> s
 
-let poll_os () =
-  let raw =
-    match Sys.os_type with
-    | "Unix" -> OpamStd.Sys.uname "-s"
-    | s -> norm s
-  in
-  match raw with
-  | None | Some "" -> None
-  | Some s -> Some (normalise_os s)
-let os = Lazy.from_fun poll_os
+module Include (OpamStdSys : OpamStd.Sys) = struct
+  let command_output c =
+    match List.filter (fun s -> String.trim s <> "")
+            (OpamSystem.read_command_output c)
+    with
+    | [""] -> None
+    | [s] -> Some s
+    | _ -> None
+    | exception (OpamSystem.Process_error _ | OpamSystem.Command_not_found _) ->
+      None
 
-let os_release_field =
-  let os_release_file = lazy (
-    List.find Sys.file_exists ["/etc/os-release"; "/usr/lib/os-release"] |>
-    OpamProcess.read_lines |>
-    OpamStd.List.filter_map (fun s ->
-        try
-          Scanf.sscanf s "%s@= %s" (fun x v ->
-              let contents =
-                try Scanf.sscanf v "\"%s@\"" (fun s -> s)
-                with Scanf.Scan_failure _ | End_of_file -> v
-              in
-              Some (x, contents))
-        with Scanf.Scan_failure _ | End_of_file -> None)
-  ) in
-  fun f ->
-    try Some (OpamStd.List.assoc String.equal f (Lazy.force os_release_file))
-    with Not_found -> None
+  let poll_arch () =
+    let raw = match Sys.os_type with
+      | "Unix" | "Cygwin" -> OpamStdSys.uname "-m"
+      | "Win32" ->
+        if Sys.word_size = 32 && not (OpamStubs.isWoW64 ()) then
+          Some "i686"
+        else
+          Some "x86_64"
+      | _ -> None
+    in
+    match raw with
+    | None | Some "" -> None
+    | Some a -> Some (normalise_arch a)
+  let arch = Lazy.from_fun poll_arch
 
-let is_android, android_release =
-  let prop = lazy (command_output ["getprop"; "ro.build.version.release"]) in
-  (fun () -> Lazy.force prop <> None),
-  (fun () -> Lazy.force prop)
+  let poll_os () =
+    let raw =
+      match Sys.os_type with
+      | "Unix" -> OpamStdSys.uname "-s"
+      | s -> norm s
+    in
+    match raw with
+    | None | Some "" -> None
+    | Some s -> Some (normalise_os s)
+  let os = Lazy.from_fun poll_os
 
-let poll_os_distribution () =
-  let lazy os = os in
-  match os with
-  | Some "macos" as macos ->
-    if OpamSystem.resolve_command "brew" <> None then Some "homebrew"
-    else if OpamSystem.resolve_command "port" <> None then Some "macports"
-    else macos
-  | Some "linux" as linux ->
-    (if is_android () then Some "android" else
-     os_release_field "ID" >>= norm >>+ fun () ->
-     command_output ["lsb_release"; "-i"; "-s"] >>= norm >>+ fun () ->
-     try
-       List.find Sys.file_exists ["/etc/redhat-release";
-                                  "/etc/centos-release";
-                                  "/etc/gentoo-release";
-                                  "/etc/issue"] |>
-       fun s -> Scanf.sscanf s " %s " norm
-     with Not_found -> linux)
-  | os -> os
-let os_distribution = Lazy.from_fun poll_os_distribution
+  let is_android, android_release =
+    let prop = lazy (command_output ["getprop"; "ro.build.version.release"]) in
+    (fun () -> Lazy.force prop <> None),
+    (fun () -> Lazy.force prop)
 
-let poll_os_version () =
-  let lazy os = os in
-  match os with
-  | Some "linux" ->
-    android_release () >>= norm >>+ fun () ->
-    command_output ["lsb_release"; "-s"; "-r"] >>= norm >>+ fun () ->
-    os_release_field "VERSION_ID" >>= norm
-  | Some "macos" ->
-    command_output ["sw_vers"; "-productVersion"] >>= norm
-  | Some "win32" ->
-    let (major, minor, build, _) = OpamStubs.getWindowsVersion () in
-    OpamStd.Option.some @@ Printf.sprintf "%d.%d.%d" major minor build
-  | Some "cygwin" ->
-    (try
-       command_output ["cmd"; "/C"; "ver"] >>= fun s ->
-       Scanf.sscanf s "%_s@[ Version %s@]" norm
-     with Scanf.Scan_failure _ | End_of_file -> None)
-  | Some "freebsd" ->
-    OpamStd.Sys.uname "-U" >>= norm
-  | _ ->
-    OpamStd.Sys.uname "-r" >>= norm
-let os_version = Lazy.from_fun poll_os_version
+  let os_release_field =
+    let os_release_file = lazy (
+      List.find Sys.file_exists ["/etc/os-release"; "/usr/lib/os-release"] |>
+      OpamProcess.read_lines |>
+      OpamStd.List.filter_map (fun s ->
+          try
+            Scanf.sscanf s "%s@= %s" (fun x v ->
+                let contents =
+                  try Scanf.sscanf v "\"%s@\"" (fun s -> s)
+                  with Scanf.Scan_failure _ | End_of_file -> v
+                in
+                Some (x, contents))
+          with Scanf.Scan_failure _ | End_of_file -> None)
+    ) in
+    fun f ->
+      try Some (OpamStd.List.assoc String.equal f (Lazy.force os_release_file))
+      with Not_found -> None
 
-let poll_os_family () =
-  let lazy os = os in
-  match os with
-  | Some "linux" ->
-    (os_release_field "ID_LIKE" >>= fun s ->
-     Scanf.sscanf s " %s" norm (* first word *))
-    ++ Lazy.force os_distribution
-  | Some ("freebsd" | "openbsd" | "netbsd" | "dragonfly") -> Some "bsd"
-  | Some ("win32" | "cygwin") -> Some "windows"
-  | _ -> Lazy.force os_distribution
-let os_family = Lazy.from_fun poll_os_family
+  let poll_os_version () =
+    let lazy os = os in
+    match os with
+    | Some "linux" ->
+      android_release () >>= norm >>+ fun () ->
+      command_output ["lsb_release"; "-s"; "-r"] >>= norm >>+ fun () ->
+      os_release_field "VERSION_ID" >>= norm
+    | Some "macos" ->
+      command_output ["sw_vers"; "-productVersion"] >>= norm
+    | Some "win32" ->
+      let (major, minor, build, _) = OpamStubs.getWindowsVersion () in
+      OpamStd.Option.some @@ Printf.sprintf "%d.%d.%d" major minor build
+    | Some "cygwin" ->
+      (try
+         command_output ["cmd"; "/C"; "ver"] >>= fun s ->
+         Scanf.sscanf s "%_s@[ Version %s@]" norm
+       with Scanf.Scan_failure _ | End_of_file -> None)
+    | Some "freebsd" ->
+      OpamStdSys.uname "-U" >>= norm
+    | _ ->
+      OpamStdSys.uname "-r" >>= norm
+  let os_version = Lazy.from_fun poll_os_version
+
+  let poll_os_distribution () =
+    let lazy os = os in
+    match os with
+    | Some "macos" as macos ->
+      if OpamSystem.resolve_command "brew" <> None then Some "homebrew"
+      else if OpamSystem.resolve_command "port" <> None then Some "macports"
+      else macos
+    | Some "linux" as linux ->
+      (if is_android () then Some "android" else
+       os_release_field "ID" >>= norm >>+ fun () ->
+       command_output ["lsb_release"; "-i"; "-s"] >>= norm >>+ fun () ->
+       try
+         List.find Sys.file_exists ["/etc/redhat-release";
+                                    "/etc/centos-release";
+                                    "/etc/gentoo-release";
+                                    "/etc/issue"] |>
+         fun s -> Scanf.sscanf s " %s " norm
+       with Not_found -> linux)
+    | os -> os
+  let os_distribution = Lazy.from_fun poll_os_distribution
+
+  let poll_os_family () =
+    let lazy os = os in
+    match os with
+    | Some "linux" ->
+      (os_release_field "ID_LIKE" >>= fun s ->
+       Scanf.sscanf s " %s" norm (* first word *))
+      ++ Lazy.force os_distribution
+    | Some ("freebsd" | "openbsd" | "netbsd" | "dragonfly") -> Some "bsd"
+    | Some ("win32" | "cygwin") -> Some "windows"
+    | _ -> Lazy.force os_distribution
+  let os_family = Lazy.from_fun poll_os_family
+end
+
+include Include(OpamStd.Sys)
 
 let variables =
   List.map

--- a/src/state/opamSysPoll.mli
+++ b/src/state/opamSysPoll.mli
@@ -13,6 +13,24 @@ open OpamStateTypes
 (** This module polls various aspects of the host, to define the [arch], [os],
     etc. variables *)
 
+module type IncludeT = functor (Runnable : OpamStd.OpamSysRunnableT) (Runner : OpamStd.Runner) -> sig
+  val poll_arch : unit -> string option Runnable(Runner).R.t
+  val arch : string option Runnable(Runner).R.t Lazy.t
+
+  val poll_os : unit -> string option Runnable(Runner).R.t
+  val os : string option Runnable(Runner).R.t Lazy.t
+
+  val poll_os_version : unit -> string option Runnable(Runner).R.t
+  val os_version : string option Runnable(Runner).R.t Lazy.t
+
+  val poll_os_distribution : unit -> string option Runnable(Runner).R.t
+  val os_distribution : string option Runnable(Runner).R.t Lazy.t
+
+  val variables : (OpamVariable.t * OpamVariable.variable_contents option Runnable(Runner).R.t lazy_t) list
+end
+
+module Include' : IncludeT
+
 (** Functions to get host specification. It checks if variables value is
     defined in the environment map before polling. *)
 val arch: gt_variables -> string option

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -385,7 +385,7 @@ first  --
 [ERROR] In ${BASEDIR}/OPAM/repo/oper2/packages/second/second.2/opam:
         This file is for package 'second.2' but has mismatching fields 'version:2.2.
 [ERROR] Strict mode: aborting
-[ERROR] Could not update repository "oper2": OpamStd.OpamSys.Exit(30)
+[ERROR] Could not update repository "oper2": OpamStd.OpamSysRunnable(R).Exit(30)
 [ERROR] Initial repository fetch failed
 # Return code 40 #
 ### opam repository --this-switch
@@ -397,7 +397,7 @@ first  --
 [ERROR] In ${BASEDIR}/OPAM/repo/oper/packages/second/second.2/opam:
         This file is for package 'second.2' but has mismatching fields 'version:2.2.
 [ERROR] Strict mode: aborting
-[ERROR] Could not update repository "oper": OpamStd.OpamSys.Exit(30)
+[ERROR] Could not update repository "oper": OpamStd.OpamSysRunnable(R).Exit(30)
 [ERROR] Fetching repository oper with file://${BASEDIR}/OPER2 fails, reverting to file://${BASEDIR}/OPER
 # Return code 40 #
 ### opam repository --this-switch
@@ -551,7 +551,7 @@ first  --
 [ERROR] In ${BASEDIR}/OPAM/repo/oper2/packages/second/second.2/opam:
         This file is for package 'second.2' but has mismatching fields 'version:2.2.
 [ERROR] Strict mode: aborting
-[ERROR] Could not update repository "oper2": OpamStd.OpamSys.Exit(30)
+[ERROR] Could not update repository "oper2": OpamStd.OpamSysRunnable(R).Exit(30)
 [ERROR] Initial repository fetch failed
 # Return code 40 #
 ### opam repository --this-switch
@@ -563,7 +563,7 @@ first  --
 [ERROR] In ${BASEDIR}/OPAM/repo/oper/packages/second/second.2/opam:
         This file is for package 'second.2' but has mismatching fields 'version:2.2.
 [ERROR] Strict mode: aborting
-[ERROR] Could not update repository "oper": OpamStd.OpamSys.Exit(30)
+[ERROR] Could not update repository "oper": OpamStd.OpamSysRunnable(R).Exit(30)
 [ERROR] Fetching repository oper with file://${BASEDIR}/OPER2 fails, reverting to file://${BASEDIR}/OPER
 # Return code 40 #
 ### opam repository --this-switch


### PR DESCRIPTION
This adds a way to create a custom `OpamStd.Sys` using a different runner (in my case Dune's `Process` which uses Dune's `Fiber.t`), which allows us to better control the processes OPAM launches.