### PR TITLE
Use git diff instead of the system diff command

### DIFF
--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -133,7 +133,7 @@ let recommended_tools () =
 let required_tools ~sandboxing () =
   req_dl_tools () @
   [
-    ["diff"], None, None;
+    ["git"], None, None;
     ["patch"], None, Some patch_filter;
     ["gpatch"], None, Some gpatch_filter;
     ["tar"], None, Some tar_filter;

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -429,8 +429,8 @@ let link ?(relative=false) ~target ~link =
   OpamSystem.link target (to_string link)
 [@@ocaml.warning "-16"]
 
-let patch ?preprocess filename dirname =
-  OpamSystem.patch ?preprocess ~dir:(Dir.to_string dirname) (to_string filename)
+let patch ?delete_stragglers filename dirname =
+  OpamSystem.patch ?delete_stragglers ~dir:(Dir.to_string dirname) (to_string filename)
 
 let flock flag ?dontblock file = OpamSystem.flock flag ?dontblock (to_string file)
 

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -258,9 +258,11 @@ val remove_prefix_dir: Dir.t -> Dir.t -> string
 (** Remove a suffix from a filename *)
 val remove_suffix: Base.t -> t -> string
 
-(** Apply a patch in a directory. If [preprocess] is set to false, there is no
-    CRLF translation. Returns [None] on success, the process error otherwise *)
-val patch: ?preprocess:bool -> t -> Dir.t -> exn option OpamProcess.job
+(** Apply a patch in a directory. The given patch file will be CRLF translated
+    and if [delete_stragglers] is true the undeleted files will be deleted
+    (e.g. when macOS patch is used).
+    Returns [None] on success, the process error otherwise *)
+val patch: ?delete_stragglers:bool -> t -> Dir.t -> exn option OpamProcess.job
 
 (** Create an empty file *)
 val touch: t -> unit

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -304,10 +304,11 @@ val get_lock_fd: lock -> Unix.file_descr
 
 (** {2 Misc} *)
 
-(** Apply a patch file in the current directory. If [preprocess] is set to
-    false, there is no CRLF translation. Returns the error if the patch didn't
-    apply. *)
-val patch: ?preprocess:bool -> dir:string -> string -> exn option OpamProcess.job
+(** Apply a patch in a directory. The given patch file will be CRLF translated
+    and if [delete_stragglers] is true the undeleted files will be deleted
+    (e.g. when macOS patch is used).
+    Returns [None] on success, the process error otherwise *)
+val patch: ?delete_stragglers:bool -> dir:string -> string -> exn option OpamProcess.job
 
 (** Returns the end-of-line encoding style for the given file. [None] means that
     either the encoding of line endings is mixed, or the file contains no line
@@ -321,8 +322,9 @@ val get_eol_encoding : string -> bool option
     endings then the patch is transformed to patch using the encoding on disk.
     In particular, this means that patches generated against Unix checkouts of
     Git sources will correctly apply to Windows checkouts of the same sources.
+    It return a list of files to be deleted after the patch has been applied.
 *)
-val translate_patch: dir:string -> string -> string -> unit
+val translate_patch: dir:string -> string -> string -> string list
 
 (** Create a temporary file in {i ~/.opam/logs/<name>XXX}, if [dir] is not set.
     ?auto_clean controls whether the file is automatically deleted when opam

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -501,12 +501,7 @@ let apply_repo_update repo repo_root = function
     log "%a: applying patch update at %a"
       (slog OpamRepositoryName.to_string) repo.repo_name
       (slog OpamFilename.to_string) f;
-    let preprocess =
-      match repo.repo_url.OpamUrl.backend with
-      | `http | `rsync -> false
-      | _ -> true
-    in
-    (OpamFilename.patch ~preprocess f repo_root @@+ function
+    (OpamFilename.patch ~delete_stragglers:true f repo_root @@+ function
       | Some e ->
         if not (OpamConsole.debug ()) then OpamFilename.remove f;
         raise e

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -84,8 +84,8 @@ let get_diff parent_dir dir1 dir2 =
   OpamSystem.make_command
     ~verbose:OpamCoreConfig.(!r.verbose_level >= 2)
     ~dir:(OpamFilename.Dir.to_string parent_dir) ~stdout:patch
-    "diff"
-    [ "-ruaN";
+    "git"
+    [ "diff"; "--no-index"; "-a"; "--";
       OpamFilename.Base.to_string dir1;
       OpamFilename.Base.to_string dir2; ]
   @@> function


### PR DESCRIPTION
opam already harbour a patch parser used to preprocess CRLF in patch files. As (yet another) alternative to #5892 and #5893 we can take advantage of this preprocessing and output the files that we detect are going to be deleted.

This can only happen if the format in the given patch file is parseable, this is too tricky to do with the system diff commands (see https://github.com/hannesm/patch/issues/8) without a robust date parser so instead we can use `git diff --no-index` when we control the input patch (during opam update). When that's the case, we delete the empty straggler files after the application of the patch that we were able to detect.

This makes the system patch command on macOS usable when packages have been deleted from an opam repository.

See https://github.com/ocaml/opam/pull/5891
Fixes https://github.com/ocaml/opam/issues/3639