### PR TITLE
opam config report: add the list of all installed repositories

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -22,6 +22,7 @@ users)
 ## Init
 
 ## Config report
+  * add the list of all installed repositories to a new all-repositories field [#5799 @kit-ty-kate]
 
 ## Actions
 

--- a/tests/reftests/config.test
+++ b/tests/reftests/config.test
@@ -38,6 +38,7 @@ Set to '"-removed"' the field solver-upgrade-criteria in global configuration
 # install-criteria     -removed
 # upgrade-criteria     -removed
 # jobs                 1
+# all-repositories     1 (local)
 # current-switch       none set
 ### # empty switch
 ### opam switch create an-empty-switch --empty
@@ -50,6 +51,7 @@ Set to '"-removed"' the field solver-upgrade-criteria in global configuration
 # install-criteria     -removed
 # upgrade-criteria     -removed
 # jobs                 1
+# all-repositories     1 (local)
 # repositories         1 (local)
 # pinned               0
 # current-switch       an-empty-switch
@@ -120,6 +122,7 @@ Done.
 # install-criteria     -removed
 # upgrade-criteria     -removed
 # jobs                 1
+# all-repositories     2 (local)
 # repositories         2 (local)
 # pinned               1 (rsync)
 # current-switch       a-switch
@@ -152,6 +155,7 @@ Done.
 # install-criteria     -removed
 # upgrade-criteria     -removed
 # jobs                 1
+# all-repositories     1 (local)
 # repositories         1 (local)
 # pinned               0
 # current-switch       an-empty-invariant-with-compiler
@@ -180,6 +184,7 @@ Done.
 # install-criteria     -removed
 # upgrade-criteria     -removed
 # jobs                 1
+# all-repositories     1 (local)
 # repositories         1 (local)
 # pinned               0
 # current-switch       a-package-invariant
@@ -208,6 +213,7 @@ Done.
 # install-criteria     -removed
 # upgrade-criteria     -removed
 # jobs                 1
+# all-repositories     1 (local)
 # repositories         1 (local)
 # pinned               0
 # current-switch       a-compiler-with-depopt


### PR DESCRIPTION
Looking at https://github.com/ocaml/opam/issues/5798 we can’t see the list of repositories in the output of `opam config report` because `repositories` only shows when the current switch is set. Having the list of all the repositories at all time is in my opinion very useful for this kind of issues.