### PR TITLE
Fix formatting in the Manual

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -1072,7 +1072,6 @@ files.
       explicitely. This can be affected by the
       [solver criteria](#configfield-solver-criteria). This can be useful for
       beta releases, or to discourage installation of releases with known bugs.
-
       Note that this behaviour is disabled when a flagged version of the package
       is already installed.
     - <a id="opamflag-deprecated">`deprecated`</a>: this flag is equivalent to

--- a/master_changes.md
+++ b/master_changes.md
@@ -127,6 +127,8 @@ users)
   * Add `wget` on Cygwin install [#5607 @rjbou]
 
 ## Doc
+  * Fix typos in readme [#5706 @MisterDA]
+  * Fix formatting in the Manual [#5708 @kit-ty-kate]
 
 ## Security fixes
 


### PR DESCRIPTION
The line with the note would make the next item of the list seem disconnected from the previous list
<img width="866" alt="Screenshot 2023-10-23 at 12 12 58" src="https://github.com/ocaml/opam/assets/2611789/aced6bd8-4289-4c28-87d0-3ebf85e429aa">
