### PR TITLE
Harden `windows_get_shell`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -105,7 +105,7 @@ users)
 ## Internal
 
 ## Internal: Windows
-  * Fix sporadic crash in shell detection (seen in native containers) [#5714 @dra27]
+  * Fix sporadic crash and segfault in shell detection (seen in native containers) [#5714 @dra27]
 
 ## Test
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -105,6 +105,7 @@ users)
 ## Internal
 
 ## Internal: Windows
+  * Fix sporadic crash in shell detection (seen in native containers) [#5714 @dra27]
 
 ## Test
 
@@ -158,3 +159,4 @@ users)
   * `OpamSystem.mk_temp_dir`: resolve real path with `OpamSystem.real_path` before returning it [#5654 @rjbou]
   * `OpamSystem.resolve_command`: in command resolution path, check that the file is not a directory and that it is a regular file [#5606 @rjbou - fix #5585 #5597 #5650 #5626]
   * `OpamStd.Config.env_level`: fix level parsing, it was inverted (eg, "no" gives level 1, and "yes" level 0) [#5686 @smorimoto]
+  * `OpamStd.Sys.chop_exe_suffix`: removes `.exe` from the end of a path, if present

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1073,6 +1073,9 @@ module OpamSys = struct
     else
       fun x -> x
 
+  let chop_exe_suffix name =
+    Option.default name (Filename.chop_suffix_opt name ~suffix:".exe")
+
   let windows_process_ancestry = Lazy.from_fun OpamStubs.getProcessAncestry
 
   type shell_choice = Accept of shell
@@ -1085,10 +1088,11 @@ module OpamSys = struct
       | "pwsh.exe" -> Some (Accept (SH_pwsh Powershell_pwsh))
       | "cmd.exe" -> Some (Accept SH_cmd)
       | "env.exe" -> Some (Accept SH_sh)
+      | "" -> None
       | name ->
         Option.map
           (fun shell -> Accept shell)
-          (shell_of_string (Filename.chop_suffix name ".exe"))
+          (shell_of_string (chop_exe_suffix name))
     in
     lazy (
       let lazy ancestors = windows_process_ancestry in

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -503,6 +503,9 @@ module Sys : sig
   (** Append .exe (only if missing) to executable filenames on Windows *)
   val executable_name : string -> string
 
+  (** Remove .exe (if present) from an executable filename on Windows *)
+  val chop_exe_suffix : string -> string
+
   (** The different families of shells we know about *)
   type powershell_host = Powershell_pwsh | Powershell
   type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish

--- a/src/stubs/win32/opamWindows.c
+++ b/src/stubs/win32/opamWindows.c
@@ -675,6 +675,7 @@ CAMLprim value OPAMW_GetProcessAncestry(value unit)
                     read_entry = FALSE;
                     break;
                   } else {
+                    cur = ptr + (cur - processes);
                     processes = ptr;
                   }
                 }

--- a/src/stubs/win32/opamWindows.c
+++ b/src/stubs/win32/opamWindows.c
@@ -680,8 +680,8 @@ CAMLprim value OPAMW_GetProcessAncestry(value unit)
                 }
                 cur->LowPart = entry.th32ProcessID;
                 cur->HighPart = entry.th32ParentProcessID;
+                cur[1].QuadPart = 0LL;
                 if (cur->LowPart == target) {
-                  cur[1].QuadPart = 0LL;
                   break;
                 } else {
                   cur++;


### PR DESCRIPTION
In Windows native containers, the `Filename.chop_suffix` call in `windows_get_shell` was occasionally failing. `OpamStubs.getProcessAncestry` can return empty strings. `windows_get_shell` now explictly handles the empty string case and `.exe` is now _optionally_ stripped.