### PR TITLE
Fix downloading URLs with invalid characters

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -50,6 +50,7 @@ users)
 ## Lint
 
 ## Repository
+  * Fix download URLs containing invalid characters on Windows (e.g. the ? character in `?full_index=1`) [#5921 @dra27]
 
 ## Lock
 

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1329,6 +1329,15 @@ module OpamSys = struct
       if !called then invalid_arg "Just what do you think you're doing, Dave?";
       called := true;
       console := printer
+
+  let is_valid_basename_char =
+    if Sys.win32 then
+      function
+      | '\000'..'\031'
+      | '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*' -> false
+      | _ -> true
+    else
+      fun c -> c <> '\000' && c <> '/'
 end
 
 

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -532,7 +532,8 @@ module Sys : sig
       OS) *)
   val path_sep: char
 
-  (** [true] if a character may be used in a filename. *)
+  (** [true] if a character may be used in a filename, depending on the OS.
+      For example, on Windows, `:` and `?` can't be in the name. *)
   val is_valid_basename_char: char -> bool
 
   (** Splits a PATH-like variable separated with [path_sep]. More involved than

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -532,6 +532,9 @@ module Sys : sig
       OS) *)
   val path_sep: char
 
+  (** [true] if a character may be used in a filename. *)
+  val is_valid_basename_char: char -> bool
+
   (** Splits a PATH-like variable separated with [path_sep]. More involved than
       it seems, because there may be quoting on Windows. By default, it returns
       the path cleaned (remove trailing, leading, contiguous delimiters).

--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -188,8 +188,18 @@ let download_as ?quiet ?validate ~overwrite ?compress ?checksum url dst =
       ()
 
 let download ?quiet ?validate ~overwrite ?compress ?checksum url dstdir =
+  let base =
+    let base = OpamUrl.basename url in
+    if Sys.win32 then
+      let f c =
+        if OpamStd.Sys.is_valid_basename_char c then c else '_'
+      in
+      String.map f base
+    else
+      base
+  in
   let dst =
-    OpamFilename.(create dstdir (Base.of_string (OpamUrl.basename url)))
+    OpamFilename.(create dstdir (Base.of_string base))
   in
   download_as ?quiet ?validate ~overwrite ?compress ?checksum url dst @@|
   fun () -> dst


### PR DESCRIPTION
`OpamDownload.download` downloads a given URL using the basename of the URL as the filename. On Windows, where are there are many restrictions on valid filenames, this causes a problem if the URL includes any query string. Since OpamDownload passes the name used to the continuation, on Windows the illegal characters are simply replaced with underscores.