### PR TITLE
sysinteract: Let wolfi be treated like alpine

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -73,6 +73,7 @@ users)
 ## Opamfile
 
 ## External dependencies
+ * Add support for Wolfi OS, treat it like Apline family as it uses apk too
 
 ## Format upgrade
 

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -181,7 +181,7 @@ let family ~env () =
     Dummy { install; installed; available; }
   | Some family ->
     match family with
-    | "alpine" -> Alpine
+    | "alpine" | "wolfi" -> Alpine
     | "amzn" | "centos" | "fedora" | "mageia" | "oraclelinux" | "ol"
     | "rhel" -> Centos
     | "archlinux" | "arch" -> Arch


### PR DESCRIPTION
sysinteract: Let wolfi be treated like alpine

## External dependencies
 * Add support for Wolfi OS, treat it like Apline family as it uses apk too

Wolfi OS uses apk like Alpine, but with glibc