### PR TITLE
Hardens the interface of OpamUrl.local_{file,dir}

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1379,8 +1379,11 @@ let filter_unpinned_locally t atoms f =
       let n,_ = at in
       if OpamSwitchState.is_pinned t n &&
          OpamStd.Option.Op.(OpamPinned.package_opt t n >>=
-                            OpamSwitchState.primary_url t >>=
-                            OpamUrl.local_dir) <> None
+                            OpamSwitchState.primary_url t >>|
+                            (fun x ->
+                               match OpamUrl.local_dir x with
+                               | Exists _ -> Some ()
+                               | DoesNotExist _ | NotLocal -> None)) <> None
       then
         Some (f at)
       else

--- a/src/core/opamUrl.ml
+++ b/src/core/opamUrl.ml
@@ -218,19 +218,26 @@ let local_path = function
     Some path
   | _ -> None
 
+type 'a local_file_detect =
+  | Exists of 'a
+  | DoesNotExist of 'a
+  | NotLocal
+
 let local_dir url =
-  let open OpamStd.Option.Op in
-  local_path url >>|
-  OpamFilename.Dir.of_string >>= fun d ->
-  if OpamFilename.exists_dir d then Some d
-  else None
+  match local_path url with
+  | Some path ->
+    let dir = OpamFilename.Dir.of_string path in
+    if OpamFilename.exists_dir dir then Exists dir
+    else DoesNotExist dir
+  | None -> NotLocal
 
 let local_file url =
-  let open OpamStd.Option.Op in
-  local_path url >>|
-  OpamFilename.of_string >>= fun f ->
-  if OpamFilename.exists f then Some f
-  else None
+  match local_path url with
+  | Some path ->
+    let file = OpamFilename.of_string path in
+    if OpamFilename.exists file then Exists file
+    else DoesNotExist file
+  | None -> NotLocal
 
 let guess_version_control s =
   let vc,transport,path,_,_ = split_url s in

--- a/src/core/opamUrl.mli
+++ b/src/core/opamUrl.mli
@@ -71,11 +71,16 @@ val root: t -> t
 
 val has_trailing_slash: t -> bool
 
+type 'a local_file_detect =
+  | Exists of 'a
+  | DoesNotExist of 'a
+  | NotLocal
+
 (** Check if the URL matches an existing local directory, and return it *)
-val local_dir: t -> OpamFilename.Dir.t option
+val local_dir: t -> OpamFilename.Dir.t local_file_detect
 
 (** Check if the URL matches an existing local file, and return it *)
-val local_file: t -> OpamFilename.t option
+val local_file: t -> OpamFilename.t local_file_detect
 
 (** If the given url-string has no 'transport://' specification and corresponds
     to an existing local path, check for version-control clues at that path *)

--- a/src/repository/opamDarcs.ml
+++ b/src/repository/opamDarcs.ml
@@ -54,8 +54,8 @@ module VCS = struct
        patches otherwise. *)
     let repo_str =
       match OpamUrl.local_dir repo_url with
-      | Some path -> OpamFilename.Dir.to_string path
-      | None -> OpamUrl.base_url repo_url
+      | Exists path -> OpamFilename.Dir.to_string path
+      | DoesNotExist _ | NotLocal -> OpamUrl.base_url repo_url
     in
     OpamFilename.with_tmp_dir_job @@ fun d ->
     let repodir = d / "repo" in

--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -172,15 +172,18 @@ let really_download
 
 let download_as ?quiet ?validate ~overwrite ?compress ?checksum url dst =
   match OpamUrl.local_file url with
-  | Some src ->
-    if src = dst then Done () else
+  | Exists src ->
+    if OpamFilename.equal src dst then Done () else
       (if OpamFilename.exists dst then
          if overwrite then OpamFilename.remove dst else
            OpamSystem.internal_error "The downloaded file will overwrite %s."
              (OpamFilename.to_string dst);
        OpamFilename.copy ~src ~dst;
        Done ())
-  | None ->
+  | DoesNotExist file ->
+    OpamConsole.error_and_exit `Not_found "File %S could not be found."
+      (OpamFilename.to_string file)
+  | NotLocal ->
     OpamFilename.(mkdir (dirname dst));
     really_download ?quiet ~overwrite ?compress ?checksum ?validate
       ~url

--- a/src/repository/opamHg.ml
+++ b/src/repository/opamHg.ml
@@ -139,24 +139,26 @@ module VCS = struct
       (match r.r_stdout with
        | [url] ->
          (let url = OpamUrl.parse ~backend:`hg url in
-       if OpamUrl.local_dir url <> None then Done None else
-          let check_remote hash =
-            hg repo_root [ "id"; "-r"; hash; "default" ]
-            @@> fun r ->
-            if OpamProcess.is_success r then
-              Done (Some { url with hash = Some hash })
-              (* default branch of hg is default *)
-            else Done (Some { url with hash = None})
-          in
-          match hash with
-          | None ->
-            (hg repo_root ["branch"] @@> function
-              | { OpamProcess.r_code = 0; OpamProcess.r_stdout = [hash]; _ } ->
-                check_remote hash
-              | { OpamProcess.r_code = 0; _ }
-              | { OpamProcess.r_code = 1; _ } -> Done (Some url)
-              | r -> OpamSystem.process_error r)
-          | Some hash -> check_remote hash)
+          match OpamUrl.local_dir url with
+          | Exists _ -> Done None
+          | DoesNotExist _ | NotLocal ->
+            let check_remote hash =
+              hg repo_root [ "id"; "-r"; hash; "default" ]
+              @@> fun r ->
+              if OpamProcess.is_success r then
+                Done (Some { url with hash = Some hash })
+                (* default branch of hg is default *)
+              else Done (Some { url with hash = None})
+            in
+            match hash with
+            | None ->
+              (hg repo_root ["branch"] @@> function
+                | { OpamProcess.r_code = 0; OpamProcess.r_stdout = [hash]; _ } ->
+                  check_remote hash
+                | { OpamProcess.r_code = 0; _ }
+                | { OpamProcess.r_code = 1; _ } -> Done (Some url)
+                | r -> OpamSystem.process_error r)
+            | Some hash -> check_remote hash)
        | _ -> Done None)
     | { OpamProcess.r_code = 1; _ } -> Done None
     | r -> OpamSystem.process_error r

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -156,13 +156,13 @@ module B = struct
     @@ fun () ->
     OpamRepositoryBackend.job_text repo_name "sync"
       (match OpamUrl.local_dir url with
-       | Some dir ->
+       | Exists dir ->
          OpamFilename.copy_dir ~src:dir ~dst:quarantine;
          (* fixme: Would be best to symlink, but at the moment our filename api
             isn't able to cope properly with the symlinks afterwards
             OpamFilename.link_dir ~target:dir ~link:quarantine; *)
          Done (Result quarantine)
-       | None ->
+       | DoesNotExist _ | NotLocal ->
          if OpamFilename.exists_dir repo_root then
            OpamFilename.copy_dir ~src:repo_root ~dst:quarantine
          else
@@ -200,10 +200,10 @@ module B = struct
     in
     let remote_url =
       match OpamUrl.local_dir remote_url with
-      | Some _ ->
+      | Exists _ ->
         (* ensure that rsync doesn't recreate a subdir: add trailing '/' *)
         OpamUrl.Op.(remote_url / "")
-      | None -> remote_url
+      | DoesNotExist _ | NotLocal -> remote_url
     in
     rsync remote_url.OpamUrl.path dir
     @@| function

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -119,8 +119,8 @@ module Make (VCS: VCS) = struct
     in
     pull_url ?subpath repo_root None repo_url @@+ fun result ->
     match OpamUrl.local_dir repo_url with
-    | None -> Done (result)
-    | Some dir ->
+    | DoesNotExist _ | NotLocal -> Done result
+    | Exists dir ->
       VCS.versioned_files dir @@+ fun vc_files ->
       VCS.modified_files dir @@+ fun vc_dirty_files ->
       let files =

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -252,6 +252,5 @@ repositories: "norepo" {"file://${BASEDIR}/REPO"}
 ### :: Show a reasonable error message when the file given to --config does not exist ::
 ### rm -rf $OPAMROOT
 ### opam init --bypass-checks --bare --no-setup --config some-non-existant-file
-Fatal error:
-File "src/repository/opamDownload.ml", line 140, characters 2-8: Assertion failed
-# Return code 99 #
+[ERROR] File "${BASEDIR}/some-non-existant-file" could not be found.
+# Return code 5 #

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -249,3 +249,9 @@ wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "ma
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
 repositories: "norepo" {"file://${BASEDIR}/REPO"}
+### :: Show a reasonable error message when the file given to --config does not exist ::
+### rm -rf $OPAMROOT
+### opam init --bypass-checks --bare --no-setup --config some-non-existant-file
+Fatal error:
+File "src/repository/opamDownload.ml", line 140, characters 2-8: Assertion failed
+# Return code 99 #


### PR DESCRIPTION
Would help to debug #5971 

This change is done to be able to show an error message instead of a raw assert failure when an expected local file does not exist.

This is a breaking API change and will require a change in https://github.com/ocaml-opam/opam-publish/pull/138. While not strictly necessary, i believe this change is an overall improvement and will help track similar issues in the future.

One related issue i'm seeing with how these functions are used at the moment, is that if you have a url like `file+git://<your-git-repo>/some/file/possibly/modified/or/untracked/since/HEAD` this function would happily return the file in question, which it seems like it should not do. I'm not sure if this behaviour is exploited in the wild or in our code but i think this issue is separate and can be tracked in a later issue.