### PR TITLE
Fix shell detection on Windows when opam is called via Cygwin's /usr/bin/env even though cmd/powershell is used

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -72,6 +72,7 @@ users)
 
 ## Build
   * Do not check for cppo in the configure script (not used directly anymore since #5498) [#5794 @kit-ty-kate]
+  * Upgrade vendored cmdliner to 1.2.0 [#5797 @kit-ty-kate]
 
 ## Infrastructure
   * Fix depexts CI workflow and ensure all workflows run on master push [#5788 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -57,6 +57,7 @@ users)
 ## Clean
 
 ## Env
+  * Fix shell detection on Windows when opam is called via Cygwin's /usr/bin/env even though cmd/powershell is used [#5797 @kit-ty-kate]
 
 ## Opamfile
 

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1093,7 +1093,6 @@ module OpamSys = struct
         Some (Accept (SH_pwsh Powershell))
       | "pwsh.exe" -> Some (Accept (SH_pwsh Powershell_pwsh))
       | "cmd.exe" -> Some (Accept SH_cmd)
-      | "env.exe" -> Some (Accept SH_sh)
       | "" -> None
       | name ->
         Option.map

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -18,8 +18,8 @@ MD5_re = 68c427f8b55507f8b61c613ee6a5b3da
 
 $(call PKG_SAME,re)
 
-URL_cmdliner = https://erratique.ch/software/cmdliner/releases/cmdliner-1.1.1.tbz
-MD5_cmdliner = 26b9af55a7456290b710e1c96a0ca231
+URL_cmdliner = https://erratique.ch/software/cmdliner/releases/cmdliner-1.2.0.tbz
+MD5_cmdliner = b860881cc90c68b703dca0f35bdd4cdb
 
 $(call PKG_SAME,cmdliner)
 


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/5644

This line was added in https://github.com/ocaml/opam/pull/4816 but looking at the relevant discussion (https://github.com/ocaml/opam/pull/4816#discussion_r927799712) I’m not sure if the change makes much sense to me (but I’m not a Windows user so most of the discussions around Windows doesn’t make sense to me anyway :D )