### PR TITLE
Fix opamfile package var typo

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -16,6 +16,7 @@ users)
   * Upgrade the opam-root-version to 2.2~beta [#5904 @kit-ty-kate]
 
 ## Global CLI
+  * Fix a typo in the variable description returned by "opam var" [#5961 @jmid]
 
 ## Plugins
 

--- a/src/state/opamPackageVar.ml
+++ b/src/state/opamPackageVar.ml
@@ -46,7 +46,7 @@ let package_variable_names = [
   "dev",       "True if this is a development package";
   "build-id",  "A hash identifying the precise package version with all its \
                 dependencies";
-  "opamfile", "Path of the curent opam file";
+  "opamfile", "Path of the current opam file";
 ]
 
 let predefined_depends_variables =

--- a/tests/reftests/var-option.test
+++ b/tests/reftests/var-option.test
@@ -101,7 +101,7 @@ PKG:build # Directory where the package was built
 PKG:hash # Hash of the package archive
 PKG:dev # True if this is a development package
 PKG:build-id # A hash identifying the precise package version with all its dependencies
-PKG:opamfile # Path of the curent opam file
+PKG:opamfile # Path of the current opam file
 ### opam var --switch var-option
 prefix   ${BASEDIR}/OPAM/var-option
 lib      ${BASEDIR}/OPAM/var-option/lib


### PR DESCRIPTION
While browsing logfiles, I spotted a small typo in the opamfile package var output.
This little PR attempts to fix it.