### PR TITLE
init: on windows, fix handling of 'git-location' when defined in init config

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -22,6 +22,7 @@ users)
   * Recommend enabling Developer Mode on Windows [#5831 @dra27]
   * Disable ACL in Cygwin internal install to avoid permission mismatch errors [#5796 @kit-ty-kate - fix #5781]
   * Add `sys-pkg-manager-cmd` as an accepted field in opamrc files [#5847 @rjbou - fix #5844]
+  * Fix `git-location` handling in init config file [#5848 @rjbou - fix #5845]
 
 ## Config report
 


### PR DESCRIPTION
fixes #5845 

If `--git-location` is given and `git-location` is defined, priority goes to the one defined via CLI. Same with `--no-git-location`, it overrides `git-location` definition in config file.

