### PR TITLE
Mitigate copying/deletion of unrecognised symlinks

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -53,6 +53,7 @@ users)
 ## Exec
 
 ## Source
+  * Fix extraction of tarballs on Windows which contain symlinks both when those symlinks can't be created or if they point to files which don't exist [#5953 @dra27]
 
 ## Lint
 
@@ -153,3 +154,4 @@ users)
 
 ## opam-core
   * `OpamStd.String`: add `split_quoted` that preserves quoted separator [#5935 @dra27]
+  * `OpamSystem.copy_dir` and `OpamSystem.mv` may display a warning on Windows if an invalid symlink (e.g. an LXSS Junction) is found [#5953 @dra27]


### PR DESCRIPTION
Partially addresses the issue reported in https://github.com/ocaml/opam/issues/5782#issuecomment-2108726192

In these situations, Cygwin is most likely to create a JUNCTION, which can't be read by `Unix.lstat`. The fix for now I propose is simply to warn. This has the very big benefit of making ocamlbuild install without needing Developer Mode.

It has the downside that we fail to copy the file... I'm suggesting we might choose to live with that for now.

Note that `OpamSystem.remove_file_t` contained an unnecessary second call to `lstat`. I needed to re-use the actual removal logic for the exception case in `remove_dir_t`, but `lstat` is very expensive in C on Unix, even more expensive in OCaml and indescribably more expensive on Windows, so eliminating the double-call seems better!