### PR TITLE
Update Install.md FreeBSD instructions

### DIFF
--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -149,6 +149,12 @@ pkg_add opam
 Opam is available in the ports and packages tree on FreeBSD 11 or higher.
 
 ```
+pkg install ocaml-opam
+```
+
+or to install from source:
+
+```
 cd /usr/ports/devel/ocaml-opam
 make install
 ```

--- a/master_changes.md
+++ b/master_changes.md
@@ -113,6 +113,7 @@ users)
 ## Github Actions
 
 ## Doc
+  * Improve the installation instructions on FreeBSD [#5775 lukstafi]
 
 ## Security fixes
 


### PR DESCRIPTION
If someone is a complete FreeBSD greenhorn newbie, they might not realize that the opam package is `ocaml-opam`, and installing from source is painful.

