### PR TITLE
Fix incorrect package installed state written on error

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -40,6 +40,7 @@ users)
 ## Var/Option
 
 ## Update / Upgrade
+  * Failure when rebuilding a package owing to upstream changes no longer marks the package as successfully installed [#5922 @dra27]
 
 ## Tree
 

--- a/tests/reftests/update-upgrade.test
+++ b/tests/reftests/update-upgrade.test
@@ -506,3 +506,38 @@ The following actions will be performed:
 -> removed   ongoing.dev
 -> installed ongoing.dev
 Done.
+### <REPO/packages/d-foo/d-foo.6/opam>
+opam-version: "2.0"
+build: [ "false" ]
+### opam update
+[NOTE] ongoing.dev has previously been updated with --working-dir, not resetting unless explicitly selected
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[second] no changes from file://${BASEDIR}/REPO2
+[default] synchronised from file://${BASEDIR}/REPO
+
+<><> Synchronising development packages <><><><><><><><><><><><><><><><><><><><>
+[quux.dev5] synchronised (no changes)
+Now run 'opam upgrade' to apply any package updates.
+### opam upgrade
+The following actions will be performed:
+=== recompile 1 package
+  - recompile d-foo 6 [upstream or system changes]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[ERROR] The compilation of d-foo.6 failed at "false".
+
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - build d-foo 6
++- 
+- No changes have been performed
+# Return code 31 #
+### : Running opam upgrade a second time should do the same thing - the same
+### : failure with the same return code 31.
+### opam upgrade
+Already up-to-date.
+Nothing to do.

--- a/tests/reftests/update-upgrade.test
+++ b/tests/reftests/update-upgrade.test
@@ -539,5 +539,19 @@ The following actions will be performed:
 ### : Running opam upgrade a second time should do the same thing - the same
 ### : failure with the same return code 31.
 ### opam upgrade
-Already up-to-date.
-Nothing to do.
+The following actions will be performed:
+=== recompile 1 package
+  - recompile d-foo 6 [upstream or system changes]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[ERROR] The compilation of d-foo.6 failed at "false".
+
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - build d-foo 6
++- 
+- No changes have been performed
+# Return code 31 #

--- a/tests/reftests/update-upgrade.test
+++ b/tests/reftests/update-upgrade.test
@@ -536,6 +536,10 @@ The following actions will be performed:
 +- 
 - No changes have been performed
 # Return code 31 #
+### : Removing the installed packages cache from the switch corrects the
+### : behaviour - i.e. at present the packages are being marked as up-to-date
+### : even though recompilation failed.
+### rm OPAM/upgrading/.opam-switch/packages/cache
 ### : Running opam upgrade a second time should do the same thing - the same
 ### : failure with the same return code 31.
 ### opam upgrade


### PR DESCRIPTION
If a package needs to be rebuilt because of upstream changes, an error in the rebuild causes a cache indicating that it's installed to be written. Something appears to be wrong in `OpamClient.parallel_apply`, but I haven't got to the bottom of exactly what.

What I have written is a test! Spotted while debugging #5921 - because errors during fetch also trigger this. Note in the commit history that erasing `.opam-switch/packages/cache` causes opam to do the right thing on the second upgrade.