### PR TITLE
basic tracing

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -97,6 +97,7 @@ users)
 ## Shell
 
 ## Internal
+  * Add tracing for opam itself, enabled if `TRACE_FILE` is set in the environment [#5757 @c-cube]
 
 ## Internal: Windows
 

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -395,6 +395,7 @@ let simulate_local_pinnings ?quiet ?(for_view=false) st to_pin =
 
 let simulate_autopin st ?quiet ?(for_view=false) ?locked ?recurse ?subpath
     atom_or_local_list =
+  OpamTrace.with_span "AuxCommands.simulate_autopin" @@ fun () ->
   let atoms, to_pin, obsolete_pins, already_pinned_set =
     autopin_aux st ?quiet ~for_view ?recurse ?subpath ?locked atom_or_local_list
   in

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -940,6 +940,7 @@ let show cli =
   let show global_options fields show_empty raw where
       list_files file normalise no_lint just_file all_versions sort atom_locs
       () =
+  OpamTrace.with_span "Commands.show" @@ fun () ->
     let print_just_file opamf opam =
       if not no_lint then OpamFile.OPAM.print_errors opam;
       let opam =
@@ -2569,6 +2570,7 @@ let with_repos_rt gt repos f =
 
 let switch_doc = "Manage multiple installation prefixes."
 let switch cli =
+  OpamTrace.with_span "Commands.switch" @@ fun () ->
   let shell = OpamStd.Sys.guess_shell_compat () in
   let doc = switch_doc in
   let commands = [
@@ -4403,6 +4405,7 @@ let admin =
 (* Note: for cli versionning check, all commands must be constructed with
    [OpamArg.mk_command] or [OpamArg.mk_command_ret]. *)
 let commands cli =
+  OpamTrace.with_span "Commands.commands" @@ fun () ->
   let show = show cli in
   let remove = remove cli in
   let repository = repository cli in

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -664,6 +664,7 @@ let default_package_listing_format = {
 }
 
 let display st format packages =
+  OpamTrace.with_span "ListCommand.display" @@ fun () ->
   let packages =
     if format.all_versions then packages else
       OpamPackage.Name.Set.fold (fun name ->
@@ -714,6 +715,7 @@ let display st format packages =
     OpamConsole.print_table ?cut:format.wrap stdout ~sep:format.separator
 
 let get_switch_state gt rt =
+  OpamTrace.with_span "ListCommand.get_switch_state" @@ fun () ->
   match OpamStateConfig.get_switch_opt () with
   | None -> OpamSwitchState.load_virtual gt rt
   | Some sw -> OpamSwitchState.load `Lock_none gt rt sw

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -246,6 +246,7 @@ let display_error (n, error) =
 
 module Json = struct
   let output_request request user_action =
+    OpamTrace.with_span "Solution.Json.output_request" @@ fun () ->
     if OpamClientConfig.(!r.json_out = None) then () else
     let atoms =
       List.map (fun a -> `String (OpamFormula.short_string_of_atom a))
@@ -264,6 +265,7 @@ module Json = struct
     OpamJson.append "request" j
 
   let output_solution t solution =
+    OpamTrace.with_span "Solution.Json.output_solution" @@ fun () ->
     if OpamClientConfig.(!r.json_out = None) then () else
     match solution with
     | Success solution ->
@@ -1302,6 +1304,7 @@ let apply ?ask t ~requested ?print_requested ?add_roots
     ?(skip=OpamPackage.Map.empty)
     ?(assume_built=false)
     ?(download_only=false) ?force_remove solution0 =
+  OpamTrace.with_span "Solution.apply" @@ fun () ->
   let names = OpamPackage.names_of_packages requested in
   let print_requested = OpamStd.Option.default names print_requested in
   log "apply";
@@ -1454,6 +1457,7 @@ let apply ?ask t ~requested ?print_requested ?add_roots
   )
 
 let resolve t action ?reinstall ~requested request =
+  OpamTrace.with_span "Solution.resolve" @@ fun () ->
   if OpamClientConfig.(!r.json_out <> None) then
     OpamJson.append "switch" (OpamSwitch.to_json t.switch);
   OpamRepositoryState.check_last_update ();

--- a/src/core/opamCached.ml
+++ b/src/core/opamCached.ml
@@ -57,6 +57,9 @@ end = struct
   let marshal_from_file file fd =
     let chrono = OpamConsole.timer () in
     let f ic =
+      OpamTrace.with_span "Cached.marshal_from_file"
+          ~data:["sz", `Float (float_of_int @@ in_channel_length ic)]
+      @@ fun () ->
       try
         let (cache: t) = Marshal.from_channel ic in
         log "Loaded %a in %.3fs" (slog OpamFilename.to_string) file (chrono ());
@@ -82,6 +85,7 @@ end = struct
     | None -> None
 
   let save cache_file t =
+    OpamTrace.with_span "Cached.save" @@ fun () ->
     if OpamCoreConfig.(!r.safe_mode) then
       log "Running in safe mode, not upgrading the %s cache" X.name
     else

--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -509,19 +509,22 @@ let clear_status =
   else
     clear_status_unix
 
+let flush_out ch =
+  flush (if ch = `stdout then stderr else stdout)
+
 let print_message =
   if Sys.win32 then
-    fun ch fmt ->
-      flush (if ch = `stdout then stderr else stdout);
+    fun ~force_flush ch fmt ->
+      if force_flush then flush_out ch;
       clear_status ();
       (* win32_print_message *always* flushes *)
       Printf.ksprintf (win32_print_message ch) fmt
   else
-    fun ch fmt ->
+    fun ~force_flush ch fmt ->
       let output_string =
         let output_string ch s =
           output_string ch s;
-          flush ch
+        if force_flush then flush ch
         in
         match ch with
         | `stdout -> flush stderr; output_string stdout
@@ -594,23 +597,23 @@ let slog to_string f x = Format.pp_print_string f (to_string x)
 
 let error fmt =
   Printf.ksprintf (fun str ->
-    print_message `stderr "%a %s\n" (acolor `red) "[ERROR]"
+    print_message ~force_flush:true `stderr "%a %s\n" (acolor `red) "[ERROR]"
       (OpamStd.Format.reformat ~start_column:8 ~indent:8 str)
   ) fmt
 
 let warning fmt =
   Printf.ksprintf (fun str ->
-    print_message `stderr "%a %s\n" (acolor `yellow) "[WARNING]"
+    print_message ~force_flush:true `stderr "%a %s\n" (acolor `yellow) "[WARNING]"
       (OpamStd.Format.reformat ~start_column:10 ~indent:10 str)
   ) fmt
 
 let note fmt =
   Printf.ksprintf (fun str ->
-    print_message `stderr "%a %s\n" (acolor `blue) "[NOTE]"
+    print_message ~force_flush:true `stderr "%a %s\n" (acolor `blue) "[NOTE]"
       (OpamStd.Format.reformat ~start_column:7 ~indent:7 str)
   ) fmt
 
-let errmsg fmt = print_message `stderr fmt
+let errmsg fmt = print_message ~force_flush:true `stderr fmt
 
 let error_and_exit reason fmt =
   Printf.ksprintf (fun str ->
@@ -618,11 +621,13 @@ let error_and_exit reason fmt =
     OpamStd.Sys.exit_because reason
   ) fmt
 
-let msg fmt = print_message `stdout fmt
+let msg fmt = print_message ~force_flush:true `stdout fmt
+let msg_no_flush fmt = print_message ~force_flush:false `stdout fmt
 
 let formatted_msg ?indent fmt =
   Printf.ksprintf
-    (fun s -> print_message `stdout "%s" (OpamStd.Format.reformat ?indent s))
+    (fun s -> print_message ~force_flush:true `stdout "%s"
+      (OpamStd.Format.reformat ?indent s))
     fmt
 
 let last_status = ref ""
@@ -680,7 +685,7 @@ let header_msg fmt =
       let wpad = header_width () - String.length str - 2 in
       let wpadl = 4 in
       let wpadr = wpad - wpadl - if utf8_extended () then 4 else 0 in
-      print_message `stdout "\n%s %s%s%s\n"
+      print_message ~force_flush:true `stdout "\n%s %s%s%s\n"
         (colorise `cyan (String.sub padding 0 wpadl))
         (colorise `bold str)
         (if wpadr > 0 then
@@ -704,7 +709,7 @@ let header_error fmt =
           let wpad = header_width () - String.length head - 8 in
           let wpadl = 4 in
           let wpadr = wpad - wpadl in
-          print_message `stderr "\n%s %s %s %s\n%s\n"
+          print_message ~force_flush:true `stderr "\n%s %s %s %s\n%s\n"
             (colorise `red (String.sub padding 0 wpadl))
             (colorise `bold "ERROR")
             (colorise `bold head)
@@ -805,6 +810,7 @@ let pause fmt =
     Printf.ifprintf () fmt
 
 let confirm ?(require_unsafe_yes=false) ?(default=true) fmt =
+  OpamTrace.with_span "Console.confirm" @@ fun () ->
   Printf.ksprintf (fun s ->
       if OpamCoreConfig.(!r.safe_mode) then false else
       let prompt =
@@ -846,6 +852,7 @@ let read fmt =
     ) fmt
 
 let print_table ?cut oc ~sep table =
+  OpamTrace.with_span "Console.print_table" @@ fun () ->
   let open OpamStd.Format in
   let cut =
     match cut with
@@ -854,7 +861,7 @@ let print_table ?cut oc ~sep table =
   in
   let output_string s =
     if oc = stdout then
-      msg "%s\n" s
+      msg_no_flush "%s\n" s
     else if oc = stderr then
       errmsg "%s\n" s
     else begin
@@ -874,15 +881,19 @@ let print_table ?cut oc ~sep table =
     in
     clean [] (List.rev sl)
   in
-  let print_line l = match cut with
+
+  let terminal_columns = OpamStd.Sys.terminal_columns () in
+
+  let print_line l =
+    match cut with
     | `None ->
       let s = List.map (replace_newlines "\\n") l |> String.concat sep in
       output_string s;
     | `Truncate ->
       let s = List.map (replace_newlines " ") l |> String.concat sep in
-      output_string (cut_at_visual s (OpamStd.Sys.terminal_columns ()));
+      output_string (cut_at_visual s terminal_columns);
     | `Wrap wrap_sep ->
-      let width = OpamStd.Sys.terminal_columns () in
+      let width = terminal_columns in
       let base_indent = 10 in
       let sep_len = visual_length sep in
       let wrap_sep_len = visual_length wrap_sep in
@@ -959,7 +970,9 @@ let print_table ?cut oc ~sep table =
       in
       output_string str;
   in
-  List.iter (fun l -> print_line (cleanup_trailing l)) table
+  List.iter (fun l -> print_line (cleanup_trailing l)) table;
+  OpamTrace.instant "console.print_table.flush";
+  flush oc
 
 let menu ?default ?unsafe_yes ?yes ~no ~options fmt =
   assert (List.length options < 10);
@@ -990,9 +1003,9 @@ let menu ?default ?unsafe_yes ?yes ~no ~options fmt =
             nums_options)
     in
     let nlines = List.length Re.(all (compile (char '\n')) text) in
-    msg "%s" text;
+    msg_no_flush "%s" text;
     let select a =
-      msg "%s\n" OpamStd.(List.assoc Compare.equal a options_nums); a
+      msg_no_flush "%s\n" OpamStd.(List.assoc Compare.equal a options_nums); a
     in
     let default_s = OpamStd.(List.assoc Compare.equal default options_nums) in
     let no_s = OpamStd.(List.assoc Compare.equal no options_nums) in

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -435,6 +435,8 @@ let patch ?preprocess filename dirname =
 let flock flag ?dontblock file = OpamSystem.flock flag ?dontblock (to_string file)
 
 let with_flock flag ?dontblock file f =
+  OpamTrace.with_span "Filename.with_flock"
+      ~data:["f", `String (to_string file)] @@ fun () ->
   let lock = OpamSystem.flock flag ?dontblock (to_string file) in
   try
     let (fd, ch) =

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1102,6 +1102,7 @@ module OpamSys = struct
     )
 
   let guess_shell_compat () =
+    OpamTrace.with_span "Std.guess_shell_compat" @@ fun () ->
     let parent_guess () =
       let ppid = Unix.getppid () in
       let dir = Filename.concat "/proc" (string_of_int ppid) in

--- a/src/core/opamTrace.ml
+++ b/src/core/opamTrace.ml
@@ -1,0 +1,110 @@
+module Json = OpamJson
+
+type state = {
+  mutable first_item: bool;
+  oc: out_channel;
+}
+
+let output : state option ref = ref None
+
+let start_time_s_ : float = Unix.gettimeofday ()
+
+let[@inline] now_s () : float =
+  Unix.gettimeofday() -. start_time_s_
+
+(** time in microseconds *)
+let[@inline] now_us () : float =
+  let t = Unix.gettimeofday () -. start_time_s_ in
+  t *. 1e6
+
+let[@inline] pid () : float = float_of_int @@ Unix.getpid ()
+let[@inline] tid () : float = float_of_int 0
+
+let last_gc_ = ref (now_s ())
+
+let counter_json_ name cnts : Json.t =
+  let cnts = List.map (fun (k,v) -> k, `Float v) cnts in
+  `O [
+    "ts", `Float (now_us ()); "pid", `Float (pid()); "tid", `Float (tid());
+    "ph", `String "C"; "name", `String name; "args", `O cnts
+  ]
+
+let emit_single_entry_ (self:state) (j:Json.t) =
+  if self.first_item then (
+    self.first_item <- false;
+  ) else (
+    output_string self.oc ",\n";
+  );
+  let str = Json.to_string ~minify:true j in
+  output_string self.oc str
+
+let[@inline never] emit_entry_ (self:state) (j:Json.t) =
+  emit_single_entry_ self j;
+
+  let now = now_s () in
+  if now -. !last_gc_ > 0.2 then (
+    (* emit GC stats *)
+    last_gc_ := now;
+    let minor, major, _ = Gc.counters() in
+    let j = counter_json_ "gc" [
+      "minor", minor;
+      "major", major
+    ] in
+    emit_single_entry_ self j
+  )
+
+let instant_json_ ?(data=[]) msg : Json.t =
+  `O [
+    "ts", `Float (now_us ()); "pid", `Float (pid()); "tid", `Float (tid());
+    "ph", `String "I"; "name", `String msg; "args", `O data
+  ]
+
+let[@inline] instant ?data msg = match !output with
+  | None -> ()
+  | Some out ->
+    let j = instant_json_ ?data msg in
+    emit_entry_ out j
+
+let[@inline] counter msg cnts = match !output with
+  | None -> ()
+  | Some out ->
+    let j = counter_json_ msg cnts in
+    emit_entry_ out j
+
+let with_span_json_ ?(data=[]) name start : Json.t =
+  let stop = now_us () in
+  `O [
+    "ts", `Float start; "pid", `Float (pid()); "tid", `Float (tid());
+    "ph", `String "X"; "args", `O data;
+    "name", `String name; "dur", `Float (stop -. start);
+  ]
+
+let[@inline] with_span ?data name f =
+  match !output with
+  | None -> f()
+  | Some out ->
+    let start = now_us () in
+    try
+      let x = f() in
+      let j = with_span_json_ ?data name start in
+      emit_entry_ out j;
+      x
+    with e ->
+      let j = with_span_json_ ?data name start in
+      emit_entry_ out j;
+      raise e
+
+(* ## setup ## *)
+
+let setup ~trace_file () : unit =
+  match trace_file, Sys.getenv_opt "TRACE_FILE" with
+  | None, None -> ()
+  | Some file, _
+  | None, Some file ->
+    let oc = open_out_bin file in
+    output_char oc '[';
+    at_exit (fun () ->
+      output_char oc ']';
+      flush oc;
+      close_out_noerr oc);
+    output := Some {oc; first_item=true}

--- a/src/core/opamTrace.mli
+++ b/src/core/opamTrace.mli
@@ -1,0 +1,9 @@
+(** Tracing *)
+
+val setup : trace_file:string option -> unit -> unit
+
+val with_span : ?data:(string * OpamJson.t) list -> string -> (unit -> 'a) -> 'a
+
+val instant : ?data:(string * OpamJson.t) list -> string -> unit
+
+val counter : string -> (string * float) list -> unit

--- a/src/format/opamFormat.ml
+++ b/src/format/opamFormat.ml
@@ -704,6 +704,7 @@ module I = struct
   type ('a, 'value) fields_def = (string * ('a, 'value) field_parser) list
 
   let fields ?name ~empty ?(sections=[]) ?(mandatory_fields=[]) ppas =
+    OpamTrace.with_span "OpamFormat.fields" @@ fun () ->
     let parse ~pos items =
       (* For consistency, always read fields in ppa order, ignoring file
          order. Some parsers may depend on it. *)

--- a/src/format/opamPackage.ml
+++ b/src/format/opamPackage.ml
@@ -226,6 +226,9 @@ let of_archive f =
 let list dir =
   log "list %a" (slog OpamFilename.Dir.to_string) dir;
   if OpamFilename.exists_dir dir then (
+    OpamTrace.with_span "pkg.list-dir"
+      ~data:["dir", `String (OpamFilename.Dir.to_string dir)] @@ fun () ->
+
     let files = OpamFilename.rec_files dir in
     List.fold_left (fun set f ->
         match of_filename f with

--- a/src/format/opamPp.ml
+++ b/src/format/opamPp.ml
@@ -88,7 +88,8 @@ let unexpected ?pos () = raise (Unexpected pos)
 
 (** Basic pp usage *)
 
-let parse pp ~pos x = try pp.parse ~pos x with
+let parse pp ~pos x =
+  try pp.parse ~pos x with
   | Bad_version _ | Bad_format _ | Bad_format_list _ as e ->
     raise (add_pos pos e)
   | Unexpected (Some pos) -> bad_format ~pos "expected %s" pp.ppname

--- a/src/format/opamSwitch.ml
+++ b/src/format/opamSwitch.ml
@@ -20,6 +20,9 @@ let is_external s =
 let external_dirname = "_opam"
 
 let check s =
+  OpamTrace.with_span "opamSwitch.check"
+      ~data:["len", `Float (float_of_int (String.length s))] @@ fun () ->
+
   if String.compare s "" = 0 &&
     let re =
       Re.(compile @@

--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -57,7 +57,7 @@ let ftp_args = [
   CIdent "url", None;
 ]
 
-let download_args ~url ~out ~retry ?checksum ~compress () =
+let download_args ~url ~out ~retry ?checksum ~compress () : string list =
   let cmd, _ = Lazy.force OpamRepositoryConfig.(!r.download_tool) in
   let cmd =
     match cmd with
@@ -117,6 +117,8 @@ let tool_return url ret =
       else Done ()
 
 let download_command ~compress ?checksum ~url ~dst () =
+  OpamTrace.with_span "Download.download_command"
+      ~data:["url", `String (OpamUrl.to_string url)] @@ fun () ->
   let cmd, args =
     match
       download_args

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -376,6 +376,8 @@ let revision dirname url =
 
 let pull_file label ?cache_dir ?(cache_urls=[])  ?(silent_hits=false)
     file checksums remote_urls =
+  OpamTrace.with_span "repository.pull-file"
+    ~data:["f", `String (OpamFilename.to_string file)] @@ fun () ->
   (match cache_dir with
    | Some cache_dir ->
      let text = OpamProcess.make_command_text label "dl" in
@@ -438,6 +440,7 @@ let packages_with_prefixes repo_root =
   OpamPackage.prefixes (OpamRepositoryPath.packages_dir repo_root)
 
 let validate_repo_update repo repo_root update =
+  OpamTrace.with_span "repository.validate-repo-update" @@ fun () ->
   match
     repo.repo_trust,
     OpamRepositoryConfig.(!r.validation_hook),
@@ -529,6 +532,7 @@ let cleanup_repo_update upd =
     | _ -> ()
 
 let update repo repo_root =
+  OpamTrace.with_span "repository.update" @@ fun () ->
   log "update %a" (slog OpamRepositoryBackend.to_string) repo;
   let module B = (val find_backend repo: OpamRepositoryBackend.S) in
   B.fetch_repo_update repo.repo_name repo_root repo.repo_url @@+ function

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -1524,6 +1524,7 @@ let call_external_solver ~version_map univ req =
     Dose_algo.Depsolver.Sat(None,Cudf.load_universe [])
 
 let check_request ?(explain=true) ~version_map univ req =
+  OpamTrace.with_span "Cudf.check_request" @@ fun () ->
   let chrono = OpamConsole.timer () in
   log "Checking request...";
   let result = Dose_algo.Depsolver.check_request ~explain (to_cudf univ req) in
@@ -1546,6 +1547,7 @@ let check_request ?(explain=true) ~version_map univ req =
 
 (* Return the universe in which the system has to go *)
 let get_final_universe ~version_map univ req =
+  OpamTrace.with_span "Cudf.get_final_universe" @@ fun () ->
   let fail msg =
     let f = dump_cudf_error ~version_map univ req in
     let msg =
@@ -1593,6 +1595,7 @@ let actions_of_diff (install, remove) =
   actions
 
 let resolve ~extern ~version_map universe request =
+  OpamTrace.with_span "Cudf.resolve" @@ fun () ->
   log "resolve request=%a" (slog string_of_request) request;
   let resp =
     let check () = check_request ~version_map universe request in

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -331,6 +331,7 @@ let opam2cudf_set universe version_map packages =
       OpamCudf.Set.empty
 
 let load_cudf_packages opam_universe ?version_map opam_packages =
+  OpamTrace.with_span "Solver.load_cudf_packages" @@ fun () ->
   let chrono = OpamConsole.timer () in
   let version_map = match version_map with
     | Some vm -> vm
@@ -367,6 +368,7 @@ let map_to_cudf_universe cudf_packages_map =
 
 (* load a cudf universe from an opam one *)
 let load_cudf_universe opam_universe ?version_map opam_packages =
+  OpamTrace.with_span "Solver.load_cudf_universe" @@ fun () ->
   let load_f = load_cudf_packages opam_universe ?version_map opam_packages in
   fun ?add_invariant ?depopts ~build ~post () ->
     log "Load cudf universe (depopts:%a, build:%b, post:%b)"
@@ -436,6 +438,7 @@ let cycle_conflict ~version_map univ cycles =
   OpamCudf.cycle_conflict ~version_map univ cycles
 
 let resolve universe request =
+  OpamTrace.with_span "Solver.resolve" @@ fun () ->
   log "resolve request=%a" (slog string_of_request) request;
   let all_packages = universe.u_available ++ universe.u_installed in
   let version_map = cudf_versions_map universe in
@@ -464,6 +467,7 @@ let resolve universe request =
     opam_invariant_package version_map universe.u_invariant
   in
   let solution =
+    OpamTrace.with_span "Solver.resolve.solution" @@ fun () ->
     try
       Cudf.add_package cudf_universe invariant_pkg;
       Cudf.add_package cudf_universe deprequest_pkg;
@@ -585,6 +589,7 @@ let dependency_graph
   g
 
 let dependency_sort ~depopts ~build ~post universe packages =
+  OpamTrace.with_span "Solver.dependency_sort" @@ fun () ->
   let cudf_universe, cudf_packages =
     load_cudf_universe_with_packages
       ~depopts ~build ~post universe universe.u_packages packages

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -1180,6 +1180,8 @@ let add_aux_files ?dir ~files_subdir_hashes opam =
     opam
 
 let read_opam dir =
+  OpamTrace.with_span "FileTools.read_opam"
+      ~data:["dir", `String (OpamFilename.Dir.to_string dir)] @@ fun () ->
   let (opam_file: OpamFile.OPAM.t OpamFile.t) =
     OpamFile.make (dir // "opam")
   in

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -196,6 +196,7 @@ let write gt =
   OpamFile.Config.write (OpamPath.config gt.root) gt.config
 
 let fix_switch_list gt =
+  OpamTrace.with_span "GlobalState.fix_switch_list" @@ fun () ->
   let known_switches0 = switches gt in
   let known_switches =
     match OpamStateConfig.get_switch_opt () with

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -253,6 +253,7 @@ let find_package_opt rt repo_list nv =
     None repo_list
 
 let build_index rt repo_list =
+  OpamTrace.with_span "RepositoryState.build_index" @@ fun () ->
   List.fold_left (fun acc repo_name ->
       try
         let repo_opams = OpamRepositoryName.Map.find repo_name rt.repo_opams in

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -229,6 +229,7 @@ let is_newer_than_self ?lock_kind gt =
   is_readonly_opamroot_t ?lock_kind gt <> Some false
 
 let load_if_possible_raw ?lock_kind root version (read,read_wo_err) f =
+  OpamTrace.with_span "StateConfig.load_if_possible_raw" @@ fun () ->
   match is_readonly_opamroot_raw ?lock_kind version with
   | None ->
     OpamConsole.error_and_exit `Locked
@@ -270,6 +271,7 @@ let load ?lock_kind opamroot =
 module Switch = struct
 
   let load_raw ?lock_kind root config readf switch =
+    OpamTrace.with_span "StateConfig.Switch.load_raw" @@ fun () ->
     load_if_possible_t ?lock_kind root config readf
       (OpamPath.Switch.switch_config root switch)
 
@@ -293,6 +295,7 @@ module Switch = struct
       switch
 
   let safe_read_selections ?lock_kind gt switch =
+    OpamTrace.with_span "StateConfig.safe_read_selections" @@ fun () ->
     load_if_possible ?lock_kind gt
       OpamFile.SwitchSelections.(safe read_opt BestEffort.read_opt empty)
       (OpamPath.Switch.selections gt.root switch)
@@ -302,6 +305,7 @@ end
 (* repos *)
 module Repos = struct
   let safe_read ?lock_kind gt =
+    OpamTrace.with_span "StateConfig.Repos.safe_read" @@ fun () ->
     load_if_possible ?lock_kind gt
       OpamFile.Repos_config.(safe read_opt BestEffort.read_opt empty)
       (OpamPath.repos_config gt.root)
@@ -331,6 +335,7 @@ let downgrade_2_1_switch f =
           |> OpamFile.Switch_config.read_from_string)
 
 let local_switch_exists root switch =
+  OpamTrace.with_span "StateConfig.local_switch_exists" @@ fun () ->
   (* we don't use safe loading function to avoid errors displaying *)
   let f = OpamPath.Switch.switch_config root switch in
   match OpamFile.Switch_config.BestEffort.read_opt f with
@@ -348,6 +353,7 @@ let local_switch_exists root switch =
         else false
 
 let resolve_local_switch root s =
+  OpamTrace.with_span "opamStateConfig.resolve_local_switch" @@ fun () ->
   let switch_root = OpamSwitch.get_root root s in
   if OpamSwitch.is_external s && OpamFilename.dirname_dir switch_root = root
   then OpamSwitch.of_string (OpamFilename.remove_prefix_dir root switch_root)
@@ -366,6 +372,7 @@ let get_current_switch_from_cwd root =
 
 (* do we want `load_defaults` to fail / run a format upgrade ? *)
 let load_defaults ?lock_kind root_dir =
+  OpamTrace.with_span "opam-state.load-defaults" @@ fun () ->
   let current_switch =
     match E.switch () with
     | Some "" | None -> get_current_switch_from_cwd root_dir

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -230,6 +230,7 @@ let depexts_unavailable_raw sys_packages nv =
   | _ -> None
 
 let load lock_kind gt rt switch =
+  OpamTrace.with_span "SwitchState.load" @@ fun () ->
   OpamFormatUpgrade.as_necessary_repo_switch_light_upgrade lock_kind `Switch gt;
   let chrono = OpamConsole.timer () in
   log "LOAD-SWITCH-STATE %@ %a" (slog OpamSwitch.to_string) switch;
@@ -617,6 +618,7 @@ let load lock_kind gt rt switch =
   st
 
 let load_virtual ?repos_list ?(avail_default=true) gt rt =
+  OpamTrace.with_span "SwitchState.load_virtual" @@ fun () ->
   let repos_list = match repos_list with
     | Some rl -> rl
     | None -> OpamGlobalState.repos_list gt
@@ -943,6 +945,7 @@ let universe st
     ?reinstall
     ~requested
     user_action =
+  OpamTrace.with_span "SwitchState.universe" @@ fun () ->
   let chrono = OpamConsole.timer () in
   let names = OpamPackage.names_of_packages requested in
   let requested_allpkgs =


### PR DESCRIPTION
This is WIP.

I'm adding tracing to find why opam is so slow on my machine. It gives excellent insights on where time is spent (e.g after `opam upd`, all 30k files are read one by one, to update the cache).

I've been instrumenting things as I explore but it needs to be more principled in general I think.

The overhead when tracing is not active (ie `TRACE_FILE` is not set) should be fairly low.
