### PR TITLE
Hijack the %{?val_if_true:val_if_false}% syntax to support extending the variables of packages with + in their name

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -247,7 +247,7 @@ and _options_:
 <section>       ::= <ident> [ <string> ] "{" <file-contents> "}"
 <ident>         ::= { <identchar> }* <letter> { <identchar> }*
 <varident>      ::= [ ( <ident> | "_" ) { "+" ( <ident> | "_" ) }* : ] <ident>
-<identchar>     ::= <letter> | <digit>  | "_" | "-"
+<identchar>     ::= <letter> | <digit>  | "_" | "-" | "+"
 <letter>        ::= "a".."z" | "A".."Z"
 <digit>         ::= "0".."9"
 <value>         ::= <bool> | <int> | <string> | <ident> | <varident> | <operator> | <list> | <option> | "(" <value> ")"
@@ -383,7 +383,14 @@ insert different strings depending on the boolean value of a variable.
 Additionally, boolean package variables may be combined using the following
 form: `name1+name2+name3:var` is the conjunction of `var` for each of `name1`,
 `name2` and `name3`, _i.e_ it is equivalent to `name1:var & name2:var &
-name3:var`
+name3:var`.
+
+**Warning**: if the package name contains a `+` character (e.g. `conf-g++`),
+their variables may only be accessed using opam 2.2 via string interpolation,
+with the following syntax:
+```
+"%{?conf-g++:your-variable:}%"
+```
 
 #### Scopes
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -62,6 +62,7 @@ users)
 ## Source
 
 ## Lint
+ * Add warning 69: Warn for new syntax when package name in variable in string interpolation contains several '+' [#5840 @rjbou]
 
 ## Repository
 
@@ -144,6 +145,7 @@ users)
   + Add a test showing the current behaviour of opam with variable expansion, in particular when the package contains pluses [#5840 @kit-ty-kate]
   + Add a test testing showing the current behaviour of opam with variable expansion, in particular when the package contains pluses [#5840 @kit-ty-kate]
   * Update lint test: W41 [#5840 @rjbou]
+  * Update lint test: W41 and W69 [#5840 @rjbou]
 
 ### Engine
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -140,6 +140,7 @@ users)
 ### Tests
   * Add init scripts tests [#5864 @rjbou]
   * Add test for init OCaml predefined eval variables and their format upgrade [#5829 @rjbou]
+  + Add a test showing the current behaviour of opam with variable expansion, in particular when the package contains pluses [#5840 @kit-ty-kate]
 
 ### Engine
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -182,6 +182,7 @@ users)
   * `OpamFile.InitConfig`: add `sys-pkg-manager-cmd` field [#5847 @rjbou]
   * `OpamTypesBase`: add `filter_ident_of_string_interp` that is used for parsing variables in string interpolation like `filter_ident_of_string` but permits the parsing of '%{?pkg+:var:}%' syntax [#5840 @rjbou]
   * `OpamTypesBase.filter_ident_of_string_interp`: add `accept` optional argument to be able to raise an error when several pluses are in the package name without using the new syntax, like `%{pkg+++:var}%`
+  * `OpamFilter`: add `extract_variables_from_string` to retrieve string of variables, and exposes it [#5840 @rjbou]
 
 ## opam-core
   * `OpamStd.Sys`: add `is_cygwin_variant_cygcheck` that returns true if in path `cygcheck` is from a Cygwin or MSYS2 installation [#5843 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -76,6 +76,7 @@ users)
   * Unixify Windows paths in init shells scripts (sh, bash, zsh, fish & tsh) [#5797 @rjbou]
 
 ## Opamfile
+  * Hijack the `%{?val_if_true:val_if_false}%` syntax to support extending the variables of packages with + in their name [#5840 @kit-ty-kate]
 
 ## External dependencies
  * Add support for Wolfi OS, treat it like Apline family as it uses apk too [#5878 @xnox]
@@ -156,6 +157,7 @@ users)
   * Fix missing spaces in `opam --help` [#5850 @sorawee].
   * Manual: add missing 'since opam 2.2' annotation when mentionning with-dev-setup [#5885 @kit-ty-kate]
   * Installation: update badges for Ubuntu and Fedora to newer versions [#5905 @AldanTanneo]
+  * Manual: update regarding `pkg+` variables new syntax [#5840 @kit-ty-kate]
 
 ## Security fixes
 
@@ -178,6 +180,7 @@ users)
 
 ## opam-format
   * `OpamFile.InitConfig`: add `sys-pkg-manager-cmd` field [#5847 @rjbou]
+  * `OpamTypesBase`: add `filter_ident_of_string_interp` that is used for parsing variables in string interpolation like `filter_ident_of_string` but permits the parsing of '%{?pkg+:var:}%' syntax [#5840 @rjbou]
 
 ## opam-core
   * `OpamStd.Sys`: add `is_cygwin_variant_cygcheck` that returns true if in path `cygcheck` is from a Cygwin or MSYS2 installation [#5843 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -142,6 +142,8 @@ users)
   * Add init scripts tests [#5864 @rjbou]
   * Add test for init OCaml predefined eval variables and their format upgrade [#5829 @rjbou]
   + Add a test showing the current behaviour of opam with variable expansion, in particular when the package contains pluses [#5840 @kit-ty-kate]
+  + Add a test testing showing the current behaviour of opam with variable expansion, in particular when the package contains pluses [#5840 @kit-ty-kate]
+  * Update lint test: W41 [#5840 @rjbou]
 
 ### Engine
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -181,6 +181,7 @@ users)
 ## opam-format
   * `OpamFile.InitConfig`: add `sys-pkg-manager-cmd` field [#5847 @rjbou]
   * `OpamTypesBase`: add `filter_ident_of_string_interp` that is used for parsing variables in string interpolation like `filter_ident_of_string` but permits the parsing of '%{?pkg+:var:}%' syntax [#5840 @rjbou]
+  * `OpamTypesBase.filter_ident_of_string_interp`: add `accept` optional argument to be able to raise an error when several pluses are in the package name without using the new syntax, like `%{pkg+++:var}%`
 
 ## opam-core
   * `OpamStd.Sys`: add `is_cygwin_variant_cygcheck` that returns true if in path `cygcheck` is from a Cygwin or MSYS2 installation [#5843 @rjbou]

--- a/src/format/opamFilter.ml
+++ b/src/format/opamFilter.ml
@@ -117,9 +117,7 @@ let fident_variables = function
         | Some n -> OpamVariable.Full.create n var
         | None -> OpamVariable.Full.self var) pkgs
 
-(* extracts variables appearing in interpolations in a string*)
-let string_variables s =
-  let matches =
+let extract_variables_from_string s =
     let rec aux acc pos =
       try
         let ss = Re.exec ~pos string_interp_regex s in
@@ -131,11 +129,13 @@ let string_variables s =
       with Not_found -> acc
     in
     aux [] 0
-  in
+
+(* extracts variables appearing in interpolations in a string *)
+let string_variables s =
   List.fold_left (fun acc s ->
-      try fident_variables (filter_ident_of_string s) @ acc
+      try fident_variables (filter_ident_of_string_interp s) @ acc
       with Failure _ -> acc)
-    [] matches
+    [] (extract_variables_from_string s)
 
 let variables filter =
   fold_down_left (fun acc -> function

--- a/src/format/opamFilter.ml
+++ b/src/format/opamFilter.ml
@@ -255,7 +255,8 @@ let expand_string_aux ?(partial=false) ?(escape_value=fun x -> x) ?default env t
        str)
     else
     let fident = String.sub str 2 (String.length str - 4) in
-    resolve_ident ~no_undef_expand:partial env (filter_ident_of_string fident)
+    resolve_ident ~no_undef_expand:partial env
+      (filter_ident_of_string_interp fident)
     |> value_string ?default:(default fident) |> escape_value
   in
   Re.replace string_interp_regex ~f text
@@ -307,7 +308,7 @@ let map_variables_in_string f =
     ~default:(fun fid_string ->
         try
           fid_string |>
-          filter_ident_of_string |>
+          filter_ident_of_string_interp |>
           map_variables_in_fident f |>
           string_of_filter_ident
         with Failure _ -> fid_string)

--- a/src/format/opamFilter.mli
+++ b/src/format/opamFilter.mli
@@ -54,6 +54,9 @@ val map_up: (filter -> filter) -> filter -> filter
     ["%{xxx"] if unclosed) *)
 val string_interp_regex : Re.re
 
+(* Extract string of variables appearing in interpolation in a string *)
+val extract_variables_from_string : string -> string list
+
 (** Returns all the variables appearing in a filter (including the ones within
     string interpolations *)
 val variables: filter -> full_variable list

--- a/src/format/opamTypesBase.mli
+++ b/src/format/opamTypesBase.mli
@@ -59,15 +59,20 @@ val string_of_user_action: user_action -> string
     preserve order *)
 val env_array: env -> string array
 
+exception Parse_variable of string * string
+
 (** Parses the data suitable for a filter.FIdent from a string. May raise
     [Failure msg] on bad package names. A self-reference [_] parses to [None] *)
 val filter_ident_of_string:
   string -> name option list * variable * (string * string) option
 
 (** Like [Filter_ident_of_string] but parses also '%{?pkg+:var:}% syntax for
-    variables with package name that contains a '+' *)
+    variables with package name that contains a '+'. if [accept] is [false],
+    [Parse_variable (pkg,var)] is raised when several '+' are encountered in
+    package name, i.e. 'pkg++:var'. *)
 val filter_ident_of_string_interp:
-  string -> name option list * variable * (string * string) option
+  ?accept:bool -> string
+  -> name option list * variable * (string * string) option
 
 val string_of_filter_ident:
   name option list * variable * (string * string) option -> string

--- a/src/format/opamTypesBase.mli
+++ b/src/format/opamTypesBase.mli
@@ -64,6 +64,11 @@ val env_array: env -> string array
 val filter_ident_of_string:
   string -> name option list * variable * (string * string) option
 
+(** Like [Filter_ident_of_string] but parses also '%{?pkg+:var:}% syntax for
+    variables with package name that contains a '+' *)
+val filter_ident_of_string_interp:
+  string -> name option list * variable * (string * string) option
+
 val string_of_filter_ident:
   name option list * variable * (string * string) option -> string
 

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -875,6 +875,31 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
     cond 68 `Warning
       "Missing field 'license'"
       (t.license = []);
+    (let vars =
+       List.flatten @@
+       List.map (fun s ->
+           List.filter_map
+             (fun f ->
+                try
+                  let _ =
+                    OpamTypesBase.filter_ident_of_string_interp
+                      ~accept:false f
+                  in
+                  None
+                with OpamTypesBase.Parse_variable (p,v) ->
+                  Some (p,v)
+             )
+             (OpamFilter.extract_variables_from_string s))
+         all_expanded_strings
+     in
+     cond 69 `Warning
+       "Package name in variable in string interpolation contains several \
+        '+', use"
+       ~detail:(List.map (fun (p,v) ->
+           Printf.sprintf "'?%s:%s:' instead of '%s:%s'"
+             p v p v)
+           vars)
+       (vars <> []));
   ]
   in
   format_errors @

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -927,6 +927,24 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:lock.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-opam-pkgvar-with-plus)
+ (action
+  (diff opam-pkgvar-with-plus.test opam-pkgvar-with-plus.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-opam-pkgvar-with-plus)))
+
+(rule
+ (targets opam-pkgvar-with-plus.out)
+ (deps root-N0REP0)
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:opam-pkgvar-with-plus.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-opamroot-versions)
  (action
   (diff opamroot-versions.test opamroot-versions.out)))

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -942,3 +942,23 @@ bug-reports: "https://nobug"
 ### opam lint ./lint.opam
 ${BASEDIR}/lint.opam: Warnings.
            warning 68: Missing field 'license'
+### : W69: Package name in variable in string interpolation contains several '+'
+### <lint.opam>
+opam-version: "2.0"
+name: "conf-g++"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+messages: [
+  "foo" { "%{?conf-c++:installed:}%" }
+  "bar" { "%{conf-g++:installed}%" }
+  "baz" { "%{abc+xyz+jkl:installed}%" }
+]
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Warnings.
+           warning 69: Package name in variable in string interpolation contains several '+', use: "'?conf-g++:installed:' instead of 'conf-g++:installed'"

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -387,6 +387,19 @@ messages: "foo" { bar:innerenv }
 ### opam lint ./lint.opam
 ${BASEDIR}/lint.opam: Warnings.
            warning 41: Some packages are mentioned in package scripts or features, but there is no dependency or depopt toward them: "bar"
+### <lint.opam>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+messages: "foo" { bar:installed }
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Passed.
 ### : E42: The 'dev-repo:' field doesn't use version control. You should use URLs of the form "git://", "git+https://", "hg+https://"...
 ### <lint.opam>
 opam-version: "2.0"

--- a/tests/reftests/opam-pkgvar-with-plus.test
+++ b/tests/reftests/opam-pkgvar-with-plus.test
@@ -1,0 +1,187 @@
+N0REP0
+### : Test the behaviour of %{?pkg+with+pluses:var:false}%
+### : See https://github.com/ocaml/opam/pull/5840
+### <pkg:pkg++.1>
+opam-version: "2.0"
+### <pkg:pkg+.1>
+opam-version: "2.0"
+### <pkg:pkg+a.1>
+opam-version: "2.0"
+### <pkg:pkg++a.1>
+opam-version: "2.0"
+### <pkg:pkg1.1>
+opam-version: "2.0"
+### <pkg:pkg2.1>
+opam-version: "2.0"
+### <pkg:var-with-plus.1>
+opam-version: "2.0"
+build: [
+  ["echo" "'?pkg+:installed:'"      "%{?pkg+:installed:}%"]
+  ["echo" "'?pkg++:installed:'"     "%{?pkg++:installed:}%"]
+  ["echo" "'?pkg+a:installed:'"     "%{?pkg+a:installed:}%"]
+  ["echo" "'?pkg++a:installed:'"    "%{?pkg++a:installed:}%"]
+  ["echo" "'?pkg1+pkg2:installed:'" "%{?pkg1+pkg2:installed:}%"]
+  ["echo" "'pkg1+pkg2:installed'"   "%{pkg1+pkg2:installed}%"]
+]
+depopts: [
+  "pkg++"
+  "pkg+"
+  "pkg+a"
+  "pkg++a"
+  "pkg1"
+  "pkg2"
+]
+### opam switch create test --empty
+### opam install --dry-run --verbose var-with-plus | sed-cmd echo | grep -v Processing
+The following actions will be simulated:
+=== install 1 package
+  - install var-with-plus 1
+
++ echo "'?pkg+:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg1+pkg2:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'pkg1+pkg2:installed'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
+-> compiled  var-with-plus.1
+Installing var-with-plus.1.
+-> installed var-with-plus.1
+Done.
+### opam install pkg++
+The following actions will be performed:
+=== install 1 package
+  - install pkg++ 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed pkg++.1
+Done.
+### opam install --dry-run --verbose var-with-plus | sed-cmd echo | grep -v Processing
+The following actions will be simulated:
+=== install 1 package
+  - install var-with-plus 1
+
++ echo "'?pkg+:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg1+pkg2:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'pkg1+pkg2:installed'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
+-> compiled  var-with-plus.1
+Installing var-with-plus.1.
+-> installed var-with-plus.1
+Done.
+### opam install pkg+
+The following actions will be performed:
+=== install 1 package
+  - install pkg+ 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed pkg+.1
+Done.
+### opam install --dry-run --verbose var-with-plus | sed-cmd echo | grep -v Processing
+The following actions will be simulated:
+=== install 1 package
+  - install var-with-plus 1
+
++ echo "'?pkg+:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg1+pkg2:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'pkg1+pkg2:installed'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
+-> compiled  var-with-plus.1
+Installing var-with-plus.1.
+-> installed var-with-plus.1
+Done.
+### opam install pkg+a
+The following actions will be performed:
+=== install 1 package
+  - install pkg+a 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed pkg+a.1
+Done.
+### opam install --dry-run --verbose var-with-plus | sed-cmd echo | grep -v Processing
+The following actions will be simulated:
+=== install 1 package
+  - install var-with-plus 1
+
++ echo "'?pkg+:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg1+pkg2:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'pkg1+pkg2:installed'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
+-> compiled  var-with-plus.1
+Installing var-with-plus.1.
+-> installed var-with-plus.1
+Done.
+### opam install pkg++a
+The following actions will be performed:
+=== install 1 package
+  - install pkg++a 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed pkg++a.1
+Done.
+### opam install --dry-run --verbose var-with-plus | sed-cmd echo | grep -v Processing
+The following actions will be simulated:
+=== install 1 package
+  - install var-with-plus 1
+
++ echo "'?pkg+:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg1+pkg2:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'pkg1+pkg2:installed'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
+-> compiled  var-with-plus.1
+Installing var-with-plus.1.
+-> installed var-with-plus.1
+Done.
+### opam install pkg1
+The following actions will be performed:
+=== install 1 package
+  - install pkg1 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed pkg1.1
+Done.
+### opam install --dry-run --verbose var-with-plus | sed-cmd echo | grep -v Processing
+The following actions will be simulated:
+=== install 1 package
+  - install var-with-plus 1
+
++ echo "'?pkg+:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg1+pkg2:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'pkg1+pkg2:installed'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
+-> compiled  var-with-plus.1
+Installing var-with-plus.1.
+-> installed var-with-plus.1
+Done.
+### opam install pkg2
+The following actions will be performed:
+=== install 1 package
+  - install pkg2 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed pkg2.1
+Done.
+### opam install --dry-run --verbose var-with-plus | sed-cmd echo | grep -v Processing
+The following actions will be simulated:
+=== install 1 package
+  - install var-with-plus 1
+
++ echo "'?pkg+:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg1+pkg2:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'pkg1+pkg2:installed'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
+-> compiled  var-with-plus.1
+Installing var-with-plus.1.
+-> installed var-with-plus.1
+Done.

--- a/tests/reftests/opam-pkgvar-with-plus.test
+++ b/tests/reftests/opam-pkgvar-with-plus.test
@@ -37,11 +37,11 @@ The following actions will be simulated:
 === install 1 package
   - install var-with-plus 1
 
-+ echo "'?pkg+:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg++:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg+a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg++a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg1+pkg2:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+a:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++a:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg1+pkg2:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
 + echo "'pkg1+pkg2:installed'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
 -> compiled  var-with-plus.1
 Installing var-with-plus.1.
@@ -60,11 +60,11 @@ The following actions will be simulated:
 === install 1 package
   - install var-with-plus 1
 
-+ echo "'?pkg+:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg++:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg+a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg++a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg1+pkg2:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+a:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++a:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg1+pkg2:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
 + echo "'pkg1+pkg2:installed'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
 -> compiled  var-with-plus.1
 Installing var-with-plus.1.
@@ -83,11 +83,11 @@ The following actions will be simulated:
 === install 1 package
   - install var-with-plus 1
 
-+ echo "'?pkg+:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg++:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg+a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg++a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg1+pkg2:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+a:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++a:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg1+pkg2:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
 + echo "'pkg1+pkg2:installed'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
 -> compiled  var-with-plus.1
 Installing var-with-plus.1.
@@ -106,11 +106,11 @@ The following actions will be simulated:
 === install 1 package
   - install var-with-plus 1
 
-+ echo "'?pkg+:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg++:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg+a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg++a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg1+pkg2:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+a:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++a:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg1+pkg2:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
 + echo "'pkg1+pkg2:installed'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
 -> compiled  var-with-plus.1
 Installing var-with-plus.1.
@@ -129,11 +129,11 @@ The following actions will be simulated:
 === install 1 package
   - install var-with-plus 1
 
-+ echo "'?pkg+:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg++:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg+a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg++a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg1+pkg2:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+a:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++a:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg1+pkg2:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
 + echo "'pkg1+pkg2:installed'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
 -> compiled  var-with-plus.1
 Installing var-with-plus.1.
@@ -152,11 +152,11 @@ The following actions will be simulated:
 === install 1 package
   - install var-with-plus 1
 
-+ echo "'?pkg+:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg++:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg+a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg++a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg1+pkg2:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+a:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++a:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg1+pkg2:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
 + echo "'pkg1+pkg2:installed'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
 -> compiled  var-with-plus.1
 Installing var-with-plus.1.
@@ -175,11 +175,11 @@ The following actions will be simulated:
 === install 1 package
   - install var-with-plus 1
 
-+ echo "'?pkg+:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg++:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg+a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg++a:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
-+ echo "'?pkg1+pkg2:installed:'" "" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg+a:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg++a:installed:'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
++ echo "'?pkg1+pkg2:installed:'" "false" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
 + echo "'pkg1+pkg2:installed'" "true" (CWD=${BASEDIR}/OPAM/test/.opam-switch/build/var-with-plus.1)
 -> compiled  var-with-plus.1
 Installing var-with-plus.1.


### PR DESCRIPTION
~Per our own documentation, '+' should not be a valid character for packages. However packages like conf-g++ or conf-c++ now exist in the wild. This solution is a compromise in hope for {name1+name2+name3:var} to be parsable again~

Related to https://github.com/ocaml/opam-file-format/issues/59