### PR TITLE
Fix rounding error when displaying the timestamp in debug mode

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -87,6 +87,7 @@ users)
 ## Solver
 
 ## Client
+  * Fix rounding error when displaying the timestamp in debug mode [#5912 @kit-ty-kate - fix #5910]
 
 ## Shell
 

--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -532,7 +532,7 @@ let print_message =
 let timestamp () =
   let time = Unix.gettimeofday () -. global_start_time in
   Printf.ksprintf (colorise `blue) "%02.0f:%06.3f"
-    (time /. 60.)
+    (Float.floor (time /. 60.))
     (mod_float time 60.)
 
 let log_formatter, finalise_output =


### PR DESCRIPTION
Fixes #5910 

Printf.printf "%f" rounds up so above 30s (30 / 60) rounds up to 1m

Noticed by David during [today's dev meeting](https://github.com/ocaml/opam/wiki/2024-Developer-Meetings#2024-04-08)