### PR TITLE
Fix the sandbox scripts in absence of the OPAMROOT variable

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -66,7 +66,7 @@ users)
 ## Format upgrade
 
 ## Sandbox
-  * Make /tmp writable again to restore POSIX compliancy [#5634 @kit-ty-kate - fixes #5462]
+  * Make /tmp writable again to restore POSIX compliancy [#5634 #5662 @kit-ty-kate - fixes #5462]
 
 ## VCS
 

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -101,7 +101,7 @@ add_dune_cache_mount() {
 
 # In case OPAMROOT happens to be in one of the writeable directories we
 # need to make sure it is read-only
-if [ -n ${OPAMROOT+x} ]; then
+if [ -n "${OPAMROOT:-}" ]; then
   add_mounts ro "$OPAMROOT"
 fi
 

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -58,7 +58,7 @@ add_dune_cache_mount() {
 
 # In case OPAMROOT happens to be in one of the writeable directories we
 # need to make sure it is read-only
-if [ -n ${OPAMROOT+x} ]; then
+if [ -n "${OPAMROOT:-}" ]; then
   add_mounts ro "$OPAMROOT"
 fi
 


### PR DESCRIPTION
Bug I introduced by error in https://github.com/ocaml/opam/pull/5634
```
/home/kit_ty_kate/.opam/opam-init/hooks/sandbox.sh contains local modification, overwrite ? [y/n] y
[ERROR] Sandboxing is not working on your platform archarm:
        "~/.opam/opam-init/hooks/sandbox.sh build sh -c echo SUCCESS | tee check-write" exited with code 1 "/home/kit_ty_kate/.opam/opam-init/hooks/sandbox.sh: line 105: OPAMROOT: unbound variable"
```