### PR TITLE
Move last-env `OPAM_LAST_ENV` files outside the switch

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -36,6 +36,7 @@ users)
   * Allow to parse opam 2.1 switch import files containing extra-files [#5943 @kit-ty-kate - fix #5941]
 
 ## Config
+  * Move last-env `OPAM_LAST_ENV` files outside the switch to be in the `opam root` [#5962 @moyodiallo - fix #5823]
 
 ## Pin
 
@@ -152,6 +153,7 @@ users)
 ## opam-solver
 
 ## opam-format
+  * `OpamPath`: remove `OpamPath.Switch.last_env` function in favor to `OpamPath.last_env` as the files are no more stored in switch directory [#5962 @moyodiallo - fix #5823]
 
 ## opam-core
   * `OpamStd.String`: add `split_quoted` that preserves quoted separator [#5935 @dra27]

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -4205,7 +4205,6 @@ let clean cli =
            cleandir (OpamPath.Switch.build_dir root sw);
            cleandir (OpamPath.Switch.remove_dir root sw);
            cleandir (OpamPath.Switch.extra_files_dir root sw);
-           cleandir (OpamPath.Switch.last_env root sw);
            let pinning_overlay_dirs =
              List.map
                (fun nv -> OpamPath.Switch.Overlay.package root sw nv.name)

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -259,9 +259,9 @@ let load_and_verify_env ~set_opamroot ~set_opamswitch ~force_path
 (* Returns [Some file] where [file] contains [updates]. [hash] should be
    [OpamEnv.hash_env_updates updates] and [n] should initially be [0]. If for
    whatever reason the file cannot be created, returns [None]. *)
-let  write_last_env_file gt switch updates =
+let  write_last_env_file gt updates =
   let updates = check_writeable updates in
-  let temp_dir = OpamPath.Switch.last_env gt.root switch in
+  let temp_dir = OpamPath.last_env gt.root in
   let hash = OpamEnv.hash_env_updates updates in
   let rec aux  n =
     (* The principal aim here is not to spam /tmp with gazillions of files, but
@@ -310,7 +310,7 @@ let ensure_env_aux ?(base=[]) ?(set_opamroot=false) ?(set_opamswitch=false)
       updates
   in
   let last_env_file =
-    write_last_env_file gt switch
+    write_last_env_file gt
       (* We remove OPAMSWITCH & OPAMROOT as they are not supposed
          to be reverted *)
       (List.filter (fun upd ->

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -548,7 +548,7 @@ external open_env_updates:
 (* cf. tests/lib/typeGymnastics.ml *)
 
 (** Cached environment updates (<switch>/.opam-switch/environment
-    <switch>/.opam-switch/last-env/env-* last env files) *)
+    <opam-root>/.last-env/env-* last env files) *)
 
 module Environment = struct include LineFile(struct
 

--- a/src/format/opamPath.ml
+++ b/src/format/opamPath.ml
@@ -79,6 +79,8 @@ let plugin t name =
   assert (sname <> "bin");
   plugins t / sname
 
+let last_env t = t / ".last-env"
+
 module type LAYOUT = sig
   type ctx
   val root : dirname -> ctx -> dirname
@@ -139,8 +141,6 @@ module Switch = struct
   let env_filename = "environment"
 
   let environment t a = meta t a /- env_filename
-
-  let last_env t a = meta t a / "last-env"
 
   let env_relative_to_prefix pfx = pfx / meta_dirname /- env_filename
 

--- a/src/format/opamPath.mli
+++ b/src/format/opamPath.mli
@@ -78,6 +78,9 @@ val plugin_bin: t -> name -> filename
     forbidden. *)
 val plugin: t -> name -> dirname
 
+(** The last environment used regardless the switch *)
+val last_env: t -> dirname
+
 module type LAYOUT = sig
   type ctx
   val root : dirname -> ctx -> dirname
@@ -173,8 +176,6 @@ module Switch: sig
 
   (** Cached environment updates. *)
   val environment: t -> switch -> OpamFile.Environment.t OpamFile.t
-
-  val last_env: t -> switch -> dirname
 
   (** Like [environment], but from the switch prefix dir *)
   val env_relative_to_prefix: dirname -> OpamFile.Environment.t OpamFile.t

--- a/tests/reftests/clean.test
+++ b/tests/reftests/clean.test
@@ -73,7 +73,6 @@ rm -rf "${BASEDIR}/OPAM/clean/.opam-switch/backup"/*
 rm -rf "${BASEDIR}/OPAM/clean/.opam-switch/build"/*
 rm -rf "${BASEDIR}/OPAM/clean/.opam-switch/remove"/*
 rm -rf "${BASEDIR}/OPAM/clean/.opam-switch/extra-files-cache"/*
-rm -rf "${BASEDIR}/OPAM/clean/.opam-switch/last-env"/*
 ### opam clean --untracked
 Cleaning up switch clean
 Remaining directories and files:

--- a/tests/reftests/env.test
+++ b/tests/reftests/env.test
@@ -518,13 +518,13 @@ Done.
 ### opam env --readonly --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | '[0-9a-f]{32}' -> 'hash' | ';' -> ':'
 CONFIG                          config-env
 FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/environment in 0.000s
-FILE(environment)               Wrote ${BASEDIR}/OPAM/switch1/.opam-switch/last-env/env-hash-0 atomically in 0.000s
-FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/last-env/env-hash-0 in 0.000s
+FILE(environment)               Wrote ${BASEDIR}/OPAM/.last-env/env-hash-0 atomically in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s
 A_VAR='${BASEDIR}/OPAM/switch1/lib': export A_VAR:
 ### opam env --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | '[0-9a-f]{32}' -> 'hash' | ';' -> ':'
 CONFIG                          config-env
 FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/environment in 0.000s
-FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/last-env/env-hash-0 in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s
 A_VAR='${BASEDIR}/OPAM/switch1/lib': export A_VAR:
 ### # missing environment file
 ### rm $OPAMROOT/switch1/.opam-switch/environment
@@ -533,7 +533,7 @@ CONFIG                          config-env
 CONFIG                          Missing environment file, regenerate it
 STATE                           LOAD-SWITCH-STATE @ switch1
 STATE                           Switch state loaded in 0.000s
-FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/last-env/env-hash-0 in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s
 A_VAR='${BASEDIR}/OPAM/switch1/lib': export A_VAR:
 ### opam env --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | '[0-9a-f]{32}' -> 'hash' | ';' -> ':'
 CONFIG                          config-env
@@ -541,19 +541,19 @@ CONFIG                          Missing environment file, regenerate it
 STATE                           LOAD-SWITCH-STATE @ switch1
 STATE                           Switch state loaded in 0.000s
 FILE(environment)               Wrote ${BASEDIR}/OPAM/switch1/.opam-switch/environment atomically in 0.000s
-FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/last-env/env-hash-0 in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s
 A_VAR='${BASEDIR}/OPAM/switch1/lib': export A_VAR:
 ### # set via OPAMSWITCH
 ### OPAMSWITCH=switch2 opam env --readonly --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | '[0-9a-f]{32}' -> 'hash' | ';' -> ':'
 CONFIG                          config-env
 FILE(environment)               Read ${BASEDIR}/OPAM/switch2/.opam-switch/environment in 0.000s
-FILE(environment)               Wrote ${BASEDIR}/OPAM/switch2/.opam-switch/last-env/env-hash-0 atomically in 0.000s
-FILE(environment)               Read ${BASEDIR}/OPAM/switch2/.opam-switch/last-env/env-hash-0 in 0.000s
+FILE(environment)               Wrote ${BASEDIR}/OPAM/.last-env/env-hash-0 atomically in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s
 A_VAR='${BASEDIR}/OPAM/switch2/lib': export A_VAR:
 ### OPAMSWITCH=switch2 opam env --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | '[0-9a-f]{32}' -> 'hash' | ';' -> ':'
 CONFIG                          config-env
 FILE(environment)               Read ${BASEDIR}/OPAM/switch2/.opam-switch/environment in 0.000s
-FILE(environment)               Read ${BASEDIR}/OPAM/switch2/.opam-switch/last-env/env-hash-0 in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s
 A_VAR='${BASEDIR}/OPAM/switch2/lib': export A_VAR:
 ### # entering directory
 ### mkdir local-sw
@@ -568,13 +568,13 @@ Done.
 ### sh -c "cd local-sw ; opam env --readonly --debug-level=-3" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | '[0-9a-f]{32}' -> 'hash' | "\(\\\\\|/\)_opam\(\\\\|/\)lib" -> '/_opam/lib' | ';' -> ':'
 CONFIG                          config-env
 FILE(environment)               Read ${BASEDIR}/local-sw/_opam/.opam-switch/environment in 0.000s
-FILE(environment)               Wrote ${BASEDIR}/local-sw/_opam/.opam-switch/last-env/env-hash-0 atomically in 0.000s
-FILE(environment)               Read ${BASEDIR}/local-sw/_opam/.opam-switch/last-env/env-hash-0 in 0.000s
+FILE(environment)               Wrote ${BASEDIR}/OPAM/.last-env/env-hash-0 atomically in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s
 A_VAR='${BASEDIR}/local-sw/_opam/lib': export A_VAR:
 ### sh -c "cd local-sw ; opam env --debug-level=-3" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | '[0-9a-f]{32}' -> 'hash' | "\(\\\\\|/\)_opam\(\\\\|/\)lib" -> '/_opam/lib' | ';' -> ':'
 CONFIG                          config-env
 FILE(environment)               Read ${BASEDIR}/local-sw/_opam/.opam-switch/environment in 0.000s
-FILE(environment)               Read ${BASEDIR}/local-sw/_opam/.opam-switch/last-env/env-hash-0 in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s
 A_VAR='${BASEDIR}/local-sw/_opam/lib': export A_VAR:
 ### # moving a switch
 ### mv local-sw local-sw.new
@@ -585,8 +585,8 @@ CONFIG                          Switch has moved from ${BASEDIR}/local-sw/_opam 
 CONFIG                          Regenerating environment file
 STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}/local-sw.new
 STATE                           Switch state loaded in 0.000s
-FILE(environment)               Wrote ${BASEDIR}/local-sw.new/_opam/.opam-switch/last-env/env-hash-0 atomically in 0.000s
-FILE(environment)               Read ${BASEDIR}/local-sw.new/_opam/.opam-switch/last-env/env-hash-0 in 0.000s
+FILE(environment)               Wrote ${BASEDIR}/OPAM/.last-env/env-hash-0 atomically in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s
 A_VAR='${BASEDIR}/local-sw.new/_opam/lib': export A_VAR:
 ### opam env --switch ./local-sw.new --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | '[0-9a-f]{32}' -> 'hash' | "\(\\\\\|/\)_opam\(\\\\|/\)lib" -> '/_opam/lib' | ';' -> ':'
 CONFIG                          config-env
@@ -596,33 +596,33 @@ CONFIG                          Regenerating environment file
 STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}/local-sw.new
 STATE                           Switch state loaded in 0.000s
 FILE(environment)               Wrote ${BASEDIR}/local-sw.new/_opam/.opam-switch/environment atomically in 0.000s
-FILE(environment)               Read ${BASEDIR}/local-sw.new/_opam/.opam-switch/last-env/env-hash-0 in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s
 A_VAR='${BASEDIR}/local-sw.new/_opam/lib': export A_VAR:
 ### opam env --switch ./local-sw.new --debug-level=-3 | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | '[0-9a-f]{32}' -> 'hash' | "\(\\\\\|/\)_opam\(\\\\|/\)lib" -> '/_opam/lib' | ';' -> ':'
 CONFIG                          config-env
 FILE(environment)               Read ${BASEDIR}/local-sw.new/_opam/.opam-switch/environment in 0.000s
-FILE(environment)               Read ${BASEDIR}/local-sw.new/_opam/.opam-switch/last-env/env-hash-0 in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s
 A_VAR='${BASEDIR}/local-sw.new/_opam/lib': export A_VAR:
 ### : opam exec & environment regeneration :
 ### opam exec --debug-level=-3 -- sh -c "echo $A_VAR" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | grep -v PROC | '[0-9a-f]{32}' -> 'hash' | ';' -> ':'
 CONFIG                          config-exec command=sh -c echo $A_VAR
 FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/environment in 0.000s
-FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/last-env/env-hash-0 in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s
 ### rm $OPAMROOT/switch1/.opam-switch/environment
 ### opam exec --readonly --debug-level=-3 -- sh -c "echo $A_VAR" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | grep -v PROC  | '[0-9a-f]{32}' -> 'hash' | ';' -> ':'
 CONFIG                          config-exec command=sh -c echo $A_VAR
 CONFIG                          Missing environment file, regenerate it
 STATE                           LOAD-SWITCH-STATE @ switch1
 STATE                           Switch state loaded in 0.000s
-FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/last-env/env-hash-0 in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s
 ### opam exec --debug-level=-3 -- sh -c "echo $A_VAR" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | grep -v PROC  | '[0-9a-f]{32}' -> 'hash' | ';' -> ':'
 CONFIG                          config-exec command=sh -c echo $A_VAR
 CONFIG                          Missing environment file, regenerate it
 STATE                           LOAD-SWITCH-STATE @ switch1
 STATE                           Switch state loaded in 0.000s
 FILE(environment)               Wrote ${BASEDIR}/OPAM/switch1/.opam-switch/environment atomically in 0.000s
-FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/last-env/env-hash-0 in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s
 ### opam exec --debug-level=-3 -- sh -c "echo $A_VAR" | grep "A_VAR\|FILE\\(environment\\)\|CONFIG\|^STATE" | grep -v PROC | '[0-9a-f]{32}' -> 'hash' | ';' -> ':'
 CONFIG                          config-exec command=sh -c echo $A_VAR
 FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/environment in 0.000s
-FILE(environment)               Read ${BASEDIR}/OPAM/switch1/.opam-switch/last-env/env-hash-0 in 0.000s
+FILE(environment)               Read ${BASEDIR}/OPAM/.last-env/env-hash-0 in 0.000s


### PR DESCRIPTION
Fixes #5823 by storing the last-env `OPAM_LAST_ENV` files in the directory `~/.opam/.last-env` instead of in the switch as the solution described in the issue.