### PR TITLE
GHA: Make sure opam init works in the absence of OPAMROOT

### DIFF
--- a/.github/scripts/main/test.sh
+++ b/.github/scripts/main/test.sh
@@ -26,3 +26,9 @@ eval $(opam env)
 opam install lwt
 opam list
 opam config report
+
+# Make sure opam init (including the sandbox script) works in the absence of OPAMROOT
+unset OPAMROOT
+rm -r ~/.opam
+opam init --bare -vvv
+rm -r ~/.opam

--- a/master_changes.md
+++ b/master_changes.md
@@ -176,6 +176,7 @@ users)
   * Speedup the gentoo depexts test [#6363 @kit-ty-kate]
   * Add OCaml 5.3 to the build matrix [#6192 @kit-ty-kate]
   * Add OCaml 5.3/MSVC to the build matrix [#6192 @kit-ty-kate]
+  * Add a test making sure `opam init` works in the absence of `OPAMROOT` [#5663 @kit-ty-kate]
 
 ## Doc
   * Update the command to install opam to point to the new simplified url on opam.ocaml.org [#6226 @kit-ty-kate]


### PR DESCRIPTION
Adds a custom test for the issue fixed in https://github.com/ocaml/opam/pull/5662