### PR TITLE
Print version when failing to parse it

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -596,6 +596,7 @@ users)
   * `OpamVCS.VCS`: add a `clean` function to the interface clearing all the uncommited files [#4879 @rjbou]
   * `OpamVCS.pull_url`: clean repository before fetching [#4879 @rjbou]
   * `OpamDownload`: Add `SWHID` submodule that implements SWH fallback (retrieve url, download, check hash, and copy in target) [#4859 @rjbou]
+  * `OpamCLIVersion.of_string`: print version when failing to parse it [#5566 @MisterDA]
 
 ## opam-state
   * `OpamSwitchState.universe`: `requested` argument moved from `name_package_set` to `package_set`, to precise installed packages with `--best-effort` [#4796 @LasseBlaauwbroek]

--- a/src/client/opamCLIVersion.ml
+++ b/src/client/opamCLIVersion.ml
@@ -19,10 +19,12 @@ let of_string s =
   | i when s.[0] <> '0' && (i >= String.length s - 2 || s.[i + 1] <> '0') ->
     begin
       try Scanf.sscanf s "%u.%u%!" (fun major minor -> (major, minor))
-      with Scanf.Scan_failure _ -> failwith "OpamVersion.CLI.of_string"
+      with Scanf.Scan_failure _ ->
+        Printf.kprintf failwith "OpamVersion.CLI.of_string: %s" s
     end
-  | exception Not_found -> failwith "OpamVersion.CLI.of_string"
-  | _ -> failwith "OpamVersion.CLI.of_string"
+  | exception Not_found ->
+     Printf.kprintf failwith "OpamVersion.CLI.of_string: %s" s
+  | _ -> Printf.kprintf failwith "OpamVersion.CLI.of_string: %s" s
 
 let current = of_string @@ OpamVersion.(to_string current_nopatch)
 


### PR DESCRIPTION
Extracted from #5555: 


>>> What is the origin/point of the second commit `OpamCLIVersion.of_string`?
>>
>> Well, I had to debug why opam was failing to parse/extract its version from the configure file. It was nice to print the actual string to see what happened, a bit like "No such file or directory" is enhanced if you actually know which file or directory has not been found.
>
> Oh i see, for that, it's better to open another PR, to keep them single purpose.

https://github.com/ocaml/opam/pull/5555#issuecomment-1568758308