### PR TITLE
admin: add `update-extrafiles` command

### DIFF
--- a/doc/man/opam-admin-topics.inc
+++ b/doc/man/opam-admin-topics.inc
@@ -11,6 +11,16 @@
   (package opam))
 
 (rule
+  (with-stdout-to opam-admin-update-extrafiles.0 (echo "")))
+(rule
+  (targets opam-admin-update-extrafiles.1 opam-admin-update-extrafiles.err)
+  (deps using-built-opam)
+  (action (progn (with-stderr-to opam-admin-update-extrafiles.err
+                   (with-stdout-to opam-admin-update-extrafiles.1 (run %{bin:opam} admin update-extrafiles --help=groff)))
+                 (diff opam-admin-update-extrafiles.err %{dep:opam-admin-update-extrafiles.0})))
+  (package opam))
+
+(rule
   (with-stdout-to opam-admin-add-hashes.0 (echo "")))
 (rule
   (targets opam-admin-add-hashes.1 opam-admin-add-hashes.err)
@@ -115,6 +125,7 @@
   (package opam)
   (files
     opam-admin-help.1 
+    opam-admin-update-extrafiles.1 
     opam-admin-add-hashes.1 
     opam-admin-add-constraint.1 
     opam-admin-filter.1 

--- a/master_changes.md
+++ b/master_changes.md
@@ -80,6 +80,7 @@ users)
   * Add ppc64le and s390x support [#5420 @kit-ty-kate]
 
 ## Admin
+  * Add `add-extrafiles` command to add, check, and update `extra-files:` field according files present in `files/` directory [#5647 @rjbou]
 
 ## Opam installer
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -105,6 +105,7 @@ users)
   * Lint: add test for W53, to test extra file with good hash [#5639 @rjbou]
   * Add several checksum & cache validation checks for archive, extra-source section, and extra-file field [#5560 @rjbou]
   * Move local-cache into archive-field-checks test [#5560 @rjbou]
+  * Admin: add `admin add-extrafiles` test cases [#5647 @rjbou]
 
 ### Engine
 

--- a/tests/reftests/admin.test
+++ b/tests/reftests/admin.test
@@ -553,8 +553,56 @@ url.checksum: md5=HASH sha256=HASH sha512=HASH
 ${BASEDIR}/packages/dolor/dolor.1/opam: Passed.
 ${BASEDIR}/packages/sit/sit.1/opam: Passed.
 ### :::::::::::::::::::::
-### :VI: Specific cases :
+### :VI: update-extrafiles :
 ### :::::::::::::::::::::
+### <packages/with-xf/with-xf.1/opam>
+opam-version: "2.0"
+extra-files: [
+  [ "bad-md5" "md5=00000000000000000000000000000000"]
+  [ "good-md5" "md5=xf-md5" ]
+  [ "bad-sha"  "sha256=0000000000000000000000000000000000000000000000000000000000000000"]
+  [ "good-sha" "sha256=xf-sha" ]
+]
+### <packages/with-xf/with-xf.1/files/good-md5>
+content
+### cp packages/with-xf/with-xf.1/files/good-md5 packages/with-xf/with-xf.1/files/bad-md5
+### cp packages/with-xf/with-xf.1/files/good-md5 packages/with-xf/with-xf.1/files/missing-hash
+### cp packages/with-xf/with-xf.1/files/good-md5 packages/with-xf/with-xf.1/files/good-sha
+### cp packages/with-xf/with-xf.1/files/good-md5 packages/with-xf/with-xf.1/files/bad-sha
+### openssl md5 packages/with-xf/with-xf.1/files/good-md5 | '.*= ' -> '' >$ XF_MD5
+### openssl sha256 packages/with-xf/with-xf.1/files/good-md5 | '.*= ' -> '' >$ XF_SHA256
+### <hash-xf.sh>
+sed -i.bak "s/xf-md5/$XF_MD5/" packages/with-xf/with-xf.1/opam
+sed -i.bak "s/xf-sha/$XF_SHA256/" packages/with-xf/with-xf.1/opam
+### sh hash-xf.sh
+### opam admin update-extrafiles
+### opam-cat packages/with-xf/with-xf.1/opam | "${XF_MD5}" -> "good-md5" | "${XF_SHA256}" -> "good-sha"
+extra-files: [["bad-md5" "md5=good-md5"] ["bad-sha" "sha256=good-sha"] ["good-md5" "md5=good-md5"] ["good-sha" "sha256=good-sha"] ["missing-hash" "md5=good-md5"]]
+opam-version: "2.0"
+### <packages/with-xf/with-xf.1/opam>
+opam-version: "2.0"
+extra-files: [
+  [ "bad-md5" "md5=00000000000000000000000000000000"]
+  [ "good-md5" "md5=xf-md5" ]
+  [ "bad-sha"  "sha256=0000000000000000000000000000000000000000000000000000000000000000"]
+  [ "good-sha" "sha256=xf-sha" ]
+]
+### sh hash-xf.sh
+### opam admin update-extrafiles --hash sha256
+### opam-cat packages/with-xf/with-xf.1/opam | "${XF_MD5}" -> "good-md5" | "${XF_SHA256}" -> "good-sha"
+extra-files: [["bad-md5" "sha256=good-sha"] ["bad-sha" "sha256=good-sha"] ["good-md5" "sha256=good-sha"] ["good-sha" "sha256=good-sha"] ["missing-hash" "sha256=good-sha"]]
+opam-version: "2.0"
+### <packages/with-xf/with-xf.2/opam>
+opam-version: "2.0"
+### mkdir -p packages/with-xf/with-xf.2/files
+### cp packages/with-xf/with-xf.1/files/good-md5 packages/with-xf/with-xf.2/files/missing-hash
+### opam admin update-extrafiles
+### opam-cat packages/with-xf/with-xf.2/opam | "${XF_MD5}" -> "good-md5" | "${XF_SHA256}" -> "good-sha"
+extra-files: ["missing-hash" "md5=good-md5"]
+opam-version: "2.0"
+### ::::::::::::::::::::::
+### :VII: Specific cases :
+### ::::::::::::::::::::::
 ### : Package version comparison error (#5334)
 ### <packages/fail-5334/fail-5334.1/opam>
 opam-version: "2.0"


### PR DESCRIPTION
This is needed with changes in #5564.
Repositories can contain opam file with no extra-files field, as opam automatically adds them. With changes in #5564, this is no more done. This command ease updating the repository to fill all extra-files fields, and permit also with the combination with the option `--hash` to choose & update used hash in a repository.