### PR TITLE
`opam source --dev` fetching git repositories without `--depth 1`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -60,6 +60,7 @@ users)
 ## Exec
 
 ## Source
+  * Using `opam source --dev` with git repositories doesn't fetch with `--depth 1` [#5888 @moyodiallo - fix #5061]
 
 ## Lint
  * Add warning 69: Warn for new syntax when package name in variable in string interpolation contains several '+' [#5840 @rjbou]
@@ -173,6 +174,7 @@ users)
   * `OpamArg.apply_global_options`: load MSYS2 Cygwin binary path too [#5843 @rjbou]
 
 ## opam-repository
+  * `OpamRepositoryBackend.S.pull_url`, `OpamVCS.fetch`, `OpamRepository.pull_tree`: add `full_fetch` optional argument to pull full history if url is a `VCS` [#5888 @moyodiallo - fix #5061]
 
 ## opam-state
   * `OpamEnv.env_expansion`: Fix detection of out-of-date environment variables, a filter predicate was inverted [#5837 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -146,6 +146,7 @@ users)
   + Add a test testing showing the current behaviour of opam with variable expansion, in particular when the package contains pluses [#5840 @kit-ty-kate]
   * Update lint test: W41 [#5840 @rjbou]
   * Update lint test: W41 and W69 [#5840 @rjbou]
+  * Add test in `source` to show retrieval of full git repository history when retrieved with `opam source --dev` [#5888 @moyodiallo @rjbou @kit-ty-kate]
 
 ### Engine
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3696,6 +3696,7 @@ let source cli =
            match
              OpamProcess.Job.run
                (OpamRepository.pull_tree
+                  ~full_fetch:true
                   ~cache_dir:(OpamRepositoryPath.download_cache
                                 OpamStateConfig.(!r.root_dir))
                   ?subpath

--- a/src/repository/opamDarcs.ml
+++ b/src/repository/opamDarcs.ml
@@ -48,7 +48,7 @@ module VCS = struct
   (* Marks the current state, in the form of a reversing patch on top of the
      fetched state *)
 
-  let fetch ?cache_dir:_ ?subpath:_ repo_root repo_url =
+  let fetch ?full_fetch:_ ?cache_dir:_ ?subpath:_ repo_root repo_url =
     (* Just do a fresh pull into a temp directory, and replace _darcs/
        There is no easy way to diff or make sure darcs forgets about local
        patches otherwise. *)

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -62,7 +62,7 @@ module VCS : OpamVCS.VCS = struct
     | Some h -> "refs/remotes/opam-ref-"^h
     | None -> "refs/remotes/opam-ref"
 
-  let fetch ?cache_dir ?subpath repo_root repo_url =
+  let fetch ?(full_fetch = false) ?cache_dir ?subpath repo_root repo_url =
     (match subpath with
      | Some sp ->
        git repo_root [ "config"; "--local"; "core.sparseCheckout"; "true" ]
@@ -95,7 +95,10 @@ module VCS : OpamVCS.VCS = struct
           OpamFilename.write alternates
             (OpamFilename.Dir.to_string (cache / "objects")))
       global_cache;
-    git repo_root [ "fetch" ; "-q"; origin; "--update-shallow"; "--depth=1"; refspec ]
+    (if full_fetch then
+       git repo_root [ "fetch" ; "-q"; origin; "--update-shallow"; refspec ]
+     else
+       git repo_root [ "fetch" ; "-q"; origin; "--update-shallow"; "--depth=1"; refspec ])
     @@> fun r ->
     if OpamProcess.check_success_and_cleanup r then
       let refspec =

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -68,7 +68,7 @@ module B = struct
 
   let repo_update_complete _ _ = Done ()
 
-  let pull_url ?cache_dir:_ ?subpath:_ dirname checksum remote_url =
+  let pull_url ?full_fetch:_ ?cache_dir:_ ?subpath:_ dirname checksum remote_url =
     log "pull-file into %a: %a"
       (slog OpamFilename.Dir.to_string) dirname
       (slog OpamUrl.to_string) remote_url;

--- a/src/repository/opamHg.ml
+++ b/src/repository/opamHg.ml
@@ -37,7 +37,7 @@ module VCS = struct
     | None -> mark_prefix
     | Some fragment -> mark_prefix ^ "-" ^ fragment
 
-  let fetch ?cache_dir:_ ?subpath:_ repo_root repo_url =
+  let fetch ?full_fetch:_ ?cache_dir:_ ?subpath:_ repo_root repo_url =
     let src = OpamUrl.base_url repo_url in
     let rev = OpamStd.Option.default "default" repo_url.OpamUrl.hash in
     let mark = mark_from_url repo_url in

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -190,7 +190,7 @@ module B = struct
 
   let repo_update_complete _ _ = Done ()
 
-  let pull_url ?cache_dir:_ ?subpath local_dirname _checksum remote_url =
+  let pull_url ?full_fetch:_ ?cache_dir:_ ?subpath local_dirname _checksum remote_url =
     let local_dirname = OpamFilename.SubPath.(local_dirname /? subpath) in
     OpamFilename.mkdir local_dirname;
     let dir = OpamFilename.Dir.to_string local_dirname in

--- a/src/repository/opamRepository.mli
+++ b/src/repository/opamRepository.mli
@@ -44,8 +44,9 @@ val pull_shared_tree:
 
 (* Same as [pull_shared_tree], but for a unique label/dirname. *)
 val pull_tree:
-  string -> ?cache_dir:dirname -> ?cache_urls:url list -> ?working_dir:bool ->
-  ?subpath:subpath -> dirname -> OpamHash.t list -> url list ->
+  string -> ?full_fetch:bool -> ?cache_dir:dirname -> ?cache_urls:url list ->
+  ?working_dir:bool -> ?subpath:subpath ->
+  dirname -> OpamHash.t list -> url list ->
   string download OpamProcess.job
 
 (** Same as [pull_tree], but for fetching a single file. *)

--- a/src/repository/opamRepository.mli
+++ b/src/repository/opamRepository.mli
@@ -42,7 +42,9 @@ val pull_shared_tree:
   (string * OpamFilename.Dir.t * subpath option) list -> OpamHash.t list ->
   url list -> string download OpamProcess.job
 
-(* Same as [pull_shared_tree], but for a unique label/dirname. *)
+(* Same as [pull_shared_tree], but for a unique label/dirname.
+   If [full_fetch] is true, VCS repository is retrieved with full history (by
+   default, no history). *)
 val pull_tree:
   string -> ?full_fetch:bool -> ?cache_dir:dirname -> ?cache_urls:url list ->
   ?working_dir:bool -> ?subpath:subpath ->

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -22,6 +22,7 @@ type update =
 module type S = sig
   val name: OpamUrl.backend
   val pull_url:
+    ?full_fetch:bool ->
     ?cache_dir:dirname -> ?subpath:subpath -> dirname -> OpamHash.t option -> url ->
     filename option download OpamProcess.job
   val fetch_repo_update:

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -31,8 +31,8 @@ module type S = sig
 
   val name: OpamUrl.backend
 
-  (** [pull_url local_dir checksum remote_url] pulls the contents of
-      [remote_url] into [local_dir].
+  (** [pull_url ?full_fetch ?cache_dir ?subpath local_dir checksum remote_url]
+      pulls the contents of [remote_url] into [local_dir].
 
       Two kinds of results are allowed:
 
@@ -43,7 +43,13 @@ module type S = sig
         been synchronised with its own, and [None] is returned
 
       [checksum] can be used for retrieval but is NOT checked by this
-      function. *)
+      function.
+
+      If [full_fetch] is set to true, VCS repository is retrieved with full
+      history (by default, no history).
+      If [cache_dir] is given, the directory is used by VCS tool as a its cache
+      directory.
+      If [subpath] is given, only that [subpath] of the url is retrieved. *)
   val pull_url:
     ?full_fetch:bool ->
     ?cache_dir:dirname -> ?subpath:subpath -> dirname -> OpamHash.t option ->

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -45,6 +45,7 @@ module type S = sig
       [checksum] can be used for retrieval but is NOT checked by this
       function. *)
   val pull_url:
+    ?full_fetch:bool ->
     ?cache_dir:dirname -> ?subpath:subpath -> dirname -> OpamHash.t option ->
     url -> filename option download OpamProcess.job
 

--- a/src/repository/opamVCS.mli
+++ b/src/repository/opamVCS.mli
@@ -29,8 +29,9 @@ module type VCS = sig
       Be aware that the remote URL might have been changed, so make sure
       to update accordingly. *)
   val fetch:
-    ?cache_dir:dirname -> ?subpath:subpath -> dirname -> url ->
-    unit OpamProcess.job
+    ?full_fetch:bool -> ?cache_dir:dirname -> ?subpath:subpath
+    -> dirname -> url
+    -> unit OpamProcess.job
 
   (** Reset the master branch of the repository to match the remote repository
       state. This might still fetch more data (git submodules...), so is

--- a/src/repository/opamVCS.mli
+++ b/src/repository/opamVCS.mli
@@ -27,7 +27,13 @@ module type VCS = sig
   (** Fetch changes from upstream. This is supposed to put the changes
       in a staging area.
       Be aware that the remote URL might have been changed, so make sure
-      to update accordingly. *)
+      to update accordingly.
+
+      If [full_fetch] is set to true, VCS repository is retrieved with full
+      history (by default, no history).
+      If [cache_dir] is given, the directory is used by VCS tool as a its cache
+      directory.
+      If [subpath] is given, only that [subpath] of the url is retrieved. *)
   val fetch:
     ?full_fetch:bool -> ?cache_dir:dirname -> ?subpath:subpath
     -> dirname -> url

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -584,3 +584,22 @@ first  --
 <><> Repository configuration for switch repos ><><><><><><><><><><><><><><><><>
  1 oper3 file://${BASEDIR}/OPER3
  2 oper  file://${BASEDIR}/OPER3
+### : Ensure that git repository is retrieved not with full history
+### OPAMREPOSITORYTARRING=0
+### <TMCS/repo>
+opam-version: "2.0"
+### <TMCS/packages/first/first.1/opam>
+opam-version: "2.0"
+### git -C ./TMCS init -q
+### git -C ./TMCS config core.autocrlf false
+### git -C ./TMCS add repo
+### git -C ./TMCS add packages/first
+### git -C ./TMCS commit -qm "init"
+### git -C ./TMCS commit --allow-empty -m "second empty commit" --quiet
+### git -C ./TMCS commit --allow-empty -m "thirs empty commit" --quiet
+### git -C ./TMCS rev-list --all --count
+3
+### opam repository add to-many-commits git+file://$BASEDIR/TMCS --this-switch
+[to-many-commits] Initialised
+### git -C ./OPAM/repo/to-many-commits rev-list --all --count
+1

--- a/tests/reftests/source.test
+++ b/tests/reftests/source.test
@@ -109,3 +109,31 @@ pandore.3/src/src.ml
 Switch phantom and all its packages will be wiped. Are you sure? [y/n] y
 ### opam source pandore
 Successfully extracted to ${BASEDIR}/pandore.3
+### : Full retrieval of git history when --dev is given :
+### git -C ./pandev commit --allow-empty -m "second empty commit" --quiet
+### git -C ./pandev rev-list --all --count
+2
+### <pkg:pandore.4>
+opam-version: "2.0"
+### <mkurl.sh>
+p=pandore.4
+file="REPO/packages/${p%.*}/$p/opam"
+basedir=`echo $BASEDIR | sed "s/\\\\\\\\/\\\\\\\\\\\\\\\\/g"`
+echo "url {" >> $file
+echo "git: \"$basedir/pandev\"" >> $file
+echo "}" >> $file
+echo "dev-repo: \"git+file://${basedir}/pandev\"" >> $file
+### sh mkurl.sh
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### opam source pandore.4 --dir pandore5
+Successfully extracted to ${BASEDIR}/pandore5
+### git -C pandore5 rev-list --all --count
+1
+### opam source pandore.4 --dev --dir pandore6
+Successfully fetched pandore development repo to ${BASEDIR}/pandore6
+### git -C pandore6 rev-list --all --count
+1

--- a/tests/reftests/source.test
+++ b/tests/reftests/source.test
@@ -136,4 +136,4 @@ Successfully extracted to ${BASEDIR}/pandore5
 ### opam source pandore.4 --dev --dir pandore6
 Successfully fetched pandore development repo to ${BASEDIR}/pandore6
 ### git -C pandore6 rev-list --all --count
-1
+2


### PR DESCRIPTION
This PR is about to fix #5061. It turns out we doesn't need a flag for fixing the issue, It is agreed during the `opam-dev` meeting to avoid fetching with `--depth 1` for `opam source` because on the client side it could be confusing, an idea from @kit-ty-kate.

- [x] Add an option in the backend
- [x] ~~Add an flag for `opam source` client~~
- [x] opam source is going to be `--deph 1` free when fetching source from dev_repo.
- [x] Add `test` for `opam source` command
- [x] Add test for `opam repository` command, to be sure the behavior remains unchanged.