### PR TITLE
Change default rule for `PKG_CONFIG_PATH` and `MANPATH` to `target`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -82,6 +82,7 @@ users)
   * [BUG] Rework the logic of := and =: so that an empty entry is correctly preserved on multiple updates [#5935 @dra27 - fix #5926]
   * [BUG] Fix incorrect reverting of `=+` and `=:` [#5935 @dra27 - fix #5926]
   * For the `Cygwin` internal operator, don't allow `make.exe` to become shadowed [#5996 @dra27]
+  * [BUG] Fix incorrect quoting rule for `PKG_CONFIG_PATH` [#5972 @dra27 - partial fix for #5923]
 
 ## Opamfile
 

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -29,7 +29,7 @@ let default_sep_fmt_str var =
   | "PATH" when Sys.win32 ->
     SSemiColon, Target_quoted
   | "PKG_CONFIG_PATH" | "MANPATH" ->
-    SColon, Target_quoted
+    SColon, Host
   | _ -> default_separator, default_format
 
 let default_sep_fmt var = default_sep_fmt_str (OpamStd.Env.Name.to_string var)

--- a/tests/reftests/env.win32.test
+++ b/tests/reftests/env.win32.test
@@ -23,12 +23,12 @@ Done.
 ### : already contains a directory which needs escaping (e.g. building with
 ### : MSVC)
 ### opam env --shell=cmd | grep "PATH" | 'XXX:.*' -> '' | 'set "P' -> 'set P'
-set "MANPATH=:"${BASEDIR}/OPAM/rewriting/man""
+set MANPATH=:${BASEDIR}/OPAM/rewriting/man
 set PATH=${BASEDIR}/OPAM/rewriting/bin;C:\Devel\bin1;C:\Devel\bin2;"C:\Devel\bin3;";C:\Devel\bin4;ZZZ:\;
 ### opam exec -- opam env --shell=cmd --revert | grep 'ZZZ:' | 'ZZZ:\\.*' -> 'ZZZ:\' | 'set "P' -> 'set P' 
 ### : Test for #5838
 ### opam env | grep MANPATH
-MANPATH=':"${BASEDIR}/OPAM/rewriting/man"'; export MANPATH;
+MANPATH=':${BASEDIR}/OPAM/rewriting/man'; export MANPATH;
 ### opam exec -- opam env --revert | grep MANPATH
 MANPATH=''; export MANPATH;
 ### : Tests forward and backslash rewriting on revert


### PR DESCRIPTION
Neither of these systems supports quoting (on Windows or Unix).

This should address the regression in #5923, but it's not the final fix for Windows, so that issue should stay open after this is merged.

cc @RyanGibb