### PR TITLE
opamfile: parse error on escapable paths

### DIFF
--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -9,6 +9,16 @@
 (*                                                                        *)
 (**************************************************************************)
 
+let is_escapable =
+  let re =
+    Re.(compile @@ seq [
+        alt [ char '/'; char '\\'];
+        str "..";
+        alt [ char '/'; char '\\']
+      ])
+  in
+  fun s -> Re.matches re s <> []
+
 module Base = struct
   include OpamStd.AbstractString
 

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -19,8 +19,17 @@ let is_escapable =
   in
   fun s -> Re.matches re s <> []
 
-module Base = struct
+module AbstractString = struct
   include OpamStd.AbstractString
+  let of_string s =
+    let path = of_string s in
+    if is_escapable path then
+      failwith ("Path must not contain '..': "^path);
+    path
+end
+
+module Base = struct
+  include AbstractString
 
   let compare = String.compare
   let equal = String.equal
@@ -37,7 +46,7 @@ let slog = OpamConsole.slog
 
 module Dir = struct
 
-  include OpamStd.AbstractString
+  include AbstractString
 
   let compare = String.compare
   let equal = String.equal
@@ -541,7 +550,7 @@ module Set = OpamStd.Set.Make(O)
 
 module SubPath = struct
 
-  include OpamStd.AbstractString
+  include AbstractString
 
   let compare = String.compare
   let equal = String.equal

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -12,6 +12,9 @@
 (** Higher level file and directory name manipulation AND file operations,
     wrappers on OpamSystem using the filename type *)
 
+(* Returns [true] if string contains '/../' or '\..\' *)
+val is_escapable: string -> bool
+
 (** Basenames *)
 module Base: sig
   include OpamStd.ABSTRACT

--- a/src/core/opamHash.mli
+++ b/src/core/opamHash.mli
@@ -27,6 +27,7 @@ val sha512: string -> t
 include OpamStd.ABSTRACT with type t := t
 
 val of_string_opt: string -> t option
+val compare_kind: kind -> kind -> int
 
 (** Check if [hash] contains only 0 *)
 val is_null: t -> bool

--- a/src/core/opamUrl.ml
+++ b/src/core/opamUrl.ml
@@ -70,6 +70,8 @@ let split_url =
     match Re.Group.all (Re.exec re u) with
     | [| _; vc; transport; path; suffix; hash |] ->
       let opt = function "" -> None | s -> Some s in
+      if OpamFilename.is_escapable path then
+        parse_error ("Url must not contain '..': "^path);
       opt vc, opt transport, path, opt suffix, opt hash
     | _ -> assert false
 

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -819,7 +819,7 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
               ("file" | "path" | "local" | "rsync") -> true
             | _, _ -> false)
            && (Filename.is_relative u.path
-               || OpamFilename.is_escapable u.path))
+               || OpamStd.String.contains ~sub:".." u.path))
          (all_urls t)
      in
      cond 65 `Error
@@ -916,19 +916,6 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
      cond 70 `Error
        "Field 'url.checksum' contains duplicated checksums"
        ?detail has_double);
-    (let relative =
-       match t.extra_files with
-       | None -> []
-       | Some extra_files ->
-         List.filter_map (fun (base, _) ->
-             let path = OpamFilename.Base.to_string base in
-             if OpamFilename.is_escapable path then Some path else None)
-           extra_files
-     in
-     cond 71 `Error
-       "Field 'extra-files' contains path with '..'"
-       ~detail:relative
-       (relative <> []));
   ]
   in
   format_errors @

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -299,11 +299,11 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
         | #OpamUrl.version_control -> true
         | _ -> false)
   in
-  let check_upstream =
-    check_upstream &&
+  let is_url_archive =
     not (OpamFile.OPAM.has_flag Pkgflag_Conf t) &&
     url_vcs = Some false
   in
+  let check_upstream = check_upstream && is_url_archive in
   let check_double compare to_str lst =
     let double =
       List.sort compare lst
@@ -700,7 +700,7 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
         Printf.sprintf "Found %s variable%s, predefined one%s" var s_ nvar)
        (rem_test || rem_doc));
     cond 59 `Warning "url doesn't contain a checksum"
-      (check_upstream &&
+      (is_url_archive &&
        OpamStd.Option.map OpamFile.URL.checksum t.url = Some []);
     (let upstream_error =
        if not check_upstream then None else

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -906,6 +906,16 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
        "Field 'extra-files' contains duplicated files"
        ?detail
        has_double);
+    (let has_double, detail =
+       check_double OpamHash.compare_kind OpamHash.string_of_kind
+         (match OpamFile.OPAM.url t with
+          | Some url ->
+            List.map OpamHash.kind (OpamFile.URL.checksum url)
+          | None -> [])
+     in
+     cond 70 `Error
+       "Field 'url.checksum' contains duplicated checksums"
+       ?detail has_double);
   ]
   in
   format_errors @

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -819,7 +819,7 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
               ("file" | "path" | "local" | "rsync") -> true
             | _, _ -> false)
            && (Filename.is_relative u.path
-               || OpamStd.String.contains ~sub:".." u.path))
+               || OpamFilename.is_escapable u.path))
          (all_urls t)
      in
      cond 65 `Error
@@ -916,6 +916,19 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
      cond 70 `Error
        "Field 'url.checksum' contains duplicated checksums"
        ?detail has_double);
+    (let relative =
+       match t.extra_files with
+       | None -> []
+       | Some extra_files ->
+         List.filter_map (fun (base, _) ->
+             let path = OpamFilename.Base.to_string base in
+             if OpamFilename.is_escapable path then Some path else None)
+           extra_files
+     in
+     cond 71 `Error
+       "Field 'extra-files' contains path with '..'"
+       ~detail:relative
+       (relative <> []));
   ]
   in
   format_errors @

--- a/tests/reftests/archive.test
+++ b/tests/reftests/archive.test
@@ -475,12 +475,15 @@ Successfully extracted to ${BASEDIR}/no-checksum.1
 Clearing cache of downloaded files
 ### :I:6: multiple md5
 ### opam lint --package multiple-md5
-<default>/multiple-md5.1: Passed.
+<default>/multiple-md5.1: Errors.
+             error 70: Field 'url.checksum' contains duplicated checksums: "md5: 2 occurences"
+# Return code 1 #
 ### opam lint --package multiple-md5 --check-upstream | '[0-9a-z]{32}' -> 'hash'
 <default>/multiple-md5.1: Errors.
              error 60: Upstream check failed: "The archive doesn't match checksum:
                 - archive: md5=hash, in opam file: md5=hash
               ."
+             error 70: Field 'url.checksum' contains duplicated checksums: "md5: 2 occurences"
 # Return code 1 #
 ### opam install multiple-md5 | '[0-9a-z]{32}' -> 'hash'
 The following actions will be performed:
@@ -781,7 +784,9 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 Clearing cache of downloaded files
 ### :I:10: clash with all md5
 ### opam lint --package clash-with-all-md5s
-<default>/clash-with-all-md5s.666: Passed.
+<default>/clash-with-all-md5s.666: Errors.
+             error 70: Field 'url.checksum' contains duplicated checksums: "md5: 17 occurences"
+# Return code 1 #
 ### opam lint --package clash-with-all-md5s --check-upstream | '[0-9a-z]{32,64}' -> 'hash'
 <default>/clash-with-all-md5s.666: Errors.
              error 60: Upstream check failed: "The archive doesn't match checksums:
@@ -803,6 +808,7 @@ Clearing cache of downloaded files
                 - archive: md5=hash, in opam file: md5=hash
                 - archive: sha256=hash, in opam file: sha256=hash
               ."
+             error 70: Field 'url.checksum' contains duplicated checksums: "md5: 17 occurences"
 # Return code 1 #
 ### opam install clash-with-all-md5s | '[0-9a-z]{32}' -> 'hash'
 The following actions will be performed:

--- a/tests/reftests/archive.test
+++ b/tests/reftests/archive.test
@@ -430,7 +430,8 @@ Successfully extracted to ${BASEDIR}/good-sha256-good-md5.1
 Clearing cache of downloaded files
 ### :I:5: no checksum
 ### opam lint --package no-checksum
-<default>/no-checksum.1: Passed.
+<default>/no-checksum.1: Warnings.
+           warning 59: url doesn't contain a checksum
 ### opam lint --package no-checksum --check-upstream
 <default>/no-checksum.1: Warnings.
            warning 59: url doesn't contain a checksum

--- a/tests/reftests/extrafile.test
+++ b/tests/reftests/extrafile.test
@@ -528,10 +528,12 @@ Clearing cache of downloaded files
 ### opam lint --package escape-good-md5
 <default>/escape-good-md5.1: Errors.
              error 53: Mismatching 'extra-files:' field: "../../../no-checksum/no-checksum.1/files/p.patch"
+             error 71: Field 'extra-files' contains path with '..': "../../../no-checksum/no-checksum.1/files/p.patch"
 # Return code 1 #
 ### opam lint --package escape-good-md5 --check-upstream
 <default>/escape-good-md5.1: Errors.
              error 53: Mismatching 'extra-files:' field: "../../../no-checksum/no-checksum.1/files/p.patch"
+             error 71: Field 'extra-files' contains path with '..': "../../../no-checksum/no-checksum.1/files/p.patch"
 # Return code 1 #
 ### # ERROR it copies it to build dir ^ relative path -> escape!!!!
 ### # currently writing in /tmp as a common it copies in

--- a/tests/reftests/extrafile.test
+++ b/tests/reftests/extrafile.test
@@ -155,7 +155,6 @@ Now run 'opam upgrade' to apply any package updates.
 ### :::::::::::::::::
 ### sh -c "rm OPAM/repo/state-*.cache"
 ### OPAMDEBUGSECTIONS="opam-file" OPAMDEBUG=-2 opam list good-md5 -s | unordered
-opam-file                       Missing expected extra files ../../../no-checksum/no-checksum.1/files/p.patch at ${BASEDIR}/OPAM/repo/default/packages/escape-good-md5/escape-good-md5.1/files
 opam-file                       Missing extra-files field for p.patch for no-checksum.1, adding them.
 opam-file                       Missing extra-files field for p.patch for not-mentioned.1, adding them.
 opam-file                       Missing expected extra files p.patch at ${BASEDIR}/OPAM/repo/default/packages/not-present/not-present.1/files
@@ -527,18 +526,17 @@ Clearing cache of downloaded files
 ### :III:2: good md5
 ### opam lint --package escape-good-md5
 <default>/escape-good-md5.1: Errors.
-             error 53: Mismatching 'extra-files:' field: "../../../no-checksum/no-checksum.1/files/p.patch"
+             error  3: File format error in 'extra-files' at line 11, column 3: while expecting file: Path must not contain '..': ../../../no-checksum/no-checksum.1/files/p.patch
 # Return code 1 #
 ### opam lint --package escape-good-md5 --check-upstream
 <default>/escape-good-md5.1: Errors.
-             error 53: Mismatching 'extra-files:' field: "../../../no-checksum/no-checksum.1/files/p.patch"
+             error  3: File format error in 'extra-files' at line 11, column 3: while expecting file: Path must not contain '..': ../../../no-checksum/no-checksum.1/files/p.patch
 # Return code 1 #
-### # ERROR it copies it to build dir ^ relative path -> escape!!!!
-### # currently writing in /tmp as a common it copies in
-### # /tmp/build_d2b6ce_dune/opam-reftest-8f9413/escape-good-md5.1/../../../no-checksum/no-checksum.1/files
-### # This is needed for test portability, windows doesn't check path before resolving it
-### mkdir ${BASEDIR}/OPAM/repo/default/packages/escape-good-md5/escape-good-md5.1/files
 ### opam install escape-good-md5
+[ERROR] In the opam file for escape-good-md5.1:
+          - At ${BASEDIR}/OPAM/repo/default/packages/escape-good-md5/escape-good-md5.1/opam:11:3-11:53::
+            while expecting file: Path must not contain '..': ../../../no-checksum/no-checksum.1/files/p.patch
+        'extra-files' has been ignored.
 The following actions will be performed:
 === install 1 package
   - install escape-good-md5 1
@@ -556,6 +554,10 @@ The following actions will be performed:
 - No changes have been performed
 # Return code 31 #
 ### opam install escape-good-md5 --require-checksums
+[ERROR] In the opam file for escape-good-md5.1:
+          - At ${BASEDIR}/OPAM/repo/default/packages/escape-good-md5/escape-good-md5.1/opam:11:3-11:53::
+            while expecting file: Path must not contain '..': ../../../no-checksum/no-checksum.1/files/p.patch
+        'extra-files' has been ignored.
 The following actions will be performed:
 === install 1 package
   - install escape-good-md5 1

--- a/tests/reftests/extrafile.test
+++ b/tests/reftests/extrafile.test
@@ -528,12 +528,10 @@ Clearing cache of downloaded files
 ### opam lint --package escape-good-md5
 <default>/escape-good-md5.1: Errors.
              error 53: Mismatching 'extra-files:' field: "../../../no-checksum/no-checksum.1/files/p.patch"
-             error 71: Field 'extra-files' contains path with '..': "../../../no-checksum/no-checksum.1/files/p.patch"
 # Return code 1 #
 ### opam lint --package escape-good-md5 --check-upstream
 <default>/escape-good-md5.1: Errors.
              error 53: Mismatching 'extra-files:' field: "../../../no-checksum/no-checksum.1/files/p.patch"
-             error 71: Field 'extra-files' contains path with '..': "../../../no-checksum/no-checksum.1/files/p.patch"
 # Return code 1 #
 ### # ERROR it copies it to build dir ^ relative path -> escape!!!!
 ### # currently writing in /tmp as a common it copies in

--- a/tests/reftests/extrafile.test
+++ b/tests/reftests/extrafile.test
@@ -200,9 +200,13 @@ Successfully extracted to ${BASEDIR}/good-md5.1
 Clearing cache of downloaded files
 ### :I:2: good md5 & sha256
 ### opam lint --package good-md5-good-sha256
-<default>/good-md5-good-sha256.1: Passed.
+<default>/good-md5-good-sha256.1: Errors.
+             error 69: Field 'extra-files' contains duplicated files: "p.patch: 2 occurences"
+# Return code 1 #
 ### opam lint --package good-md5-good-sha256 --check-upstream
-<default>/good-md5-good-sha256.1: Passed.
+<default>/good-md5-good-sha256.1: Errors.
+             error 69: Field 'extra-files' contains duplicated files: "p.patch: 2 occurences"
+# Return code 1 #
 ### opam install good-md5-good-sha256
 The following actions will be performed:
 === install 1 package
@@ -284,9 +288,13 @@ Bad hash for   - ${BASEDIR}/OPAM/repo/default/packages/bad-md5/bad-md5.1/files/p
 Clearing cache of downloaded files
 ### :I:4: good md5 & bad sha256
 ### opam lint --package good-md5-bad-sha256
-<default>/good-md5-bad-sha256.1: Passed.
+<default>/good-md5-bad-sha256.1: Errors.
+             error 69: Field 'extra-files' contains duplicated files: "p.patch: 2 occurences"
+# Return code 1 #
 ### opam lint --package good-md5-bad-sha256 --check-upstream
-<default>/good-md5-bad-sha256.1: Passed.
+<default>/good-md5-bad-sha256.1: Errors.
+             error 69: Field 'extra-files' contains duplicated files: "p.patch: 2 occurences"
+# Return code 1 #
 ### opam install good-md5-bad-sha256
 The following actions will be performed:
 === install 1 package

--- a/tests/reftests/extrasource.test
+++ b/tests/reftests/extrasource.test
@@ -1243,23 +1243,33 @@ Done.
 Successfully extracted to ${BASEDIR}/escape-absolute.1
 ### test -f escape-absolute.1/etc/passwd
 ### :IV:2: good md5
-### # /!\ all escape!!!
 ### opam lint --package escape-build-good-md5
-<default>/escape-build-good-md5.1: Passed.
+<default>/escape-build-good-md5.1: Errors.
+             error  3: File format error in 'extra-source': Path must not contain '..': ../../../../../shouldnt-exist
+# Return code 1 #
 ### opam lint --package escape-build-good-md5 --check-upstream
-<default>/escape-build-good-md5.1: Passed.
+<default>/escape-build-good-md5.1: Errors.
+             error  3: File format error in 'extra-source': Path must not contain '..': ../../../../../shouldnt-exist
+# Return code 1 #
 ### opam install escape-build-good-md5
+[ERROR] In the opam file for escape-build-good-md5.1:
+          - In ${BASEDIR}/OPAM/repo/default/packages/escape-build-good-md5/escape-build-good-md5.1/opam:
+            Path must not contain '..': ../../../../../shouldnt-exist
+        'extra-source' has been ignored.
 The following actions will be performed:
 === install 1 package
   - install escape-build-good-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved escape-build-good-md5.1  (cached)
 -> installed escape-build-good-md5.1
 Done.
 ### test -f shouldnt-exist
-### rm shouldnt-exist
+# Return code 1 #
 ### opam remove escape-build-good-md5
+[ERROR] In the opam file for escape-build-good-md5.1:
+          - In ${BASEDIR}/OPAM/repo/default/packages/escape-build-good-md5/escape-build-good-md5.1/opam:
+            Path must not contain '..': ../../../../../shouldnt-exist
+        'extra-source' has been ignored.
 The following actions will be performed:
 === remove 1 package
   - remove escape-build-good-md5 1
@@ -1268,16 +1278,19 @@ The following actions will be performed:
 -> removed   escape-build-good-md5.1
 Done.
 ### opam install escape-build-good-md5 --require-checksums
+[ERROR] In the opam file for escape-build-good-md5.1:
+          - In ${BASEDIR}/OPAM/repo/default/packages/escape-build-good-md5/escape-build-good-md5.1/opam:
+            Path must not contain '..': ../../../../../shouldnt-exist
+        'extra-source' has been ignored.
 The following actions will be performed:
 === install 1 package
   - install escape-build-good-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved escape-build-good-md5.1  (cached)
 -> installed escape-build-good-md5.1
 Done.
 ### test -f shouldnt-exist
-### rm shouldnt-exist
+# Return code 1 #
 ### opam source escape-source-good-md5
 Successfully extracted to ${BASEDIR}/escape-source-good-md5.1
 ### test -f shouldnt-exist

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -725,9 +725,46 @@ license: "ISC"
 dev-repo: "hg+https://to@li.nt"
 bug-reports: "https://nobug"
 url { src:"an-archive.tgz" }
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Passed.
 ### opam lint ./lint.opam --check-upstream
 ${BASEDIR}/lint.opam: Warnings.
            warning 59: url doesn't contain a checksum
+### <lint.opam>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+url { src:"an-archive.tgz" }
+flags: conf
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Errors.
+             error 46: Package is flagged "conf" but has source, install or remove instructions
+# Return code 1 #
+### opam lint ./lint.opam --check-upstream
+${BASEDIR}/lint.opam: Errors.
+             error 46: Package is flagged "conf" but has source, install or remove instructions
+# Return code 1 #
+### <lint.opam>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+url { src:"git+https://a/repo" }
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Passed.
+### opam lint ./lint.opam --check-upstream
+${BASEDIR}/lint.opam: Passed.
 ### : E60: Upstream check failed
 ### <lint.opam>
 opam-version: "2.0"

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -727,7 +727,8 @@ dev-repo: "hg+https://to@li.nt"
 bug-reports: "https://nobug"
 url { src:"an-archive.tgz" }
 ### opam lint ./lint.opam
-${BASEDIR}/lint.opam: Passed.
+${BASEDIR}/lint.opam: Warnings.
+           warning 59: url doesn't contain a checksum
 ### opam lint ./lint.opam --check-upstream
 ${BASEDIR}/lint.opam: Warnings.
            warning 59: url doesn't contain a checksum

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -865,7 +865,7 @@ pin-depends: [
 ]
 ### opam lint ./lint.opam
 ${BASEDIR}/lint.opam: Errors.
-             error 65: URLs must be absolute: "./my/url/path", "/wrong/../mirror", "./../to@li.nt", "/my/./../extrasource/path", "/my/../pinned/package"
+             error 65: URLs must be absolute: "./my/url/path", "/wrong/../mirror", "./../to@li.nt", "/my/./../extrasource/path", "/my/extrasource..path.patch", "/my/../pinned/package"
 # Return code 1 #
 ### : W66: String that can't be resolved to bool in filtered package formula
 ### <lint.opam>
@@ -1006,30 +1006,4 @@ url {
 ### opam lint ./lint.opam
 ${BASEDIR}/lint.opam: Errors.
              error 70: Field 'url.checksum' contains duplicated checksums: "md5: 2 occurences", "sha256: 3 occurences"
-# Return code 1 #
-### : E71: 
-### <lint.opam>
-opam-version: "2.0"
-synopsis: "A word"
-description: "Two words."
-authors: "the testing team"
-homepage: "egapemoh"
-maintainer: "maint@tain.er"
-license: "ISC"
-dev-repo: "hg+https://to@li.nt"
-bug-reports: "https://nobug"
-extra-source "double-file" {
-  src:"https://git.url/repo.tgz"
-  checksum:"md5=00000000000000000000000000000000"
-}
-extra-files: [
-  [ "./relative/path"            "md5=00000000000000000000000000000000"]
-  [ "/absolute/../relative/path" "md5=00000000000000000000000000000000"]
-  [ "/absolute/path"             "md5=00000000000000000000000000000000"]
-  [ "extra-files..patch.patch"   "md5=00000000000000000000000000000000"]
-]
-### opam lint ./lint.opam
-${BASEDIR}/lint.opam: Errors.
-             error 53: Mismatching 'extra-files:' field: "./relative/path", "/absolute/../relative/path", "/absolute/path", "extra-files..patch.patch"
-             error 71: Field 'extra-files' contains path with '..': "/absolute/../relative/path"
 # Return code 1 #

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -864,7 +864,7 @@ pin-depends: [
 ]
 ### opam lint ./lint.opam
 ${BASEDIR}/lint.opam: Errors.
-             error 65: URLs must be absolute: "./my/url/path", "/wrong/../mirror", "./../to@li.nt", "/my/./../extrasource/path", "/my/extrasource..path.patch", "/my/../pinned/package"
+             error 65: URLs must be absolute: "./my/url/path", "/wrong/../mirror", "./../to@li.nt", "/my/./../extrasource/path", "/my/../pinned/package"
 # Return code 1 #
 ### : W66: String that can't be resolved to bool in filtered package formula
 ### <lint.opam>
@@ -1005,4 +1005,30 @@ url {
 ### opam lint ./lint.opam
 ${BASEDIR}/lint.opam: Errors.
              error 70: Field 'url.checksum' contains duplicated checksums: "md5: 2 occurences", "sha256: 3 occurences"
+# Return code 1 #
+### : E71: 
+### <lint.opam>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+extra-source "double-file" {
+  src:"https://git.url/repo.tgz"
+  checksum:"md5=00000000000000000000000000000000"
+}
+extra-files: [
+  [ "./relative/path"            "md5=00000000000000000000000000000000"]
+  [ "/absolute/../relative/path" "md5=00000000000000000000000000000000"]
+  [ "/absolute/path"             "md5=00000000000000000000000000000000"]
+  [ "extra-files..patch.patch"   "md5=00000000000000000000000000000000"]
+]
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Errors.
+             error 53: Mismatching 'extra-files:' field: "./relative/path", "/absolute/../relative/path", "/absolute/path", "extra-files..patch.patch"
+             error 71: Field 'extra-files' contains path with '..': "/absolute/../relative/path"
 # Return code 1 #

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -265,10 +265,24 @@ homepage: "egapemoh"
 maintainer: "maint@tain.er"
 license: "ISC"
 bug-reports: "https://nobug"
-url { src:"https://u.rl" }
+url {
+  src:"an-archive.tgz"
+  checksum: "md5=00000000000000000000000000000000"
+}
 ### opam lint ./lint.opam
 ${BASEDIR}/lint.opam: Warnings.
            warning 37: Missing field 'dev-repo'
+### <lint.opam>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+bug-reports: "https://nobug"
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Passed.
 ### : E39: Command 'make' called directly, use the built-in variable instead
 ### <lint.opam>
 opam-version: "2.0"

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -585,6 +585,7 @@ echo "extra-files: [ \"more-file-good-md5\" \"md5=$hsh\" ]" >> REPO/packages/lin
 # Return code 1 #
 ### opam lint --package lint.2
 <default>/lint.2: Passed.
+### OPAMREPOSITORYTARRING=0
 ### : W54: External dependencies should not contain spaces nor empty string
 ### <lint.opam>
 opam-version: "2.0"
@@ -912,3 +913,70 @@ bug-reports: "https://nobug"
 ### opam lint ./lint.opam
 ${BASEDIR}/lint.opam: Warnings.
            warning 68: Missing field 'license'
+### : E69: Field 'extra-files' contains duplicated files
+### <pkg:lint.3>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+### <pkg:lint.3:single-file>
+file
+### <pkg:lint.3:double-file>
+file
+### <pkg:lint.3:quadra-file>
+file
+### <hash.sh>
+set -ue
+path=REPO/packages/lint/lint.3
+md5=`openssl md5 $path/files/single-file | cut -f2 -d' '`
+echo "extra-files:[" >> $path/opam
+echo "  [\"single-file\" \"md5=$md5\"]" >> $path/opam
+echo "  [\"double-file\" \"md5=$md5\"]" >> $path/opam
+echo "  [\"double-file\" \"md5=$md5\"]" >> $path/opam
+echo "  [\"quadra-file\" \"md5=$md5\"]" >> $path/opam
+echo "  [\"quadra-file\" \"md5=$md5\"]" >> $path/opam
+echo "  [\"quadra-file\" \"md5=$md5\"]" >> $path/opam
+echo "  [\"quadra-file\" \"md5=$md5\"]" >> $path/opam
+echo "]" >> $path/opam
+### sh hash.sh
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### opam lint --package lint.3
+<default>/lint.3: Errors.
+             error 69: Field 'extra-files' contains duplicated files: "double-file: 2 occurences", "quadra-file: 4 occurences"
+# Return code 1 #
+### : several extra-source
+### <lint.opam>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+extra-source "double-file" {
+  src:"https://git.url/repo.tgz"
+  checksum:"md5=00000000000000000000000000000000"
+}
+extra-source "single-file" {
+  src:"https://git.url/repo.tgz"
+  checksum:"md5=00000000000000000000000000000000"
+}
+extra-source "double-file" {
+  src:"https://git.url/repo.tgz"
+  checksum:"md5=00000000000000000000000000000000"
+}
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Errors.
+             error  3: File format error in 'extra-source': Duplicate section extra-source
+# Return code 1 #

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -839,12 +839,31 @@ authors: "the testing team"
 homepage: "egapemoh"
 maintainer: "maint@tain.er"
 license: "ISC"
-dev-repo: "hg+https://to@li.nt"
+dev-repo: "git+file://./../to@li.nt"
 bug-reports: "https://nobug"
-url { src:"file://./my/path" }
+url {
+  src:"file://./my/url/path"
+  checksum: "md5=00000000000000000000000000000000"
+  mirrors: [
+    "file:///good/mirror"
+    "file:///wrong/../mirror"
+    "file:///another/./mirror/"
+  ]
+}
+extra-source "relative" {
+  src:"file:///my/./../extrasource/path"
+  checksum: "md5=00000000000000000000000000000000"
+}
+extra-source "notrelative" {
+  src:"file:///my/extrasource..path.patch"
+  checksum: "md5=00000000000000000000000000000000"
+}
+pin-depends: [
+  [ "pinned.1" "/my/../pinned/package" ]
+]
 ### opam lint ./lint.opam
 ${BASEDIR}/lint.opam: Errors.
-             error 65: URLs must be absolute: "./my/path"
+             error 65: URLs must be absolute: "./my/url/path", "/wrong/../mirror", "./../to@li.nt", "/my/./../extrasource/path", "/my/extrasource..path.patch", "/my/../pinned/package"
 # Return code 1 #
 ### : W66: String that can't be resolved to bool in filtered package formula
 ### <lint.opam>

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -865,7 +865,12 @@ pin-depends: [
 ]
 ### opam lint ./lint.opam
 ${BASEDIR}/lint.opam: Errors.
-             error 65: URLs must be absolute: "./my/url/path", "/wrong/../mirror", "./../to@li.nt", "/my/./../extrasource/path", "/my/extrasource..path.patch", "/my/../pinned/package"
+             error  3: File format error in 'dev-repo' at line 8, column 0: while expecting vc-url: OpamUrl.Parse_error("Url must not contain '..': ./../to@li.nt")
+             error  3: File format error in 'pin-depends' at line 28, column 15: while expecting URL: OpamUrl.Parse_error("Url must not contain '..': /my/../pinned/package")
+             error  3: File format error in 'extra-source': missing URL
+             error  3: File format error in 'url.mirrors' at line 15, column 4: while expecting url: OpamUrl.Parse_error("Url must not contain '..': /wrong/../mirror")
+           warning 37: Missing field 'dev-repo'
+             error 65: URLs must be absolute: "./my/url/path"
 # Return code 1 #
 ### : W66: String that can't be resolved to bool in filtered package formula
 ### <lint.opam>

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -980,3 +980,29 @@ extra-source "double-file" {
 ${BASEDIR}/lint.opam: Errors.
              error  3: File format error in 'extra-source': Duplicate section extra-source
 # Return code 1 #
+### : E70: Field 'url.checksum' contains duplicated checksums
+### <lint.opam>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+url {
+  src:"an-archive.tgz"
+  checksum:[
+  "md5=00000000000000000000000000000000"
+  "md5=11111111111111111111111111111111"
+  "sha256=2222222222222222222222222222222222222222222222222222222222222222"
+  "sha256=3333333333333333333333333333333333333333333333333333333333333333"
+  "sha256=4444444444444444444444444444444444444444444444444444444444444444"
+  "sha512=55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555"
+  ]
+}
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Errors.
+             error 70: Field 'url.checksum' contains duplicated checksums: "md5: 2 occurences", "sha256: 3 occurences"
+# Return code 1 #

--- a/tests/reftests/show.test
+++ b/tests/reftests/show.test
@@ -353,6 +353,7 @@ depexts devel/llvm10 llvm-10-dev
 opam-version: "2.0"
 url {
   src:"https://an.arch/i/ve.tgz"
+  checksum: "md5=00000000000000000000000000000000"
   mirrors:
     [ "https://a.mi/rror"
       "http://swhid.opam.ocaml.org/swh:1:dir:309cf2674ee7a0749978cf8265ab91a60aea0f7d" ]
@@ -364,18 +365,19 @@ name         swhid
 all-versions dev
 
 <><> Version-specific details <><><><><><><><><><><><><><><><><><><><><><><><><>
-version     dev
-pin         https://an.arch/i/ve.tgz
-url.src     "https://an.arch/i/ve.tgz"
-url.swhid   "swh:1:dir:309cf2674ee7a0749978cf8265ab91a60aea0f7d"
-homepage    "egapemoh"
-bug-reports "https://nobug"
-dev-repo    "hg+https://pkg@op.am"
-authors     "the testing team"
-maintainer  "maint@tain.er"
-license     "MIT"
-synopsis    A word
-description Two words.
+version      dev
+pin          https://an.arch/i/ve.tgz
+url.src      "https://an.arch/i/ve.tgz"
+url.swhid    "swh:1:dir:309cf2674ee7a0749978cf8265ab91a60aea0f7d"
+url.checksum "md5=00000000000000000000000000000000"
+homepage     "egapemoh"
+bug-reports  "https://nobug"
+dev-repo     "hg+https://pkg@op.am"
+authors      "the testing team"
+maintainer   "maint@tain.er"
+license      "MIT"
+synopsis     A word
+description  Two words.
 ### opam show ./swhid.opam --raw
 opam-version: "2.0"
 name: "swhid"
@@ -390,6 +392,7 @@ bug-reports: "https://nobug"
 dev-repo: "hg+https://pkg@op.am"
 url {
   src: "https://an.arch/i/ve.tgz"
+  checksum: "md5=00000000000000000000000000000000"
   mirrors: [
     "https://swhid.opam.ocaml.org/swh:1:dir:309cf2674ee7a0749978cf8265ab91a60aea0f7d"
     "https://a.mi/rror"


### PR DESCRIPTION
Escapable path, containing `..` now raise a parse error.

Removes lint 71 introduced in #5561

/cc @hannesm @reynir 

* [x] queued on #5560
* [x] queued on #5561