### PR TITLE
Fix incorrect error message in configure

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@ check_linker text eol=lf
 *.m4 text eol=lf
 changelog_checker text eol=lf
 *.cmd text eol=crlf
+shell/autogen text eol=lf
 
 # For diffing simplicity, the patch re-write test uses LF endings on Windows
 tests/patcher-test.reference text eol=lf

--- a/configure
+++ b/configure
@@ -5141,9 +5141,11 @@ then :
       if  test "$ARCH" = "i386"
 then :
   T_CC64=x86_64-w64-mingw32-gcc
+        COMP_ARCH='x86_64'
         ac_tool_prefix='i686-w64-mingw32-'
 else $as_nop
   T_CC64=i686-w64-mingw32-gcc
+        COMP_ARCH='i686'
         ac_tool_prefix='x86_64-w64-mingw32-'
 fi
 fi
@@ -5314,7 +5316,7 @@ fi
   if  test "x${CC64}" = "xno"
 then :
 
-    as_fn_error $? "${ARCH} C compiler not found - opam-putenv cannot be built" "$LINENO" 5
+    as_fn_error $? "${COMP_ARCH} C compiler not found - opam-putenv cannot be built" "$LINENO" 5
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -202,8 +202,10 @@ AS_IF([ test ${WIN32} -eq 1 ],[
     AS_IF([ test "x${CC64}" = "x" ], [
       AS_IF([ test "$ARCH" = "i386" ],
         [T_CC64=x86_64-w64-mingw32-gcc
+        COMP_ARCH='x86_64'
         ac_tool_prefix='i686-w64-mingw32-'],
         [T_CC64=i686-w64-mingw32-gcc
+        COMP_ARCH='i686'
         ac_tool_prefix='x86_64-w64-mingw32-'])])
     AC_CHECK_TOOL(CC64,[${T_CC64}],[no])
     AS_IF([ test "x${CC64}" != "xno" ],[
@@ -243,7 +245,7 @@ AS_IF([ test ${WIN32} -eq 1 ],[
     ])
   ])
   AS_IF([ test "x${CC64}" = "xno" ],[
-    AC_MSG_ERROR([${ARCH} C compiler not found - opam-putenv cannot be built])
+    AC_MSG_ERROR([${COMP_ARCH} C compiler not found - opam-putenv cannot be built])
   ])
 ])
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -80,6 +80,7 @@ users)
   * Remove `bigarray` dependency [#5612 @kit-ty-kate]
   * Remove use of deprecated `Printf.kprintf" [#5612 @kit-ty-kate]
   * [BUG] Fix "make cold" on Windows when gcc is available [#5635 @kit-ty-kate - fixes #5600]
+  * Fix incorrect error message when alternate C compiler is missing [#5667 @dra27 - partial fix #5661]
 
 ## Infrastructure
   * Test OCaml 5.0 and 5.1 in CI [#5672 @kit-ty-kate]


### PR DESCRIPTION
opam requires both a 32-bit and a 64-bit C compiler when compiling for 64-bit Windows. However, for mingw-w64, the error message confusingly displayed the architecture of the compiler which was _installed_.