### PR TITLE
Install rsync to the internal Cygwin installation

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -18,6 +18,7 @@ users)
 ## Plugins
 
 ## Init
+  * Add rsync package to internal Cygwin packages list (enables local pinning and is used by the VCS backends [#5808 @dra27]
 
 ## Config report
 

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -154,6 +154,7 @@ let required_packages_for_cygwin =
     "patch";
     "tar";
     "unzip";
+    "rsync";
   ] |> List.map OpamSysPkg.of_string
 
 let init_scripts () = [

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -932,7 +932,7 @@ let install_packages_commands_t ?(env=OpamVariable.Map.empty) config sys_package
                  |> OpamStd.String.Set.elements);
        `AsUser "rpm", "-q"::"--whatprovides"::packages], None
   | Cygwin ->
-    (* We use setp_x86_64 to install package instead of `cygcheck` that is
+    (* We use setup_x86_64 to install package instead of `cygcheck` that is
        stored in `sys-pkg-manager-cmd` field *)
     [`AsUser (OpamFilename.to_string (Cygwin.cygsetup ())),
      [ "--root"; (OpamFilename.Dir.to_string (Cygwin.cygroot config));


### PR DESCRIPTION
The VCS backends all require rsync, and this enables the local backend by default.