### PR TITLE
Test OCaml 5.0 and 5.1 in CI

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -15,7 +15,7 @@ open Lib
 
 let ocamls = [
   (* Fully supported versions *)
-   "4.08.1"; "4.09.1"; "4.10.2"; "4.11.2"; "4.12.1"; "4.13.1"; "4.14.1";
+   "4.08.1"; "4.09.1"; "4.10.2"; "4.11.2"; "4.12.1"; "4.13.1"; "5.0.0"; "5.1.0"; "4.14.1";
 ]
 
 (* Entry point for the workflow. Workflows are specified as continuations where
@@ -85,7 +85,7 @@ let latest_ocaml = List.fold_left (fun _ (v, _) -> v) (0, 0) ocamls
 
 let platform_ocaml_matrix ?(dir=List.drop_while) ~fail_fast start_version =
   (fail_fast,
-   [("ocamlv", List.map snd (dir (fun ocaml -> fst ocaml < start_version) ocamls))],
+   [("ocamlv", List.map snd (dir (fun ocaml -> fst ocaml <> start_version) ocamls))],
    [])
 
 let git_lf_checkouts ?(title="Configure Git") ?cond ?shell () =
@@ -470,8 +470,8 @@ let main oc : unit =
     ("OPAM12CACHE", "~/.cache/opam1.2/cache");
     (* These should be identical to the values in appveyor.yml *)
     ("OPAM_REPO", "https://github.com/ocaml/opam-repository.git");
-    ("OPAM_TEST_REPO_SHA", "849d953adddc9c44486de3307e9c757aba85b225");
-    ("OPAM_REPO_SHA", "849d953adddc9c44486de3307e9c757aba85b225");
+    ("OPAM_TEST_REPO_SHA", "b251e0d9d0a8bcb0742d4d495c70f479effe16c2");
+    ("OPAM_REPO_SHA", "b251e0d9d0a8bcb0742d4d495c70f479effe16c2");
     ("SOLVER", "");
     (* Cygwin configuration *)
     ("CYGWIN_MIRROR", "http://mirrors.kernel.org/sourceware/cygwin/");

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,8 @@ env:
   OPAMBSROOT: ~/.cache/.opam.cached
   OPAM12CACHE: ~/.cache/opam1.2/cache
   OPAM_REPO: https://github.com/ocaml/opam-repository.git
-  OPAM_TEST_REPO_SHA: 849d953adddc9c44486de3307e9c757aba85b225
-  OPAM_REPO_SHA: 849d953adddc9c44486de3307e9c757aba85b225
+  OPAM_TEST_REPO_SHA: b251e0d9d0a8bcb0742d4d495c70f479effe16c2
+  OPAM_REPO_SHA: b251e0d9d0a8bcb0742d4d495c70f479effe16c2
   SOLVER:
   CYGWIN_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
   CYGWIN_ROOT: D:\cygwin
@@ -122,7 +122,7 @@ jobs:
     needs: Analyse
     strategy:
       matrix:
-        ocamlv: [ 4.08.1, 4.09.1, 4.10.2, 4.11.2, 4.12.1, 4.13.1, 4.14.1 ]
+        ocamlv: [ 4.08.1, 4.09.1, 4.10.2, 4.11.2, 4.12.1, 4.13.1, 5.0.0, 5.1.0, 4.14.1 ]
       fail-fast: true
     steps:
     - name: Install bubblewrap

--- a/master_changes.md
+++ b/master_changes.md
@@ -76,6 +76,7 @@ users)
   * Fix "make cold" on Windows when gcc is available [#5635 @kit-ty-kate - fixes #5600]
 
 ## Infrastructure
+  * Test OCaml 5.0 and 5.1 in CI [#5672 @kit-ty-kate]
 
 ## Release scripts
   * Add ppc64le and s390x support [#5420 @kit-ty-kate]


### PR DESCRIPTION
5.x doesn’t support MSVC and PPC64 yet so we can’t use either as default version but we can at least test them in CI as a quick check