### PR TITLE
Improve the performance of opam update/init on Windows

### DIFF
--- a/configure
+++ b/configure
@@ -6104,7 +6104,7 @@ esac
 if test "${enable_static}" = yes
 then :
 
-  echo "(-noautolink -cclib -lunix -cclib -lmccs_stubs -cclib -lmccs_glpk_stubs -cclib -lsha_stubs ${platform_dependant_stuff})" > src/client/linking.sexp
+  echo "(-noautolink -cclib -lunixnat -cclib -lmccs_stubs -cclib -lmccs_glpk_stubs -cclib -lsha_stubs ${platform_dependant_stuff})" > src/client/linking.sexp
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: static" >&5
 printf "%s\n" "static" >&6; }
 

--- a/configure.ac
+++ b/configure.ac
@@ -356,7 +356,7 @@ AS_CASE([${support_static},${enable_static}],
   [no,yes],[AC_MSG_ERROR([--enable-static is not available on this platform (${TARGET}).])],
   [*,auto],[enable_static=${default_static}])
 AS_IF([test "${enable_static}" = yes],[
-  echo "(-noautolink -cclib -lunix -cclib -lmccs_stubs -cclib -lmccs_glpk_stubs -cclib -lsha_stubs ${platform_dependant_stuff})" > src/client/linking.sexp
+  echo "(-noautolink -cclib -lunixnat -cclib -lmccs_stubs -cclib -lmccs_glpk_stubs -cclib -lsha_stubs ${platform_dependant_stuff})" > src/client/linking.sexp
   AC_MSG_RESULT([static])
 ],[
   AC_MSG_RESULT([shared])

--- a/src/core/opamStubs.win32.ml
+++ b/src/core/opamStubs.win32.ml
@@ -14,4 +14,4 @@ let getpid () = Int32.to_int (getCurrentProcessID ())
 
 external win_create_process : string -> string -> string option ->
                               Unix.file_descr -> Unix.file_descr -> Unix.file_descr -> int
-                            = "win_create_process" "win_create_process_native"
+                            = "caml_unix_create_process" "caml_unix_create_process_native"

--- a/src/core/opamUrl.ml
+++ b/src/core/opamUrl.ml
@@ -43,7 +43,7 @@ let equal u v = compare u v = 0
 exception Parse_error of string
 let parse_error s = raise (Parse_error s)
 
-let split_url =
+let split_url u =
   let re =
     Re.(compile @@ whole_string @@ seq [
         (* Parse the scheme, which is either backend+protocol or just a protocol *)
@@ -66,7 +66,6 @@ let split_url =
         opt @@ seq [ char '#'; group @@ rep any ];
       ])
   in
-  fun u ->
     match Re.Group.all (Re.exec re u) with
     | [| _; vc; transport; path; suffix; hash |] ->
       let opt = function "" -> None | s -> Some s in
@@ -103,7 +102,7 @@ let backend_of_string = function
                 (OpamConsole.colorise `underline p))
 
 
-let looks_like_ssh_path =
+let looks_like_ssh_path path =
   (* ':' before any '/' : assume ssh, like git does. Exception for 'x:' with
      single char, because Windows *)
   let re =
@@ -121,7 +120,6 @@ let looks_like_ssh_path =
         eos;
       ])
   in
-  fun path ->
     try
       let sub = Re.exec re path in
       Some (Re.Group.get sub 1 ^

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -127,7 +127,7 @@ module MakeIO (F : IO_Arg) = struct
       let ic = OpamFilename.open_in f in
       try
         Unix.lockf (Unix.descr_of_in_channel ic) Unix.F_RLOCK 0;
-        Stats.read_files := filename :: !Stats.read_files;
+        (*Stats.read_files := filename :: !Stats.read_files;*)
         let r = F.of_channel f ic in
         close_in ic;
         log ~level:3 "Read %s in %.3fs" filename (chrono ());

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -120,14 +120,19 @@ end = struct
     {kill; threads; tasks_mutex; tasks; value_mutex; value}
 
   let async {tasks_mutex; tasks; _} f =
+    log "Async";
     Mutex.protect tasks_mutex (fun () ->
         Queue.add f tasks;
       )
 
   let value {kill; threads; value_mutex; value; _} =
+    log "Getting all the values...";
     Atomic.set kill true;
     List.iter Domain.join threads;
-    Mutex.protect value_mutex (fun () -> !value)
+    Mutex.protect value_mutex (fun () ->
+        log "Got %d values" (OpamPackage.Map.cardinal !value);
+        !value
+      )
 end
 
 let load_opams_from_dir repo_name repo_root =

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -114,7 +114,7 @@ end = struct
           done
         )
     in
-    let max_jobs = Domain.recommended_domain_count () in
+    let max_jobs = Int.max (Domain.recommended_domain_count () - 1) 1 in
     log "Spawning %d threads" max_jobs;
     let threads = List.init max_jobs (fun _ -> aux ()) in
     {kill; threads; tasks_mutex; tasks; value_mutex; value}

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -100,7 +100,7 @@ end = struct
     let value = ref OpamPackage.Map.empty in
     let aux () =
       Domain.spawn (fun () ->
-          while Atomic.get kill do
+          while not (Atomic.get kill && Mutex.protect tasks_mutex (fun () -> Queue.is_empty tasks)) do
             Mutex.protect tasks_mutex (fun () ->
                 Queue.take_opt tasks
               ) |>

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -120,7 +120,6 @@ end = struct
     {kill; threads; tasks_mutex; tasks; value_mutex; value}
 
   let async {tasks_mutex; tasks; _} f =
-    log "Async";
     Mutex.protect tasks_mutex (fun () ->
         Queue.add f tasks;
       )

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -114,7 +114,9 @@ end = struct
           done
         )
     in
-    let threads = List.init 3 (fun _ -> aux ()) in (* optimized for 4core CPUs *)
+    let max_jobs = Domain.recommended_domain_count () - 1 in
+    log "Spawning %d threads" max_jobs;
+    let threads = List.init max_jobs (fun _ -> aux ()) in
     {kill; threads; tasks_mutex; tasks; value_mutex; value}
 
   let async {tasks_mutex; tasks; _} f =

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -114,7 +114,7 @@ end = struct
           done
         )
     in
-    let max_jobs = Domain.recommended_domain_count () - 1 in
+    let max_jobs = Domain.recommended_domain_count () in
     log "Spawning %d threads" max_jobs;
     let threads = List.init max_jobs (fun _ -> aux ()) in
     {kill; threads; tasks_mutex; tasks; value_mutex; value}

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -11,8 +11,8 @@ endif
 
 PATCH ?= patch
 
-URL_ocaml = https://caml.inria.fr/pub/distrib/ocaml-4.14/ocaml-4.14.1.tar.gz
-MD5_ocaml = c45b013a233c9a4b80c3930d723d19dd
+URL_ocaml = https://caml.inria.fr/pub/distrib/ocaml-5.2/ocaml-5.2.0.tar.gz
+MD5_ocaml = 17b0e3d4eec32c8960fd0e1e6a7ec672
 
 URL_flexdll = https://github.com/ocaml/flexdll/archive/0.43.tar.gz
 MD5_flexdll = 6ce706f6c65b2c5adf5791fac678f090

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -32,7 +32,7 @@ URL_PKG_$(1) = $(URL_$(1))
 MD5_PKG_$(1) = $(MD5_$(1))
 endef
 
-SRC_EXTS = cppo base64 extlib re cmdliner ocamlgraph cudf dose3 opam-file-format seq stdlib-shims spdx_licenses opam-0install-cudf 0install-solver uutf jsonm sha swhid_core
+SRC_EXTS = cppo base64 extlib re cmdliner ocamlgraph cudf dose3 opam-file-format seq stdlib-shims spdx_licenses opam-0install-cudf 0install-solver uutf jsonm sha swhid_core menhir
 PKG_EXTS = $(SRC_EXTS) dune-local findlib ocamlbuild topkg mccs
 
 ifeq ($(MCCS_ENABLED),true)

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -53,8 +53,8 @@ MD5_0install-solver = 030edc9b1d3676c06d51397ffb5a737d
 
 $(call PKG_SAME,0install-solver)
 
-URL_opam-file-format = https://github.com/ocaml/opam-file-format/archive/refs/tags/2.1.6.tar.gz
-MD5_opam-file-format = 706ce5fc3e77db746a4c8b11d79cefef
+URL_opam-file-format = https://github.com/kit-ty-kate/opam-file-format/archive/menhir.tar.gz
+MD5_opam-file-format = 1d905cc8d0c2185fd408b69d7753cf1f
 
 $(call PKG_SAME,opam-file-format)
 

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -105,3 +105,6 @@ URL_swhid_core = https://github.com/OCamlPro/swhid_core/archive/refs/tags/0.1.ta
 MD5_swhid_core = 77d88d4b1d96261c866f140c64d89af8
 
 $(call PKG_SAME,swhid_core)
+
+URL_menhir = https://gitlab.inria.fr/fpottier/menhir/-/archive/20231231/archive.tar.gz
+MD5_menhir = 799748bc3b7a542798a85956c7863865

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -54,7 +54,7 @@ MD5_0install-solver = 030edc9b1d3676c06d51397ffb5a737d
 $(call PKG_SAME,0install-solver)
 
 URL_opam-file-format = https://github.com/kit-ty-kate/opam-file-format/archive/menhir.tar.gz
-MD5_opam-file-format = 1d905cc8d0c2185fd408b69d7753cf1f
+MD5_opam-file-format = ee0ae73225e3f96d1dd39b18fb1c1730
 
 $(call PKG_SAME,opam-file-format)
 


### PR DESCRIPTION
WIP attempt at (temporary) fixing #5741 by throwing more silicon^Wdomains at the problem while #5648 is being worked on.

This currently requires:
- https://github.com/ocaml/ocaml-re/issues/287 to be fixed or alternatively we could just use mutexes for now
- https://github.com/ocaml/opam-file-format/pull/60 to be merged and released
- to remove or add a mutex around `Stats.read_files`
- more testing as i'm sure there are more data races

Current result:
- On Linux: `opam update default` goes from 6 seconds to 4 seconds
- On Windows: `opam init --bare` goes from 6 and a half minutes to 3 minutes exactly. Of that 3 minutes, 1 minute is unchanged and taken by the extraction of the tar.gz archive.

Partly inspired by [NTFS really isn't that bad - Robert Collins (LCA 2020)](https://www.youtube.com/watch?v=qbKGw8MQ0i8)

Related to #5591 