### PR TITLE
Update bootstrap to use FlexDLL 0.43 from ocaml/flexdll

### DIFF
--- a/.github/scripts/main/ocaml-cache.sh
+++ b/.github/scripts/main/ocaml-cache.sh
@@ -44,7 +44,7 @@ case "$HOST" in
     PREFIX="$OCAML_LOCAL";;
 esac
 
-FLEXDLL_VERSION=0.42
+FLEXDLL_VERSION=0.43
 
 curl -sLO "https://caml.inria.fr/pub/distrib/ocaml-${OCAML_VERSION%.*}/ocaml-$OCAML_VERSION.tar.gz"
 if [[ $PLATFORM = 'Windows' ]] ; then

--- a/master_changes.md
+++ b/master_changes.md
@@ -65,6 +65,7 @@ users)
 
 ## Build
   * Run autoupdate to silence autogen warnings [#5555 @MisterDA]
+  * Update bootstrap to use FlexDLL 0.43 from ocaml/flexdll [#5579 @MisterDA]
 
 ## Infrastructure
 

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -14,8 +14,8 @@ PATCH ?= patch
 URL_ocaml = https://caml.inria.fr/pub/distrib/ocaml-4.14/ocaml-4.14.1.tar.gz
 MD5_ocaml = c45b013a233c9a4b80c3930d723d19dd
 
-URL_flexdll = https://github.com/ocaml/flexdll/archive/0.42.tar.gz
-MD5_flexdll = 9464ae7a7e566ba7c96336cf2f34cc73
+URL_flexdll = https://github.com/ocaml/flexdll/archive/0.43.tar.gz
+MD5_flexdll = 6ce706f6c65b2c5adf5791fac678f090
 
 ifndef FETCH
   ifneq ($(shell command -v curl 2>/dev/null),)


### PR DESCRIPTION
Summary

This release fixes support for parallel usage of Dynlink in OCaml 5.x, several issues with parsing archives correctly, and introduces support for MSYS2's mingw-w64 compilers. Cygwin32 support has been completely removed, following the retirement of the Cygwin32 distribution.

- GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the
  Cygwin flexdll package (David Allsopp)
- GPR#112: Put error global variables into thread-local storage (Samuel Hym, Nicolás Ojeda Bär)
- GPR#114: Support for /alternatename directive. Fixes GPR#113 (Jonah Beckford)
- GPR#116: Remove Cygwin32 (David Allsopp)
- GPR#117: Fix handling of object names of length > 16 in archive files. Fixes GPR#110 (Nicolás Ojeda Bär)
- GPR#118: Defer the detection of cygpath to the first time it's actually
  required, reducing the overall number of calls. Further, detect whether
  mingw-w64 gcc's library path requires cygpath, which further reduces the
  calls when using Cygwin's build of mingw-w64 as the search path is then
  converted only once. In passing, this trivially adds support for MSYS2's
  mingw-w64 compilers, fixing GPR#97. (David Allsopp)


Notes

The binary release includes flexlink.exe compiled with 32-bit mingw-w64 and MSVC objects compiled using the Windows SDK version 7.0 (Windows 7 + .NET 3.5). If you are using large COFF objects you may need to recompile flexlink with a 64-bit compiler. If you are using Visual Studio 2015 or later, the pre-compiled C object files will need to be rebuilt (make CHAINS=msvs support or make CHAINS=msvc64 support). We (still) hope to address both of these issues properly in the next release.

OCaml has supported bootstrap of FlexDLL since 4.03. When compiling from a Git clone, simply run git submodule update --init flexdll or, when compiling from a tarball, unzip the FlexDLL sources into flexdll/. OCaml 4.13 and later will then automatically build FlexDLL as part of the main build.

For OCaml 4.03-4.12, you must explictly run make [-j] flexdll before running make [-j] world[.opt] followed, optionally, by make flexlink.opt. This mode guarantees C objects built with the same C compiler as OCaml and also builds flexlink with the compiler you just built.