### PR TITLE
reftest engine tweaks for Windows

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -128,6 +128,7 @@ users)
   * Add environment variables path addition [#5606 @rjbou]
   * Remove duplicated environment variables in environmenet [#5606 @rjbou]
   * Add `PATH` to replaceable variables [#5606 @rjbou]
+  * Set `SHELL` to `/bin/sh` in Windows to ensure `opam env` commands are consistent [#5723 @dra27]
 
 ## Github Actions
   * Add coreutils install for cheksum validation tests [#5560 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -159,3 +159,4 @@ users)
   * `OpamSystem.mk_temp_dir`: resolve real path with `OpamSystem.real_path` before returning it [#5654 @rjbou]
   * `OpamSystem.resolve_command`: in command resolution path, check that the file is not a directory and that it is a regular file [#5606 @rjbou - fix #5585 #5597 #5650 #5626]
   * `OpamStd.Config.env_level`: fix level parsing, it was inverted (eg, "no" gives level 1, and "yes" level 0) [#5686 @smorimoto]
+  * `OpamSystem.apply_cygpath`: runs `cygpath` over the argument [#5723 @dra27 - function itself added in #3348]

--- a/master_changes.md
+++ b/master_changes.md
@@ -129,6 +129,8 @@ users)
   * Remove duplicated environment variables in environmenet [#5606 @rjbou]
   * Add `PATH` to replaceable variables [#5606 @rjbou]
   * Set `SHELL` to `/bin/sh` in Windows to ensure `opam env` commands are consistent [#5723 @dra27]
+  * Substitution for `BASEDIR` and `OPAMTMP` now recognise the directory with either forward-slashes, back-slashes, or converted to Cygwin
+    notation (i.e. C:\cygwin64\tmp\..., C:/cygwin64/tmp/..., or /tmp/...) [#5723 @dra27]
 
 ## Github Actions
   * Add coreutils install for cheksum validation tests [#5560 @rjbou]

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -196,6 +196,9 @@ val get_cygpath_function: command:string -> (string -> string) lazy_t
     otherwise. *)
 val get_cygpath_path_transform: (string -> string) lazy_t
 
+(** Applies the cygpath command to the argument. Requires cygpath to be resolved. *)
+val apply_cygpath: string -> string
+
 (** [command cmd] executes the command [cmd] in the correct OPAM
     environment. *)
 val command: ?verbose:bool -> ?env:string array -> ?name:string ->

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -121,6 +121,7 @@ let base_env =
   propagate "TMPDIR" @
   propagate "TMP" @
   propagate "TEMP" @
+  (if Sys.win32 then ["SHELL", "/bin/sh"] else []) @
   [
     "OPAMKEEPBUILDDIR", "1";
     "OPAMCOLOR", "never";

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -541,6 +541,11 @@ let parse_command = Parse.command
 let common_filters ?opam dir =
    let tmpdir = OpamSystem.real_path (Filename.get_temp_dir_name ()) in
    let open Re in
+   let dir_to_regex dir =
+     if Sys.win32 then
+       [str dir; str (OpamSystem.back_to_forward dir); str (OpamSystem.apply_cygpath dir)]
+     else
+       [str dir] in
    [
      seq [ bol;
            alt [ str "#=== ERROR";
@@ -554,11 +559,10 @@ let common_filters ?opam dir =
      GrepV;
      seq [bol; str cmd_prompt],
      Sed "##% ";
-     alt [str dir; str (OpamSystem.back_to_forward dir)],
+     alt (dir_to_regex dir),
      Sed "${BASEDIR}";
      seq [
-          alt [str tmpdir;
-               str (OpamSystem.back_to_forward tmpdir)];
+          alt (dir_to_regex tmpdir);
           rep (set "/\\");
           str "opam-";
           rep1 (alt [xdigit; char '-'])],


### PR DESCRIPTION
On Windows, when run in GitHub Actions, the `opam env` in reftests is using a `sh` as the default shell (so we get `ENV='value'; export ENV` format). When run locally, I get `cmd` as the default shell, which causes conflicts as we get `set ENV=value` notation instead.

I had a deeper dive into this as part of looking at #5636 and #5714. Process hierarchy is a slightly strange thing on Windows - it's already the case that the ancestry returned gets "chopped" (process groups, etc. can do this). The ancestry being returned is not incorrect, or at least it is consistent - tools such as Process Explorer see the same thing.

For whatever reason, the GitHub Actions get Cygwin's `sh.exe` as one of the ancestor processes. Locally, it's `make.exe` for me 🤷 I'm not totally sure why, but it doesn't particularly matter - the ancestry detection _is_ correct when run from cmd or powershell, which is when it's needed. When native opam is run from a Cygwin shell, `SHELL` is set, and opam uses that.

So the only issue is the reftests, which don't propagate the `SHELL` environment variable. The first commit here rather than propagating it, simply sets it. We might consider doing this for Unix as well - I'm not sure whether running `make tests` from `fish` has the same problem. I think this could also be done with `OPAMSHELL`, but given that we weren't propagating the `SHELL` variable before, I don't think an issue with just setting it instead.

Also while looking at things for #5636, it's quite easy now to end up with the opam root or the temporary directory being translated to Cygwin notation which doesn't then get caught by the regex for conversion to `BASEDIR` or `OPAMTMP`. I've factored out the code which was doing the previous forward/backslash manipulation and exposed `OpamSystem.apply_cygpath` so now those directories are captured with backslashes, forward-slashes *or* in Cygwin notation.