### PR TITLE
Fix the value of the 'arch' variable when the current OS is 32bit on a 64bit machine

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -61,6 +61,7 @@ users)
 ## Show
 
 ## Var/Option
+  * Fix the value of the 'arch' variable when the current OS is 32bit on a 64bit machine [#5950 @kit-ty-kate - fix #5949]
 
 ## Update / Upgrade
 
@@ -261,3 +262,4 @@ users)
   * `OpamStd.Env`: add `env_string_list` for parsing string list environment variables (comma separated) [#5682 @desumn]
   * `OpamHash`: export `compare_kind` [#5561 @rjbou]
   * `OpamFilename`: add `might_escape` to check if a path is escapable, ie contains `<sep>..<sep>` [#5561 @rjbou]
+  * Add `OpamStd.Sys.getconf` [#5950 @kit-ty-kate]

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -995,18 +995,21 @@ module OpamSys = struct
 
   let etc () = "/etc"
 
-  let uname =
+  let memo_command =
     let memo = Hashtbl.create 7 in
-    fun arg ->
-      try Hashtbl.find memo arg with Not_found ->
+    fun cmd arg ->
+      try Hashtbl.find memo (cmd, arg) with Not_found ->
         let r =
           try
-            with_process_in "uname" arg
+            with_process_in cmd arg
               (fun ic -> Some (OpamString.strip (input_line ic)))
           with Unix.Unix_error _ | Sys_error _ | Not_found -> None
         in
-        Hashtbl.add memo arg r;
+        Hashtbl.add memo (cmd, arg) r;
         r
+
+  let uname = memo_command "uname"
+  let getconf = memo_command "getconf"
 
   let system =
     let system = Lazy.from_fun OpamStubs.getPathToSystem in

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -513,6 +513,9 @@ module Sys : sig
   (** The output of the command "uname", with the given argument. Memoised. *)
   val uname: string -> string option
 
+  (** The output of the command "getconf", with the given argument. Memoised. *)
+  val getconf: string -> string option
+
   (** Append .exe (only if missing) to executable filenames on Windows *)
   val executable_name : string -> string
 


### PR DESCRIPTION
Fixes #5949 

`getconf LONG_BIT` is POSIX-complient and thus should work on any Unix-like systems (including cygwin)

Tested successfully on Linux, macOS, Cygwin and MSYS2