### PR TITLE
tree: fix `--with-test/doc` when packages are missing

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -102,6 +102,7 @@ users)
 
 ## Reftests
 ### Tests
+  * Add test for `opam tree pkg --with-test --no-switch` [#XXX @rjbou]
 
 ### Engine
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -42,6 +42,7 @@ users)
 ## Update / Upgrade
 
 ## Tree
+  * Fix `--with-test` selection when a new state need to be simulated [#XXX @rjbou - fix #5920]
 
 ## Exec
 

--- a/tests/reftests/tree.test
+++ b/tests/reftests/tree.test
@@ -343,12 +343,14 @@ h.1
     '-- b.1 (>= 1 & < 3) [*]
 ### opam tree j --with-test
 The following actions are simulated:
-=== install 2 packages
+=== install 3 packages
   - install a 1 [required by j]
   - install j 1
+  - install k 1 [required by j]
 
 j.1
-'-- a.1
+|-- a.1
+'-- k.1 (with-test)
 ### opam tree e
 The following actions are simulated:
 === install 3 packages
@@ -483,13 +485,15 @@ e.1
 '-- a.1
 ### opam tree e --with-test --no-switch
 The following actions are simulated:
-=== install 3 packages
+=== install 4 packages
   - install a 1 [required by e]
   - install b 1
+  - install d 1 [required by e]
   - install e 1
 
 e.1
-'-- a.1
+|-- a.1
+'-- d.1 (< 2 & with-test)
 ### ::::::::::::::::::::::::::::::::::::
 ### : Arguments as packages, directory :
 ### ::::::::::::::::::::::::::::::::::::

--- a/tests/reftests/tree.test
+++ b/tests/reftests/tree.test
@@ -363,7 +363,7 @@ e.1
 [ERROR] No package to display
 # Return code 5 #
 ### ::::::::::::::::
-### : --not-switch :
+### : --no-switch :
 ### ::::::::::::::::
 ### opam tree --no-switch | '…' -> '...' | '`' -> "'"
 opam: --no-switch can't be used without specifying a package or a path
@@ -472,6 +472,24 @@ Done.
     You can temporarily relax the switch invariant with `--update-invariant'
 
 # Return code 20 #
+### opam tree e --no-switch
+The following actions are simulated:
+=== install 3 packages
+  - install a 1 [required by e]
+  - install b 1
+  - install e 1
+
+e.1
+'-- a.1
+### opam tree e --with-test --no-switch
+The following actions are simulated:
+=== install 3 packages
+  - install a 1 [required by e]
+  - install b 1
+  - install e 1
+
+e.1
+'-- a.1
 ### ::::::::::::::::::::::::::::::::::::
 ### : Arguments as packages, directory :
 ### ::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
When packages need to be installed (simulate install), either on normal mode or with `--no-switch` option, dependencies where not retrieved with the good selection (with-test,, etc.). The constructed universe was base on `installed` field instead of all packages.

fix #5920 