### PR TITLE
Add CLI option to specify additional packages for internal Cygwin.

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -20,6 +20,7 @@ users)
 ## Plugins
 
 ## Init
+  * ◈ New option `opam init --cygwin-extra-packages=CYGWIN_PKGS --cygwin-internal-install`, to specify additional packages for internal Cygwin [#5930 @moyodiallo - fix #5834]
 
 ## Config report
 
@@ -123,6 +124,7 @@ users)
 
 # API updates
 ## opam-client
+  * `OpamClient.init` and `OpamClient.reinit`: now can have additional cygwin packages to install [#5930 @moyodiallo]
 
 ## opam-repository
 

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -28,7 +28,7 @@ val init:
   ?env_hook:bool ->
   ?completion:bool ->
   ?check_sandbox:bool ->
-  ?cygwin_setup: [ `internal | `default_location | `location of dirname | `no ] ->
+  ?cygwin_setup: [ `internal of OpamSysPkg.t list | `default_location | `location of dirname | `no ] ->
   ?git_location:(dirname, unit) either ->
   shell ->
   rw global_state * unlocked repos_state * atom list
@@ -46,7 +46,7 @@ val reinit:
   ?init_config:OpamFile.InitConfig.t -> interactive:bool -> ?dot_profile:filename ->
   ?update_config:bool -> ?env_hook:bool -> ?completion:bool -> ?inplace:bool ->
   ?check_sandbox:bool -> ?bypass_checks:bool ->
-  ?cygwin_setup: [ `internal | `default_location | `location of dirname | `no ] ->
+  ?cygwin_setup: [ `internal of OpamSysPkg.t list | `default_location | `location of dirname | `no ] ->
   ?git_location:(dirname, unit) either ->
   OpamFile.Config.t -> shell -> unit
 


### PR DESCRIPTION
Fixes #5834.

Instead of reusing `--cygwin-internal-install`, it is more suitable to have new option (`--cygwin-packages=CYGWIN_PACKAGES`), to avoid ending up checking the exclusion between `--cygwin-internal-install` and `--cygwin-local-install`.
