### PR TITLE
Fix `OPAMFETCH`/`OPAMCURL` handling

### DIFF
--- a/.github/scripts/cygwin.cmd
+++ b/.github/scripts/cygwin.cmd
@@ -96,6 +96,9 @@ if "%1" equ "x86_64-pc-cygwin" (
 :: is found
 set CYGWIN_PACKAGES=make,patch,curl,diffutils,tar,unzip,git,gcc-g++,libicu-devel%CYGWIN_PACKAGES%
 
+:: wget is needed for download.test OPAMFETCH/OPAMCURL testing
+set CYGWIN_PACKAGES=wget,%CYGWIN_PACKAGES%
+
 :: D:\cygwin-packages is specified just to keep the build directory clean; the
 :: files aren't preserved.
 %CYGWIN_ROOT%\setup.exe --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root %CYGWIN_ROOT% --site "%CYGWIN_MIRROR%" --local-package-dir D:\cygwin-packages --packages %CYGWIN_PACKAGES%

--- a/master_changes.md
+++ b/master_changes.md
@@ -115,6 +115,7 @@ users)
 
 ## Github Actions
   * Add coreutils install for cheksum validation tests [#5560 @rjbou]
+  * Add `wget` on Cygwin install [#5607 @rjbou]
 
 ## Doc
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -108,6 +108,7 @@ users)
   * Add several checksum & cache validation checks for archive, extra-source section, and extra-file field [#5560 @rjbou]
   * Move local-cache into archive-field-checks test [#5560 @rjbou]
   * Admin: add `admin add-extrafiles` test cases [#5647 @rjbou]
+  * Add download test, to check `OPAMCURL/OPAMFETCH` handling [#5607 @rjbou]
 
 ### Engine
   * With real path resolved for all opam temp dir, remove `/private` from mac temp dir regexp [#5654 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -54,6 +54,7 @@ users)
   * Allow to mark a set of warnings as errors using a new syntax -W @1..9 [#5652 @kit-ty-kate @rjbou - fixes #5651]
 
 ## Repository
+  * Fix `OPAMCURL` and `OPAMFETCH` handling [#5607 @rjbou - fix #5597]
 
 ## Lock
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -111,7 +111,7 @@ users)
 
 ### Engine
   * With real path resolved for all opam temp dir, remove `/private` from mac temp dir regexp [#5654 @rjbou]
-  * Reimplement `sed-cmd` command regexp, to handle prefixed commands with path not only in subprocess, but anywere in output [#5657 @rjbou]
+  * Reimplement `sed-cmd` command regexp, to handle prefixed commands with path not only in subprocess, but anywere in output [#5657 #5607 @rjbou]
 
 ## Github Actions
   * Add coreutils install for cheksum validation tests [#5560 @rjbou]

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -1,0 +1,150 @@
+N0REP0
+### ::::::::::::::::::::::::::::::::::
+### :I: OPAMFETCH & OPAMCURL variables
+### ::::::::::::::::::::::::::::::::::
+### OPAMVERBOSE=2
+### opam --version >$ OPAMVERSION
+### <pkg:foo.1>
+opam-version: "2.0"
+url {
+  src: "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
+  checksum: "md5=c9c157af4229fbb45d3f59f0d6d75dbe"
+}
+### opam switch create download --empty
+### opam install foo --download-only | grep -v "^+-" | ".*\(curl\|wget\).* \"--\"" -> 'curl-or-wget --' | sed-cmd tar
+The following actions will be performed:
+=== install 1 package
+  - install foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  1/1: [foo.1: http]
+curl-or-wget -- "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
+Processing  1/1:
++ tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
+Done.
+### opam clean -c
+Clearing cache of downloaded files
+### :I:a: FETCH wget
+### OPAMFETCH=wget
+### opam install foo --download-only | grep -v "^+-" | sed-cmd wget | sed-cmd tar | "${OPAMVERSION}" -> "current"
+The following actions will be performed:
+=== install 1 package
+  - install foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  1/1: [foo.1: http]
++ wget "--content-disposition" "-t" "3" "-O" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
+Processing  1/1:
++ tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
+Done.
+### opam clean -c
+Clearing cache of downloaded files
+### :I:b: FETCH curl
+### OPAMFETCH=curl
+### opam install foo --download-only | grep -v "^+-" | sed-cmd curl | sed-cmd tar | "${OPAMVERSION}" -> "current"
+The following actions will be performed:
+=== install 1 package
+  - install foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  1/1: [foo.1: http]
++ curl "--write-out" "%{http_code}\n" "--retry" "3" "--retry-delay" "2" "--user-agent" "opam/current" "-L" "-o" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
+Processing  1/1:
++ tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
+Done.
+### opam clean -c
+Clearing cache of downloaded files
+### :I:c: FETCH curl with args
+### OPAMFETCH="curl --another-args %{retry}%"
+### opam install foo --download-only | grep -v "^+-" | sed-cmd curl
+The following actions will be performed:
+=== install 1 package
+  - install foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  1/1: [foo.1: http]
++ curl "--another-args" "3"
+[ERROR] Failed to get sources of foo.1: Curl failed
+
+OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (Curl failed: \"curl --another-args 3\" exited with code 2)")
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+'${OPAM} install foo --download-only' failed.
+# Return code 40 #
+### opam clean -c
+Clearing cache of downloaded files
+### <bin/curl>
+#!/usr/bin/env bash
+echo "***The curl is a lie*** [args: $@]"
+### chmod +x bin/curl
+### :I:d: local curl
+### OPAMCURL=$BASEDIR/bin/curl
+### opam install foo --download-only | grep -v "^+-" | sed-cmd curl
+The following actions will be performed:
+=== install 1 package
+  - install foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  1/1: [foo.1: http]
++ curl "--another-args" "3"
+[ERROR] Failed to get sources of foo.1: Curl failed
+
+OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (Curl failed: \"curl --another-args 3\" exited with code 2)")
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+'${OPAM} install foo --download-only' failed.
+# Return code 40 #
+### opam clean -c
+Clearing cache of downloaded files
+### :I:e: FETCH curl & local curl
+### OPAMFETCH=curl OPAMCURL=$BASEDIR/bin/curl
+### opam install foo --download-only | grep -v "^+-" | sed-cmd curl | sed-cmd tar | "${OPAMVERSION}" -> "current"
+The following actions will be performed:
+=== install 1 package
+  - install foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  1/1: [foo.1: http]
++ curl "--write-out" "%{http_code}\n" "--retry" "3" "--retry-delay" "2" "--user-agent" "opam/current" "-L" "-o" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
+Processing  1/1:
++ tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
+Done.
+### opam clean -c
+Clearing cache of downloaded files
+### :I:f: FETCH curl with args & local curl
+### OPAMFETCH="curl --another-args %{retry}%" OPAMCURL=$BASEDIR/bin/curl
+### opam install foo --download-only | grep -v "^+-" | sed-cmd curl
+The following actions will be performed:
+=== install 1 package
+  - install foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  1/1: [foo.1: http]
++ curl "--another-args" "3"
+[ERROR] Failed to get sources of foo.1: Curl failed
+
+OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (Curl failed: \"curl --another-args 3\" exited with code 2)")
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+'${OPAM} install foo --download-only' failed.
+# Return code 40 #
+### opam clean -c
+Clearing cache of downloaded files
+### :I:g: FETCH wget & local curl
+### OPAMFETCH=wget OPAMCURL=$BASEDIR/bin/curl
+### opam install foo --download-only | grep -v "^+-" | sed-cmd wget | sed-cmd tar | "${OPAMVERSION}" -> "current"
+The following actions will be performed:
+=== install 1 package
+  - install foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  1/1: [foo.1: http]
++ wget "--content-disposition" "-t" "3" "-O" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
+Processing  1/1:
++ tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
+Done.
+### opam clean -c
+Clearing cache of downloaded files

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -88,9 +88,9 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
 + curl "--another-args" "3"
-[ERROR] Failed to get sources of foo.1: Curl failed
+[ERROR] Failed to get sources of foo.1: curl error code ***The curl is a lie*** [args: --another-args 3]
 
-OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (Curl failed: \"curl --another-args 3\" exited with code 2)")
+OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (curl: code ***The curl is a lie*** [args: --another-args 3] while downloading https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz)")
 
 
 <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
@@ -100,7 +100,7 @@ OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.t
 Clearing cache of downloaded files
 ### :I:e: FETCH curl & local curl
 ### OPAMFETCH=curl OPAMCURL=$BASEDIR/bin/curl
-### opam install foo --download-only | grep -v "^+-" | sed-cmd curl | sed-cmd tar | "${OPAMVERSION}" -> "current"
+### opam install foo --download-only | grep -v "^+-" | sed-cmd curl | "${OPAMVERSION}" -> "current"
 The following actions will be performed:
 === install 1 package
   - install foo 1
@@ -108,9 +108,14 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
 + curl "--write-out" "%{http_code}\n" "--retry" "3" "--retry-delay" "2" "--user-agent" "opam/current" "-L" "-o" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
-Processing  1/1:
-+ tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
-Done.
+[ERROR] Failed to get sources of foo.1: curl error code ***The curl is a lie*** [args: --write-out %{http_code}\n --retry 3 --retry-delay 2 --user-agent opam/current -L -o ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part -- https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz]
+
+OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (curl: code ***The curl is a lie*** [args: --write-out %{http_code}\n --retry 3 --retry-delay 2 --user-agent opam/current -L -o ${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part -- https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz] while downloading https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz)")
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+'${OPAM} install foo --download-only' failed.
+# Return code 40 #
 ### opam clean -c
 Clearing cache of downloaded files
 ### :I:f: FETCH curl with args & local curl
@@ -123,9 +128,9 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
 + curl "--another-args" "3"
-[ERROR] Failed to get sources of foo.1: Curl failed
+[ERROR] Failed to get sources of foo.1: curl error code ***The curl is a lie*** [args: --another-args 3]
 
-OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (Curl failed: \"curl --another-args 3\" exited with code 2)")
+OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (curl: code ***The curl is a lie*** [args: --another-args 3] while downloading https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz)")
 
 
 <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -360,6 +360,24 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:dot-install.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-download)
+ (action
+  (diff download.test download.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-download)))
+
+(rule
+ (targets download.out)
+ (deps root-N0REP0)
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:download.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-empty-conflicts-001)
  (action
   (diff empty-conflicts-001.test empty-conflicts-001.out)))

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -468,8 +468,9 @@ module Parse = struct
               *)
               opt_quoted @@ [
                 alpha; char ':';
-                rep1 @@ seq [ char '\\'; rep1 @@ diff any (with_quote_set "\\") ];
-                char '\\';
+                rep1 @@ seq [ char '\\'; opt @@ char '\\';
+                              rep1 @@ diff any (with_quote_set "\\") ];
+                char '\\'; opt @@ char '\\';
                 Re.str cmd;
                 opt @@ Re.str ".exe";
               ] in


### PR DESCRIPTION
`OPAMCURL` is ignored if `OPAMFETCH` is set. This is changed to handle `OPAMCURL` specification when `OPAMFETCH` is set to `curl` (simple command, or new arguments). If `OPAMFETCH` is set to another tool, OPAMCURL is ignored.

Todo:
* [x] update changes
* [x] queud on #5654