### PR TITLE
Recommend Developer Mode on Windows

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -19,6 +19,7 @@ users)
 
 ## Init
   * Add rsync package to internal Cygwin packages list (enables local pinning and is used by the VCS backends [#5808 @dra27]
+  * Recommend enabling Developer Mode on Windows [#5831 @dra27]
 
 ## Config report
 

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -731,6 +731,16 @@ let git_for_windows_check =
     git_location
 
 let windows_checks ?cygwin_setup ?git_location config =
+  if (not (Unix.has_symlink ())) then begin
+    OpamConsole.header_msg "Windows Developer Mode";
+    OpamConsole.msg "opam does not require Developer Mode to be enabled on Windows, but it is\n\
+                     recommended, in particular because it enables support for symlinks without\n\
+                     requiring opam to be run elevated (which we do %s recommend doing).\n\
+                     \n\
+                     More information on enabling Developer Mode may be obtained from\n\
+                       https://learn.microsoft.com/en-gb/windows/apps/get-started/enable-your-device-for-development\n"
+                     (OpamConsole.colorise `bold "not")
+  end;
   let vars = OpamFile.Config.global_variables config in
   let env =
     List.map (fun (v, c, s) -> v, (lazy (Some c), s)) vars


### PR DESCRIPTION
Apropos note in #5782. The motivation behind this is to have symlinks available as an optimisation (for example, to allow caches, compiler installations, etc. to use `ln` instead of `cp` to save space, just as on Unix, but not to be a _requirement_ for any packages). There are other ways to enable this, but "Developer Mode" is by far the simplest, and is recommended (or even required) by Microsoft's own SDKs.