### PR TITLE
opam lint: Allow to mark a set of warnings as errors

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -51,6 +51,7 @@ users)
 
 ## Lint
   * Fix extra-files handling when linting packages from repositories, see #5068 [#5639 @rjbou]
+  * Allow to mark a set of warnings as errors using a new syntax -W @1..9 [#5652 @kit-ty-kate @rjbou - fixes #5651]
 
 ## Repository
 

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -281,8 +281,8 @@ val dep_formula: formula Arg.conv
 (** [var=value,...] argument *)
 val variable_bindings: (OpamVariable.t * string) list Arg.conv
 
-(** Warnings string ["+3..10-4"] *)
-val warn_selector: (int * bool) list Arg.conv
+(** Warnings string ["+3..10-4@12"] *)
+val warn_selector: (int * [`Enable | `Disable | `EnableError]) list Arg.conv
 
 val opamlist_columns: OpamListCommand.output_format list Arg.conv
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3904,6 +3904,7 @@ let lint cli =
                 ) ([], false) warnings
             in
             let warnings =
+              if warnings_sel = [] then warnings else
               List.map (fun ((n, _, s) as warn) ->
                   match OpamStd.IntMap.find_opt n warnings_sel_map with
                   | Some `EnableError -> (n, `Error, s)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3780,8 +3780,9 @@ let lint cli =
   let warnings =
     mk_opt ~cli cli_original ["warnings";"W"] "WARNS"
       "Select the warnings to show or hide. $(i,WARNS) should be a \
-       concatenation of $(b,+N), $(b,-N), $(b,+N..M), $(b,-N..M) to \
-       respectively enable or disable warning or error number $(b,N) or \
+       concatenation of $(b,+N), $(b,-N), $(b,@N), $(b,+N..M), \
+       $(b,-N..M), $(b,@N..M) to respectively enable, disable or \
+       enable-as-error warning or error number $(b,N) or \
        all warnings with numbers between $(b,N) and $(b,M) inclusive.\n\
        All warnings are enabled by default, unless $(i,WARNS) starts with \
        $(b,+), which disables all but the selected ones."
@@ -3866,6 +3867,10 @@ let lint cli =
       | None -> None
       | Some _ -> Some []
     in
+    let default_warn = match warnings_sel with
+      | (_, (`Enable | `EnableError)) :: _ -> `Disable
+      | (_, `Disable) :: _ | [] -> `Enable
+    in
     let err,json =
       List.fold_left (fun (err,json) opam_f ->
           try
@@ -3886,20 +3891,20 @@ let lint cli =
                 None
             in
             let enabled =
-              let default = match warnings_sel with
-                | (_,true) :: _ -> false
-                | _ -> true
-              in
               let map =
                 List.fold_left
-                  (fun acc (wn, enable) -> OpamStd.IntMap.add wn enable acc)
+                  (fun acc (wn, state) -> OpamStd.IntMap.add wn state acc)
                   OpamStd.IntMap.empty warnings_sel
               in
-              fun w -> try OpamStd.IntMap.find w map with Not_found -> default
+              fun w -> try OpamStd.IntMap.find w map with Not_found -> default_warn
             in
-            let warnings = List.filter (fun (n, _, _) -> enabled n) warnings in
-            let failed =
-              List.exists (function _,`Error,_ -> true | _ -> false) warnings
+            let warnings, failed =
+              List.fold_left (fun (warnings, failed) ((n, state, _) as warn) ->
+                  match enabled n, state with
+                  | `Enable, `Warning -> (warnings @ [warn], failed)
+                  | `Enable, `Error | `EnableError, _ -> (warnings @ [warn], true)
+                  | `Disable, _ -> (warnings, failed)
+                ) ([], false) warnings
             in
             if short then
               (if warnings <> [] then

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -64,31 +64,31 @@ ${BASEDIR}/lint.opam: Errors.
 ### opam lint ./lint.opam --warn=@0..99
 ${BASEDIR}/lint.opam: Errors.
              error 23: Missing field 'maintainer'
-           warning 25: Missing field 'authors'
-           warning 35: Missing field 'homepage'
-           warning 36: Missing field 'bug-reports'
+             error 25: Missing field 'authors'
+             error 35: Missing field 'homepage'
+             error 36: Missing field 'bug-reports'
              error 57: Synopsis must not be empty
-           warning 68: Missing field 'license'
+             error 68: Missing field 'license'
 # Return code 1 #
 ### opam lint ./lint.opam --warn=@0..99
 ${BASEDIR}/lint.opam: Errors.
              error 23: Missing field 'maintainer'
-           warning 25: Missing field 'authors'
-           warning 35: Missing field 'homepage'
-           warning 36: Missing field 'bug-reports'
+             error 25: Missing field 'authors'
+             error 35: Missing field 'homepage'
+             error 36: Missing field 'bug-reports'
              error 57: Synopsis must not be empty
-           warning 68: Missing field 'license'
+             error 68: Missing field 'license'
 # Return code 1 #
 ### opam lint ./lint.opam --warn=+25@25
 ${BASEDIR}/lint.opam: Errors.
-           warning 25: Missing field 'authors'
+             error 25: Missing field 'authors'
 # Return code 1 #
 ### opam lint ./lint.opam --warn=+20..40@30..40
 ${BASEDIR}/lint.opam: Errors.
              error 23: Missing field 'maintainer'
            warning 25: Missing field 'authors'
-           warning 35: Missing field 'homepage'
-           warning 36: Missing field 'bug-reports'
+             error 35: Missing field 'homepage'
+             error 36: Missing field 'bug-reports'
 # Return code 1 #
 ### ::::::::::::::
 ### : Test lints :

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -61,6 +61,35 @@ ${BASEDIR}/lint.opam: Errors.
              error 57: Synopsis must not be empty
            warning 68: Missing field 'license'
 # Return code 1 #
+### opam lint ./lint.opam --warn=@0..99
+${BASEDIR}/lint.opam: Errors.
+             error 23: Missing field 'maintainer'
+           warning 25: Missing field 'authors'
+           warning 35: Missing field 'homepage'
+           warning 36: Missing field 'bug-reports'
+             error 57: Synopsis must not be empty
+           warning 68: Missing field 'license'
+# Return code 1 #
+### opam lint ./lint.opam --warn=@0..99
+${BASEDIR}/lint.opam: Errors.
+             error 23: Missing field 'maintainer'
+           warning 25: Missing field 'authors'
+           warning 35: Missing field 'homepage'
+           warning 36: Missing field 'bug-reports'
+             error 57: Synopsis must not be empty
+           warning 68: Missing field 'license'
+# Return code 1 #
+### opam lint ./lint.opam --warn=+25@25
+${BASEDIR}/lint.opam: Errors.
+           warning 25: Missing field 'authors'
+# Return code 1 #
+### opam lint ./lint.opam --warn=+20..40@30..40
+${BASEDIR}/lint.opam: Errors.
+             error 23: Missing field 'maintainer'
+           warning 25: Missing field 'authors'
+           warning 35: Missing field 'homepage'
+           warning 36: Missing field 'bug-reports'
+# Return code 1 #
 ### ::::::::::::::
 ### : Test lints :
 ### ::::::::::::::

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -6,6 +6,64 @@ N0REP0
 ### <one-more-file>
 and it also has content
 ### tar czf an-archive.tgz one-more-file
+### ::::::::::::::::::::::
+### : Test --warn option :
+### ::::::::::::::::::::::
+### <lint.opam>
+opam-version: "2.0"
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Errors.
+             error 23: Missing field 'maintainer'
+           warning 25: Missing field 'authors'
+           warning 35: Missing field 'homepage'
+           warning 36: Missing field 'bug-reports'
+             error 57: Synopsis must not be empty
+           warning 68: Missing field 'license'
+# Return code 1 #
+### opam lint ./lint.opam --warn=+25
+${BASEDIR}/lint.opam: Warnings.
+           warning 25: Missing field 'authors'
+### opam lint ./lint.opam --warn=-25
+${BASEDIR}/lint.opam: Errors.
+             error 23: Missing field 'maintainer'
+           warning 35: Missing field 'homepage'
+           warning 36: Missing field 'bug-reports'
+             error 57: Synopsis must not be empty
+           warning 68: Missing field 'license'
+# Return code 1 #
+### opam lint ./lint.opam --warn=+25-25
+${BASEDIR}/lint.opam: Passed.
+### opam lint ./lint.opam --warn=+20..50
+${BASEDIR}/lint.opam: Errors.
+             error 23: Missing field 'maintainer'
+           warning 25: Missing field 'authors'
+           warning 35: Missing field 'homepage'
+           warning 36: Missing field 'bug-reports'
+# Return code 1 #
+### opam lint ./lint.opam --warn=-20..40
+${BASEDIR}/lint.opam: Errors.
+             error 57: Synopsis must not be empty
+           warning 68: Missing field 'license'
+# Return code 1 #
+### opam lint ./lint.opam --warn=+25+25+30..38
+${BASEDIR}/lint.opam: Warnings.
+           warning 25: Missing field 'authors'
+           warning 35: Missing field 'homepage'
+           warning 36: Missing field 'bug-reports'
+### opam lint ./lint.opam --warn=+50..38+23+25
+${BASEDIR}/lint.opam: Errors.
+             error 23: Missing field 'maintainer'
+           warning 25: Missing field 'authors'
+# Return code 1 #
+### opam lint ./lint.opam --warn=-25-25-30..38
+${BASEDIR}/lint.opam: Errors.
+             error 23: Missing field 'maintainer'
+             error 57: Synopsis must not be empty
+           warning 68: Missing field 'license'
+# Return code 1 #
+### ::::::::::::::
+### : Test lints :
+### ::::::::::::::
 ### : W20: Field 'opam-version' refers to the patch version of opam, it should be of the form MAJOR.MINOR
 ### : E21: Field 'opam-version' doesn't match the current version, validation may not be accurate
 ### <lint.opam>


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/5651

This PR allows to mark a set of warnings as error and make the command fail.

Examples:
* `opam lint -W@0..999` enables all warnings and errors and fail if any is detected.
* `opam lint -W@62` enables W62 and fail if this warning is detected but ignore any other warnings or errors

The syntax is inspired from the `ocamlc -w` option.