### PR TITLE
Revert "Merge pull request #5400 from kit-ty-kate/no-gpatch"

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -888,11 +888,10 @@ files.
 - <a id="opamfield-patches">`patches: [ <string> { <filter> } ... ]`</a>: a list
   of files relative to the project source root (often added through the `files/`
   metadata subdirectory). The listed patch files will be applied sequentially to
-  the source using the `patch` command (before opam 2.2) or `git apply`
-  (since opam 2.2), stripping one level of leading directories (`-p1`) -- which
-  is what version control systems generally use. Variable interpolation is
-  available, so you can specify `patches: [ "file" ]` to have the patch
-  processed from `file.in`.
+  the source as with the `patch` command, stripping one level of leading
+  directories (`-p1`) -- which is what version control systems generally use .
+  Variable interpolation is available, so you can specify `patches: [ "file" ]`
+  to have the patch processed from `file.in`.
 
     Patches may be applied conditionally by adding _filters_.
 
@@ -1532,9 +1531,8 @@ them modified with [`opam option --global`](man/opam-option.html).
     - `quorum`: integer, the currently defined quorum
     - `repo`: directory containing the already-validated state of the repository
       (empty for an initial validation)
-    - `patch`: for incremental validation, filename of a patch applying to `repo`
-      (using `patch -p1` before opam 2.2, and using `git apply -p1` since opam 2.2)
-      and that needs verification
+    - `patch`: for incremental validation, filename of a patch applying to
+      `repo` (with `patch -p1`) and that needs verification
     - `dir`: for initial validation, the directory to verify
     - `incremental`: `false` if doing an initial validation based on `dir`,
       `true` for an incremental validation based on `repo` and `patch`.

--- a/master_changes.md
+++ b/master_changes.md
@@ -168,4 +168,3 @@ users)
 
 ## opam-core
   * `OpamStd.Sys`: add `is_cygwin_variant_cygcheck` that returns true if in path `cygcheck` is from a Cygwin or MSYS2 installation [#5843 @rjbou]
-  * `OpamSystem.patch`: use `git -c core.autocrlf=false apply --unsafe-paths -p1 <patch>` instead of `patch` [#5400 @kit-ty-kate - fix #3433 #3782 #3639]

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -57,6 +57,9 @@ let not_win32_filter =
   FOp (FIdent ([], OpamVariable.of_string "os", None), `Neq, FString "win32")
 let sandbox_filter = FOr (linux_filter, macos_filter)
 
+let gpatch_filter = FOr (openbsd_filter, freebsd_filter)
+let patch_filter = FNot gpatch_filter
+
 let gtar_filter = openbsd_filter
 let tar_filter = FNot gtar_filter
 
@@ -131,7 +134,8 @@ let required_tools ~sandboxing () =
   req_dl_tools () @
   [
     ["diff"], None, None;
-    ["git"], None, None;
+    ["patch"], None, Some patch_filter;
+    ["gpatch"], None, Some gpatch_filter;
     ["tar"], None, Some tar_filter;
     ["gtar"], None, Some gtar_filter;
     ["unzip"], None, None;

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -1645,7 +1645,13 @@ let patch ?(preprocess=true) ~dir p =
     else
       p
   in
-  make_command ~name:"git apply" ~dir "git" ["-c"; "core.autocrlf=false"; "apply"; "--unsafe-paths"; "-p1"; p'] @@> fun r ->
+  let patch_cmd =
+    match OpamStd.Sys.os () with
+    | OpamStd.Sys.OpenBSD
+    | OpamStd.Sys.FreeBSD -> "gpatch"
+    | _ -> "patch"
+  in
+  make_command ~name:"patch" ~dir patch_cmd ["-p1"; "-i"; p'] @@> fun r ->
     if not (OpamConsole.debug ()) then Sys.remove p';
     if OpamProcess.is_success r then Done None
     else Done (Some (Process_error r))

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -6,9 +6,9 @@ build: ["test" "-f" "bar"]
 some content
 ### : Internal repository storage as archive or plain directory :
 ### opam switch create tarring --empty
-### opam update -vv | grep '^\+' | sed-cmd diff | sed-cmd git | 'patch-[^"]+' -> 'patch'
+### opam update -vv | grep '^\+' | sed-cmd diff | sed-cmd patch | 'patch-[^"]+' -> 'patch'
 + diff "-ruaN" "default" "default.new" (CWD=${BASEDIR}/OPAM/repo)
-+ git "-c" "core.autocrlf=false" "apply" "--unsafe-paths" "-p1" "${BASEDIR}/OPAM/log/patch" (CWD=${BASEDIR}/OPAM/repo/default)
++ patch "-p1" "-i" "${BASEDIR}/OPAM/log/patch" (CWD=${BASEDIR}/OPAM/repo/default)
 ### ls $OPAMROOT/repo | grep -v "cache"
 default
 lock
@@ -24,9 +24,9 @@ opam-version: "2.0"
 build: ["test" "-f" "baz"]
 ### <REPO/packages/foo/foo.2/files/baz>
 some content
-### opam update default -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd git | 'patch-[^"]+' -> 'patch'
+### opam update default -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd patch | 'patch-[^"]+' -> 'patch'
 + diff "-ruaN" "default" "default.new" (CWD=${BASEDIR}/OPAM/repo)
-+ git "-c" "core.autocrlf=false" "apply" "--unsafe-paths" "-p1" "${BASEDIR}/OPAM/log/patch" (CWD=${BASEDIR}/OPAM/repo/default)
++ patch "-p1" "-i" "${BASEDIR}/OPAM/log/patch" (CWD=${BASEDIR}/OPAM/repo/default)
 + tar "cfz" "${BASEDIR}/OPAM/repo/default.tar.gz.tmp" "-C" "${BASEDIR}/OPAM/repo" "default"
 ### ls $OPAMROOT/repo | grep -v "cache"
 default.tar.gz
@@ -61,10 +61,10 @@ opam-version: "2.0"
 build: ["test" "-f" "baz"]
 ### <REPO/packages/foo/foo.4/files/baz>
 some content
-### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd git | 'patch-[^"]+' -> 'patch'
+### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd patch | 'patch-[^"]+' -> 'patch'
 + tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
 + diff "-ruaN" "tarred" "tarred.new" (CWD=${OPAMTMP})
-+ git "-c" "core.autocrlf=false" "apply" "--unsafe-paths" "-p1" "${BASEDIR}/OPAM/log/patch" (CWD=${OPAMTMP}/tarred)
++ patch "-p1" "-i" "${BASEDIR}/OPAM/log/patch" (CWD=${OPAMTMP}/tarred)
 + tar "cfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz.tmp" "-C" "${OPAMTMP}" "tarred"
 ### opam install foo.4 -vv | grep '^\+' | sed-cmd test | sed-cmd tar
 + tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
@@ -83,10 +83,10 @@ opam-version: "2.0"
 build: ["test" "-f" "quux"]
 ### <REPO/packages/foo/foo.5/files/quux>
 some content
-### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd git | 'patch-[^"]+' -> 'patch'
+### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd patch | 'patch-[^"]+' -> 'patch'
 + tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
 + diff "-ruaN" "tarred" "tarred.new" (CWD=${OPAMTMP})
-+ git "-c" "core.autocrlf=false" "apply" "--unsafe-paths" "-p1" "${BASEDIR}/OPAM/log/patch" (CWD=${OPAMTMP}/tarred)
++ patch "-p1" "-i" "${BASEDIR}/OPAM/log/patch" (CWD=${OPAMTMP}/tarred)
 ### opam install foo.5 -vv | grep '^\+' | sed-cmd test
 + test "-f" "quux" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.5)
 ### ls $OPAMROOT/repo | grep -v "cache"


### PR DESCRIPTION
Reverts #5400 

After a couple of weeks of tests, `git apply` turned out to be bad choice for 2 main reason:
* the format accepted by it is too strict and will make applications of a number of patches from opam-repository fail. See for example https://github.com/ocaml/opam-repository/pull/25430#issuecomment-2007103671
* The `--unsafe-paths` option is not just used `When git apply is used as a "better GNU patch"` (as the git documentation puts it), but is actually highly unsafe (who could have guessed!) and allows the application of patches outside of the selected path using `../`. However opam requires one part of the behaviour of this option to work: accepting to apply changes inside of a `.git` directory. This is required for `opam update` to function properly.

I've also observed some non-deterministic failures but it's harder to understand the reason why.

We have a couple of alternative solutions in mind, but given the critical aspect of those two issues we chose to revert it separately first to give us some more time to implement and choose a better solution. 