### PR TITLE
Update badges to newer distro versions for Ubuntu and Fedora

### DIFF
--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -111,7 +111,7 @@ cave resolve -x repository/ocaml-unofficial
 
 #### [Fedora](http://fedoraproject.org), [CentOS](http://centos.org) and RHEL
 
-[![Fedora 32](https://repology.org/badge/version-for-repo/fedora_32/opam.svg)](https://repology.org/project/opam/versions)
+[![Fedora 39](https://repology.org/badge/version-for-repo/fedora_39/opam.svg)](https://repology.org/project/opam/versions)
 
 The opam package for Fedora can be installed with the command:
 
@@ -179,7 +179,7 @@ for Opam usage.
 
 #### Ubuntu
 
-[![badge](https://repology.org/badge/version-for-repo/ubuntu_20_04/opam.svg)](https://repology.org/project/opam/versions)
+[![badge](https://repology.org/badge/version-for-repo/ubuntu_22_04/opam.svg)](https://repology.org/project/opam/versions)
 
 ##### Versions 18.04 and newer
 There is a [ppa](https://launchpad.net/~avsm/+archive/ubuntu/ppa) available that contains the current stable version of `opam`.

--- a/master_changes.md
+++ b/master_changes.md
@@ -154,6 +154,7 @@ users)
   * Fix a dead link to SPDX license expressions spec [#5849 @kit-ty-kate - fix #5846]
   * Fix missing spaces in `opam --help` [#5850 @sorawee].
   * Manual: add missing 'since opam 2.2' annotation when mentionning with-dev-setup [#5885 @kit-ty-kate]
+  * Installation: update badges for Ubuntu and Fedora to newer versions [#5905 @AldanTanneo]
 
 ## Security fixes
 


### PR DESCRIPTION
Update the install page with newer badges for Ubuntu (20.04 -> 22.04) and Fedora (32 -> 39)