### PR TITLE
arg: fix loading git location from config file at init

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -101,6 +101,7 @@ users)
 
 ## Internal: Windows
   * Ensure that the system critical error dialog is disabled when opam starts [#5828 @dra27]
+  * Fix loading git location at init [#5843 @rjbou]
 
 ## Test
 

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -597,12 +597,12 @@ let apply_global_options cli o =
               { pelem = String cygcheck; _}::_  ->
               let cygbin = Filename.dirname cygcheck in
               OpamCoreConfig.update ~cygbin ()
-            | Some { pelem = String "git-location"; _},
-              { pelem = String git_location; _}::_  ->
-              OpamCoreConfig.update ~git_location ()
             | _, element::elements -> aux (Some element) elements
           in
           aux None elements
+        | { pelem = Variable ({ pelem = "git-location"; _},
+                              {pelem = String git_location; _}); _} ->
+          OpamCoreConfig.update ~git_location ()
         | _ -> ())
       opamfile.file_contents
   with


### PR DESCRIPTION
Cygwin support added the need to retrieve some information (cygwin binary path) from the config file before its proper loading by the global state (see https://github.com/ocaml/opam/pull/5544/files#diff-e674376a5ba688da9b6f11571be146af2e7bbde7c583630c6e8d4fc15c575035R575).
Git on windows PR #5718 used the same mechanism to load git location information at an early stage.
This PR fixes that retrieval implemented in #5718: `git-location` was searched among `global-variables` variables, not among field as implemented in this PR.
