### PR TITLE
Clarify documentation for `enable` pseudo-variable

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -512,9 +512,11 @@ the package being defined.
   resolved direct dependencies of the package
 - <a id="pkgvar-installed">`installed`</a>:
   whether the package is installed
-- <a id="pkgvar-enable">`enable`</a>:
-  takes the value "enable" or "disable" depending on whether the package is
-  installed
+- <a id="pkgvar-enable">`enable`</a>: is not a variable.
+  It takes the value "enable" or "disable" depending on whether the package is
+  installed. Used with the combination operator `+`, 
+  `name1+name2+name3:enable` is syntactic sugar for
+  `name1+name2+name3:installed?enable:disable`.
 - <a id="pkgvar-pinned">`pinned`</a>: whether the package is pinned
 - <a id="pkgvar-dirs">`bin`, `sbin`, `lib`, `man`, `doc`, `share`, `etc`</a>:
   the corresponding directories for this package (similar to

--- a/master_changes.md
+++ b/master_changes.md
@@ -149,6 +149,7 @@ users)
   * Fix a typo in the default man page [#6267 @fccm2]
   * Point users to ways to override the default opam root location in the opam init manpage [#6251 @kit-ty-kate]
   * Manual: Document the stamp field from repo files [#6306 @kit-ty-kate]
+  * Clarify documentation for `enable` pseudo-variable [#5659 @gridbugs]
 
 ## Security fixes
 


### PR DESCRIPTION
The documentation for variables says that for boolean variables the form `name1+name2+name3:var` is equivalent to
`name1:var & name2:var & name3:var` but it's possible to write `name1+name2:enable` despite `enable` being the string "enable" or "disable". This change clarifies that `enable` isn't really a variable but syntactic sugar instead.