### PR TITLE
Support `avoid-version` and `deprecated` with the 0install-solver

### DIFF
--- a/src/solver/opamBuiltin0install.ml
+++ b/src/solver/opamBuiltin0install.ml
@@ -108,7 +108,7 @@ let call ~criteria ?timeout:_ (preamble, universe, request) =
   let {drop_installed_packages; prefer_oldest} = parse_criteria criteria in
   let timer = OpamConsole.timer () in
   let pkgs, constraints = create_spec ~drop_installed_packages universe request in
-  let context = Opam_0install_cudf.create ~prefer_oldest ~constraints universe in
+  let context = Opam_0install_cudf.create ~handle_avoid_version:true ~prefer_oldest ~constraints universe in
   match Opam_0install_cudf.solve context pkgs with
   | Ok selections ->
     let universe = reconstruct_universe universe selections in

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -22,6 +22,7 @@ let s_reinstall = "reinstall"
 let s_installed_root = "installed-root"
 let s_pinned = "pinned"
 let s_version_lag = "version-lag"
+let s_avoid_version = "avoid-version"
 
 let opam_invariant_package_name =
   Dose_common.CudfAdd.encode "=opam-invariant"

--- a/src/solver/opamCudf.mli
+++ b/src/solver/opamCudf.mli
@@ -186,6 +186,9 @@ val s_pinned: string
 (** the number of versions of the package since this one, cubed *)
 val s_version_lag: string
 
+(** the avoid-version flag *)
+val s_avoid_version: string
+
 (** valid cudf name for the dummy package used for enforcing opam's switch
     invariants *)
 val opam_invariant_package_name: string


### PR DESCRIPTION
This plumbs in https://github.com/ocaml-opam/opam-0install-solver/pull/37, both of which I think we should sort out, but possibly not for 2.2.0.