### PR TITLE
Add a verbose-on option.

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -171,3 +171,4 @@ users)
   * Add `OpamTypesBase.switch_selections_{compare,equal}`: proper comparison functions for `OpamTypes.switch_selections` [#6102 @kit-ty-kate]
 
 ## opam-core
+  * `OpamStd.Env`: add `env_string_list` for parsing string list environment variables (comma separated) [#5682 @desumn]

--- a/master_changes.md
+++ b/master_changes.md
@@ -158,6 +158,9 @@ users)
 # API updates
 ## opam-client
   * `OpamSwitchCommand.import`: add optional `?deps_only` argument to install only dependencies of root packages [#5388 @rjbou]
+  * `OpamArg.build_options`: add `--verbose-on` flag [#5682 @desumn @rjbou]
+  * `OpamClientConfig.build_options`: add `verbose_on` field [#5682 @desumn]
+  * `OpamClientConfig.E`, `OpamArg.environment_variables`: and `OPAMVERBOSEON` support [#5682 @desumn @rjbou]
 
 ## opam-repository
  * `OpamRepository.fetch_from_cache`: when an archive is found, add a symlink (or copy) for the ones found in opam file but not in cache [#6068 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -32,6 +32,9 @@ users)
   * Fix package name display for no agreement conflicts [#6055 @rjbou - fix #6030]
   * Make fetching an archive from cache add missing symlinks [#6068 @kit-ty-kate - fix #6064]
 
+## Build (package)
+  * ◈ Add `--verbose-on` option to enable verbose mode on specified package names [#5682 @desumn @rjbou]
+
 ## Remove
 
 ## Switch

--- a/master_changes.md
+++ b/master_changes.md
@@ -139,6 +139,7 @@ users)
   * Add admin cache test [#6068 @rjbou]
   * env: Add a test for `build-env` overwrites build env opam environment variables [#5377 @rjbou]
   * clean: Add to check cleaning of sources directories [#5474 @rjbou]
+  * Add reftest for `--verbose-on` option [#5682 @rjbou]
 
 ### Engine
 

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -688,7 +688,9 @@ let make_command st opam ?dir ?text_command (cmd, args) =
   OpamSystem.make_command ~env ~name ?dir ~text
     ~resolve_path:OpamStateConfig.(not !r.dryrun)
     ~metadata:["context", context]
-    ~verbose:(OpamConsole.verbose ())
+    ~verbose:(OpamConsole.verbose () ||
+              OpamPackage.Name.Set.mem (OpamPackage.name nv)
+                OpamClientConfig.(!r.verbose_on))
     cmd args
 
 let remove_commands t nv =
@@ -977,7 +979,10 @@ let build_package t ?(test=false) ?(doc=false) ?(dev_setup=false) build_dir nv =
       (OpamPackage.to_string nv) (OpamProcess.string_of_command cmd);
     Done (Some (OpamSystem.Process_error result))
   | None, None ->
-    if commands <> [] && OpamConsole.verbose () then
+    if commands <> [] && (OpamConsole.verbose () ||
+                          OpamPackage.Name.Set.mem (OpamPackage.name nv)
+                            OpamClientConfig.(!r.verbose_on))
+    then
       OpamConsole.msg "%s compiled  %s.%s\n"
         (if not (OpamConsole.utf8 ()) then "->"
          else OpamActionGraph.

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -33,6 +33,7 @@ module E: sig
     | SKIPUPDATE of bool option
     | STATS of bool option
     | WORKINGDIR of bool option
+    | VERBOSEON of string list option
     val cli: unit -> string option
     val rootisok: unit -> bool option
     val noaggregate: unit -> bool option
@@ -59,6 +60,7 @@ type t = private {
   assume_depexts: bool;
   cli: OpamCLIVersion.t;
   scrubbed_environment_variables: string list;
+  verbose_on:OpamTypes.name_set;
 }
 
 type 'a options_fun =
@@ -82,6 +84,7 @@ type 'a options_fun =
   ?assume_depexts:bool ->
   ?cli:OpamCLIVersion.t ->
   ?scrubbed_environment_variables:string list ->
+  ?verbose_on:OpamTypes.name_set -> 
   'a
   (* constraint 'a = 'b -> 'c *)
 
@@ -120,6 +123,7 @@ val opam_init:
   ?assume_depexts:bool ->
   ?cli:OpamCLIVersion.t ->
   ?scrubbed_environment_variables:string list ->
+  ?verbose_on:OpamTypes.name_set ->
   ?original_root_dir:OpamTypes.dirname ->
   ?current_switch:OpamSwitch.t ->
   ?switch_from:OpamStateTypes.provenance ->

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1854,6 +1854,9 @@ module Config = struct
   let env_string var =
     env (fun s -> s) var
 
+  let env_string_list var =
+    env (fun s -> OpamString.split s ',') var
+
   let env_float var =
     env float_of_string var
 

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -698,6 +698,8 @@ module Config : sig
 
   val env_string: env_var -> string option
 
+  val env_string_list : env_var -> string list option
+
   val env_float: env_var -> float option
 
   val env_when: env_var -> when_ option

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1578,6 +1578,24 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:var-option.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-verbose-on)
+ (action
+  (diff verbose-on.test verbose-on.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-verbose-on)))
+
+(rule
+ (targets verbose-on.out)
+ (deps root-N0REP0)
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:verbose-on.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-with-dev-setup)
  (action
   (diff with-dev-setup.test with-dev-setup.out)))

--- a/tests/reftests/verbose-on.test
+++ b/tests/reftests/verbose-on.test
@@ -1,0 +1,312 @@
+N0REP0
+### <pkg:foo.1>
+opam-version: "2.0"
+build: [ "echo" name ]
+depends: "bar"
+### <pkg:bar.1>
+opam-version: "2.0"
+build: [ "echo" name ]
+depends: "baz"
+### <pkg:baz.1>
+opam-version: "2.0"
+build: [ "echo" name ]
+depends: "qux"
+### <pkg:qux.1>
+opam-version: "2.0"
+build: [ "echo" name ]
+### OPAMYES=1
+### opam switch create verbose-on --empty
+### : with --verbose-on option
+### opam install foo
+The following actions will be performed:
+=== install 4 packages
+  - install bar 1 [required by foo]
+  - install baz 1 [required by bar]
+  - install foo 1
+  - install qux 1 [required by baz]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed qux.1
+-> installed baz.1
+-> installed bar.1
+-> installed foo.1
+Done.
+### opam reinstall qux --verbose-on foo | unordered | sed-cmd echo
+The following actions will be performed:
+=== recompile 4 packages
+  - recompile bar 1 [uses baz]
+  - recompile baz 1 [uses qux]
+  - recompile foo 1 [uses bar]
+  - recompile qux 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.1
+-> removed   bar.1
+-> removed   baz.1
+-> removed   qux.1
+-> installed qux.1
+-> installed baz.1
+-> installed bar.1
++ echo "foo" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/foo.1)
+- foo
+-> compiled  foo.1
+-> installed foo.1
+Done.
+### opam reinstall qux --verbose-on bar | unordered | sed-cmd echo
+The following actions will be performed:
+=== recompile 4 packages
+  - recompile bar 1 [uses baz]
+  - recompile baz 1 [uses qux]
+  - recompile foo 1 [uses bar]
+  - recompile qux 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.1
+-> removed   bar.1
+-> removed   baz.1
+-> removed   qux.1
+-> installed qux.1
+-> installed baz.1
++ echo "bar" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/bar.1)
+- bar
+-> compiled  bar.1
+-> installed bar.1
+-> installed foo.1
+Done.
+### opam reinstall qux --verbose-on bar,qux | unordered | sed-cmd echo
+The following actions will be performed:
+=== recompile 4 packages
+  - recompile bar 1 [uses baz]
+  - recompile baz 1 [uses qux]
+  - recompile foo 1 [uses bar]
+  - recompile qux 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++ echo "qux" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/qux.1)
+- qux
+-> compiled  qux.1
+-> removed   foo.1
+-> removed   bar.1
+-> removed   baz.1
+-> removed   qux.1
+-> installed qux.1
+-> installed baz.1
++ echo "bar" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/bar.1)
+- bar
+-> compiled  bar.1
+-> installed bar.1
+-> installed foo.1
+Done.
+### opam reinstall qux --verbose-on foo,bar,baz,qux | unordered | sed-cmd echo
+The following actions will be performed:
+=== recompile 4 packages
+  - recompile bar 1 [uses baz]
+  - recompile baz 1 [uses qux]
+  - recompile foo 1 [uses bar]
+  - recompile qux 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++ echo "qux" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/qux.1)
+- qux
+-> compiled  qux.1
+-> removed   foo.1
+-> removed   bar.1
+-> removed   baz.1
+-> removed   qux.1
+-> installed qux.1
++ echo "baz" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/baz.1)
+- baz
+-> compiled  baz.1
+-> installed baz.1
++ echo "bar" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/bar.1)
+- bar
+-> compiled  bar.1
+-> installed bar.1
++ echo "foo" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/foo.1)
+- foo
+-> compiled  foo.1
+-> installed foo.1
+Done.
+### : unknown package
+### opam reinstall qux --verbose-on unknown-pkg | unordered
+The following actions will be performed:
+=== recompile 4 packages
+  - recompile bar 1 [uses baz]
+  - recompile baz 1 [uses qux]
+  - recompile foo 1 [uses bar]
+  - recompile qux 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.1
+-> removed   bar.1
+-> removed   baz.1
+-> removed   qux.1
+-> installed qux.1
+-> installed baz.1
+-> installed bar.1
+-> installed foo.1
+Done.
+### : upgrade
+### <pkg:bar.2>
+opam-version: "2.0"
+build: [ "echo" name ]
+depends: "baz"
+### opam upgrade --verbose-on bar | unordered | sed-cmd echo
+The following actions will be performed:
+=== recompile 1 package
+  - recompile foo 1      [uses bar]
+=== upgrade 1 package
+  - upgrade   bar 1 to 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.1
+-> removed   bar.1
+-> installed bar.2
++ echo "bar" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/bar.2)
+- bar
+-> compiled  bar.2
+-> installed foo.1
+Done.
+### : with OPAMVERBOSEON environment variable
+### OPAMVERBOSEON=foo
+### opam reinstall qux | unordered | sed-cmd echo
+The following actions will be performed:
+=== recompile 4 packages
+  - recompile bar 2 [uses baz]
+  - recompile baz 1 [uses qux]
+  - recompile foo 1 [uses bar]
+  - recompile qux 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.1
+-> removed   bar.2
+-> removed   baz.1
+-> removed   qux.1
+-> installed qux.1
+-> installed baz.1
+-> installed bar.2
++ echo "foo" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/foo.1)
+- foo
+-> compiled  foo.1
+-> installed foo.1
+Done.
+### OPAMVERBOSEON=bar
+### opam reinstall qux | unordered | sed-cmd echo
+The following actions will be performed:
+=== recompile 4 packages
+  - recompile bar 2 [uses baz]
+  - recompile baz 1 [uses qux]
+  - recompile foo 1 [uses bar]
+  - recompile qux 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.1
+-> removed   bar.2
+-> removed   baz.1
+-> removed   qux.1
+-> installed qux.1
+-> installed baz.1
++ echo "bar" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/bar.2)
+- bar
+-> compiled  bar.2
+-> installed bar.2
+-> installed foo.1
+Done.
+### OPAMVERBOSEON=baz,qux
+### opam reinstall qux | unordered | sed-cmd echo
+The following actions will be performed:
+=== recompile 4 packages
+  - recompile bar 2 [uses baz]
+  - recompile baz 1 [uses qux]
+  - recompile foo 1 [uses bar]
+  - recompile qux 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++ echo "qux" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/qux.1)
+- qux
+-> compiled  qux.1
+-> removed   foo.1
+-> removed   bar.2
+-> removed   baz.1
+-> removed   qux.1
+-> installed qux.1
++ echo "baz" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/baz.1)
+- baz
+-> compiled  baz.1
+-> installed baz.1
+-> installed bar.2
+-> installed foo.1
+Done.
+### OPAMVERBOSEON=foo,bar,baz,qux
+### opam reinstall qux | unordered | sed-cmd echo
+The following actions will be performed:
+=== recompile 4 packages
+  - recompile bar 2 [uses baz]
+  - recompile baz 1 [uses qux]
+  - recompile foo 1 [uses bar]
+  - recompile qux 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++ echo "qux" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/qux.1)
+- qux
+-> compiled  qux.1
+-> removed   foo.1
+-> removed   bar.2
+-> removed   baz.1
+-> removed   qux.1
+-> installed qux.1
++ echo "baz" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/baz.1)
+- baz
+-> compiled  baz.1
+-> installed baz.1
++ echo "bar" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/bar.2)
+- bar
+-> compiled  bar.2
+-> installed bar.2
++ echo "foo" (CWD=${BASEDIR}/OPAM/verbose-on/.opam-switch/build/foo.1)
+- foo
+-> compiled  foo.1
+-> installed foo.1
+Done.
+### OPAMVERBOSEON=""
+### opam reinstall qux | unordered
+The following actions will be performed:
+=== recompile 4 packages
+  - recompile bar 2 [uses baz]
+  - recompile baz 1 [uses qux]
+  - recompile foo 1 [uses bar]
+  - recompile qux 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.1
+-> removed   bar.2
+-> removed   baz.1
+-> removed   qux.1
+-> installed qux.1
+-> installed baz.1
+-> installed bar.2
+-> installed foo.1
+Done.
+### OPAMVERBOSEON=3
+### opam reinstall qux
+Fatal error: Package name "3" should contain at least one letter
+# Return code 99 #
+### OPAMVERBOSEON=unknown-pkg
+### opam reinstall qux | unordered
+The following actions will be performed:
+=== recompile 4 packages
+  - recompile bar 2 [uses baz]
+  - recompile baz 1 [uses qux]
+  - recompile foo 1 [uses bar]
+  - recompile qux 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.1
+-> removed   bar.2
+-> removed   baz.1
+-> removed   qux.1
+-> installed qux.1
+-> installed baz.1
+-> installed bar.2
+-> installed foo.1
+Done.


### PR DESCRIPTION
Implementation of #5331 

Add a `verbose-on=PACKAGES` parameters to build options. For the time being, it's equivalent to a simple `-v` for a list of package.

I'm not sure how I'd be able to simulate a modification of the opam file of a specific package to change add the verbose flag, so it's not exactly what #5331 asked for, however if there's a way I'd be glad to implement it!