### PR TITLE
Replace every use of GNU Patch by the OCaml patch library

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -527,8 +527,8 @@ let main oc : unit =
     ("OPAM12CACHE", "~/.cache/opam1.2/cache");
     (* These should be identical to the values in appveyor.yml *)
     ("OPAM_REPO", "https://github.com/ocaml/opam-repository.git");
-    ("OPAM_TEST_REPO_SHA", "67e940587b8aca227f511e1943bcd31eabe6b1db");
-    ("OPAM_REPO_SHA", "67e940587b8aca227f511e1943bcd31eabe6b1db");
+    ("OPAM_TEST_REPO_SHA", "0c42e982f4cf97fc698132fb2a16b49524a26ab3");
+    ("OPAM_REPO_SHA", "0c42e982f4cf97fc698132fb2a16b49524a26ab3");
     ("SOLVER", "");
     (* Cygwin configuration *)
     ("CYGWIN_MIRROR", "http://mirrors.kernel.org/sourceware/cygwin/");

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,8 @@ env:
   OPAMBSROOT: ~/.cache/.opam.cached
   OPAM12CACHE: ~/.cache/opam1.2/cache
   OPAM_REPO: https://github.com/ocaml/opam-repository.git
-  OPAM_TEST_REPO_SHA: 67e940587b8aca227f511e1943bcd31eabe6b1db
-  OPAM_REPO_SHA: 67e940587b8aca227f511e1943bcd31eabe6b1db
+  OPAM_TEST_REPO_SHA: 0c42e982f4cf97fc698132fb2a16b49524a26ab3
+  OPAM_REPO_SHA: 0c42e982f4cf97fc698132fb2a16b49524a26ab3
   SOLVER:
   CYGWIN_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
   CYGWIN_ROOT: D:\cygwin

--- a/configure
+++ b/configure
@@ -622,6 +622,7 @@ ac_ct_CXX
 CXXFLAGS
 CXX
 OCAML_PKG_mccs
+OCAML_PKG_patch
 OCAML_PKG_swhid_core
 OCAML_PKG_sha
 OCAML_PKG_uutf
@@ -6521,6 +6522,30 @@ printf "%s\n" "not found" >&6; }
 
 
 
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for OCaml findlib package patch" >&5
+printf %s "checking for OCaml findlib package patch... " >&6; }
+
+  unset found
+  unset pkg
+  found=no
+  for pkg in patch  ; do
+    if $OCAMLFIND query $pkg >/dev/null 2>/dev/null; then
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found" >&5
+printf "%s\n" "found" >&6; }
+      OCAML_PKG_patch=$pkg
+      found=yes
+      break
+    fi
+  done
+  if test "$found" = "no" ; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: not found" >&5
+printf "%s\n" "not found" >&6; }
+    OCAML_PKG_patch=no
+  fi
+
+
+
+
 # Optional dependencies
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for OCaml findlib package mccs 1.1+17 or later" >&5
@@ -7047,6 +7072,7 @@ if test "x${enable_checks}" != "xno" && {
        test "x$OCAML_PKG_uutf" = "xno" ||
        test "x$OCAML_PKG_sha" = "xno" ||
        test "x$OCAML_PKG_swhid_core" = "xno" ||
+       test "x$OCAML_PKG_patch" = "xno" ||
        test "x$OCAML_PKG_mccs$MCCS_ENABLED" = "xnotrue";}
 then :
 

--- a/configure.ac
+++ b/configure.ac
@@ -366,6 +366,7 @@ AC_CHECK_OCAML_PKG([jsonm])
 AC_CHECK_OCAML_PKG([uutf])
 AC_CHECK_OCAML_PKG([sha])
 AC_CHECK_OCAML_PKG([swhid_core])
+AC_CHECK_OCAML_PKG([patch])
 
 # Optional dependencies
 AC_CHECK_OCAML_PKG_AT_LEAST([mccs],[1.1+17])
@@ -414,6 +415,7 @@ AS_IF([test "x${enable_checks}" != "xno" && {
        test "x$OCAML_PKG_uutf" = "xno" ||
        test "x$OCAML_PKG_sha" = "xno" ||
        test "x$OCAML_PKG_swhid_core" = "xno" ||
+       test "x$OCAML_PKG_patch" = "xno" ||
        test "x$OCAML_PKG_mccs$MCCS_ENABLED" = "xnotrue";}],[
   AS_IF([test "x${with_vendored_deps}" != "xyes"],[
     AC_MSG_ERROR([Dependencies missing. Use --with-vendored-deps or --disable-checks])

--- a/master_changes.md
+++ b/master_changes.md
@@ -174,6 +174,7 @@ users)
 ## Internal: Windows
 
 ## Test
+  * Add a library test for the new OCaml implementation of patch and diff [#5892 @rjbou]
 
 ## Benchmarks
   * Add benchmarks for `opam show` [#6212 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -68,7 +68,7 @@ users)
   * [BUG] Do not show the not-up-to-date message with packages tagged with avoid-version [#6273 @kit-ty-kate - fix #6271]
   * [BUG] Fix a regression on `opam upgrade <package>` upgrading unrelated packages [#6373 @AltGr]
   * [BUG] Fix a regression on `opam upgrade --all <uninstalled-pkg>` not upgrading the whole switch [#6373 @kit-ty-kate]
-  * Updates are now applied using the `patch` OCaml library instead of the system GNU Patch [#5892 @kit-ty-kate - fix ocaml/setup-ocaml#933 #6052]
+  * Updates are now applied using the `patch` OCaml library instead of the system GNU Patch and diff utilities [#5892 @kit-ty-kate - fix ocaml/setup-ocaml#933 #6052]
 
 ## Tree
 
@@ -87,6 +87,7 @@ users)
   * Update SWH API request [#6036 @rjbou]
   * Rework SWH fallback to have a more correct archive retrieval and more fine grained error handling [#6036 @rjbou - fix #5721]
   * Check that the repositories given to `opam repository remove` actually exist [#5014 @kit-ty-kate - fixes #5012]
+  * ✘ Symlinks in repositories are no longer supported [#5892 @kit-ty-kate]
 
 ## Lock
   * [BUG] Fix `pin-depends` for `with-*` dependencies [#5471 @rjbou - fix #5428]
@@ -104,7 +105,7 @@ users)
   * Lookup at `gpatch` before `patch` on macOS now that both homebrew and macports expose `gpatch` as `gpatch` since Homebrew/homebrew-core#174687 [#6255 @kit-ty-kate]
   * Relax lookup on OpenBSD to consider all installed packages [#6362 @semarie]
   * Speedup the detection of available system packages with pacman and brew [#6324 @kit-ty-kate]
-  * The system GNU Patch is no longer runtime dependency of opam [#5892 @kit-ty-kate - fix #6052]
+  * The system GNU Patch and diff are no longer runtime dependencies of opam [#5892 @kit-ty-kate - fix #6052]
 
 ## Format upgrade
 
@@ -245,6 +246,8 @@ users)
   * `OpamDownload.download`: more fine grained HTTP request error code detection for curl [#6036 @rjbou]
   * `OpamRepository.revision`: now returns a `string` instead of a `version` [#6409 @kit-ty-kate]
   * `OpamRepositoryBackend.S.revision`: now returns a `string` instead of a `version` [#6409 @kit-ty-kate]
+  * `OpamRepositoryBackend.get_diff`: now returns `exn option` instead of `exn option OpamProcess.job` and no longer calls the system `diff` utility [#5892 @kit-ty-kate]
+  * `OpamRepositoryBackend.get_diff`: now raises `Stdlib.Failure` if an unsupported file type or comparison is detected [#5892 @kit-ty-kate]
 
 ## opam-state
   * `OpamStateConfig`: Make the `?lock_kind` parameters non-optional to avoid breaking the library users after they upgrade their opam root [#5488 @kit-ty-kate]
@@ -272,6 +275,7 @@ users)
   * `OpamStd.Sys.get_freebsd_version`: was added, which returns the output of the `uname -U` command [#6217 @kit-ty-kate]
   * `OpamStubs.get_stdout_ws_col`: new Unix-only function returning the number of columns of the current terminal window [#6244 @kit-ty-kate]
   * `OpamSystem`: add `is_archive_from_string` that does the same than `is_archive` but without looking at the file, only analysing the string (extension) [#6219 @rjbou]
+  * `OpamSystem.get_files`: was exposed which returns the list of files (without prefix) inside the given directory [#5892 @kit-ty-kate]
   * `OpamSystem.remove_dir`: do not fail with an exception when directory is a symbolic link [#6276 @btjorge @rjbou - fix #6275]
   * `OpamSystem.patch`: now returns `exn option` instead of `exn option OpamProcess.job` and no longer calls the system GNU Patch [#5892 @kit-ty-kate]
   * `OpamSystem.patch`: a named-parameter `~allow_unclean` was added [#5892 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -275,5 +275,6 @@ users)
   * `OpamSystem.remove_dir`: do not fail with an exception when directory is a symbolic link [#6276 @btjorge @rjbou - fix #6275]
   * `OpamSystem.patch`: now returns `exn option` instead of `exn option OpamProcess.job` and no longer calls the system GNU Patch [#5892 @kit-ty-kate]
   * `OpamSystem.patch`: a named-parameter `~allow_unclean` was added [#5892 @kit-ty-kate]
+  * `OpamSystem.patch`: do not remove the original patch file if called with `~preprocess:false` [#5892 @kit-ty-kate]
   * `OpamParallel.*.{map,reduce,iter}`: Run `Gc.compact` when the main process is waiting for the children processes for the first time [#5396 @kkeundotnet]
   * `OpamSystem`, `OpamFilename`: add `with_tmp_file` and `with_tmp_file_job` function, that create a file name in temporary directory and removes it at the end of the call [#6036 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -29,6 +29,9 @@ users)
 ## Install
 
 ## Build (package)
+  * Patches are now applied using the `patch` OCaml library instead of GNU Patch [#5892 @kit-ty-kate - fix #6019 #6052]
+  * ✘ Patches: Context diffs are not supported anymore, only Unified diffs are (including its git extensions) [#5892 @kit-ty-kate]
+  * ✘ Patches: Stop support of file permission changes via git extension to the unified diff specification [#5892 @kit-ty-kate - fix #3782]
 
 ## Remove
 
@@ -65,6 +68,7 @@ users)
   * [BUG] Do not show the not-up-to-date message with packages tagged with avoid-version [#6273 @kit-ty-kate - fix #6271]
   * [BUG] Fix a regression on `opam upgrade <package>` upgrading unrelated packages [#6373 @AltGr]
   * [BUG] Fix a regression on `opam upgrade --all <uninstalled-pkg>` not upgrading the whole switch [#6373 @kit-ty-kate]
+  * Updates are now applied using the `patch` OCaml library instead of the system GNU Patch [#5892 @kit-ty-kate - fix ocaml/setup-ocaml#933 #6052]
 
 ## Tree
 
@@ -100,6 +104,7 @@ users)
   * Lookup at `gpatch` before `patch` on macOS now that both homebrew and macports expose `gpatch` as `gpatch` since Homebrew/homebrew-core#174687 [#6255 @kit-ty-kate]
   * Relax lookup on OpenBSD to consider all installed packages [#6362 @semarie]
   * Speedup the detection of available system packages with pacman and brew [#6324 @kit-ty-kate]
+  * The system GNU Patch is no longer runtime dependency of opam [#5892 @kit-ty-kate - fix #6052]
 
 ## Format upgrade
 
@@ -226,6 +231,7 @@ users)
 
 # API updates
 ## opam-client
+  * `OpamAction.prepare_package_build`: now returns `exn option` instead of `exn option OpamProcess.job` and no longer calls the system GNU Patch [#5892 @kit-ty-kate]
   * `OpamArg.InvalidCLI`: export exception [#6150 @rjbou]
   * `OpamArg`: export `require_checksums` and `no_checksums`, that are shared with `build_options` [#5563 @rjbou]
   * `OpamArg.hash_kinds`: was added [#5960 @kit-ty-kate]
@@ -254,6 +260,8 @@ users)
 ## opam-core
   * `OpamConsole`: Replace `black` text style (unused and not very readable) by `gray` [#6358 @kit-ty-kate]
   * `OpamConsole.pause`: Ensure the function always prints a newline character at the end [#6376 @kit-ty-kate]
+  * `OpamFilename.patch`: now returns `exn option` instead of `exn option OpamProcess.job` and no longer calls the system GNU Patch [#5892 @kit-ty-kate]
+  * `OpamFilename.patch`: a named-parameter `~allow_unclean` was added [#5892 @kit-ty-kate]
   * `OpamHash.all_kinds`: was added, which returns the list of all possible values of `OpamHash.kind` [#5960 @kit-ty-kate]
   * `OpamStd.List.split`: Improve performance [#6210 @kit-ty-kate]
   * `OpamStd.Option.equal_some`: was added, which tests equality of an option with a value [#6381 @kit-ty-kate]
@@ -265,5 +273,7 @@ users)
   * `OpamStubs.get_stdout_ws_col`: new Unix-only function returning the number of columns of the current terminal window [#6244 @kit-ty-kate]
   * `OpamSystem`: add `is_archive_from_string` that does the same than `is_archive` but without looking at the file, only analysing the string (extension) [#6219 @rjbou]
   * `OpamSystem.remove_dir`: do not fail with an exception when directory is a symbolic link [#6276 @btjorge @rjbou - fix #6275]
+  * `OpamSystem.patch`: now returns `exn option` instead of `exn option OpamProcess.job` and no longer calls the system GNU Patch [#5892 @kit-ty-kate]
+  * `OpamSystem.patch`: a named-parameter `~allow_unclean` was added [#5892 @kit-ty-kate]
   * `OpamParallel.*.{map,reduce,iter}`: Run `Gc.compact` when the main process is waiting for the children processes for the first time [#5396 @kkeundotnet]
   * `OpamSystem`, `OpamFilename`: add `with_tmp_file` and `with_tmp_file_job` function, that create a file name in temporary directory and removes it at the end of the call [#6036 @rjbou]

--- a/opam-core.opam
+++ b/opam-core.opam
@@ -30,6 +30,7 @@ depends: [
   "sha" {>= "1.13"}
   "jsonm"
   "swhid_core"
+  "patch" {>= "3.0.0~alpha1"}
   "uutf"
   (("host-system-mingw" {os = "win32" & os-distribution != "cygwinports"} &
     "conf-mingw-w64-gcc-i686" {os = "win32" & os-distribution != "cygwinports"} &

--- a/opam-repository.opam
+++ b/opam-repository.opam
@@ -30,5 +30,6 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
+  "patch" {>= "3.0.0~alpha1"}
   "dune" {>= "2.8.0"}
 ]

--- a/src/client/opamAction.mli
+++ b/src/client/opamAction.mli
@@ -40,7 +40,7 @@ val prepare_package_source:
     of `prepare_package_source`, without requiring a switch and
     without handling extra downloads. *)
 val prepare_package_build:
-  OpamFilter.env -> OpamFile.OPAM.t -> package -> dirname -> exn option OpamProcess.job
+  OpamFilter.env -> OpamFile.OPAM.t -> package -> dirname -> exn option
 
 (** [build_package t build_dir pkg] builds the package [pkg] within [build_dir].
     Returns [None] on success, [Some exn] on error.

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -126,7 +126,6 @@ let recommended_tools () =
 let required_tools ~sandboxing () =
   req_dl_tools () @
   [
-    ["diff"], None, None;
     ["tar"], None, Some tar_filter;
     ["gtar"], None, Some gtar_filter;
     ["unzip"], None, None;
@@ -139,7 +138,6 @@ let required_tools ~sandboxing () =
 
 let required_packages_for_cygwin =
   [
-    "diffutils";
     "make";
     "tar";
     "unzip";

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -52,11 +52,6 @@ let not_win32_filter =
   FOp (FIdent ([], OpamVariable.of_string "os", None), `Neq, FString "win32")
 let sandbox_filter = FOr (linux_filter, macos_filter)
 
-let gpatch_filter =
-  FOr (FOr (openbsd_filter, netbsd_filter),
-       FOr (freebsd_filter, FOr (dragonflybsd_filter, macos_filter)))
-let patch_filter = FNot gpatch_filter
-
 let gtar_filter = openbsd_filter
 let tar_filter = FNot gtar_filter
 
@@ -132,8 +127,6 @@ let required_tools ~sandboxing () =
   req_dl_tools () @
   [
     ["diff"], None, None;
-    ["patch"], None, Some patch_filter;
-    ["gpatch"], None, Some gpatch_filter;
     ["tar"], None, Some tar_filter;
     ["gtar"], None, Some gtar_filter;
     ["unzip"], None, None;
@@ -148,7 +141,6 @@ let required_packages_for_cygwin =
   [
     "diffutils";
     "make";
-    "patch";
     "tar";
     "unzip";
     "rsync";

--- a/src/core/dune
+++ b/src/core/dune
@@ -3,7 +3,7 @@
   (public_name opam-core)
   (synopsis    "OCaml Package Manager core internal stdlib")
   ; TODO: Remove (re_export ...) when CI uses the OCaml version that includes https://github.com/ocaml/ocaml/pull/11989
-  (libraries   re (re_export ocamlgraph) unix sha jsonm swhid_core uutf)
+  (libraries   re (re_export ocamlgraph) unix sha jsonm swhid_core uutf patch)
   (flags       (:standard
                (:include ../ocaml-flags-standard.sexp)
                (:include ../ocaml-flags-configure.sexp)

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -445,8 +445,9 @@ let link ?(relative=false) ~target ~link =
   OpamSystem.link target (to_string link)
 [@@ocaml.warning "-16"]
 
-let patch ?preprocess filename dirname =
-  OpamSystem.patch ?preprocess ~dir:(Dir.to_string dirname) (to_string filename)
+let patch ?preprocess ~allow_unclean filename dirname =
+  OpamSystem.patch ?preprocess ~allow_unclean ~dir:(Dir.to_string dirname)
+    (to_string filename)
 
 let flock flag ?dontblock file = OpamSystem.flock flag ?dontblock (to_string file)
 

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -271,8 +271,12 @@ val remove_prefix_dir: Dir.t -> Dir.t -> string
 val remove_suffix: Base.t -> t -> string
 
 (** Apply a patch in a directory. If [preprocess] is set to false, there is no
-    CRLF translation. Returns [None] on success, the process error otherwise *)
-val patch: ?preprocess:bool -> t -> Dir.t -> exn option OpamProcess.job
+    CRLF translation. Returns [None] on success, the process error otherwise.
+
+    @param allow_unclean decides if applying a patch on a directory which
+    differs slightly from the one described in the patch file is allowed.
+    Allowing unclean applications imitates the default behaviour of GNU Patch. *)
+val patch: ?preprocess:bool -> allow_unclean:bool -> t -> Dir.t -> exn option
 
 (** Create an empty file *)
 val touch: t -> unit

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -1670,7 +1670,7 @@ let patch ?(preprocess=true) ~allow_unclean ~dir p =
   try
     let diffs = Patch.parse ~p:1 content in
     internal_patch ~allow_unclean ~patch_filename:p ~dir diffs;
-    if not (OpamConsole.debug ()) then Sys.remove p';
+    if preprocess && not (OpamConsole.debug ()) then Sys.remove p';
     None
   with exn -> Some exn
 

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -1588,41 +1588,73 @@ let translate_patch ~dir orig corrected =
   end;
   close_in ch
 
-let gpatch = lazy begin
-  let rec search_gpatch = function
-    | [] -> None
-    | patch_cmd::patch_cmds ->
-      match OpamProcess.run (make_command ~name:"patch" patch_cmd ["--version"]) with
-      | r ->
-        (match OpamProcess.is_success r, r.OpamProcess.r_stdout with
-         | true, full::_ when
-             OpamStd.String.is_prefix_of ~from:0 ~full "GNU patch " ->
-           Some patch_cmd
-         | _ ->
-           search_gpatch patch_cmds)
-      | exception _ -> search_gpatch patch_cmds
-  in
-  let default_cmd, other_cmds =
-    match OpamStd.Sys.os () with
-    | Darwin
-    | DragonFly
-    | FreeBSD
-    | NetBSD
-    | OpenBSD -> ("gpatch", ["patch"])
-    | Cygwin
-    | Linux
-    | Unix
-    | Win32
-    | Other _ -> ("patch", ["gpatch"])
-  in
-  match search_gpatch (default_cmd :: other_cmds) with
-  | Some gpatch -> gpatch
-  | None ->
-    OpamConsole.warning "Invalid patch utility. Please install GNU patch";
-    default_cmd
-end
+exception Internal_patch_error of string
 
-let patch ?(preprocess=true) ~dir p =
+let internal_patch ~allow_unclean ~patch_filename ~dir diffs =
+  let internal_patch_error fmt =
+    Printf.ksprintf (fun str -> raise (Internal_patch_error str)) fmt
+  in
+  (* NOTE: It is important to keep this `concat dir ""` to ensure the
+     is_prefix_of below doesn't match another similarly named directory *)
+  let dir = Filename.concat (real_path dir) "" in
+  let get_path file =
+    let file = real_path (Filename.concat dir file) in
+    if not (OpamStd.String.is_prefix_of ~from:0 ~full:file dir) then
+      internal_patch_error "Patch %S tried to escape its scope."
+        patch_filename;
+    file
+  in
+  let patch ~file content diff =
+    (* NOTE: The None case returned by [Patch.patch] is only returned
+       if [diff = Patch.Delete _]. This sub-function is not called in
+       this case so we [assert false] instead. *)
+    match Patch.patch ~cleanly:true content diff with
+    | Some x -> x
+    | None -> assert false (* See NOTE above *)
+    | exception _ when not allow_unclean ->
+      internal_patch_error "Patch %S does not apply cleanly."
+        patch_filename
+    | exception _ ->
+      match Patch.patch ~cleanly:false content diff with
+      | Some x ->
+        OpamStd.Option.iter (write (file^".orig")) content;
+        x
+      | None -> assert false (* See NOTE above *)
+      | exception _ ->
+        OpamStd.Option.iter (write (file^".orig")) content;
+        write (file^".rej") (Format.asprintf "%a" Patch.pp diff);
+        internal_patch_error "Patch %S does not apply cleanly."
+          patch_filename
+  in
+  let apply diff = match diff.Patch.operation with
+    | Patch.Edit (file1, file2) ->
+      (* That seems to be the GNU patch behaviour *)
+      let file =
+        let file1 = get_path file1 in
+        if Sys.file_exists file1 then
+          file1
+        else
+          get_path file2
+      in
+      let content = read file in
+      let content = patch ~file:file (Some content) diff in
+      write file content;
+    | Patch.Delete file ->
+      let file = get_path file in
+      remove_file_t ~with_log:false file
+    | Patch.Create file ->
+      let file = get_path file in
+      let content = patch ~file None diff in
+      write file content
+    | Patch.Rename_only (src, dst) ->
+      let src = get_path src in
+      let dst = get_path dst in
+      (* we use rename as we have all guarantee *)
+      Unix.rename src dst
+  in
+  List.iter apply diffs
+
+let patch ?(preprocess=true) ~allow_unclean ~dir p =
   if not (Sys.file_exists p) then
     (OpamConsole.error "Patch file %S not found." p;
      raise Not_found);
@@ -1634,11 +1666,13 @@ let patch ?(preprocess=true) ~dir p =
     else
       p
   in
-  let patch_cmd = Lazy.force gpatch in
-  make_command ~name:"patch" ~dir patch_cmd ["-p1"; "-i"; p'] @@> fun r ->
+  let content = read p' in
+  try
+    let diffs = Patch.parse ~p:1 content in
+    internal_patch ~allow_unclean ~patch_filename:p ~dir diffs;
     if not (OpamConsole.debug ()) then Sys.remove p';
-    if OpamProcess.is_success r then Done None
-    else Done (Some (Process_error r))
+    None
+  with exn -> Some exn
 
 let register_printer () =
   Printexc.register_printer (function

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -327,8 +327,12 @@ val get_lock_fd: lock -> Unix.file_descr
 
 (** Apply a patch file in the current directory. If [preprocess] is set to
     false, there is no CRLF translation. Returns the error if the patch didn't
-    apply. *)
-val patch: ?preprocess:bool -> dir:string -> string -> exn option OpamProcess.job
+    apply.
+
+    @param allow_unclean decides if applying a patch on a directory which
+    differs slightly from the one described in the patch file is allowed.
+    Allowing unclean applications imitates the default behaviour of GNU Patch. *)
+val patch: ?preprocess:bool -> allow_unclean:bool -> dir:string -> string -> exn option
 
 (** Returns the end-of-line encoding style for the given file. [None] means that
     either the encoding of line endings is mixed, or the file contains no line

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -125,6 +125,10 @@ val read: string -> string
     advisory write lock to prevent concurrent reads or writes) *)
 val write: string -> string -> unit
 
+(** [get_files dir] returns the list of files (without prefix) inside the
+    directory [dir]. *)
+val get_files : string -> string list
+
 (** [remove filename] removes [filename]. Works whether [filename] is
     a file or a directory *)
 val remove: string -> unit

--- a/src/repository/dune
+++ b/src/repository/dune
@@ -3,7 +3,7 @@
   (public_name opam-repository)
   (synopsis    "OCaml Package Manager remote repository handling library")
   ; TODO: Remove (re_export ...) when CI uses the OCaml version that includes https://github.com/ocaml/ocaml/pull/11989
-  (libraries   (re_export opam-format))
+  (libraries   (re_export opam-format) patch)
   (flags       (:standard
                (:include ../ocaml-flags-standard.sexp)
                (:include ../ocaml-flags-configure.sexp)

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -56,15 +56,14 @@ module B = struct
        OpamFilename.dir_is_empty repo_root then
       Done (OpamRepositoryBackend.Update_full quarantine)
     else
-      OpamProcess.Job.finally finalise @@ fun () ->
-      OpamRepositoryBackend.job_text repo_name "diff"
-        (OpamRepositoryBackend.get_diff
-           (OpamFilename.dirname_dir repo_root)
-           (OpamFilename.basename_dir repo_root)
-           (OpamFilename.basename_dir quarantine))
-      @@| function
-      | None -> OpamRepositoryBackend.Update_empty
-      | Some patch -> OpamRepositoryBackend.Update_patch patch
+      OpamStd.Exn.finally finalise @@ fun () ->
+      OpamRepositoryBackend.get_diff
+        (OpamFilename.dirname_dir repo_root)
+        (OpamFilename.basename_dir repo_root)
+        (OpamFilename.basename_dir quarantine)
+      |> function
+      | None -> Done OpamRepositoryBackend.Update_empty
+      | Some patch -> Done (OpamRepositoryBackend.Update_patch patch)
 
   let repo_update_complete _ _ = Done ()
 

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -178,15 +178,14 @@ module B = struct
          OpamFilename.dir_is_empty repo_root then
         Done (OpamRepositoryBackend.Update_full quarantine)
       else
-        OpamProcess.Job.finally finalise @@ fun () ->
-        OpamRepositoryBackend.job_text repo_name "diff" @@
+        OpamStd.Exn.finally finalise @@ fun () ->
         OpamRepositoryBackend.get_diff
           (OpamFilename.dirname_dir repo_root)
           (OpamFilename.basename_dir repo_root)
           (OpamFilename.basename_dir quarantine)
-        @@| function
-        | None -> OpamRepositoryBackend.Update_empty
-        | Some p -> OpamRepositoryBackend.Update_patch p
+        |> function
+        | None -> Done OpamRepositoryBackend.Update_empty
+        | Some p -> Done (OpamRepositoryBackend.Update_patch p)
 
   let repo_update_complete _ _ = Done ()
 

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -538,11 +538,11 @@ let apply_repo_update repo repo_root = function
       | `http | `rsync -> false
       | _ -> true
     in
-    (OpamFilename.patch ~preprocess f repo_root @@+ function
-      | Some e ->
-        if not (OpamConsole.debug ()) then OpamFilename.remove f;
-        raise e
-      | None -> OpamFilename.remove f; Done ())
+    (match OpamFilename.patch ~preprocess ~allow_unclean:false f repo_root with
+     | Some e ->
+       if not (OpamConsole.debug ()) then OpamFilename.remove f;
+       raise e
+     | None -> OpamFilename.remove f; Done ())
   | Update_empty ->
     OpamConsole.msg "[%s] no changes from %s\n"
       (OpamConsole.colorise `green

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -111,8 +111,9 @@ val job_text:
     subdirs of [parent_dir], returns None if they are equal, and the
     corresponding patch otherwise.
 
-    Note: this relies on the [diff -ruN] command, a built-in diff may be more
-    portable -- in particular, [-u], [-N] are not POSIX, and recursive diffs
-    might not be completely reliable. It also assumes text files only, and fails
-    otherwise. *)
-val get_diff: dirname -> basename -> basename -> filename option OpamProcess.job
+    @raise Stdlib.Failure if an unsupported file type or comparison is
+    detected in any of [subdir1] or [subdir2].
+    Unsupported file types: symlinks, character devices, block devices,
+    named pipes, sockets.
+    Unsupported comparison: comparison between regular files and directories. *)
+val get_diff: dirname -> basename -> basename -> filename option

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -22,7 +22,10 @@ ifndef FETCH
   endif
 endif
 
-SRC_EXTS = cppo base64 extlib re cmdliner ocamlgraph cudf dose3 opam-file-format seq stdlib-shims spdx_licenses opam-0install-cudf 0install-solver uutf jsonm sha swhid_core menhir
+SRC_EXTS = \
+  cppo base64 extlib re cmdliner ocamlgraph cudf dose3 opam-file-format seq \
+  stdlib-shims spdx_licenses opam-0install-cudf 0install-solver uutf \
+  jsonm sha swhid_core menhir patch
 
 ifeq ($(MCCS_ENABLED),true)
 SRC_EXTS := $(SRC_EXTS) mccs

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -59,3 +59,6 @@ MD5_swhid_core = 77d88d4b1d96261c866f140c64d89af8
 
 URL_menhir = https://gitlab.inria.fr/fpottier/menhir/-/archive/20240715/archive.tar.gz
 MD5_menhir = d39a8943fe1be28199e5ec1f4133504c
+
+URL_patch = https://github.com/hannesm/patch/releases/download/v3.0.0-alpha1/patch-3.0.0-alpha1.tar.gz
+MD5_patch = 03aa87f8500c9caf4a73b2299c19b514

--- a/tests/lib/dune
+++ b/tests/lib/dune
@@ -8,3 +8,8 @@
   (libraries opam-format)
   (modules TypeGymnastics)
   (action (run %{test})))
+
+(test
+  (name patchDiff)
+  (modules patchDiff)
+  (libraries opam-repository))

--- a/tests/lib/patchDiff.expected
+++ b/tests/lib/patchDiff.expected
@@ -1,0 +1,339 @@
+
+----------------------
+ Test 1: normal
+----------------------
+
+*** SETUP ***
++ first/
++ first/diff-dir-plus-fst
++ first/diff-dir-plus-fst/fst
+  > foo
++ first/diff-dir-plus-snd
++ first/diff-dir-plus-snd/fst
+  > foo
+  > bar
++ first/diff-file
+  > foo
++ first/diff-file-plus-fst
+  > foo
+  > bar
++ first/diff-file-plus-snd
+  > foo
++ first/dir-only-fst
++ first/dir-only-fst/fst
+  > foo
++ first/file-only-fst
+  > foo
++ first/same-file
+  > foo
++ second/
++ second/diff-dir-plus-fst
++ second/diff-dir-plus-fst/fst
+  > foo
+  > bar
++ second/diff-dir-plus-snd
++ second/diff-dir-plus-snd/fst
+  > foo
++ second/diff-file
+  > bar
++ second/diff-file-plus-fst
+  > foo
++ second/diff-file-plus-snd
+  > foo
+  > bar
++ second/file-only-snd
+  > foo
++ second/same-file
+  > foo
+
+*** DIFF ***
+--- first/diff-dir-plus-fst/fst
++++ second/diff-dir-plus-fst/fst
+@@ -2,0 +2,1 @@
++bar
+--- first/diff-dir-plus-snd/fst
++++ second/diff-dir-plus-snd/fst
+@@ -2,1 +2,0 @@
+-bar
+--- first/diff-file
++++ second/diff-file
+@@ -1,1 +1,1 @@
+-foo
++bar
+--- first/diff-file-plus-fst
++++ second/diff-file-plus-fst
+@@ -2,1 +2,0 @@
+-bar
+--- first/diff-file-plus-snd
++++ second/diff-file-plus-snd
+@@ -2,0 +2,1 @@
++bar
+--- first/dir-only-fst/fst
++++ /dev/null
+@@ -1,1 +0,0 @@
+-foo
+--- first/file-only-fst
++++ /dev/null
+@@ -1,1 +0,0 @@
+-foo
+--- /dev/null
++++ second/file-only-snd
+@@ -0,0 +1,1 @@
++foo
+
+*** PATCHED ***
++ first/
++ first/diff-dir-plus-fst
++ first/diff-dir-plus-fst/fst
+  > foo
+  > bar
++ first/diff-dir-plus-snd
++ first/diff-dir-plus-snd/fst
+  > foo
++ first/diff-file
+  > bar
++ first/diff-file-plus-fst
+  > foo
++ first/diff-file-plus-snd
+  > foo
+  > bar
++ first/dir-only-fst
++ first/file-only-snd
+  > foo
++ first/same-file
+  > foo
++ second/
++ second/diff-dir-plus-fst
++ second/diff-dir-plus-fst/fst
+  > foo
+  > bar
++ second/diff-dir-plus-snd
++ second/diff-dir-plus-snd/fst
+  > foo
++ second/diff-file
+  > bar
++ second/diff-file-plus-fst
+  > foo
++ second/diff-file-plus-snd
+  > foo
+  > bar
++ second/file-only-snd
+  > foo
++ second/same-file
+  > foo
+
+
+----------------------
+ Test 2: diff file/dir error
+----------------------
+
+*** SETUP ***
++ first/
++ first/file-fst-dir-snd
+  > foo
++ first/same-file
+  > foo
++ second/
++ second/file-fst-dir-snd
++ second/file-fst-dir-snd/fst
+  > foo
++ second/same-file
+  > foo
+
+*** DIFF ***
+ERROR: Change from a regular file to a directory is unsupported
+
+----------------------
+ Test 3: diff dir/file error
+----------------------
+
+*** SETUP ***
++ first/
++ first/dir-fst-file-snd
++ first/dir-fst-file-snd/fst
+  > foo
++ first/same-file
+  > foo
++ second/
++ second/dir-fst-file-snd
+  > foo
++ second/same-file
+  > foo
+
+*** DIFF ***
+ERROR: Change from a directory to a regular file is unsupported
+
+----------------------
+ Test 4: symlink fst
+----------------------
+
+*** SETUP ***
++ first/
++ first/linked-file-fst
+  > bar
++ first/same-file
+  > foo
++ second/
++ second/linked-file-fst
+  > foo
++ second/same-file
+  > foo
+
+*** DIFF ***
+ERROR: Symlinks are unsupported
+
+----------------------
+ Test 5: symlink snd
+----------------------
+
+*** SETUP ***
++ first/
++ first/linked-file-snd
+  > foo
++ first/same-file
+  > foo
++ second/
++ second/linked-file-snd
+  > bar
++ second/same-file
+  > foo
+
+*** DIFF ***
+ERROR: Symlinks are unsupported
+
+----------------------
+ Test 6: hardlink fst
+----------------------
+
+*** SETUP ***
++ first/
++ first/hardlinked-file-fst
+  > bar
++ first/same-file
+  > foo
++ second/
++ second/hardlinked-file-fst
+  > foo
++ second/same-file
+  > foo
+
+*** DIFF ***
+--- first/hardlinked-file-fst
++++ second/hardlinked-file-fst
+@@ -1,1 +1,1 @@
+-bar
++foo
+
+*** PATCHED ***
++ first/
++ first/hardlinked-file-fst
+  > foo
++ first/same-file
+  > foo
++ second/
++ second/hardlinked-file-fst
+  > foo
++ second/same-file
+  > foo
+
+
+----------------------
+ Test 7: hardlink snd
+----------------------
+
+*** SETUP ***
++ first/
++ first/hardlinked-file-snd
+  > foo
++ first/same-file
+  > foo
++ second/
++ second/hardlinked-file-snd
+  > foo
++ second/same-file
+  > foo
+
+*** DIFF ***
+No diff
+
+----------------------
+ Test 8: patch error garbage
+----------------------
+
+*** SETUP ***
++ first/
++ first/diff-file
+  > foo
++ first/same-file
+  > foo
++ second/
++ second/diff-file
+  > bar
++ second/same-file
+  > foo
+
+*** GIVEN DIFF ***
+something in
+the file
+that is not
+patch format
+
+*** PATCHED ***
++ first/
++ first/diff-file
+  > foo
++ first/same-file
+  > foo
++ second/
++ second/diff-file
+  > bar
++ second/same-file
+  > foo
+
+
+----------------------
+ Test 9: patch truncated
+----------------------
+
+*** SETUP ***
++ first/
++ first/diff-file
+  > foo
++ first/diff-file-plus-fst
+  > foo
+  > bar
++ first/same-file
+  > foo
++ second/
++ second/diff-file
+  > bar
++ second/diff-file-plus-fst
+  > foo
++ second/same-file
+  > foo
+
+*** GIVEN DIFF ***
+--- first/diff-file
++++ second/diff-file
+@@ -1,1 +1,1 @@
+-foo
++bar
+--- first/diff-fi
+
+*** PATCHED ***
++ first/
++ first/diff-file
+  > bar
++ first/diff-file-plus-fst
+  > foo
+  > bar
++ first/same-file
+  > foo
++ second/
++ second/diff-file
+  > bar
++ second/diff-file-plus-fst
+  > foo
++ second/same-file
+  > foo
+

--- a/tests/lib/patchDiff.ml
+++ b/tests/lib/patchDiff.ml
@@ -1,0 +1,312 @@
+type content =
+  | File of string (* file *)
+  | Dir of (string * string) list (* directory with list filename * content *)
+  | Symlink (* Soft Link *)
+  | Hardlink (* Hard link *)
+  | V (* void *)
+
+type arborescence = {
+  name: string;
+  first : content;
+  second : content;
+}
+
+(** Contents *)
+
+let foo = "foo\n"
+let bar = "bar\n"
+let foobar = "foo\nbar\n"
+let same_file = {
+  name = "same-file";
+  first = File foo;
+  second = File foo;
+}
+let diff_file = {
+  name = "diff-file";
+  first = File foo;
+  second = File bar;
+}
+let diff_file_plus_fst = {
+  name = "diff-file-plus-fst";
+  first = File foobar;
+  second = File foo;
+}
+let diff_file_plus_snd = {
+  name = "diff-file-plus-snd";
+  first = File foo;
+  second = File foobar;
+}
+
+let content_working_diff = [
+  same_file;
+  diff_file;
+  diff_file_plus_fst;
+  diff_file_plus_snd;
+  { name = "diff-file";
+    first = File foo;
+    second = File bar;
+  };
+  { name = "diff-file-plus-fst";
+    first = File foobar;
+    second = File foo;
+  };
+  { name = "diff-file-plus-snd";
+    first = File foo;
+    second = File foobar;
+  };
+  { name = "file-only-fst";
+    first = File foo;
+    second = V;
+  };
+  { name = "file-only-snd";
+    first = V;
+    second = File foo;
+  };
+  { name = "same-dir";
+    first = Dir [];
+    second = Dir [];
+  };
+  { name = "diff-dir-plus-fst";
+    first = Dir [ "fst", foo ];
+    second = Dir [ "fst", foobar ] ;
+  };
+  { name = "diff-dir-plus-snd";
+    first = Dir [ "fst", foobar ];
+    second = Dir [ "fst", foo ];
+  };
+  { name = "dir-only-fst";
+    first = Dir [ "fst", foo ];
+    second = V;
+  };
+]
+
+let content_dir_file = [
+  same_file;
+  { name = "file-fst-dir-snd";
+    first = File foo;
+    second = Dir [ "fst", foo];
+  };
+]
+
+let content_file_dir = [
+  same_file;
+  { name = "dir-fst-file-snd";
+    first = Dir [ "fst", foo ];
+    second = File foo;
+  };
+]
+
+let content_symlink_fst = [
+  same_file;
+  { name = "linked-file-fst";
+    first = Symlink;
+    second = File foo;
+  };
+]
+
+let content_symlink_snd = [
+  same_file;
+  { name = "linked-file-snd";
+    first = File foo;
+    second = Symlink;
+  };
+]
+
+let content_hardlink_fst = [
+  same_file;
+  { name = "hardlinked-file-fst";
+    first = Hardlink;
+    second = File foo;
+  };
+]
+
+let content_hardlink_snd = [
+  same_file;
+  { name = "hardlinked-file-snd";
+    first = File foo;
+    second = Hardlink;
+  };
+]
+
+
+let content_patch_failure_garbage = [
+  same_file;
+  diff_file;
+]
+let diff_patch_failure_garbage =
+  "something in\n" ^
+  "the file\n" ^
+  "that is not\n" ^
+  "patch format\n"
+
+let content_patch_failure_truncated = [
+  same_file;
+  diff_file;
+  diff_file_plus_fst;
+]
+let diff_patch_failure_truncated =
+  "--- first/diff-file\n" ^
+  "+++ second/diff-file\n" ^
+  "@@ -1,1 +1,1 @@\n" ^
+  "-foo\n" ^
+  "+bar\n" ^
+  "--- first/diff-fi\n"
+
+let _good_diff =
+  "\n" ^
+  "--- first/diff-file\n" ^
+  "+++ second/diff-file\n" ^
+  "@@ -1,1 +1,1 @@\n" ^
+  "-foo\n" ^
+  "+bar\n" ^
+  "--- first/diff-file-plus-fst\n" ^
+  "+++ second/diff-file-plus-fst\n" ^
+  "@@ -2,1 +2,0 @@\n" ^
+  "-bar\n"
+
+(** Utils *)
+
+let print = Printf.printf
+
+open OpamFilename.Op
+let read_dir root names =
+  let lst =
+    List.map (fun name ->
+        let dir = root / name in
+        (name^"/", []) ::
+        List.map (fun f ->
+            OpamFilename.remove_prefix root f,
+            OpamStd.String.split (OpamFilename.read f) '\n')
+          (OpamFilename.rec_files dir)
+        @
+        List.map (fun d -> OpamFilename.remove_prefix_dir root d, [])
+          (OpamFilename.rec_dirs dir))
+      names
+    |> List.flatten
+    |> List.map (fun (file, content) ->
+        (OpamSystem.back_to_forward file, content))
+  in
+
+  let lst = List.sort (fun (f,_) (f',_) -> String.compare f f') lst in
+  OpamStd.Format.itemize ~bullet:"+ "
+    (function
+      | d, [] -> d
+      | d, c ->
+        Printf.sprintf "%s\n%s"
+          d
+          (OpamStd.List.concat_map ~left:"" ~right:"" "\n"
+             (Printf.sprintf "> %s") c))
+    lst
+
+let first = "first"
+let second = "second"
+
+let write_setup dir content =
+  let first_root = dir / first in
+  let second_root = dir / second in
+  List.iter (fun d ->
+      OpamFilename.cleandir d;
+      OpamFilename.mkdir d)
+    [ first_root; second_root; ] ;
+  let link_f =
+    let link = lazy (
+      let f = dir // "linked_file" in
+      if not (OpamFilename.exists f) then
+        OpamFilename.write f bar;
+      f
+    ) in
+    fun () -> Lazy.force link
+  in
+  let create inner_dir name = function
+    | File content ->
+      OpamFilename.write (inner_dir // name) content
+    | Dir lst ->
+      let inner_dir = inner_dir / name in
+      List.iter (fun (n,c) -> OpamFilename.write (inner_dir // n) c) lst
+    | Symlink ->
+      OpamFilename.link ~relative:false ~target:(link_f ())
+        ~link:(inner_dir // name)
+    | Hardlink ->
+      let target = OpamFilename.to_string (link_f ()) in
+      let link = OpamFilename.to_string (inner_dir // name) in
+      Unix.link target link
+    | V -> ()
+  in
+  List.iter (fun {name; first; second} ->
+      create first_root name first;
+      create second_root name second)
+    content
+
+type diff_patch =
+  | DiffPatch
+  | Patch of string
+
+let print_dirs dir =
+  print "%s\n" (read_dir dir [ first; second ])
+
+let diff_patch dir content kind =
+  write_setup dir content;
+  print "*** SETUP ***\n";
+  print_dirs dir;
+  let diff =
+    match kind with
+    | Patch patch ->
+      print "*** GIVEN DIFF ***\n";
+      let fpatch = dir // "patch" in
+      OpamFilename.write fpatch patch;
+      Some fpatch
+    | DiffPatch ->
+      print "*** DIFF ***\n";
+      match
+        OpamRepositoryBackend.get_diff dir
+          (OpamFilename.Base.of_string first)
+          (OpamFilename.Base.of_string second)
+      with
+      | exception Failure s -> print "ERROR: %s\n" s; None
+      | None -> print "No diff\n"; None
+      | some -> some
+  in
+  match diff with
+  | None -> ()
+  | Some diff ->
+    print "%s\n" (OpamFilename.read diff);
+    let result =
+      OpamFilename.patch ~allow_unclean:false diff
+        (dir / first)
+    in
+    match result with
+    | None ->
+      print "*** PATCHED ***\n";
+      print_dirs dir
+    | Some exn ->
+      print "*** PATCH ERROR ***\n";
+      print "ERROR: %s\n" (Printexc.to_string exn)
+
+(** The tests *)
+
+let tests = [
+  "normal", content_working_diff, DiffPatch;
+  "diff file/dir error", content_dir_file, DiffPatch;
+  "diff dir/file error", content_file_dir, DiffPatch;
+  "symlink fst", content_symlink_fst, DiffPatch;
+  "symlink snd", content_symlink_snd, DiffPatch;
+  "hardlink fst", content_hardlink_fst, DiffPatch;
+  "hardlink snd", content_hardlink_snd, DiffPatch;
+  "patch error garbage", content_patch_failure_garbage,
+  Patch diff_patch_failure_garbage;
+  "patch truncated", content_patch_failure_truncated,
+  Patch diff_patch_failure_truncated;
+]
+
+let () =
+  (* This causes Windows to use LF endings instead of CRLF, which simplifies the comparison with the reference file *)
+  Unix.putenv "LC_ALL" "C";
+  set_binary_mode_out stdout true;
+  Unix.dup2 Unix.stdout Unix.stderr;
+  OpamFilename.with_tmp_dir @@ fun dir ->
+  List.iteri (fun i (label, content, kind) ->
+      print "\n----------------------\n";
+      print " Test %d: %s\n" (i+1) label;
+      print "----------------------\n\n";
+      diff_patch dir content kind)
+    tests

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -18,8 +18,7 @@ some content
 ### sh hash.sh REPO foo.1
 ### : Internal repository storage as archive or plain directory :
 ### opam switch create tarring --empty
-### opam update -vv | grep '^\+' | sed-cmd diff
-+ diff "-ruaN" "default" "default.new" (CWD=${BASEDIR}/OPAM/repo)
+### opam update -vv | grep '^\+'
 ### ls $OPAMROOT/repo | grep -v "cache"
 default
 lock
@@ -36,8 +35,7 @@ build: ["test" "-f" "baz"]
 ### <REPO/packages/foo/foo.2/files/baz>
 some content
 ### sh hash.sh REPO foo.2
-### opam update default -vv | grep '^\+' | sed-cmd tar | sed-cmd diff
-+ diff "-ruaN" "default" "default.new" (CWD=${BASEDIR}/OPAM/repo)
+### opam update default -vv | grep '^\+' | sed-cmd tar
 + tar "cfz" "${BASEDIR}/OPAM/repo/default.tar.gz.tmp" "-C" "${BASEDIR}/OPAM/repo" "default"
 ### ls $OPAMROOT/repo | grep -v "cache"
 default.tar.gz
@@ -74,9 +72,8 @@ build: ["test" "-f" "baz"]
 ### <REPO/packages/foo/foo.4/files/baz>
 some content
 ### sh hash.sh REPO foo.4
-### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff
+### opam update -vv | grep '^\+' | sed-cmd tar
 + tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
-+ diff "-ruaN" "tarred" "tarred.new" (CWD=${OPAMTMP})
 + tar "cfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz.tmp" "-C" "${OPAMTMP}" "tarred"
 ### opam install foo.4 -vv | grep '^\+' | sed-cmd test | sed-cmd tar
 + tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
@@ -96,9 +93,8 @@ build: ["test" "-f" "quux"]
 ### <REPO/packages/foo/foo.5/files/quux>
 some content
 ### sh hash.sh REPO foo.5
-### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff
+### opam update -vv | grep '^\+' | sed-cmd tar
 + tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
-+ diff "-ruaN" "tarred" "tarred.new" (CWD=${OPAMTMP})
 ### opam install foo.5 -vv | grep '^\+' | sed-cmd test
 + test "-f" "quux" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.5)
 ### ls $OPAMROOT/repo | grep -v "cache"

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -18,10 +18,8 @@ some content
 ### sh hash.sh REPO foo.1
 ### : Internal repository storage as archive or plain directory :
 ### opam switch create tarring --empty
-### opam update -vv | grep '^\+' | sed-cmd diff | sed-cmd patch | sed-cmd gpatch | '\+ gpatch ' -> '+ patch ' | 'patch-[^"]+' -> 'patch'
+### opam update -vv | grep '^\+' | sed-cmd diff
 + diff "-ruaN" "default" "default.new" (CWD=${BASEDIR}/OPAM/repo)
-+ patch "--version"
-+ patch "-p1" "-i" "${BASEDIR}/OPAM/log/patch" (CWD=${BASEDIR}/OPAM/repo/default)
 ### ls $OPAMROOT/repo | grep -v "cache"
 default
 lock
@@ -38,10 +36,8 @@ build: ["test" "-f" "baz"]
 ### <REPO/packages/foo/foo.2/files/baz>
 some content
 ### sh hash.sh REPO foo.2
-### opam update default -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd patch | sed-cmd gpatch | '\+ gpatch ' -> '+ patch ' | 'patch-[^"]+' -> 'patch'
+### opam update default -vv | grep '^\+' | sed-cmd tar | sed-cmd diff
 + diff "-ruaN" "default" "default.new" (CWD=${BASEDIR}/OPAM/repo)
-+ patch "--version"
-+ patch "-p1" "-i" "${BASEDIR}/OPAM/log/patch" (CWD=${BASEDIR}/OPAM/repo/default)
 + tar "cfz" "${BASEDIR}/OPAM/repo/default.tar.gz.tmp" "-C" "${BASEDIR}/OPAM/repo" "default"
 ### ls $OPAMROOT/repo | grep -v "cache"
 default.tar.gz
@@ -78,11 +74,9 @@ build: ["test" "-f" "baz"]
 ### <REPO/packages/foo/foo.4/files/baz>
 some content
 ### sh hash.sh REPO foo.4
-### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd patch | sed-cmd gpatch | '\+ gpatch ' -> '+ patch ' | 'patch-[^"]+' -> 'patch'
+### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff
 + tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
 + diff "-ruaN" "tarred" "tarred.new" (CWD=${OPAMTMP})
-+ patch "--version"
-+ patch "-p1" "-i" "${BASEDIR}/OPAM/log/patch" (CWD=${OPAMTMP}/tarred)
 + tar "cfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz.tmp" "-C" "${OPAMTMP}" "tarred"
 ### opam install foo.4 -vv | grep '^\+' | sed-cmd test | sed-cmd tar
 + tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
@@ -102,11 +96,9 @@ build: ["test" "-f" "quux"]
 ### <REPO/packages/foo/foo.5/files/quux>
 some content
 ### sh hash.sh REPO foo.5
-### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd patch | sed-cmd gpatch | '\+ gpatch ' -> '+ patch ' | 'patch-[^"]+' -> 'patch'
+### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff
 + tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
 + diff "-ruaN" "tarred" "tarred.new" (CWD=${OPAMTMP})
-+ patch "--version"
-+ patch "-p1" "-i" "${BASEDIR}/OPAM/log/patch" (CWD=${OPAMTMP}/tarred)
 ### opam install foo.5 -vv | grep '^\+' | sed-cmd test
 + test "-f" "quux" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.5)
 ### ls $OPAMROOT/repo | grep -v "cache"

--- a/tests/reftests/update.test
+++ b/tests/reftests/update.test
@@ -4,7 +4,6 @@ opam-version: "2.0"
 ### opam update --verbose
 
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
-Processing  1/1: [default: rsync]
 [default] synchronised from file://${BASEDIR}/REPO
 Processing: [default: loading data]
 Now run 'opam upgrade' to apply any package updates.


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/6019
Fixes https://github.com/ocaml/opam/issues/3782 by removing any handling of chmod entirely (git extensions). Every patched files keep their permissions and every new file has the default file permission (644).
Fixes https://github.com/ocaml/setup-ocaml/pull/933
Fixes #6052
see #5891 

A large amount of work was necessary in the `patch` library to make this work. See https://github.com/hannesm/patch/pull/9, https://github.com/hannesm/patch/pull/7 and especially https://github.com/hannesm/patch/pull/22

Moving the logic of `OpamSystem.translate_patch` into `patch` can be done later. Possibly during the 2.4 alpha phase.
The 2.4 alpha phase will also serve to test this new version of patch (3.0.0), once it has been sufficiently tested the stable release of `patch.3.0.0` will be published.