### PR TITLE
Disable Windows critical error handler

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -96,6 +96,7 @@ users)
 ## Internal
 
 ## Internal: Windows
+  * Ensure that the system critical error dialog is disabled when opam starts [#5828 @dra27]
 
 ## Test
 

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -483,6 +483,9 @@ let json_out () =
         (Printexc.to_string e)
 
 let main () =
+  if Sys.win32 then
+    (* Disable the critical error handling dialog *)
+    ignore (OpamStubs.setErrorMode (1 lor OpamStubs.getErrorMode ()));
   OpamStd.Sys.at_exit (fun () ->
       flush_all_noerror ();
       if OpamClientConfig.(!r.print_stats) then (

--- a/src/core/opamStubs.dummy.ml
+++ b/src/core/opamStubs.dummy.ml
@@ -37,3 +37,5 @@ let getProcessAncestry = that's_a_no_no
 let getConsoleAlias _ = that's_a_no_no
 let win_create_process _ _ _ _ _ = that's_a_no_no
 let getConsoleWindowClass = that's_a_no_no
+let setErrorMode = that's_a_no_no
+let getErrorMode = that's_a_no_no

--- a/src/core/opamStubs.mli
+++ b/src/core/opamStubs.mli
@@ -135,3 +135,9 @@ val win_create_process : string -> string -> string option -> Unix.file_descr ->
 val getConsoleWindowClass : unit -> string option
 (** Windows only. Returns the name of the class for the Console window or [None]
     if there is no console. *)
+
+val setErrorMode : int -> int
+(** Windows only. Directly wraps SetErrorMode. *)
+
+val getErrorMode : unit -> int
+(** Windows only. Directly wraps GetErrorMode. *)

--- a/src/stubs/win32/opamWin32Stubs.ml
+++ b/src/stubs/win32/opamWin32Stubs.ml
@@ -35,3 +35,5 @@ external sendMessageTimeout : nativeint -> int -> int -> 'a -> 'b -> 'c -> int *
 external getProcessAncestry : unit -> (int32 * string) list = "OPAMW_GetProcessAncestry"
 external getConsoleAlias : string -> string -> string = "OPAMW_GetConsoleAlias"
 external getConsoleWindowClass : unit -> string option = "OPAMW_GetConsoleWindowClass"
+external setErrorMode : int -> int = "OPAMW_SetErrorMode"
+external getErrorMode : unit -> int = "OPAMW_GetErrorMode"

--- a/src/stubs/win32/opamWindows.c
+++ b/src/stubs/win32/opamWindows.c
@@ -778,3 +778,13 @@ CAMLprim value OPAMW_GetConsoleWindowClass(value unit)
 
   CAMLreturn(result);
 }
+
+CAMLprim value OPAMW_SetErrorMode(value mode)
+{
+  return Val_int(SetErrorMode((UINT)Int_val(mode)));
+}
+
+CAMLprim value OPAMW_GetErrorMode(value mode)
+{
+  return Val_int(GetErrorMode());
+}


### PR DESCRIPTION
When the WIndows loader cannot find DLLs, the default, very very legacy behaviour is to display a dialog such as this:

![image](https://github.com/ocaml/opam/assets/5250680/9654b085-03c6-4157-ad46-fe8b42b67da9)

This dialog is problematic, as it's part of the loader, so the application itself is not able to handle this itself. It's doubly problematic for us, as it's blocking.

The convention is that _calling_ applications are expected to disable this error handler. New processes inherit this setting, which causes the loader to suppress the dialog box and instead return an exit code. This is documented best practice (see the notes for `SEM_FAILCRITICALERRORS` in [SetErrorMode on MSDN](https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-seterrormode)).