### PR TITLE
Quote all the paths to OPAMROOT when creating the init scripts on Unix

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -100,6 +100,7 @@ users)
 ## Client
 
 ## Shell
+  * Quote all the paths to OPAMROOT when creating the init scripts on Unix in case OPAMROOT contains spaces, backslashes or special characters [#5841 @kit-ty-kate - fix #5804]
 
 ## Internal
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -63,6 +63,7 @@ users)
   * Fix shell detection on Windows when opam is called via Cygwin's /usr/bin/env even though cmd/powershell is used [#5797 @kit-ty-kate]
   * Fix incorrect deduplication of environment variables on update. Effect was that FOO += "" would occlude the value of FOO in the environment [#5837 @dra27]
   * Fix regression from #5356 on the detection of out-of-date environment variables. As part of a refactoring, a filter predicate got inverted [#5837 @dra27]
+  * Unixify Windows paths in init shells scripts (sh, bash, zsh, fish & tsh) [#5797 @rjbou]
 
 ## Opamfile
 

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -202,8 +202,7 @@ val get_cygpath_function: command:string -> (string -> string) lazy_t
 val get_cygpath_path_transform: (pathlist:bool -> string -> string) lazy_t
 
 (** [apply_cygpath path] applies the `cygpath` command to [name] using
-    `cygpath -- name`. `cygpath` is resolved with default environment
-    in the function. *)
+    `cygpath -- name`. *)
 val apply_cygpath: string -> string
 
 (** [command cmd] executes the command [cmd] in the correct OPAM

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -877,14 +877,18 @@ let source root shell f =
   let fname = OpamFilename.to_string (OpamPath.init root // f) in
   match shell with
   | SH_csh ->
-    Printf.sprintf "if ( -f %s ) source %s >& /dev/null\n" fname fname
+    let fname = OpamStd.Env.escape_single_quotes fname in
+    Printf.sprintf "if ( -f '%s' ) source '%s' >& /dev/null\n" fname fname
   | SH_fish ->
-    Printf.sprintf "source %s > /dev/null 2> /dev/null; or true\n" fname
+    let fname = OpamStd.Env.escape_single_quotes ~using_backslashes:true fname in
+    Printf.sprintf "source '%s' > /dev/null 2> /dev/null; or true\n" fname
   | SH_sh | SH_bash ->
-    Printf.sprintf "test -r %s && . %s > /dev/null 2> /dev/null || true\n"
+    let fname = OpamStd.Env.escape_single_quotes fname in
+    Printf.sprintf "test -r '%s' && . '%s' > /dev/null 2> /dev/null || true\n"
       fname fname
   | SH_zsh ->
-    Printf.sprintf "[[ ! -r %s ]] || source %s  > /dev/null 2> /dev/null\n"
+    let fname = OpamStd.Env.escape_single_quotes fname in
+    Printf.sprintf "[[ ! -r '%s' ]] || source '%s' > /dev/null 2> /dev/null\n"
       fname fname
   | SH_cmd ->
     Printf.sprintf "if exist \"%s\" call \"%s\" >NUL 2>NUL\n" fname fname


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/5804

I personally think keeping the Windows style paths on Windows when using cygwin shell is fine, however none of the paths were previously quoted which is a big issue and the reason why the user in #5804 looked in the file in the first place as such command will always fail on Windows.

On cmd and powershell double quoting is apparently enough to make sure the string can't escape its context (?) (e.g. `"` and `$` are not valid file characters)