### PR TITLE
Make opam config report and opam switch set-invariant return the actual invariant syntax expected by --invariant

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -24,6 +24,7 @@ users)
 
 ## Config report
   * Always list all the repositories regardless of whether or not a switch is currently set [#6116 @kit-ty-kate]
+  * Make `opam config report` return the actual invariant syntax expected by `--invariant` [#5619 @kit-ty-kate - fixes #5491]
 
 ## Actions
   * Add support for wget2 [#6104 @kit-ty-kate]
@@ -45,6 +46,7 @@ users)
   * ◈ Add `opam switch import --deps-only` option to install only dependencies of root package at import [#5388 @rjbou - fix #5200]
   * [BUG] Make accepted `--repos` URLs on creation consistent with `opam repository` [#6091 @Keryan-dev - fix #4673]
   * ◈ opam switch list-available will not display compilers flagged with avoid-version/deprecated unless --all is given [#6098 @kit-ty-kate - fix #6089]
+  * Make `opam switch set-invariant` return the actual invariant syntax expected by `--invariant` [#5619 @kit-ty-kate - fixes #5491]
 
 ## Config
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1555,7 +1555,7 @@ let config cli =
             print "current-switch" "%s"
               (OpamSwitch.to_string state.switch);
             print "invariant" "%s"
-              (OpamFormula.to_string state.switch_invariant);
+              (OpamFileTools.dep_formula_to_string state.switch_invariant);
             print "compiler-packages" "%s"
               (let packages = OpamSwitchState.compiler_packages state in
                if OpamPackage.Set.is_empty packages then "none" else
@@ -3118,7 +3118,7 @@ let switch cli =
          in
          let st = OpamSwitchCommand.set_invariant ~force st invariant in
          OpamConsole.msg "The switch invariant was set to %s\n"
-           (OpamFormula.to_string invariant);
+           (OpamFileTools.dep_formula_to_string invariant);
          let st =
            if no_action || OpamFormula.satisfies_depends st.installed invariant
            then OpamSwitchAction.update_switch_state st

--- a/tests/reftests/cli-versioning.test
+++ b/tests/reftests/cli-versioning.test
@@ -33,7 +33,7 @@ Added 'cli: "version"' to field variables in switch cli-versioning
 [WARNING] OPAMNODEPEXTS was ignored because CLI 2.0 was requested and it was introduced in 2.1.
 Added 'cli: "version"' to field variables in switch cli-versioning
 ### OPAMSHOW=0 opam switch set-invariant baz.1 --no-action
-The switch invariant was set to baz = 1
+The switch invariant was set to ["baz" {= "1"}]
 ### OPAMCLI=2.0 opam install baz.2
 [WARNING] OPAMNODEPEXTS was ignored because CLI 2.0 was requested and it was introduced in 2.1.
 [ERROR] Package conflict!

--- a/tests/reftests/config.test
+++ b/tests/reftests/config.test
@@ -124,7 +124,7 @@ Done.
 # repositories         2 (local)
 # pinned               1 (rsync)
 # current-switch       a-switch
-# invariant            meta-compiler = 1
+# invariant            ["meta-compiler" {= "1"}]
 # compiler-packages    compiler.1, dep-compiler.1
 # meta-compiler:compvar something
 ### opam repository remove second --all
@@ -184,7 +184,7 @@ Done.
 # repositories         1 (local)
 # pinned               0
 # current-switch       a-package-invariant
-# invariant            a-package
+# invariant            ["a-package"]
 # compiler-packages    compiler.1, dep-compiler.1
 # meta-compiler:compvar something
 ### # compiler with depopt
@@ -212,6 +212,6 @@ Done.
 # repositories         1 (local)
 # pinned               0
 # current-switch       a-compiler-with-depopt
-# invariant            meta-compiler & depopt-compiler
+# invariant            ["meta-compiler" "depopt-compiler"]
 # compiler-packages    compiler.1, dep-compiler.1, depopt-compiler.1
 # meta-compiler:compvar something

--- a/tests/reftests/list-large-dependencies.test
+++ b/tests/reftests/list-large-dependencies.test
@@ -336,7 +336,7 @@ abt
 No solution found, exiting
 # Return code 20 #
 ### opam switch set-invariant --formula '["ocaml" {>= "4.01.0"}]' --no-action
-The switch invariant was set to ocaml >= 4.01.0
+The switch invariant was set to ["ocaml" {>= "4.01.0"}]
 ### opam list ab* -s --installable
 abella
 absolute

--- a/tests/reftests/switch-invariant.test
+++ b/tests/reftests/switch-invariant.test
@@ -15,7 +15,7 @@ opam-version: "2.0"
 [non-default] no changes from file://${BASEDIR}/repo2
 ### opam switch create inv --empty --repo=default,non-default
 ### opam switch set-invariant foo
-The switch invariant was set to foo
+The switch invariant was set to ["foo"]
 The following actions will be performed:
 === install 1 package
   - install foo 1
@@ -24,11 +24,11 @@ The following actions will be performed:
 -> installed foo.1
 Done.
 ### opam switch set-invariant foo
-The switch invariant was set to foo
+The switch invariant was set to ["foo"]
 ### opam switch set-invariant --package foo
-The switch invariant was set to foo
+The switch invariant was set to ["foo"]
 ### opam switch set-invariant bar
-The switch invariant was set to bar
+The switch invariant was set to ["bar"]
 The following actions will be performed:
 === install 1 package
   - install bar 1
@@ -37,7 +37,7 @@ The following actions will be performed:
 -> installed bar.1
 Done.
 ### opam switch set-invariant --package bar
-The switch invariant was set to bar
+The switch invariant was set to ["bar"]
 ### <pkg:bar.1>
 opam-version: "2.0"
 ### <pkg:bar.2>

--- a/tests/reftests/switch-list.test
+++ b/tests/reftests/switch-list.test
@@ -41,7 +41,7 @@ The following actions will be performed:
 -> installed g.1
 Done.
 ### opam switch set-invariant b
-The switch invariant was set to b
+The switch invariant was set to ["b"]
 ### opam switch list
 #   switch   compiler  description
 ->  display  a.1       display
@@ -113,7 +113,7 @@ The following actions will be performed:
 -> installed g.1
 Done.
 ### opam switch set-invariant b
-The switch invariant was set to b
+The switch invariant was set to ["b"]
 The following actions will be performed:
 === install 1 package
   - install b 1


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/5491