### PR TITLE
OPAMVERBOSE: Fix `level` by flipping the `env_level` implementation

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -14,6 +14,7 @@ users)
   * Bump to 2.2.0~alpha3~dev [#5615 @rjbou]
 
 ## Global CLI
+  * Fix `OPAMVERBOSE` setting, 0 and 1 levels was inverted: eg, "no" gives level 1, and "yes" level 0 [#5686 @smorimoto]
 
 ## Plugins
 
@@ -150,3 +151,4 @@ users)
 ## opam-core
   * `OpamSystem.mk_temp_dir`: resolve real path with `OpamSystem.real_path` before returning it [#5654 @rjbou]
   * `OpamSystem.resolve_command`: in command resolution path, check that the file is not a directory and that it is a regular file [#5606 @rjbou - fix #5585 #5597]
+  * `OpamStd.Config.env_level`: fix level parsing, it was inverted (eg, "no" gives level 1, and "yes" level 0) [#5686 @smorimoto]

--- a/master_changes.md
+++ b/master_changes.md
@@ -112,6 +112,7 @@ users)
   * Admin: add `admin add-extrafiles` test cases [#5647 @rjbou]
   * Add download test, to check `OPAMCURL/OPAMFETCH` handling [#5607 @rjbou]
   * Add `core/opamSystem.ml` specific tests, to test command resolution [#5600 @rjbou]
+  * Add test for `OpamCoreConfig`, to check `OPAMVERBOSE` values [#5686 @rjbou]
 
 ### Engine
   * With real path resolved for all opam temp dir, remove `/private` from mac temp dir regexp [#5654 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -141,14 +141,11 @@ users)
 ## opam-solver
 
 ## opam-format
-
-* Add `OpamFilter.expand_interpolations_in_file_full` which allows setting the
-  output file along with the input file [#5629 @rgrinberg]
-
-* Expose `OpamFilter.string_interp_regex` which allows clients to identify
-  variable interpolations in strings [#5633 @gridbugs]
+## opam-format
+  * `OpamFilter`: add `expand_interpolations_in_file_full` which allows setting the output file along with the input file [#5629 @rgrinberg]
+  * `OpamFilter`: expose `string_interp_regex` which allows clients to identify variable interpolations in strings [#5633 @gridbugs]
 
 ## opam-core
   * `OpamSystem.mk_temp_dir`: resolve real path with `OpamSystem.real_path` before returning it [#5654 @rjbou]
-  * `OpamSystem.resolve_command`: in command resolution path, check that the file is not a directory and that it is a regular file [#5606 @rjbou - fix #5585 #5597]
+  * `OpamSystem.resolve_command`: in command resolution path, check that the file is not a directory and that it is a regular file [#5606 @rjbou - fix #5585 #5597 #5650 #5626]
   * `OpamStd.Config.env_level`: fix level parsing, it was inverted (eg, "no" gives level 1, and "yes" level 0) [#5686 @smorimoto]

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1683,8 +1683,8 @@ module Config = struct
     env (function s ->
         if s = "" then 0 else
         match bool_of_string s with
-        | Some true -> 0
-        | Some false -> 1
+        | Some true -> 1
+        | Some false -> 0
         | None -> int_of_string s)
       var
 

--- a/tests/reftests/core-config.test
+++ b/tests/reftests/core-config.test
@@ -1,0 +1,123 @@
+N0REP0
+### <pkg:foo.1>
+opam-version: "2.0"
+build: ["echo" "hej"]
+### opam switch create core-config --empty
+### :::::::::::::::::::::::
+### : OPAMVERBOSE setting :
+### :::::::::::::::::::::::
+### opam install foo
+The following actions will be performed:
+=== install 1 package
+  - install foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed foo.1
+Done.
+### OPAMVERBOSE=1
+### opam reinstall foo
+The following actions will be performed:
+=== recompile 1 package
+  - recompile foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.1
+-> installed foo.1
+Done.
+### OPAMVERBOSE=yes
+### opam reinstall foo
+The following actions will be performed:
+=== recompile 1 package
+  - recompile foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.1
+-> installed foo.1
+Done.
+### OPAMVERBOSE=true
+### opam reinstall foo
+The following actions will be performed:
+=== recompile 1 package
+  - recompile foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.1
+-> installed foo.1
+Done.
+### OPAMVERBOSE=2
+### opam reinstall foo | sed-cmd echo
+The following actions will be performed:
+=== recompile 1 package
+  - recompile foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/4: [foo: echo hej]
++ echo "hej" (CWD=${BASEDIR}/OPAM/core-config/.opam-switch/build/foo.1)
+- hej
+-> compiled  foo.1
+-> removed   foo.1
+-> installed foo.1
+Done.
+### OPAMVERBOSE=0
+### opam reinstall foo | sed-cmd echo
+The following actions will be performed:
+=== recompile 1 package
+  - recompile foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/4: [foo: echo hej]
++ echo "hej" (CWD=${BASEDIR}/OPAM/core-config/.opam-switch/build/foo.1)
+- hej
+-> compiled  foo.1
+-> removed   foo.1
+-> installed foo.1
+Done.
+### OPAMVERBOSE=""
+### opam reinstall foo
+The following actions will be performed:
+=== recompile 1 package
+  - recompile foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.1
+-> installed foo.1
+Done.
+### OPAMVERBOSE=false
+### opam reinstall foo | sed-cmd echo
+The following actions will be performed:
+=== recompile 1 package
+  - recompile foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/4: [foo: echo hej]
++ echo "hej" (CWD=${BASEDIR}/OPAM/core-config/.opam-switch/build/foo.1)
+- hej
+-> compiled  foo.1
+-> removed   foo.1
+-> installed foo.1
+Done.
+### OPAMVERBOSE=no
+### opam reinstall foo | sed-cmd echo
+The following actions will be performed:
+=== recompile 1 package
+  - recompile foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/4: [foo: echo hej]
++ echo "hej" (CWD=${BASEDIR}/OPAM/core-config/.opam-switch/build/foo.1)
+- hej
+-> compiled  foo.1
+-> removed   foo.1
+-> installed foo.1
+Done.
+### OPAMVERBOSE=another
+### opam reinstall foo
+[WARNING] Invalid value for environment variable OPAMVERBOSE, ignored.
+The following actions will be performed:
+=== recompile 1 package
+  - recompile foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   foo.1
+-> installed foo.1
+Done.

--- a/tests/reftests/core-config.test
+++ b/tests/reftests/core-config.test
@@ -15,32 +15,44 @@ The following actions will be performed:
 -> installed foo.1
 Done.
 ### OPAMVERBOSE=1
-### opam reinstall foo
+### opam reinstall foo | sed-cmd echo
 The following actions will be performed:
 === recompile 1 package
   - recompile foo 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/4: [foo: echo hej]
++ echo "hej" (CWD=${BASEDIR}/OPAM/core-config/.opam-switch/build/foo.1)
+- hej
+-> compiled  foo.1
 -> removed   foo.1
 -> installed foo.1
 Done.
 ### OPAMVERBOSE=yes
-### opam reinstall foo
+### opam reinstall foo | sed-cmd echo
 The following actions will be performed:
 === recompile 1 package
   - recompile foo 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/4: [foo: echo hej]
++ echo "hej" (CWD=${BASEDIR}/OPAM/core-config/.opam-switch/build/foo.1)
+- hej
+-> compiled  foo.1
 -> removed   foo.1
 -> installed foo.1
 Done.
 ### OPAMVERBOSE=true
-### opam reinstall foo
+### opam reinstall foo | sed-cmd echo
 The following actions will be performed:
 === recompile 1 package
   - recompile foo 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/4: [foo: echo hej]
++ echo "hej" (CWD=${BASEDIR}/OPAM/core-config/.opam-switch/build/foo.1)
+- hej
+-> compiled  foo.1
 -> removed   foo.1
 -> installed foo.1
 Done.
@@ -59,16 +71,12 @@ Processing  2/4: [foo: echo hej]
 -> installed foo.1
 Done.
 ### OPAMVERBOSE=0
-### opam reinstall foo | sed-cmd echo
+### opam reinstall foo
 The following actions will be performed:
 === recompile 1 package
   - recompile foo 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-Processing  2/4: [foo: echo hej]
-+ echo "hej" (CWD=${BASEDIR}/OPAM/core-config/.opam-switch/build/foo.1)
-- hej
--> compiled  foo.1
 -> removed   foo.1
 -> installed foo.1
 Done.
@@ -83,30 +91,22 @@ The following actions will be performed:
 -> installed foo.1
 Done.
 ### OPAMVERBOSE=false
-### opam reinstall foo | sed-cmd echo
+### opam reinstall foo
 The following actions will be performed:
 === recompile 1 package
   - recompile foo 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-Processing  2/4: [foo: echo hej]
-+ echo "hej" (CWD=${BASEDIR}/OPAM/core-config/.opam-switch/build/foo.1)
-- hej
--> compiled  foo.1
 -> removed   foo.1
 -> installed foo.1
 Done.
 ### OPAMVERBOSE=no
-### opam reinstall foo | sed-cmd echo
+### opam reinstall foo
 The following actions will be performed:
 === recompile 1 package
   - recompile foo 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-Processing  2/4: [foo: echo hej]
-+ echo "hej" (CWD=${BASEDIR}/OPAM/core-config/.opam-switch/build/foo.1)
-- hej
--> compiled  foo.1
 -> removed   foo.1
 -> installed foo.1
 Done.

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -270,6 +270,24 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:conflict-solo5.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-core-config)
+ (action
+  (diff core-config.test core-config.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-core-config)))
+
+(rule
+ (targets core-config.out)
+ (deps root-N0REP0)
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:core-config.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-core-system.unix)
  (enabled_if (= %{os_type} "Unix"))
  (action


### PR DESCRIPTION
This literally flips the implementation. As you can see in the implementation of `bool_of_string`, the original implementation does not seem correct.

https://github.com/ocaml/opam/blob/b0cb137edebc5e7d7ac1e650086e3be5800ae743/src/core/opamStd.ml#L1666-L1670

In fact, I found this when debugging a GitHub Actions issue, and you can easily reproduce the issue on your computer by just try each of the following commands:

```sh
OPAMVERBOSE=no opam update
```

```sh
OPAMVERBOSE=yes opam update
```