### PR TITLE
Relax error 31 for non-tautological packages

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -48,6 +48,8 @@ users)
 ## Source
 
 ## Lint
+  * Relax warning 41 not to trigger on uses of package variables which are guarded by a package:installed filter [#5927 @dra27]
+  * Relax error 31 not to trigger on packages mentioned in depends and depopts in a conjunction with packages with a filter [#5928 @dra27]
 
 ## Repository
 

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -253,6 +253,25 @@ depopts: "foo"
 ${BASEDIR}/lint.opam: Errors.
              error 31: Fields 'depends' and 'depopts' refer to the same package names: "foo"
 # Return code 1 #
+### <lint.opam>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+depends: "bar" {os = ""} & "foo"
+depopts: [
+  "foo"
+  "bar"
+]
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Errors.
+             error 31: Fields 'depends' and 'depopts' refer to the same package names: "foo"
+# Return code 1 #
 ### : E32: Field 'ocaml-version:' and variable 'ocaml-version' are deprecated, use a dependency towards the 'ocaml' package instead for availability, and the 'ocaml:version' package variable for scripts
 ### <lint.opam>
 opam-version: "2.0"

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -269,9 +269,7 @@ depopts: [
   "bar"
 ]
 ### opam lint ./lint.opam
-${BASEDIR}/lint.opam: Errors.
-             error 31: Fields 'depends' and 'depopts' refer to the same package names: "foo"
-# Return code 1 #
+${BASEDIR}/lint.opam: Passed.
 ### : E32: Field 'ocaml-version:' and variable 'ocaml-version' are deprecated, use a dependency towards the 'ocaml' package instead for availability, and the 'ocaml:version' package variable for scripts
 ### <lint.opam>
 opam-version: "2.0"


### PR DESCRIPTION
The compiler's packages presently contain:

```
depends: [
  "ocaml-option-bytecode-only" {arch = "x86_32"}
]
depopts : [
  "ocaml-option-bytecode-only"
]
build : [
  [ "./configure" "--disable-native-compiler" {ocaml-option-bytecode-only:installed}]
]
```

This package _correctly_ contains `ocaml-option-bytecode-only` in _both_ `depends` and `depopts`. It is a limited dependency and if `arch != "x86_32"` it must be treated as a `depopt` in order to trigger a recompilation. This scheme above does _not_ trigger lint error 31, because the use of `ocaml-option-bytecode-only` in `depends` is guarded with a filter.

Upgrades for Windows packaging change this pattern slightly, adding an additional depends formula:

```
depends: [
  ("ocaml-arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only")
  "ocaml-option-bytecode-only" {arch = "x86_32"}
]
```
This does trigger lint error 31, and this is an error. Lint error 31 should only trigger when we can prove that the package atom is _always_ a dependency. Likewise, it should not trigger for a formula such as `("ocaml-arch-x86_64" | "ocaml-arch-x86_32" & "ocaml-option-bytecode-only")` i.e. it's not just about the presence of a filter - the point is that there is a way of satisfying the dependency formula which does _not_ depend on `ocaml-option-bytecode-only` so it's valid in the depopt list.

I'm not sure why this has always been an _error_, rather than a _warning_, though @AltGr? I've worked around it in the compiler packages simply by adding an unnecessary `{os = "win32"}` to the `"ocaml-option-bytecode-only"`.