### PR TITLE
`OpamFilter` file substitutions with source & destination

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -114,4 +114,7 @@ users)
 
 ## opam-format
 
+* Add `OpamFilter.expand_interpolations_in_file_full` which allows setting the
+  output file along with the input file [#5629 @rgrinberg]
+
 ## opam-core

--- a/src/format/opamFilter.ml
+++ b/src/format/opamFilter.ml
@@ -417,12 +417,10 @@ let ident_string ?default env id = value_string ?default (resolve_ident env id)
 
 let ident_bool ?default env id = value_bool ?default (resolve_ident env id)
 
-(* Substitute the file contents *)
-let expand_interpolations_in_file env file =
-  let f = OpamFilename.of_basename file in
-  let src = OpamFilename.add_extension f "in" in
+(* Substitute the file contents and specify the source and destination *)
+let expand_interpolations_in_file_full env ~src ~dst =
   let ic = OpamFilename.open_in_bin src in
-  let oc = OpamFilename.open_out_bin f in
+  let oc = OpamFilename.open_out_bin dst in
   (* Determine if the input file parses in opam-file-format *)
   let is_opam_format =
     try
@@ -454,6 +452,12 @@ let expand_interpolations_in_file env file =
   process ();
   close_in ic;
   close_out oc
+
+(* Substitute the file contents *)
+let expand_interpolations_in_file env file =
+  let file = OpamFilename.of_basename file in
+  let src = OpamFilename.add_extension file "in" in
+  expand_interpolations_in_file_full env ~src ~dst:file
 
 (* Apply filters and interpolations to package commands *)
 

--- a/src/format/opamFilter.mli
+++ b/src/format/opamFilter.mli
@@ -129,6 +129,8 @@ val ident_string: ?default:string -> env -> fident -> string
 (** Like [ident_value], but casts the result to a bool *)
 val ident_bool: ?default:bool -> env -> fident -> bool
 
+val expand_interpolations_in_file_full: env -> src:filename -> dst:filename -> unit
+
 (** Rewrites [basename].in to [basename], expanding interpolations.
     If the first line begins ["opam-version:"], assumes that expansion of
     variables within strings should be properly escaped. In particular, this

--- a/src/format/opamFilter.mli
+++ b/src/format/opamFilter.mli
@@ -130,6 +130,8 @@ val ident_string: ?default:string -> env -> fident -> string
 val ident_bool: ?default:bool -> env -> fident -> bool
 
 val expand_interpolations_in_file_full: env -> src:filename -> dst:filename -> unit
+(** Same as [expand_interpolations_in_file] but allows to set the source [src] and
+    destination [dst] files independently instead of implying [src] = [dst].in *)
 
 (** Rewrites [basename].in to [basename], expanding interpolations.
     If the first line begins ["opam-version:"], assumes that expansion of


### PR DESCRIPTION
Adds a new function `OpamFilter.expand_interpolations_in_file_full` that takes both input path and also output path instead of inferring it.

This feature is upstreamed from the dune fork of OPAM.