### PR TITLE
`opam admin lint`: clean output when stdout is not tty

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -69,6 +69,7 @@ users)
 ## Release scripts
 
 ## Admin
+  * When linting, clean output when stdout is not tty [#5594 @rjbou]
 
 ## Opam installer
 
@@ -113,4 +114,4 @@ users)
 ## opam-format
 
 ## opam-core
-
+  * `OpamConsole.carriage_delete`: no-op when not tty out [XXX @rjbou]

--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -451,6 +451,7 @@ let carriage_delete_windows () =
       carriage_delete_unix ()
 
 let carriage_delete =
+  if not OpamStd.Sys.tty_out then fun () -> () else
   if Sys.win32 then
     let carriage_delete = lazy (
       match get_win32_console_shim `stdout Mode with

--- a/tests/reftests/admin.test
+++ b/tests/reftests/admin.test
@@ -392,9 +392,9 @@ packages/ocaml-system/ocaml-system.1.2/files/gen_ocaml_config.ml.in
 repo
 ### : lint :
 ### opam admin lint
-[KIn base-comp.base:
+In base-comp.base:
            warning 47: Synopsis should start with a capital and not end with a dot
-[KIn risus.1:
+In risus.1:
              error 23: Missing field 'maintainer'
            warning 25: Missing field 'authors'
            warning 35: Missing field 'homepage'


### PR DESCRIPTION

see https://github.com/ocaml/opam/pull/5385#discussion_r1135565693

* [x] queued on #5385 