### PR TITLE
[PoC] Generalize the detection of GNU Make ("make" variable)

### DIFF
--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -95,10 +95,15 @@ let default = {
   build_doc = false;
   dev_setup = false;
   dryrun = false;
-  makecmd = lazy OpamStd.Sys.(
-      match os () with
-      | FreeBSD | OpenBSD | NetBSD | DragonFly -> "gmake"
-      | _ -> "make"
+  makecmd = lazy (
+      OpamFilename.with_tmp_dir (fun dir ->
+          let open OpamFilename.Op in
+          OpamFilename.write (dir // "GNUmakefile") "all: ; printf make > output\n";
+          OpamFilename.write (dir // "Makefile") "all: ; printf gmake > output\n";
+          match OpamProcess.run (OpamSystem.make_command ~allow_stdin:false ~dir:(OpamFilename.Dir.to_string dir) "make" []) with
+          | {OpamProcess.r_code = 0; _} -> OpamFilename.read (dir // "output")
+          | _ -> failwith "TODO"
+        )
     );
   ignore_constraints_on = OpamPackage.Name.Set.empty;
   unlock_base = false;


### PR DESCRIPTION
Per https://github.com/ocaml/opam/issues/5704#issuecomment-1768784715

As far as I know this is the only and most reliable way to detect whether or not the `make` command is GNU Make or some other superset of POSIX Make.

`make` is POSIX compliant (https://www.unix.com/man-page/posix/1p/make/) so the command will always be there on all the platforms we support (including Windows as we require Cygwin or similar which brings its own POSIX environment)

Per GNU Make's manual (https://www.gnu.org/software/make/manual/make.html#Makefile-Names) `GNUmakefile` always takes priority before `Makefile` if it exists, but non-GNU Make implementations do not.

The code is tested and works as expected but I'm not sure of the intricacies of using `OpamProcess` + dealing with `TMPDIR` at this stage of the setup, even if lazy, so since it's not urgent at all this is only a Proof of Concept for me, and we can look at it again once 2.2.0 is out.