### PR TITLE
Return the retrieved checksums on failure

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -594,6 +594,7 @@ users)
   * `OpamVCS.VCS`: add a `clean` function to the interface clearing all the uncommited files [#4879 @rjbou]
   * `OpamVCS.pull_url`: clean repository before fetching [#4879 @rjbou]
   * `OpamDownload`: Add `SWHID` submodule that implements SWH fallback (retrieve url, download, check hash, and copy in target) [#4859 @rjbou]
+  * Functions that download now return the mismatching checksums on verification failure [#5552, @Leonidas-from-XIV]
 
 ## opam-state
   * `OpamSwitchState.universe`: `requested` argument moved from `name_package_set` to `package_set`, to precise installed packages with `--best-effort` [#4796 @LasseBlaauwbroek]

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -296,7 +296,7 @@ let download_shared_source st url nvs =
       Done (Some na))
   @@ fun () ->
   OpamUpdate.download_shared_package_source st url nvs @@| function
-  | Some (Not_available (s, l)), _ ->
+  | Some (Not_available (Generic_error (s, l))), _ ->
     let msg = OpamStd.Option.default l s in
     OpamConsole.error "Failed to get sources of %s%s: %s"
       (labelise OpamPackage.to_string)
@@ -306,7 +306,10 @@ let download_shared_source st url nvs =
          Printf.sprintf " (%s)" (OpamUrl.to_string (OpamFile.URL.url url)))
       msg;
     Some (s, l)
-  | _, ((nv, name, Not_available (s, l)) :: _) ->
+  | Some (Not_available (Checksum_error _)), _ ->
+    (* no checksums provided, can't trigger *)
+    assert false
+  | _, ((nv, name, Not_available (Generic_error (s, l))) :: _) ->
     let msg = match s with None -> l | Some s -> s in
     OpamConsole.error "Failed to get extra source \"%s\" of %s: %s"
       name (OpamPackage.to_string nv) msg;
@@ -468,7 +471,14 @@ let prepare_package_source st nv dir =
         (OpamFile.URL.url urlf :: OpamFile.URL.mirrors urlf)
       @@| function
       | Result () | Up_to_date () -> None
-      | Not_available (_,msg) -> Some (Failure msg)
+      | Not_available (Checksum_error actual_checksums) ->
+        let failures =
+          List.map OpamHash.to_string actual_checksums
+          |> String.concat ", "
+        in
+        let msg = Printf.sprintf "Unexpected checksums: %s" failures in
+        Some (Failure msg)
+      | Not_available (Generic_error (_,msg)) -> Some (Failure msg)
     in
     List.fold_left (fun job dl ->
         job @@+ function

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -174,7 +174,14 @@ let package_files_to_cache repo_root cache_dir cache_urls
               checksums
               (OpamFile.URL.url urlf :: OpamFile.URL.mirrors urlf)
             @@| fun r -> match OpamRepository.report_fetch_result nv r with
-            | Not_available (_,m) -> Some m
+            | Not_available (Generic_error (_,m)) -> Some m
+            | Not_available (Checksum_error failing_checksums) ->
+                let failures =
+                  List.map OpamHash.to_string failing_checksums
+                  |> String.concat ", "
+                in
+                let msg = Printf.sprintf "Failing checksums: %s" failures in
+                Some msg
             | Up_to_date () | Result () -> None
         in
         error_opt @@| function

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3249,7 +3249,10 @@ let pin ?(unpin_only=false) cli =
             ~cache_dir:(OpamRepositoryPath.download_cache
                           OpamStateConfig.(!r.root_dir))
             basename pin_cache_dir [] [url] @@| function
-          | Not_available (_,u) ->
+          | Not_available (Checksum_error _) ->
+            (* no checksums passed *)
+            assert false
+          | Not_available (Generic_error (_,u)) ->
             OpamConsole.error_and_exit `Sync_error
               "Could not retrieve %s" u
           | Result _ | Up_to_date _ ->
@@ -3627,7 +3630,10 @@ let source cli =
                   (OpamPackage.to_string nv) dir []
                   [url])
            with
-           | Not_available (_,u) ->
+           | Not_available (Checksum_error _) ->
+             (* no checksums passed *)
+             assert false
+           | Not_available (Generic_error (_,u)) ->
              OpamConsole.error_and_exit `Sync_error "%s is not available" u
            | Result _ | Up_to_date _ ->
              OpamConsole.formatted_msg
@@ -3638,7 +3644,11 @@ let source cli =
         (let job =
            let open OpamProcess.Job.Op in
            OpamUpdate.download_package_source t nv dir @@+ function
-           | Some (Not_available (_,s)), _ | _, (_, Not_available (_, s)) :: _ ->
+           | Some (Not_available (Checksum_error _)), _
+           | _, (_, Not_available (Checksum_error _)) :: _ ->
+             assert false
+           | Some (Not_available (Generic_error (_,s))), _
+           | _, (_, Not_available (Generic_error (_, s))) :: _ ->
              OpamConsole.error_and_exit `Sync_error "Download failed: %s" s
            | None, _ | Some (Result _ | Up_to_date _), _ ->
              OpamAction.prepare_package_source t nv dir @@| function

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -48,13 +48,19 @@ type std_path =
   | Lib | Bin | Sbin | Share | Doc | Etc | Man
   | Toplevel | Stublibs
 
+type not_available = 
+  | Generic_error of string option * string
+  | Checksum_error of OpamHash.t list
+(** Arguments are respectively the short and long version of an error message.
+    The usage is: the first argument is displayed on normal mode (nothing
+    if [None]), and the second one on verbose mode.
+    If there was an error with checksum validation, the actual checksum
+    is passed in [checksum]. *)
+
 (** Download result *)
 type 'a download =
   | Up_to_date of 'a
-  | Not_available of string option * string
-  (** Arguments are respectively the short and long version of an error message.
-      The usage is: the first argument is displayed on normal mode (nothing
-      if [None]), and the second one on verbose mode. *)
+  | Not_available of not_available
   | Result of 'a
 
 (** {2 Packages} *)

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -81,7 +81,8 @@ module B = struct
            | OpamDownload.Download_fail (s,l) -> s, str l
            | _ -> Some "Download failed", str "download failed"
          in
-         Done (Not_available (s,l)))
+         let na = Generic_error (s, l) in
+         Done (Not_available na))
     @@ fun () ->
     OpamDownload.download ~quiet:true ~overwrite:true ?checksum remote_url dirname
     @@+ fun local_file -> Done (Result (Some local_file))

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -83,7 +83,7 @@ module Make (VCS: VCS) = struct
            (OpamFilename.Dir.to_string dirname)
            (OpamUrl.to_string url)
            (match e with Failure fw -> fw | _ -> Printexc.to_string e);
-         Done (Not_available (None, OpamUrl.to_string url)))
+         Done (Not_available (Generic_error (None, OpamUrl.to_string url))))
     @@ fun () ->
     if VCS.exists dirname then
       VCS.clean dirname @@+ fun () ->

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -735,7 +735,10 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
            OpamLocal.rsync_file url filename
            @@| function
            | Up_to_date f | Result f -> check_checksum f
-           | Not_available (_,src) ->
+           | Not_available (Checksum_error _) ->
+             (* no checksums passed *)
+             assert false
+           | Not_available (Generic_error (_,src)) ->
              Some ("Source not found: "^src)
      in
      cond 60 `Error "Upstream check failed"

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -578,13 +578,13 @@ let download_package_source_t st url nv_dirs =
          dirnames checksums
          (OpamFile.URL.url url :: OpamFile.URL.mirrors url))
       @@+ function
-      | Not_available (_s,_l) as source_result
+      | Not_available _not_available as source_result
         when OpamFile.Config.swh_fallback st.switch_global.config ->
         (OpamDownload.SWHID.archive_fallback url dirnames
          @@| function
          | Result None -> Some source_result
          | Result (Some r) -> Some (Result r)
-         | Not_available (s,l) -> Some (Not_available (s,l))
+         | Not_available na -> Some (Not_available na)
          | Up_to_date _ -> assert false)
       | source_result -> Done (Some source_result)
   in


### PR DESCRIPTION
Before this change it was not possible to get the actual checksum from the API, because OPAM would download the file, compare checksums, emit an error message and delete the file with the wrong checksum.

So to be able to get the actual checksum, one needed to disable the validation and reimplement the validation on top of the unvalidated API call. This PR returns the invalid checksums.
