### PR TITLE
Expose string_interp_regex

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -117,4 +117,7 @@ users)
 * Add `OpamFilter.expand_interpolations_in_file_full` which allows setting the
   output file along with the input file [#5629 @rgrinberg]
 
+* Expose `OpamFilter.string_interp_regex` which allows clients to identify
+  variable interpolations in strings [#5633 @gridbugs]
+
 ## opam-core

--- a/src/format/opamFilter.mli
+++ b/src/format/opamFilter.mli
@@ -50,6 +50,10 @@ val fold_down_left: ('a -> filter -> 'a) -> 'a -> filter -> 'a
 (** Maps on all nodes of a filter, bottom-up *)
 val map_up: (filter -> filter) -> filter -> filter
 
+(** Regex matching string interpolation syntax (["%%"], ["%{xxx}%"], or
+    ["%{xxx"] if unclosed) *)
+val string_interp_regex : Re.re
+
 (** Returns all the variables appearing in a filter (including the ones within
     string interpolations *)
 val variables: filter -> full_variable list


### PR DESCRIPTION
This function is needed by dune to parse variable interpolations from opam fields.