### PR TITLE
Fix macos sandbox script incorrectly assuming that `getconf` doesn't exist

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -67,6 +67,7 @@ users)
 ## Format upgrade
 
 ## Sandbox
+  * Mark the user temporary directory (as returned by `getconf DARWIN_USER_TEMP_DIR`) as writable when TMPDIR is not defined on macOS [#5780 @ElectreAAS]
 
 ## VCS
 

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This script is only used on macOS, where /bin/bash is both guaranteed to exist and
+# This script is only used on macOS, where /bin/bash is both guaranteed to exist
 # and to be for the native architecture, which is why /usr/bin/env bash is not used.
 # See https://github.com/ocaml/opam/issues/5450
 set -ue
@@ -20,10 +20,10 @@ add_mounts() {
 }
 
 if [ -z ${TMPDIR+x} ]; then
-  # Others applications obtain the per-user temporary
+  # Other applications obtain the per-user temporary
   # directory differently; the latter should be made readable/writable
   # too and getconf seems to be a robust way to get it
-  if [ -z /usr/bin/getconf ]; then
+  if command -v getconf > /dev/null ; then
     TMPDIR=$(getconf DARWIN_USER_TEMP_DIR)
     add_mounts rw "$TMPDIR"
     export TMPDIR


### PR DESCRIPTION
As noted in #5778, this is a proper bugfix:
- `[ -z /usr/bin/getconf ]` tests if the literal string "/usr/bin/getconf" is empty - which is always false - and doesn't probe the filesystem at all.
- `[ -n "$(which getconf)" ]` actually asks the system if that command exists. The place where it is defined (/usr/bin or anything else) doesn't matter since we call it directly below.

It should be noted that if `$TMPDIR` is not set *and* `getconf` doesn't exist, we carry on the program silently. Is that intended?

I do not have a macos machine on hand and cannot test this, but this could be related to #4958