### PR TITLE
Make sure to use the vendored dune when using ./configure --with-vendored-deps

### DIFF
--- a/configure
+++ b/configure
@@ -5981,6 +5981,12 @@ x$ax_compare_version_B" | sed 's/^ *//' | sort -r | sed "s/x${ax_compare_version
 
 
 
+if test -n "$DUNE" -a "x$with_vendored_deps" = "xyes"
+then :
+
+  DUNE=''
+
+fi
 case $DUNE,$with_dune in #(
   ,yes) :
     as_fn_error $? "Dune was not found in PATH" "$LINENO" 5 ;; #(

--- a/configure.ac
+++ b/configure.ac
@@ -281,6 +281,9 @@ AX_COMPARE_VERSION([$OCAMLVERSION], [lt], [4.08.0],
   [DUNE_SECONDARY=])
 AC_SUBST([DUNE_SECONDARY])
 
+AS_IF([test -n "$DUNE" -a "x$with_vendored_deps" = "xyes"],[
+  DUNE=''
+])
 AS_CASE([$DUNE,$with_dune],
   [,yes],     [AC_MSG_ERROR([Dune was not found in PATH])],
   [*,no],     [DUNE=''],

--- a/master_changes.md
+++ b/master_changes.md
@@ -83,6 +83,7 @@ users)
   * Do not check for cppo in the configure script (not used directly anymore since #5498) [#5794 @kit-ty-kate]
   * Upgrade vendored cmdliner to 1.2.0 [#5797 @kit-ty-kate]
   * Add winsymlinks:native to the CYGWIN environment variable when installing a package on Windows [#5793 @kit-ty-kate - fix #5782]
+  * Make sure to use the vendored dune when using ./configure --with-vendored-deps [#5868 @kit-ty-kate]
 
 ## Infrastructure
   * Fix depexts CI workflow and ensure all workflows run on master push [#5788 @dra27]


### PR DESCRIPTION
Partially fixes https://github.com/ocaml/opam/issues/5770 (the remaining part is to be fixed in the 2.1 branch)