### PR TITLE
fix missing spaces

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -119,6 +119,7 @@ users)
   * Fix a typo in the documentation of `opam lint --recursive` [#5812 @Khady]
   * Fix the documentation of opam lint --warnings [#5818 @kit-ty-kate]
   * Fix a dead link to SPDX license expressions spec [#5849 @kit-ty-kate - fix #5846]
+  * Fix missing spaces in `opam --help` [#5850 @sorawee].
 
 ## Security fixes
 

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1353,9 +1353,9 @@ let global_options cli =
        version-controlled directory, update to the current working state of \
        their source instead of the last committed state, or the ref they are \
        pointing to. As source directory is copied as it is, if it isn't clean \
-       it may result on a opam build failure.\
-       This only affects packages explicitly listed on the command-line.\
-       It can also be set with $(b,\\$OPAMWORKINGDIR). "
+       it may result on a opam build failure. This only affects packages \
+       explicitly listed on the command-line. It can also be set with \
+       $(b,\\$OPAMWORKINGDIR)."
   in
   let ignore_pin_depends =
     mk_flag ~cli cli_original ~section ["ignore-pin-depends"]


### PR DESCRIPTION
Fix missing spaces in `opam --help`.