### PR TITLE
Silently mark packages requiring an unsupported version of opam as unavailable

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -82,6 +82,7 @@ users)
 
 ## Repository
  * Mitigate curl/curl#13845 by falling back from --write-out to --fail if exit code 43 is returned by curl [#6168 @dra27 - fix #6120]
+  * Silently mark packages requiring an unsupported version of opam as unavailable [#5665 @kit-ty-kate - fix #5631]
 
 ## Lock
 

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -130,7 +130,7 @@ module MakeIO (F : IO_Arg) = struct
     with
     | OpamSystem.File_not_found _ ->
       None
-    | e ->
+    | Pp.Bad_format _ as e ->
       OpamStd.Exn.fatal e;
       if OpamFormatConfig.(!r.strict) then
         (OpamConsole.error "%s"
@@ -160,7 +160,7 @@ module MakeIO (F : IO_Arg) = struct
 
   let read_from_f f input =
     try f input with
-    | (Pp.Bad_version _ | Pp.Bad_format _) as e->
+    | Pp.Bad_format _ as e ->
       if OpamFormatConfig.(!r.strict) then
         (OpamConsole.error "%s" (Pp.string_of_bad_format e);
          OpamConsole.error_and_exit `File_error "Strict mode: aborting")
@@ -1181,7 +1181,9 @@ module SyntaxFile(X: SyntaxFileArg) : IO_FILE with type t := X.t = struct
                         {pelem = Section {section_kind = {pelem = "#"; _}; _}; pos}]; _}
       when OpamVersion.(compare (nopatch (of_string ver))
                           (nopatch OpamVersion.current)) <= 0 ->
-        raise (OpamPp.Bad_version (Some pos, "Parse error"))
+      raise
+        (OpamPp.Bad_version ((Some pos, "Parse error"),
+                             Some (OpamVersion.of_string ver)))
     | opamfile -> opamfile
 
     let of_channel filename (ic:in_channel) =

--- a/src/format/opamPp.mli
+++ b/src/format/opamPp.mli
@@ -22,13 +22,13 @@ type bad_format = pos option * string
     input does not have the right format. *)
 exception Bad_format of bad_format
 exception Bad_format_list of bad_format list
-exception Bad_version of bad_format
+exception Bad_version of bad_format * OpamVersion.t option
 
 (** Raise [Bad_format]. *)
 val bad_format: ?pos:pos -> ('a, unit, string, 'b) format4 -> 'a
 
 (** Raise [Bad_version]. *)
-val bad_version: ?pos:pos -> ('a, unit, string, 'b) format4 -> 'a
+val bad_version: OpamVersion.t option -> ?pos:pos -> ('a, unit, string, 'b) format4 -> 'a
 
 val string_of_bad_format: ?file:string -> exn -> string
 
@@ -101,7 +101,7 @@ val ignore : ('a, 'b option) t
     [Bad_format]. *)
 val check :
   ?name:string ->
-  ?raise:(?pos:pos -> (string -> 'a, unit, string, 'a) format4
+  ?raise:('a -> ?pos:pos -> (string -> 'a, unit, string, 'a) format4
           -> string -> 'a) ->
   ?errmsg:string -> ('a -> bool) -> ('a, 'a) t
 

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -269,9 +269,12 @@ Continue anyway? [y/n] y
 opam-version: "2.1"
 ### opam install ./pin-at-two-one
 [ERROR] In ${BASEDIR}/pin-at-two-one/pin-at-two-one.opam:
-        unsupported or missing file format version; should be 2.0 or older
-[ERROR] Strict mode: aborting
-# Return code 30 #
+        unsupported or missing file format version; should be 2.0 or older [skipped]
+
+[ERROR] Invalid opam file in pin-at-two-one source from file://${BASEDIR}/pin-at-two-one:
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+[ERROR] No package named pin-at-two-one found.
+# Return code 5 #
 ### OPAMSTRICT=0 opam install ./pin-at-two-one
 [ERROR] In ${BASEDIR}/pin-at-two-one/pin-at-two-one.opam:
         unsupported or missing file format version; should be 2.0 or older [skipped]
@@ -284,9 +287,12 @@ opam-version: "2.1"
 opam-version: "2.2"
 ### opam install ./pin-at-two-two
 [ERROR] In ${BASEDIR}/pin-at-two-two/pin-at-two-two.opam:
-        unsupported or missing file format version; should be 2.0 or older
-[ERROR] Strict mode: aborting
-# Return code 30 #
+        unsupported or missing file format version; should be 2.0 or older [skipped]
+
+[ERROR] Invalid opam file in pin-at-two-two source from file://${BASEDIR}/pin-at-two-two:
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+[ERROR] No package named pin-at-two-two found.
+# Return code 5 #
 ### OPAMSTRICT=0 opam install ./pin-at-two-two
 [ERROR] In ${BASEDIR}/pin-at-two-two/pin-at-two-two.opam:
         unsupported or missing file format version; should be 2.0 or older [skipped]
@@ -299,9 +305,12 @@ opam-version: "2.2"
 opam-version: "2.3"
 ### opam install ./pin-at-two-three
 [ERROR] In ${BASEDIR}/pin-at-two-three/pin-at-two-three.opam:
-        unsupported or missing file format version; should be 2.0 or older
-[ERROR] Strict mode: aborting
-# Return code 30 #
+        unsupported or missing file format version; should be 2.0 or older [skipped]
+
+[ERROR] Invalid opam file in pin-at-two-three source from file://${BASEDIR}/pin-at-two-three:
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+[ERROR] No package named pin-at-two-three found.
+# Return code 5 #
 ### OPAMSTRICT=0 opam install ./pin-at-two-three
 [ERROR] In ${BASEDIR}/pin-at-two-three/pin-at-two-three.opam:
         unsupported or missing file format version; should be 2.0 or older [skipped]
@@ -314,9 +323,12 @@ opam-version: "2.3"
 opam-version: "50.0"
 ### opam install ./pin-at-future
 [ERROR] In ${BASEDIR}/pin-at-future/pin-at-future.opam:
-        unsupported or missing file format version; should be 2.0 or older
-[ERROR] Strict mode: aborting
-# Return code 30 #
+        unsupported or missing file format version; should be 2.0 or older [skipped]
+
+[ERROR] Invalid opam file in pin-at-future source from file://${BASEDIR}/pin-at-future:
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+[ERROR] No package named pin-at-future found.
+# Return code 5 #
 ### OPAMSTRICT=0 opam install ./pin-at-future
 [ERROR] In ${BASEDIR}/pin-at-future/pin-at-future.opam:
         unsupported or missing file format version; should be 2.0 or older [skipped]
@@ -373,9 +385,12 @@ echo GARBAGE>>"$1"
 ### sh junk.sh pin-at-future/pin-at-future.opam
 ### opam install ./pin-at-future
 [ERROR] In ${BASEDIR}/pin-at-future/pin-at-future.opam:
-        unsupported or missing file format version; should be 2.0 or older
-[ERROR] Strict mode: aborting
-# Return code 30 #
+        unsupported or missing file format version; should be 2.0 or older [skipped]
+
+[ERROR] Invalid opam file in pin-at-future source from file://${BASEDIR}/pin-at-future:
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+[ERROR] No package named pin-at-future found.
+# Return code 5 #
 ### OPAMSTRICT=0 opam install ./pin-at-future
 [ERROR] In ${BASEDIR}/pin-at-future/pin-at-future.opam:
         unsupported or missing file format version; should be 2.0 or older [skipped]

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -637,12 +637,10 @@ some-field-that-do-not-exist: true
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [repo] no changes from file://${BASEDIR}/REPO
 [versions] synchronised from file://${BASEDIR}/VRS
-[ERROR] In ${BASEDIR}/OPAM/repo/versions/packages/bad-opam-version/bad-opam-version.1/opam:
-        unsupported or missing file format version; should be 2.0 or older
-[ERROR] Strict mode: aborting
-[ERROR] Could not update repository "versions": OpamStd.OpamSys.Exit(30)
-# Return code 40 #
+opam-file                       opam-version "5.0" unsupported on ${BASEDIR}/OPAM/repo/versions/packages/bad-opam-version/bad-opam-version.1/opam. Added as dummy unavailable package.
+Now run 'opam upgrade' to apply any package updates.
 ### opam list -A --all-versions -s
+bad-opam-version.1
 foo.1
 foo.2
 foo.3
@@ -651,8 +649,15 @@ foo.5
 foo.6
 good-opam-version.1
 ### opam show --raw bad-opam-version.1 | "${OPAMMAJORVERSION}" -> "CURRENTMAJOR"
-[ERROR] No package matching bad-opam-version.1 found
-# Return code 5 #
+opam-version: "2.0"
+name: "bad-opam-version"
+version: "1"
+synopsis: ""
+description: """\
+This package uses opam 5.0 file format which opam CURRENTMAJOR cannot read.
+
+In order to install or view information on this package, please upgrade your opam installation to at least version 5.0."""
+available: opam-version >= "5.0"
 ### :: without opam strict
 ### OPAMSTRICT=0
 ### <REPO/packages/bad-opam-version/bad-opam-version.2/opam>
@@ -667,13 +672,16 @@ opam-version: "2.0"
 
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [repo] synchronised from file://${BASEDIR}/REPO
-[ERROR] Could not update repository "repo": In ${BASEDIR}/OPAM/repo/repo/packages/bad-opam-version/bad-opam-version.2/opam:
-        unsupported or missing file format version; should be 2.0 or older
+opam-file                       opam-version "5.0" unsupported on ${BASEDIR}/OPAM/repo/repo/packages/bad-opam-version/bad-opam-version.2/opam. Added as dummy unavailable package.
+opam-file                       opam-version "5.0" unsupported on ${BASEDIR}/OPAM/repo/repo/packages/bad-opam-version/bad-opam-version.3/opam. Added as dummy unavailable package.
 [versions] synchronised from file://${BASEDIR}/VRS
-[ERROR] Could not update repository "versions": In ${BASEDIR}/OPAM/repo/versions/packages/bad-opam-version/bad-opam-version.1/opam:
-        unsupported or missing file format version; should be 2.0 or older
-# Return code 40 #
+opam-file                       opam-version "5.0" unsupported on ${BASEDIR}/OPAM/repo/versions/packages/bad-opam-version/bad-opam-version.1/opam. Added as dummy unavailable package.
+Now run 'opam upgrade' to apply any package updates.
 ### opam list -A --all-versions -s
+a.1
+bad-opam-version.1
+bad-opam-version.2
+bad-opam-version.3
 foo.1
 foo.2
 foo.3
@@ -686,33 +694,61 @@ good-opam-version.1
 ### opam list -A --all-versions -s
 ### opam repository --this-switch add repo ./REPO
 [repo] Initialised
-[ERROR] Could not update repository "repo": In ${BASEDIR}/OPAM/repo/repo/packages/bad-opam-version/bad-opam-version.3/opam:
-        unsupported or missing file format version; should be 2.0 or older
-[ERROR] Initial repository fetch failed
-# Return code 40 #
 ### opam repository --this-switch add versions ./VRS
 [versions] Initialised
-[ERROR] Could not update repository "versions": In ${BASEDIR}/OPAM/repo/versions/packages/bad-opam-version/bad-opam-version.1/opam:
-        unsupported or missing file format version; should be 2.0 or older
-[ERROR] Initial repository fetch failed
-# Return code 40 #
 ### opam list -A --all-versions -s
+a.1
+bad-opam-version.1
+bad-opam-version.2
+bad-opam-version.3
+foo.1
+foo.2
+foo.3
+foo.4
+foo.5
+foo.6
+good-opam-version.1
 ### opam show --raw bad-opam-version.1 | "${OPAMMAJORVERSION}" -> "CURRENTMAJOR"
-[ERROR] No package matching bad-opam-version.1 found
-# Return code 5 #
+opam-version: "2.0"
+name: "bad-opam-version"
+version: "1"
+synopsis: ""
+description: """\
+This package uses opam 5.0 file format which opam CURRENTMAJOR cannot read.
+
+In order to install or view information on this package, please upgrade your opam installation to at least version 5.0."""
+available: opam-version >= "5.0"
 ### opam show --raw bad-opam-version.2 | "${OPAMMAJORVERSION}" -> "CURRENTMAJOR"
-[ERROR] No package matching bad-opam-version.2 found
-# Return code 5 #
+opam-version: "2.0"
+name: "bad-opam-version"
+version: "2"
+synopsis: ""
+description: """\
+This package uses opam 5.0 file format which opam CURRENTMAJOR cannot read.
+
+In order to install or view information on this package, please upgrade your opam installation to at least version 5.0."""
+available: opam-version >= "5.0"
 ### opam show --raw bad-opam-version.3 | "${OPAMMAJORVERSION}" -> "CURRENTMAJOR"
-[ERROR] No package matching bad-opam-version.3 found
-# Return code 5 #
+opam-version: "2.0"
+name: "bad-opam-version"
+version: "3"
+synopsis: ""
+description: """\
+This package uses opam 5.0 file format which opam CURRENTMAJOR cannot read.
+
+In order to install or view information on this package, please upgrade your opam installation to at least version 5.0."""
+available: opam-version >= "5.0"
 ### :: Parse errors
 ### <VRS/packages/two-zero/two-zero.1/opam>
 opam-version: "2.0"
 GARBAGE
 ### opam update versions
-[ERROR] Unknown repositories or installed packages: versions
-# Return code 40 #
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[versions] synchronised from file://${BASEDIR}/VRS
+[WARNING] Could not read file ${BASEDIR}/OPAM/repo/versions/packages/two-zero/two-zero.1/opam. skipping:
+          At ${BASEDIR}/OPAM/repo/versions/packages/two-zero/two-zero.1/opam:3:0-3:0::
+          Parse error
 ### opam show two-zero --raw
 [ERROR] No package matching two-zero found
 # Return code 5 #
@@ -721,8 +757,13 @@ GARBAGE
 opam-version: "2.1"
 GARBAGE
 ### opam update versions
-[ERROR] Unknown repositories or installed packages: versions
-# Return code 40 #
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[versions] synchronised from file://${BASEDIR}/VRS
+[WARNING] Could not read file ${BASEDIR}/OPAM/repo/versions/packages/two-one/two-one.1/opam. skipping:
+          At ${BASEDIR}/OPAM/repo/versions/packages/two-one/two-one.1/opam:3:0-3:0::
+          Parse error
+Now run 'opam upgrade' to apply any package updates.
 ### opam show two-one --raw
 [ERROR] No package matching two-one found
 # Return code 5 #
@@ -731,8 +772,12 @@ GARBAGE
 opam-version: "2.2"
 GARBAGE
 ### opam update versions
-[ERROR] Unknown repositories or installed packages: versions
-# Return code 40 #
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[versions] synchronised from file://${BASEDIR}/VRS
+[WARNING] Could not read file ${BASEDIR}/OPAM/repo/versions/packages/two-two/two-two.1/opam. skipping:
+          At ${BASEDIR}/OPAM/repo/versions/packages/two-two/two-two.1/opam:3:0-3:0::
+          Parse error
 ### opam show two-two --raw
 [ERROR] No package matching two-two found
 # Return code 5 #
@@ -741,8 +786,12 @@ GARBAGE
 opam-version: "2.3"
 GARBAGE
 ### opam update versions
-[ERROR] Unknown repositories or installed packages: versions
-# Return code 40 #
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[versions] synchronised from file://${BASEDIR}/VRS
+[WARNING] Could not read file ${BASEDIR}/OPAM/repo/versions/packages/two-three/two-three.1/opam. skipping:
+          At ${BASEDIR}/OPAM/repo/versions/packages/two-three/two-three.1/opam:3:0-3:0::
+          Parse error
 ### opam show two-three --raw
 [ERROR] No package matching two-three found
 # Return code 5 #

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -607,3 +607,142 @@ opam-version: "2.0"
 [to-many-commits] Initialised
 ### git -C ./OPAM/repo/to-many-commits rev-list --all --count
 1
+### : Test repository upgrade path (packages requiring newer version of opam) ::::
+### OPAMDEBUGSECTIONS="opam-file"
+### sh -c "opam --version | cut -f -2 -d '.'" >$ OPAMMAJORVERSION
+### opam repository remove -a oper3 oper repo2 to-many-commits
+### <VRS/repo>
+opam-version: "2.0"
+### <VRS/packages/good-opam-version/good-opam-version.1/opam>
+opam-version: "2.0"
+### opam repository --this-switch add versions ./VRS
+[versions] Initialised
+### opam repository --this-switch add repo ./REPO
+[repo] Initialised
+### opam list -A --all-versions -s
+foo.1
+foo.2
+foo.3
+foo.4
+foo.5
+foo.6
+good-opam-version.1
+### :: with opam strict
+### OPAMSTRICT=1
+### <VRS/packages/bad-opam-version/bad-opam-version.1/opam>
+opam-version: "5.0"
+some-field-that-do-not-exist: true
+### opam update -a --debug-level=-1
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[repo] no changes from file://${BASEDIR}/REPO
+[versions] synchronised from file://${BASEDIR}/VRS
+[ERROR] In ${BASEDIR}/OPAM/repo/versions/packages/bad-opam-version/bad-opam-version.1/opam:
+        unsupported or missing file format version; should be 2.0 or older
+[ERROR] Strict mode: aborting
+[ERROR] Could not update repository "versions": OpamStd.OpamSys.Exit(30)
+# Return code 40 #
+### opam list -A --all-versions -s
+foo.1
+foo.2
+foo.3
+foo.4
+foo.5
+foo.6
+good-opam-version.1
+### opam show --raw bad-opam-version.1 | "${OPAMMAJORVERSION}" -> "CURRENTMAJOR"
+[ERROR] No package matching bad-opam-version.1 found
+# Return code 5 #
+### :: without opam strict
+### OPAMSTRICT=0
+### <REPO/packages/bad-opam-version/bad-opam-version.2/opam>
+opam-version: "5.0"
+some-field-that-do-not-exist: true
+### <REPO/packages/bad-opam-version/bad-opam-version.3/opam>
+opam-version: "5.0"
+GARBAGE
+### <VRS/packages/a/a.1/opam>
+opam-version: "2.0"
+### opam update -a --debug-level=-1
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[repo] synchronised from file://${BASEDIR}/REPO
+[ERROR] Could not update repository "repo": In ${BASEDIR}/OPAM/repo/repo/packages/bad-opam-version/bad-opam-version.2/opam:
+        unsupported or missing file format version; should be 2.0 or older
+[versions] synchronised from file://${BASEDIR}/VRS
+[ERROR] Could not update repository "versions": In ${BASEDIR}/OPAM/repo/versions/packages/bad-opam-version/bad-opam-version.1/opam:
+        unsupported or missing file format version; should be 2.0 or older
+# Return code 40 #
+### opam list -A --all-versions -s
+foo.1
+foo.2
+foo.3
+foo.4
+foo.5
+foo.6
+good-opam-version.1
+### opam repository remove -a versions
+### opam repository remove -a repo
+### opam list -A --all-versions -s
+### opam repository --this-switch add repo ./REPO
+[repo] Initialised
+[ERROR] Could not update repository "repo": In ${BASEDIR}/OPAM/repo/repo/packages/bad-opam-version/bad-opam-version.3/opam:
+        unsupported or missing file format version; should be 2.0 or older
+[ERROR] Initial repository fetch failed
+# Return code 40 #
+### opam repository --this-switch add versions ./VRS
+[versions] Initialised
+[ERROR] Could not update repository "versions": In ${BASEDIR}/OPAM/repo/versions/packages/bad-opam-version/bad-opam-version.1/opam:
+        unsupported or missing file format version; should be 2.0 or older
+[ERROR] Initial repository fetch failed
+# Return code 40 #
+### opam list -A --all-versions -s
+### opam show --raw bad-opam-version.1 | "${OPAMMAJORVERSION}" -> "CURRENTMAJOR"
+[ERROR] No package matching bad-opam-version.1 found
+# Return code 5 #
+### opam show --raw bad-opam-version.2 | "${OPAMMAJORVERSION}" -> "CURRENTMAJOR"
+[ERROR] No package matching bad-opam-version.2 found
+# Return code 5 #
+### opam show --raw bad-opam-version.3 | "${OPAMMAJORVERSION}" -> "CURRENTMAJOR"
+[ERROR] No package matching bad-opam-version.3 found
+# Return code 5 #
+### :: Parse errors
+### <VRS/packages/two-zero/two-zero.1/opam>
+opam-version: "2.0"
+GARBAGE
+### opam update versions
+[ERROR] Unknown repositories or installed packages: versions
+# Return code 40 #
+### opam show two-zero --raw
+[ERROR] No package matching two-zero found
+# Return code 5 #
+### rm -r VRS/packages
+### <VRS/packages/two-one/two-one.1/opam>
+opam-version: "2.1"
+GARBAGE
+### opam update versions
+[ERROR] Unknown repositories or installed packages: versions
+# Return code 40 #
+### opam show two-one --raw
+[ERROR] No package matching two-one found
+# Return code 5 #
+### rm -r VRS/packages
+### <VRS/packages/two-two/two-two.1/opam>
+opam-version: "2.2"
+GARBAGE
+### opam update versions
+[ERROR] Unknown repositories or installed packages: versions
+# Return code 40 #
+### opam show two-two --raw
+[ERROR] No package matching two-two found
+# Return code 5 #
+### rm -r VRS/packages
+### <VRS/packages/two-three/two-three.1/opam>
+opam-version: "2.3"
+GARBAGE
+### opam update versions
+[ERROR] Unknown repositories or installed packages: versions
+# Return code 40 #
+### opam show two-three --raw
+[ERROR] No package matching two-three found
+# Return code 5 #


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/5631

This makes it possible to have a smoother upgrade path for the opam repository when opam adds a new syntax for example.

In the future it would be nice to have a specific error message to tell the user why this package is not available, but I feel like we can do this later (TODO: open a ticket for it if this is merged first)