### PR TITLE
Fix "make cold" on Windows when gcc is available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,9 +267,7 @@ release-%:
 
 ifeq ($(OCAML_PORT),)
 ifneq ($(COMSPEC),)
-ifeq ($(shell which gcc 2>/dev/null),)
 OCAML_PORT=auto
-endif
 endif
 endif
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -66,6 +66,7 @@ users)
 ## Build
   * Remove `bigarray` dependency [#5612 @kit-ty-kate]
   * Remove use of deprecated `Printf.kprintf" [#5612 @kit-ty-kate]
+  * Fix "make cold" on Windows when gcc is available [#5635 @kit-ty-kate - fixes #5600]
 
 ## Infrastructure
 


### PR DESCRIPTION
Partially f.i.x.e.s. #5628
Fixes https://github.com/ocaml/opam/issues/5600