### PR TITLE
Various cleanups related to OCaml 5.0

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -4,7 +4,7 @@ mandir = @mandir@
 version = @PACKAGE_VERSION@
 FETCH = @fetch@
 
-PACKS = $(filter-out no,@OCAML_PKG_unix@ @OCAML_PKG_bigarray@ @OCAML_PKG_extlib@ @OCAML_PKG_re@ @OCAML_PKG_re_glob@ @OCAML_PKG_cmdliner@ @OCAML_PKG_ocamlgraph@ @OCAML_PKG_cudf@ @OCAML_PKG_dose3_common@ @OCAML_PKG_dose3_algo@ @OCAML_PKG_opam_file_format@ @OCAML_PKG_mccs@)
+PACKS = $(filter-out no,@OCAML_PKG_unix@ @OCAML_PKG_extlib@ @OCAML_PKG_re@ @OCAML_PKG_re_glob@ @OCAML_PKG_cmdliner@ @OCAML_PKG_ocamlgraph@ @OCAML_PKG_cudf@ @OCAML_PKG_dose3_common@ @OCAML_PKG_dose3_algo@ @OCAML_PKG_opam_file_format@ @OCAML_PKG_mccs@)
 
 CONF_OCAMLFLAGS = @CONF_OCAMLFLAGS@
 

--- a/configure
+++ b/configure
@@ -668,7 +668,6 @@ OCAML_PKG_ocamlgraph
 OCAML_PKG_cmdliner
 OCAML_PKG_base64
 OCAML_PKG_re
-OCAML_PKG_bigarray
 OCAML_PKG_unix
 CONF_MANIFEST_O
 RUNTIME_GCC_S
@@ -6176,30 +6175,6 @@ printf "%s\n" "found" >&6; }
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: not found" >&5
 printf "%s\n" "not found" >&6; }
     OCAML_PKG_unix=no
-  fi
-
-
-
-
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for OCaml findlib package bigarray" >&5
-printf %s "checking for OCaml findlib package bigarray... " >&6; }
-
-  unset found
-  unset pkg
-  found=no
-  for pkg in bigarray  ; do
-    if $OCAMLFIND query $pkg >/dev/null 2>/dev/null; then
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found" >&5
-printf "%s\n" "found" >&6; }
-      OCAML_PKG_bigarray=$pkg
-      found=yes
-      break
-    fi
-  done
-  if test "$found" = "no" ; then
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: not found" >&5
-printf "%s\n" "not found" >&6; }
-    OCAML_PKG_bigarray=no
   fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -329,7 +329,6 @@ echo
 
 # Dependencies
 AC_CHECK_OCAML_PKG([unix])
-AC_CHECK_OCAML_PKG([bigarray])
 AC_CHECK_OCAML_PKG_AT_LEAST([re], [1.9.0])
 AC_CHECK_OCAML_PKG_AT_LEAST([base64], [3.1.0])
 AC_CHECK_OCAML_PKG([cmdliner])

--- a/master_changes.md
+++ b/master_changes.md
@@ -63,6 +63,8 @@ users)
 ## VCS
 
 ## Build
+  * Remove `bigarray` dependency [#5612 @kit-ty-kate]
+  * Remove use of deprecated `Printf.kprintf" [#5612 @kit-ty-kate]
 
 ## Infrastructure
 

--- a/opam-core.opam
+++ b/opam-core.opam
@@ -30,7 +30,6 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "base-unix"
-  "base-bigarray"
   "ocamlgraph"
   "re" {>= "1.9.0"}
   "dune" {>= "2.0.0"}

--- a/src/client/opamCLIVersion.ml
+++ b/src/client/opamCLIVersion.ml
@@ -20,11 +20,11 @@ let of_string s =
     begin
       try Scanf.sscanf s "%u.%u%!" (fun major minor -> (major, minor))
       with Scanf.Scan_failure _ ->
-        Printf.kprintf failwith "OpamVersion.CLI.of_string: %s" s
+        Printf.ksprintf failwith "OpamVersion.CLI.of_string: %s" s
     end
   | exception Not_found ->
-     Printf.kprintf failwith "OpamVersion.CLI.of_string: %s" s
-  | _ -> Printf.kprintf failwith "OpamVersion.CLI.of_string: %s" s
+     Printf.ksprintf failwith "OpamVersion.CLI.of_string: %s" s
+  | _ -> Printf.ksprintf failwith "OpamVersion.CLI.of_string: %s" s
 
 let current = of_string @@ OpamVersion.(to_string current_nopatch)
 

--- a/src/core/dune
+++ b/src/core/dune
@@ -3,7 +3,7 @@
   (public_name opam-core)
   (synopsis    "OCaml Package Manager core internal stdlib")
   ; TODO: Remove (re_export ...) when CI uses the OCaml version that includes https://github.com/ocaml/ocaml/pull/11989
-  (libraries   re (re_export ocamlgraph) unix bigarray sha jsonm swhid_core uutf
+  (libraries   re (re_export ocamlgraph) unix sha jsonm swhid_core uutf
                (select opamACL.ml from
                        (opam-core.libacl -> opamACL.libacl.ml)
                        (                 -> opamACL.dummy.ml))


### PR DESCRIPTION
This PR brings a couple of cleanups noticed when using OCaml >= 5.0:
* In OCaml 5.0 the `bigarray` library was removed. Since opam now requires at least OCaml 4.08 and bigarray has been part of the standard library since 4.08 we can now remove the dependencies on it
* Since OCaml 5.0 `Printf.kprintf` now shows a deprecation warning when used. `Printf.ksprintf` should be used instead