### PR TITLE
Tweak incorrect case in `--cygwin-extra-packages`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -21,7 +21,7 @@ users)
 ## Plugins
 
 ## Init
-  * ◈ New option `opam init --cygwin-extra-packages=CYGWIN_PKGS --cygwin-internal-install`, to specify additional packages for internal Cygwin [#5930 @moyodiallo - fix #5834]
+  * ◈ New option `opam init --cygwin-extra-packages=CYGWIN_PKGS --cygwin-internal-install`, to specify additional packages for internal Cygwin [#5930, #5964 @moyodiallo - fix #5834]
 
 ## Config report
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -435,6 +435,8 @@ let init cli =
         bad_arg "no-cygwin-setup" "cygwin-extra-packages"
       | `none, Some _, Some _ ->
         bad_arg "cygwin-location" "cygwin-extra-packages"
+      | `none, None, None ->
+        None
       | (`internal | `none), None, pkgs ->
         Some (`internal
                 (OpamStd.Option.default [] pkgs


### PR DESCRIPTION
An incorrectly translated case in #5930 means `opam init` with no arguments at the moment unconditionally installs an internal Cygwin! Easy to review based on the diff of the original commit in https://github.com/ocaml/opam/pull/5930/commits/8bc1214c171e588cd3e574c86c798e6a193ca073 - the ```| `none, None -> None``` deleted case at L419 has no equivalent in the new code (indeed, no case yields `None`).

