### PR TITLE
Add winsymlinks:native to the CYGWIN environment variable when running a Cygwin executable on Windows

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -1175,6 +1175,7 @@ files.
     - `OPAM_PACKAGE_VERSION=<ver>` (`<ver>` is the version of the package being built/installed/removed)
     - `OPAMCLI=2.0` (since opam 2.1)
     - `TMP` and `TMPDIR` are set by the sandbox script (bubblewrap), but should not be relied on since the sandbox is not used on all platforms and can be disabled by the user.
+    - `CYGWIN=winsymlinks:native` on Windows, or `CYGWIN=$CYGWIN winsymlinks:native` if `CYGWIN` is defined and not empty and `CYGWIN` does not contain either `winsymlinks:native` or `winsymlinks:nativestrict` already (since opam 2.2). In some cases `noglob` can also be added to this variable, such that the default value becomes `CYGWIN=winsymlinks:native noglob` (since opam 2.1)
 
   See [`x-env-path-rewrite:`](#opamfield-x-env-path-rewrite)
   for path portability of environment variables on Windows.

--- a/master_changes.md
+++ b/master_changes.md
@@ -74,6 +74,7 @@ users)
 ## Build
   * Do not check for cppo in the configure script (not used directly anymore since #5498) [#5794 @kit-ty-kate]
   * Upgrade vendored cmdliner to 1.2.0 [#5797 @kit-ty-kate]
+  * Add winsymlinks:native to the CYGWIN environment variable when installing a package on Windows [#5793 @kit-ty-kate - fix #5782]
 
 ## Infrastructure
   * Fix depexts CI workflow and ensure all workflows run on master push [#5788 @dra27]


### PR DESCRIPTION
~Fixes #5782~ 

Actually no, at least not yet. Upon creating the PR I realized another point in the code also modifies `CYGWIN` (in a destructive manner)

@dra27 I’m reading the comments for `OpamProcess.cygwin_create_process_env` and the use of `win_create_process` (which i’m also realizing does not exist in OCaml >= 5.0, which means opam can’t be compiled on Windows if you’re using ocaml 5) and I’m not sure if it’s just a relic of the past that can now be replaced by `Unix.create_process_env` or not? Was the issue encountered with `Unix.create_process_env` ever got fixed or was it only an issue in opam and thus not something that could actually be fixed upstream?

If it is a relic of the past I’ll go ahead and remove it and together with the current code, it should work.