### PR TITLE
Tweaks to internal Cygwin setup

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -66,6 +66,7 @@ users)
 ## Opamfile
 
 ## External dependencies
+  * Pass --symlink-type native to Cygwin setup if symlinks are available [#5830 @dra27]
 
 ## Format upgrade
   * Handle init OCaml `sys-ocaml-*` eval variables during format upgrade from 2.0 -> 2.1 -> 2.2 [#5829 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -68,6 +68,7 @@ users)
 ## External dependencies
   * Pass --symlink-type native to Cygwin setup if symlinks are available [#5830 @dra27]
   * Pass --no-version-check to Cygwin setup (suppresses a message box if setup needs updating) [#5830 @dra27]
+  * Pass --quiet-mode noinput to stop the user interrupting the setup GUI [#5830 @dra27]
 
 ## Format upgrade
   * Handle init OCaml `sys-ocaml-*` eval variables during format upgrade from 2.0 -> 2.1 -> 2.2 [#5829 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -67,6 +67,7 @@ users)
 
 ## External dependencies
   * Pass --symlink-type native to Cygwin setup if symlinks are available [#5830 @dra27]
+  * Pass --no-version-check to Cygwin setup (suppresses a message box if setup needs updating) [#5830 @dra27]
 
 ## Format upgrade
   * Handle init OCaml `sys-ocaml-*` eval variables during format upgrade from 2.0 -> 2.1 -> 2.2 [#5829 @dra27]

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -318,7 +318,7 @@ module Cygwin = struct
          "--no-startmenu";
          "--no-write-registry";
          "--no-version-check";
-         "--quiet-mode";
+         "--quiet-mode"; "noinput";
        ] @
          match packages with
          | [] -> []
@@ -973,7 +973,7 @@ let install_packages_commands_t ?(env=OpamVariable.Map.empty) config sys_package
        stored in `sys-pkg-manager-cmd` field *)
     [`AsUser (OpamFilename.to_string (Cygwin.cygsetup ())),
      [ "--root"; (OpamFilename.Dir.to_string (Cygwin.cygroot config));
-       "--quiet-mode";
+       "--quiet-mode"; "noinput";
        "--no-shortcuts";
        "--no-startmenu";
        "--no-desktop";

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -317,6 +317,7 @@ module Cygwin = struct
          "--no-shortcuts";
          "--no-startmenu";
          "--no-write-registry";
+         "--no-version-check";
          "--quiet-mode";
        ] @
          match packages with
@@ -983,6 +984,7 @@ let install_packages_commands_t ?(env=OpamVariable.Map.empty) config sys_package
             let common =
               [ "--upgrade-also";
                 "--only-site";
+                "--no-version-check";
                 "--site"; Cygwin.mirror;
                 "--local-package-dir";
                 OpamFilename.Dir.to_string (Cygwin.internal_cygcache ());


### PR DESCRIPTION
Related to #5793, this adds `--symlink-type native` to the Cygwin setup invocation if the user has the ability to create them. This is more to disable the use of WSL symlinks than to actually enable any additional binaries (Cygwin names binaries `.exe`, but it doesn't do that for a symlink to an executable, so they're not any more available than they were before).

We can save a small amount of time and a potential error message by passing `--no-version-check` - that simply tells Cygwin not to report if the version of setup is older than the latest reported in `setup.ini`.

Hot off the presses in Setup 2.929 is an option to reduce the noise of the installation. We should definitely use the `noinput` version at all times, but the `hidden` version is nice as it suppresses the GUI completely. The caveat, and why I'm keeping this as draft for now, is that there is _no_ UI for Cygwin at all, then, so we need to display some kind of "Please wait..." indicator and possibly spinner ourselves.