### PR TITLE
release: Workaround missing -O option to tar on OpenBSD

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -72,6 +72,7 @@ users)
 
 ## Release scripts
   * Workaround incorrect `NGROUPS_MAX` in `<limits.h>` in musl for release builds [#5383 @dra27]
+  * Fix check for adding `-lsha_stubs` only on `master` on OpenBSD [#5733 @punchagan]
 
 ## Admin
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -52,7 +52,7 @@ build/%.image: build/Dockerfile.%
 	docker build -t opam-build-$* -f $^ build
 	touch $@
 
-SHA_LINK = $(if $(shell mkdir -p build/tmp_extract && tar xf "$(OUTDIR)/opam-full-$(VERSION).tar.gz" -C build/tmp_extract && grep -F URL_sha build/tmp_extract/opam-full-$(VERSION)/src_ext/Makefile.sources),-lsha_stubs)
+SHA_LINK = $(if $(shell mkdir -p build/tmp_extract && tar xzf "$(OUTDIR)/opam-full-$(VERSION).tar.gz" -C build/tmp_extract && grep -F URL_sha build/tmp_extract/opam-full-$(VERSION)/src_ext/Makefile.sources),-lsha_stubs)
 
 # Actually, this is for alpine 3.13, and varies
 CLINKING_linux = \

--- a/release/Makefile
+++ b/release/Makefile
@@ -52,7 +52,7 @@ build/%.image: build/Dockerfile.%
 	docker build -t opam-build-$* -f $^ build
 	touch $@
 
-SHA_LINK = $(if $(shell tar xOf "$(OUTDIR)/opam-full-$(VERSION).tar.gz" opam-full-$(VERSION)/src_ext/Makefile.sources | grep -F URL_sha),-lsha_stubs)
+SHA_LINK = $(if $(shell mkdir -p build/tmp_extract && tar xf "$(OUTDIR)/opam-full-$(VERSION).tar.gz" -C build/tmp_extract && grep -F URL_sha build/tmp_extract/opam-full-$(VERSION)/src_ext/Makefile.sources),-lsha_stubs)
 
 # Actually, this is for alpine 3.13, and varies
 CLINKING_linux = \


### PR DESCRIPTION
abe02fc6ff39c0191406c83de8fc91ab4eeca0b3 added a fix to add the -lsha_stubs only on opam master, but OpenBSD's tar doesn't have the -O option. This commit extracts the tar archive to a temporary directory as a workaround.
