### PR TITLE
Documentation: Fix a dead link to SPDX license expressions spec

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -867,7 +867,7 @@ files.
 
 - <a id="opamfield-license">`license: [ <string> ... ]`</a>:
   The SPDX expression of the license(s) under which the source software is available
-  (see http://spdx.org/licenses/). The [SPDX standard](https://spdx.github.io/spdx-spec/SPDX-license-expressions/) allows to define custom licenses if necessary using the `LicenseRef-your-custom-name` syntax (e.g. `license: "LicenseRef-My-Custom-Non-Commercial-License"`).
+  (see http://spdx.org/licenses/). The [SPDX standard](https://spdx.github.io/spdx-spec/latest/SPDX-license-expressions/) allows to define custom licenses if necessary using the `LicenseRef-your-custom-name` syntax (e.g. `license: "LicenseRef-My-Custom-Non-Commercial-License"`).
   When several licenses are defined, the combination of them is equivalent to a single license expression separated by `AND`. For instance: `license: ["MIT" "ISC"]` is equivalent to `license: "MIT AND ISC"`. 
 
 - <a id="opamfield-homepage">`homepage: [ <string> ... ]`</a>,

--- a/master_changes.md
+++ b/master_changes.md
@@ -117,6 +117,7 @@ users)
 ## Doc
   * Fix a typo in the documentation of `opam lint --recursive` [#5812 @Khady]
   * Fix the documentation of opam lint --warnings [#5818 @kit-ty-kate]
+  * Fix a dead link to SPDX license expressions spec [#5849 @kit-ty-kate - fix #5846]
 
 ## Security fixes
 


### PR DESCRIPTION
Fix #5846 