### PR TITLE
Windows-inspired tweaks the UI

### DIFF
--- a/src/core/dune
+++ b/src/core/dune
@@ -3,7 +3,7 @@
   (public_name opam-core)
   (synopsis    "OCaml Package Manager core internal stdlib")
   ; TODO: Remove (re_export ...) when CI uses the OCaml version that includes https://github.com/ocaml/ocaml/pull/11989
-  (libraries   re (re_export ocamlgraph) unix sha jsonm swhid_core uutf
+  (libraries   re (re_export ocamlgraph) unix sha jsonm swhid_core uutf threads
                (select opamACL.ml from
                        (opam-core.libacl -> opamACL.libacl.ml)
                        (                 -> opamACL.dummy.ml))

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -624,16 +624,29 @@ let set_verbose_f, print_verbose_f, isset_verbose_f, stop_verbose_f =
     stop ();
     (* implem relies on sigalrm, not implemented on win32.
        This will fall back to buffered output. *)
-    if Sys.win32 then () else
+    (*if Sys.win32 then () else*)
     let files = OpamStd.List.sort_nodup compare files in
     let ics =
       List.map
         (open_in_gen [Open_nonblock;Open_rdonly;Open_text;Open_creat] 0o600)
         files
     in
-    let f () =
+    let f =
+      let buffer = Buffer.create 80 in
+      fun () ->
       List.iter (fun ic ->
-          try while true do verbose_print_out (input_line ic) done
+          try while true do
+            (* XXX This should with a better read function *)
+            let line = input_line ic in (* line = "" => we must have read a newline, right, therefore if line = "", we can't possibly be at the start of the file??? *)
+            seek_in ic (pos_in ic - 1);
+            let c = input_char ic in
+            if c <> '\n' then
+              Buffer.add_string buffer line
+            else
+              let buffered = Buffer.contents buffer in
+              let () = Buffer.clear buffer in
+              verbose_print_out (buffered ^ line)
+            done
           with End_of_file -> flush stdout
         ) ics
     in
@@ -644,6 +657,7 @@ let set_verbose_f, print_verbose_f, isset_verbose_f, stop_verbose_f =
     | None -> ()
   in
   let isset () = !verbose_f <> None in
+  (* XXX Need a "super print" mechanism here - nothing should be buffered at the end *)
   let flush_and_stop () = print (); stop () in
   set, print, isset, flush_and_stop
 
@@ -685,22 +699,43 @@ let exit_status p return =
     r_cleanup  = cleanup;
   }
 
+let win32_thread (hndl, running) =
+  let rec loop () =
+    try
+      while !running do
+        Unix.sleepf 0.1;
+        if !running then
+          hndl ();
+      done
+    with Sys.Break ->
+      loop () (* XXX This __cannot__ be correct! *)
+  in loop ()
+
 let safe_wait fallback_pid f x =
   let sh =
     if isset_verbose_f () then
-      let hndl _ = print_verbose_f () in
-      Some (Sys.signal Sys.sigalrm (Sys.Signal_handle hndl))
+      if Sys.win32 then
+        let running = ref true in
+        (* XXX Do we need to wait on these threads to release resources??? *)
+        let _ = Thread.create win32_thread (print_verbose_f, running) in
+        Some (fun () -> running := false)
+      else
+        let hndl _ = print_verbose_f () in
+        let sh = Sys.signal Sys.sigalrm (Sys.Signal_handle hndl) in
+        Some (fun () -> Sys.set_signal Sys.sigalrm sh)
     else None
   in
   let cleanup () =
     match sh with
     | Some sh ->
-      ignore (Unix.alarm 0); (* cancels the alarm *)
-      Sys.set_signal Sys.sigalrm sh
+      if not Sys.win32 then
+        ignore (Unix.alarm 0); (* cancels the alarm *)
+      sh ()
     | None -> ()
   in
   let rec aux () =
-    if sh <> None then ignore (Unix.alarm 1);
+    if sh <> None && not Sys.win32 then
+      ignore (Unix.alarm 1);
     match
       try f x with
       | Unix.Unix_error (Unix.EINTR,_,_) -> aux () (* handled signal *)

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -269,6 +269,7 @@ type t = {
   p_time   : float;
   p_stdout : string option;
   p_stderr : string option;
+  mutable p_cycle : int;
   p_env    : string option;
   p_info   : string option;
   p_metadata: (string * string) list;
@@ -492,6 +493,7 @@ let create ?info_file ?env_file ?(allow_stdin=not Sys.win32) ?stdout_file ?stder
     p_time   = time;
     p_stdout = stdout_file;
     p_stderr = stderr_file;
+    p_cycle  = 0;
     p_env    = env_file;
     p_info   = info_file;
     p_metadata = metadata;
@@ -591,6 +593,7 @@ let dry_run_background c = {
   p_time   = Unix.gettimeofday ();
   p_stdout = None;
   p_stderr = None;
+  p_cycle  = 0;
   p_env    = None;
   p_info   = None;
   p_metadata = OpamStd.Option.default [] c.cmd_metadata;

--- a/src/core/opamProcess.mli
+++ b/src/core/opamProcess.mli
@@ -69,6 +69,7 @@ type t = {
   p_time   : float;         (** Process start time *)
   p_stdout : string option; (** stdout dump file *)
   p_stderr : string option; (** stderr dump file *)
+  mutable p_cycle : int;    (** Number of times output has been detected *)
   p_env    : string option; (** dump environment variables *)
   p_info   : string option; (** dump process info *)
   p_metadata: (string * string) list; (** Metadata associated to the process *)

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -259,9 +259,11 @@ let pull_tree_t
       | Some e -> Done (Not_available (None, Printexc.to_string e))
     in
     match dirnames with
-    | [ _label, local_dirname, _subpath ] ->
+    | [ label, local_dirname, _subpath ] ->
       (fun archive msg ->
          OpamFilename.cleandir local_dirname;
+         let text = OpamProcess.make_command_text label "extract" in
+         OpamProcess.Job.with_text text @@
          OpamFilename.extract_job archive local_dirname
          @@+ fallback (fun () ->  Done (Up_to_date msg)))
     | _ ->
@@ -281,6 +283,17 @@ let pull_tree_t
                            (Some label, OpamProcess.result_summary r))))
             dirnames
         in
+        let text =
+          let label =
+            match dirnames with
+            | [(label1, _, _); (label2, _, _)] ->
+              label1 ^ ", " ^ label2
+            | (label, _, _)::rest ->
+              Printf.sprintf "%s + %d others" label (List.length rest)
+            | [] -> assert false in
+          OpamProcess.make_command_text label "extract"
+        in
+        OpamProcess.Job.with_text text @@
         OpamFilename.extract_job archive tmpdir
         @@+ fallback (fun () ->
             let failing =


### PR DESCRIPTION
None of this is intended for direct merging - it's the result of some idle hacking while travelling at the moment.

There are four separable parts of this PR, which anyone should feel free to take and move to completion 🙂

- The display of command output (when `-v`) is specified is implemented on Unix using `Unix.alarm` and so was consequently disabled on Windows in #1915. It's an irritating limitation when debugging the compiler in opam on Windows, though! The approach is to use a thread instead of sigalrm, but the implementation needs to be hardened (the `XXX` notes are things I didn't have in my frontal lobe and couldn't be bothered to lookup!)
- Hidden in that first commit is also an actual bug fix. The code in #1915 uses `input_line` until it reaches `End_of_file`, but the final line may not actually be complete. Regardless, opam then displays it on a complete. Even on Linux, this causes lines in `configure` scripts to get split. There's a hack in the commit to fix it by using `seek_in`, but it would be better to use proper input functions and do the job properly (but it's fiddly). I'm fairly sure the statement of correctness in a comment in the code is _wrong_.
- Extracting tarballs with many files is slow on Windows... the next two commits were starts of an implementation to display an "extract" item at this point, which makes opam looks much less like it's crashed while it extracts either the compiler or Dune tarballs (I was amused when installing a package from npm earlier to note that it really ought to do the same thing.......)
- Finally, packages are slower on Windows to build at the moment (especially the compiler) and the last commit provides a PoC for displaying spinners. The commit message has a few more notes. This needs massively tidying up - `OpamProcess` should acquire a more structured way of determining "progress" (which might allow, say, the download jobs to tick when content is received and the tarball extractions to tick when a file has been extracted) and the type for the status bar in `OpamParallel` should be made richer so that it can be much less hackily annotated the a spinner. Obviously the spinner itself needs to get through the usual mechanisms in OpamConsole for UTF-8 detection, but I was hacking all this in Windows Terminal, with full Unicode joy...

The verbose fixes are optional for 2.2.0, but both the extract and spinners I think _are_ required for 2.2.0 because there are otherwise extremely long pauses on Windows which invite pressing CTRL+C.