### PR TITLE
Two (more) environment fixes

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -60,6 +60,7 @@ users)
 ## Env
   * Fix shell detection on Windows when opam is called via Cygwin's /usr/bin/env even though cmd/powershell is used [#5797 @kit-ty-kate]
   * Fix incorrect deduplication of environment variables on update. Effect was that FOO += "" would occlude the value of FOO in the environment [#5837 @dra27]
+  * Fix regression from #5356 on the detection of out-of-date environment variables. As part of a refactoring, a filter predicate got inverted [#5837 @dra27]
 
 ## Opamfile
 
@@ -124,6 +125,7 @@ users)
 ## opam-repository
 
 ## opam-state
+  * `OpamEnv.env_expansion`: Fix detection of out-of-date environment variables, a filter predicate was inverted [#5837 @dra27]
 
 ## opam-solver
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -59,6 +59,7 @@ users)
 
 ## Env
   * Fix shell detection on Windows when opam is called via Cygwin's /usr/bin/env even though cmd/powershell is used [#5797 @kit-ty-kate]
+  * Fix incorrect deduplication of environment variables on update. Effect was that FOO += "" would occlude the value of FOO in the environment [#5837 @dra27]
 
 ## Opamfile
 

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -449,9 +449,10 @@ let add (env: env) (updates: 'r env_update list) : env =
     else
       updates
   in
+  let updates = expand updates in
   let update_keys =
-    List.fold_left (fun m upd ->
-        OpamStd.Env.Name.(Set.add (of_string upd.envu_var) m))
+    List.fold_left (fun m (var, _, _) ->
+        OpamStd.Env.Name.(Set.add var m))
       OpamStd.Env.Name.Set.empty updates
   in
   let env =
@@ -459,7 +460,7 @@ let add (env: env) (updates: 'r env_update list) : env =
         not (OpamStd.Env.Name.Set.mem k update_keys))
       env
   in
-  env @ expand updates
+  env @ updates
 
 let env_expansion ?opam st upd =
   let fenv v =

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -625,7 +625,7 @@ let is_up_to_date_raw ?(skip=OpamStateConfig.(!r.no_env_notice)) updates =
           if reverse_env_update ~sepfmt var op arg
               (split_var ~sepfmt var v) = None then upd::notutd
           else List.filter (fun upd ->
-              OpamStd.Env.Name.equal_string var upd.envu_var) notutd)
+              not (OpamStd.Env.Name.equal_string var upd.envu_var)) notutd)
       []
       updates
   in

--- a/tests/reftests/env.test
+++ b/tests/reftests/env.test
@@ -80,6 +80,7 @@ setenv: [
   [ NV_VARS3 := ""    ]
   [ NV_VARS3 := "foo" ]
   [ NV_VARS4  = ""    ]
+  [ NV_VARS5 += ""    ] # undefined in the environment
 ]
 flags: compiler
 ### opam switch create emptyvar nv
@@ -90,6 +91,10 @@ Switch invariant: ["nv"]
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed nv.1
 Done.
+### # ERROR: NV_VARS should appear in the output
+### opam exec -- env | grep "NV_VARS" | ';' -> ':'
+NV_VARS3=foo:
+NV_VARS4=
 ### opam env | grep "NV_VARS" | ';' -> ':'
 NV_VARS3='foo:': export NV_VARS3:
 NV_VARS4='': export NV_VARS4:
@@ -100,6 +105,10 @@ NV_VARS4='': export NV_VARS4:
 ### NV_VARS2=/another/different/path
 ### NV_VARS3=/yet/another/different/path
 ### NV_VARS4=ignored-value
+### # ERROR: NV_VARS and NV_VARS2 should appear in the output
+### opam exec -- env | grep "NV_VARS" | ';' -> ':'
+NV_VARS3=foo:/yet/another/different/path
+NV_VARS4=
 ### opam env | grep "NV_VARS" | ';' -> ':'
 NV_VARS3='foo:/yet/another/different/path': export NV_VARS3:
 NV_VARS4='': export NV_VARS4:

--- a/tests/reftests/env.test
+++ b/tests/reftests/env.test
@@ -91,8 +91,8 @@ Switch invariant: ["nv"]
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed nv.1
 Done.
-### # ERROR: NV_VARS should appear in the output
 ### opam exec -- env | grep "NV_VARS" | ';' -> ':'
+NV_VARS=
 NV_VARS3=foo:
 NV_VARS4=
 ### opam env | grep "NV_VARS" | ';' -> ':'
@@ -105,8 +105,9 @@ NV_VARS4='': export NV_VARS4:
 ### NV_VARS2=/another/different/path
 ### NV_VARS3=/yet/another/different/path
 ### NV_VARS4=ignored-value
-### # ERROR: NV_VARS and NV_VARS2 should appear in the output
 ### opam exec -- env | grep "NV_VARS" | ';' -> ':'
+NV_VARS=/another/path
+NV_VARS2=/another/different/path
 NV_VARS3=foo:/yet/another/different/path
 NV_VARS4=
 ### opam env | grep "NV_VARS" | ';' -> ':'


### PR DESCRIPTION
Two fixes here, both relatively subtle:

- If the environment contained `FOO=bar`, the update `FOO += ""` would cause opam to execute _without_ `FOO` in the environment
- A small regression in #5356 - in the refactoring for case-preserving updates, a boolean check got accidentally inverted