### PR TITLE
resolve command: don't select directories

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -148,3 +148,4 @@ users)
 
 ## opam-core
   * `OpamSystem.mk_temp_dir`: resolve real path with `OpamSystem.real_path` before returning it [#5654 @rjbou]
+  * `OpamSystem.resolve_command`: in command resolution path, check that the file is not a directory and that it is a regular file [#5606 @rjbou - fix #5585 #5597]

--- a/master_changes.md
+++ b/master_changes.md
@@ -118,6 +118,7 @@ users)
   * Reimplement `sed-cmd` command regexp, to handle prefixed commands with path not only in subprocess, but anywere in output [#5657 #5607 @rjbou]
   * Add environment variables path addition [#5606 @rjbou]
   * Remove duplicated environment variables in environmenet [#5606 @rjbou]
+  * Add `PATH` to replaceable variables [#5606 @rjbou]
 
 ## Github Actions
   * Add coreutils install for cheksum validation tests [#5560 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -111,6 +111,7 @@ users)
   * Move local-cache into archive-field-checks test [#5560 @rjbou]
   * Admin: add `admin add-extrafiles` test cases [#5647 @rjbou]
   * Add download test, to check `OPAMCURL/OPAMFETCH` handling [#5607 @rjbou]
+  * Add `core/opamSystem.ml` specific tests, to test command resolution [#5600 @rjbou]
 
 ### Engine
   * With real path resolved for all opam temp dir, remove `/private` from mac temp dir regexp [#5654 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -115,6 +115,7 @@ users)
 ### Engine
   * With real path resolved for all opam temp dir, remove `/private` from mac temp dir regexp [#5654 @rjbou]
   * Reimplement `sed-cmd` command regexp, to handle prefixed commands with path not only in subprocess, but anywere in output [#5657 #5607 @rjbou]
+  * Add environment variables path addition [#5606 @rjbou]
 
 ## Github Actions
   * Add coreutils install for cheksum validation tests [#5560 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -117,6 +117,7 @@ users)
   * With real path resolved for all opam temp dir, remove `/private` from mac temp dir regexp [#5654 @rjbou]
   * Reimplement `sed-cmd` command regexp, to handle prefixed commands with path not only in subprocess, but anywere in output [#5657 #5607 @rjbou]
   * Add environment variables path addition [#5606 @rjbou]
+  * Remove duplicated environment variables in environmenet [#5606 @rjbou]
 
 ## Github Actions
   * Add coreutils install for cheksum validation tests [#5560 @rjbou]

--- a/tests/reftests/core-system.unix.test
+++ b/tests/reftests/core-system.unix.test
@@ -1,0 +1,33 @@
+N0REP0
+### # This test is unix only until https://github.com/ocaml/opam/pull/5682 resolution
+### ::::::::::::::::::::::::::::::::::
+### :I: System.resolve_commands checks
+### ::::::::::::::::::::::::::::::::::
+### opam switch create resolve --empty
+### :I:a: System one
+### opam exec -- echo system
+system
+### opam exec --no-switch -- echo system
+system
+### :I:b: is a directory
+### mkdir -p bin/echo
+### PATH+=$BASEDIR/bin/
+### opam exec -- echo system
+Fatal error: exception ${OPAM}: "execvpe" failed on ${BASEDIR}/bin/echo: Permission denied
+# Return code 2 #
+### opam exec --no-switch -- echo system
+system
+### :I:c: is not executable
+### rm -rf bin/echo
+### <bin/echo>
+echo 'echo'
+### opam exec -- echo system
+system
+### opam exec --no-switch -- echo system
+system
+### :I:d: is executable
+### chmod +x bin/echo
+### opam exec -- echo system
+echo
+### opam exec --no-switch -- echo system
+system

--- a/tests/reftests/core-system.unix.test
+++ b/tests/reftests/core-system.unix.test
@@ -13,11 +13,9 @@ system
 ### mkdir -p bin/echo
 ### PATH+=$BASEDIR/bin/
 ### opam exec -- echo system
-Fatal error: exception ${OPAM}: "execvpe" failed on ${BASEDIR}/bin/echo: Permission denied
-# Return code 2 #
+system
 ### opam exec --no-switch -- echo system
-Fatal error: exception ${OPAM}: "execvpe" failed on ${BASEDIR}/bin/echo: Permission denied
-# Return code 2 #
+system
 ### :I:c: is not executable
 ### rm -rf bin/echo
 ### <bin/echo>

--- a/tests/reftests/core-system.unix.test
+++ b/tests/reftests/core-system.unix.test
@@ -16,7 +16,8 @@ system
 Fatal error: exception ${OPAM}: "execvpe" failed on ${BASEDIR}/bin/echo: Permission denied
 # Return code 2 #
 ### opam exec --no-switch -- echo system
-system
+Fatal error: exception ${OPAM}: "execvpe" failed on ${BASEDIR}/bin/echo: Permission denied
+# Return code 2 #
 ### :I:c: is not executable
 ### rm -rf bin/echo
 ### <bin/echo>
@@ -30,4 +31,4 @@ system
 ### opam exec -- echo system
 echo
 ### opam exec --no-switch -- echo system
-system
+echo

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -270,6 +270,27 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:conflict-solo5.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-core-system.unix)
+ (enabled_if (= %{os_type} "Unix"))
+ (action
+  (diff core-system.unix.test core-system.unix.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (= %{os_type} "Unix"))
+ (deps (alias reftest-core-system.unix)))
+
+(rule
+ (targets core-system.unix.out)
+ (deps root-N0REP0)
+ (enabled_if (= %{os_type} "Unix"))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:core-system.unix.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-cudf-preprocess)
  (action
   (diff cudf-preprocess.test cudf-preprocess.out)))

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -196,7 +196,10 @@ let command
   let env =
     Array.of_list @@
     List.map (fun (var, value) -> Printf.sprintf "%s=%s" var value) @@
-    (base_env @ vars)
+    (List.filter (fun (v,_) ->
+         List.find_opt (fun (v',_) -> String.equal v v') vars = None)
+        base_env)
+    @ vars
   in
   let input, stdout = Unix.pipe () in
   Unix.set_close_on_exec input;

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -696,6 +696,7 @@ let run_test ?(vars=[]) ~opam t =
     "OPAM", opam.as_seen_in_opam;
     "OPAMROOT", opamroot;
     "BASEDIR", dir;
+    "PATH", Sys.getenv "PATH";
   ] @ vars
   in
   if t.repo_hash = no_opam_repo then


### PR DESCRIPTION
This PR contains 2 different fixes, that can't be split. It fixes #5585, #5650 and partially #5597, as it fixes command resolve that is it happen to be a directory. I also add a test for that, and to have the test working, reftest engine needs a fix. It was keeping duplicated environment variables in environment given as argument to process creation, and it was not expanding `PATH` on variable export.
It also add syntax to declare env vars paths additions `PATH+=path/to` or `PATH=+path/to`, to make it portable between unix & windows (`:` versus `;`).

Todo:
* [x] update changes