### PR TITLE
Fix performance regression when calling opam install --deps-only on an already installed package

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -24,6 +24,7 @@ users)
 ## Actions
 
 ## Install
+  * Fix performance regression when calling opam install --deps-only on an already installed package [#5908 @kit-ty-kate - fix #5817]
 
 ## Remove
 

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1471,6 +1471,8 @@ let install_t t ?ask ?(ignore_conflicts=false) ?(depext_only=false)
           nvs (t, deps_of_packages))
       dname_map (t, OpamPackage.Set.empty)
   in
+  let pkg_skip, pkg_new =
+    get_installed_atoms t atoms in
   let atoms, deps_atoms =
     if deps_only then
       [],
@@ -1478,10 +1480,11 @@ let install_t t ?ask ?(ignore_conflicts=false) ?(depext_only=false)
     else
       atoms, []
   in
-  let pkg_skip, pkg_new =
-    get_installed_atoms t atoms in
   let pkg_reinstall =
     if assume_built then OpamPackage.Set.of_list pkg_skip
+    else if deps_only then OpamPackage.Set.empty
+    (* NOTE: As we only install dependency packages, there are no intersections
+       between t.reinstall and pkg_skip *)
     else Lazy.force t.reinstall %% OpamPackage.Set.of_list pkg_skip
   in
   (* Add the packages to the list of package roots and display a
@@ -1544,8 +1547,7 @@ let install_t t ?ask ?(ignore_conflicts=false) ?(depext_only=false)
   OpamSolution.check_availability t available_packages atoms;
 
   if pkg_new = [] && OpamPackage.Set.is_empty pkg_reinstall &&
-     formula = OpamFormula.Empty &&
-     deps_atoms = []
+     formula = OpamFormula.Empty
   then t else
   let t, atoms =
     if assume_built then


### PR DESCRIPTION
Fixes #5817 
~Requires #5909 to be merged first~

https://github.com/ocaml/opam/commit/9aa22900ded5bdaeef2e9ac7e2e894d6a4d68a8d changed the behaviour of opam in this particular case. This here PR takes a bit of the previous code to get this behaviour back.

### Code explanation:
https://github.com/ocaml/opam/commit/9aa22900ded5bdaeef2e9ac7e2e894d6a4d68a8d splits the input atoms and the atoms that are the dependencies of each input atoms. The former is empty when `--deps-only` and the second is empty when not in deps-only mode. Now there is a function that takes the former atoms into "atoms that are already installed" and "atoms that are not installed". Near the end of the function before doing the solve, the function tests if the "atoms that are not installed" is empty and simply stops the function in that case. Basically this is all to check if you call `opam install installed-pkg` then the solver won't be called unnecessarily. However now if you pass `--deps-only` that check won't pass and instead a new `deps_atoms = []` check is done which fails since it will always be false (unless you're asking `opam install --deps pkg-without-any-dependencies-at-all`).

The goal of this here PR is to get `pkg_skip` and `pkg_new` before it's emptied by the deps-only check and only rely on it to check if we should skip the solver. The change in `pkg_reinstall` is done here to ensure no unnecessary `Lazy.force` is done since `pkg_skip` was always empty in the previous version of the code