### PR TITLE
Fix GitHub Actions for macOS

### DIFF
--- a/.github/scripts/main/preamble.sh
+++ b/.github/scripts/main/preamble.sh
@@ -10,6 +10,9 @@ fi
 echo "Cache -> $CACHE"
 OCAML_LOCAL=$CACHE/ocaml-local
 OPAM_LOCAL=$CACHE/opam-local
+if [ "$RUNNER_OS" = 'macOS' ]; then
+  PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"
+fi
 PATH=$OPAM_LOCAL/bin:$OCAML_LOCAL/bin:$PATH; export PATH
 
 OPAM_COLD=${OPAM_COLD:-0}

--- a/master_changes.md
+++ b/master_changes.md
@@ -70,6 +70,7 @@ users)
 ## Build
 
 ## Infrastructure
+  * Ensure GNU coreutils available on the macOS 14 CI runners [#5938 @dra27]
 
 ## Release scripts
 


### PR DESCRIPTION
The default macOS runners are now Ventura (14) which has added a realpath utility which causes brew's coreutils package to install realpath as grealpath. Follow brew's configuration advice for the PATH variable.