### PR TITLE
Check that all the binaries are running on their own hosts before copying them

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -115,6 +115,7 @@ host: $(OUTDIR)/opam-full-$(VERSION).tar.gz build/$(HOST).env
 	)
 	cp build/opam-full-$(VERSION)/opam $(OUTDIR)/opam-$(VERSION)-$(HOST)
 	strip $(OUTDIR)/opam-$(VERSION)-$(HOST)
+	$(OUTDIR)/opam-$(VERSION)-$(HOST) --version
 	rm -rf build/opam-full-$(VERSION)
 
 # Containerised builds


### PR DESCRIPTION
Should avoid #5621 in the future