### PR TITLE
Allow to parse opam 2.1 switch import files containing extra-files

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -28,6 +28,7 @@ users)
 ## Remove
 
 ## Switch
+  * Allow to parse opam 2.1 switch import files containing extra-files [#5943 @kit-ty-kate - fix #5941]
 
 ## Config
 

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -629,7 +629,7 @@ let export rt ?(freeze=false) ?(full=false)
               List.fold_left (fun (hmap,err) (file, base, hash) ->
                   if OpamFilename.exists file &&
                      OpamHash.check_file (OpamFilename.to_string file) hash then
-                    let value = Base64.encode_string (OpamFilename.read file) in
+                    let value = Base64.encode_string ~pad:false (OpamFilename.read file) in
                     OpamHash.Map.add hash value hmap, err
                   else hmap, base::err)
                 (hmap,[]) files

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -398,7 +398,7 @@ let import_t ?ask importfile t =
     OpamPath.Switch.extra_files_dir t.switch_global.root t.switch
   in
   OpamHash.Map.iter (fun hash content ->
-      let value = Base64.decode_exn content in
+      let value = Base64.decode_exn ~pad:false content in
       let my = OpamHash.compute_from_string ~kind:(OpamHash.kind hash) value in
       if OpamHash.contents my = OpamHash.contents hash then
         let dst =

--- a/tests/reftests/switch-import.test
+++ b/tests/reftests/switch-import.test
@@ -270,3 +270,79 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed c.1
 Done.
+### # Test that 2.1 unpadded export files are well imported
+### opam switch create padded-base64-extra-files --empty
+### <padded-base64-extra-files.xp>
+extra-files: ["md5=d8e8fca2dc0f896fd7cb4cb0031ba249" "dGVzdAo="]
+opam-version: "2.0"
+roots: ["test.dev"]
+installed: ["test.dev"]
+pinned: "test.dev"
+package "test" {
+  opam-version: "2.0"
+  version: "dev"
+  extra-files: ["test" "md5=d8e8fca2dc0f896fd7cb4cb0031ba249"]
+  install: ["cp" "test" "%{prefix}%/test"]
+}
+### opam switch import padded-base64-extra-files.xp
+The following actions will be performed:
+=== install 1 package
+  - install test dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed test.dev
+Done.
+### cat OPAM/padded-base64-extra-files/test
+test
+### opam switch create unpadded-base64-extra-files --empty
+### <unpadded-base64-extra-files.xp>
+extra-files: ["md5=d8e8fca2dc0f896fd7cb4cb0031ba249" "dGVzdAo"]
+opam-version: "2.0"
+roots: ["test.dev"]
+installed: ["test.dev"]
+pinned: "test.dev"
+package "test" {
+  opam-version: "2.0"
+  version: "dev"
+  extra-files: ["test" "md5=d8e8fca2dc0f896fd7cb4cb0031ba249"]
+  install: ["cp" "test" "%{prefix}%/test"]
+}
+### opam switch import unpadded-base64-extra-files.xp
+Fatal error:
+Invalid_argument("Wrong padding")
+# Return code 99 #
+### cat OPAM/unpadded-base64-extra-files/test
+cat: OPAM/unpadded-base64-extra-files/test: No such file or directory
+# Return code 1 #
+### <export-extra-files/test.opam>
+opam-version: "2.0"
+extra-files: ["test" "md5=d8e8fca2dc0f896fd7cb4cb0031ba249"]
+### <export-extra-files/files/test>
+test
+### opam switch create export-extra-files --empty
+### opam pin ./export-extra-files
+test is now pinned to file://${BASEDIR}/export-extra-files (version 1)
+
+The following actions will be performed:
+=== install 1 package
+  - install test 1 (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved test.1  (file://${BASEDIR}/export-extra-files)
+-> installed test.1
+Done.
+### opam switch export extra-files.xp
+### opam-cat ./extra-files.xp
+extra-files: ["md5=d8e8fca2dc0f896fd7cb4cb0031ba249" "dGVzdAo="]
+installed: ["test.1"]
+opam-version: "2.0"
+pinned: "test.1"
+roots: ["test.1"]
+package "test" {
+opam-version: "2.0"
+version: "1"
+extra-files: ["test" "md5=d8e8fca2dc0f896fd7cb4cb0031ba249"]
+url {
+src: "file://${BASEDIR}/export-extra-files"
+}
+}

--- a/tests/reftests/switch-import.test
+++ b/tests/reftests/switch-import.test
@@ -336,7 +336,7 @@ The following actions will be performed:
 Done.
 ### opam switch export extra-files.xp
 ### opam-cat ./extra-files.xp
-extra-files: ["md5=d8e8fca2dc0f896fd7cb4cb0031ba249" "dGVzdAo="]
+extra-files: ["md5=d8e8fca2dc0f896fd7cb4cb0031ba249" "dGVzdAo"]
 installed: ["test.1"]
 opam-version: "2.0"
 pinned: "test.1"

--- a/tests/reftests/switch-import.test
+++ b/tests/reftests/switch-import.test
@@ -308,12 +308,15 @@ package "test" {
   install: ["cp" "test" "%{prefix}%/test"]
 }
 ### opam switch import unpadded-base64-extra-files.xp
-Fatal error:
-Invalid_argument("Wrong padding")
-# Return code 99 #
+The following actions will be performed:
+=== install 1 package
+  - install test dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed test.dev
+Done.
 ### cat OPAM/unpadded-base64-extra-files/test
-cat: OPAM/unpadded-base64-extra-files/test: No such file or directory
-# Return code 1 #
+test
 ### <export-extra-files/test.opam>
 opam-version: "2.0"
 extra-files: ["test" "md5=d8e8fca2dc0f896fd7cb4cb0031ba249"]


### PR DESCRIPTION
Fixes #5941 

opam 2.1 used the Base64 module from extlib which does not seem to pad encoded outputs. In contrast, opam 2.2 uses the Base64 module from the base64 library (after extlib's Base64 module was removed in extlib.1.7.8) which by default pads outputs and requires padded inputs when decoding them.

cc-ing base64 implementations maintainers @dinosaure @ygrek 

- Question for @dinosaure: is this fix fine? Should `Base64.encode` be also called with `~pad:false`? What are the pitfalls of disabling padding?

- Question for @ygrek: Just to double-check, am i correct in assuming the output of extlib's base64 implementation is always not padded?