### PR TITLE
Allow to compile opam when the environment contains unicode characters on Windows (upgrade to dune 3.14.2)

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -89,6 +89,8 @@ users)
   * Upgrade the vendored re to 1.11.0 [#5869 @dra27]
   * Upgrade the vendored ocamlgraph to 2.1.0 [#5869 @dra27]
   * Upgrade the vendored opam-file-format to 2.1.6 [#5869 @dra27]
+  * Allow to compile opam when the environment contains unicode characters on Windows [#5880 @kit-ty-kate]
+  * Upgrade the vendored dune to 3.14.2 [#5880 @kit-ty-kate]
 
 ## Infrastructure
   * Fix depexts CI workflow and ensure all workflows run on master push [#5788 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -89,7 +89,7 @@ users)
   * Upgrade the vendored re to 1.11.0 [#5869 @dra27]
   * Upgrade the vendored ocamlgraph to 2.1.0 [#5869 @dra27]
   * Upgrade the vendored opam-file-format to 2.1.6 [#5869 @dra27]
-  * Allow to compile opam when the environment contains unicode characters on Windows [#5880 @kit-ty-kate]
+  * Allow to compile opam when the environment contains unicode characters on Windows [#5880 @kit-ty-kate - fix #5861]
   * Upgrade the vendored dune to 3.14.2 [#5880 @kit-ty-kate]
 
 ## Infrastructure

--- a/src_ext/Makefile.dune
+++ b/src_ext/Makefile.dune
@@ -1,3 +1,3 @@
 # NB If minimum OCaml version for Dune changes, update DUNE_SECONDARY in configure.ac
-URL_dune-local = https://github.com/ocaml/dune/releases/download/3.14.0/dune-3.14.0.tbz
-MD5_dune-local = bff778fff4996b890e5af3da7ecf5baa
+URL_dune-local = https://github.com/ocaml/dune/releases/download/3.14.2/dune-3.14.2.tbz
+MD5_dune-local = 9496e02635c05a8288781b55fb837b6f


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/5861
See https://github.com/janestreet/spawn/pull/58

~To be merged when https://github.com/ocaml/opam-repository/pull/25474 is merged.~