### PR TITLE
Display a note when reloading a repository

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -55,6 +55,7 @@ users)
 ## Update / Upgrade
   * [BUG] Stop triggering "Undefined filter variable variable" warning for `?variable` [#5983 @dra27]
   * Display extractions in the status bar [#5977 @dra27]
+  * Display a note when reloading a repository [#5977 @kit-ty-kate]
 
 ## Tree
   * [BUG] Fix `opam tree --with-*` assigning the `with-*` variables to unrequested packages [#5919 @kit-ty-kate @rjbou - fix #5755]

--- a/master_changes.md
+++ b/master_changes.md
@@ -54,6 +54,7 @@ users)
 
 ## Update / Upgrade
   * [BUG] Stop triggering "Undefined filter variable variable" warning for `?variable` [#5983 @dra27]
+  * Display extractions in the status bar [#5977 @dra27]
 
 ## Tree
   * [BUG] Fix `opam tree --with-*` assigning the `with-*` variables to unrequested packages [#5919 @kit-ty-kate @rjbou - fix #5755]

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -78,6 +78,9 @@ module Cache = struct
 end
 
 let load_opams_from_dir repo_name repo_root =
+  if OpamConsole.disp_status_line () || OpamConsole.verbose () then
+    OpamConsole.status_line "Processing: [%s: loading data]"
+      (OpamConsole.colorise `blue (OpamRepositoryName.to_string repo_name));
   (* FIXME: why is this different from OpamPackage.list ? *)
   let rec aux r dir =
     if OpamFilename.exists_dir dir then
@@ -104,7 +107,9 @@ let load_opams_from_dir repo_name repo_root =
           r fnames
     else r
   in
-  aux OpamPackage.Map.empty (OpamRepositoryPath.packages_dir repo_root)
+  Fun.protect
+    (fun () -> aux OpamPackage.Map.empty (OpamRepositoryPath.packages_dir repo_root))
+    ~finally:OpamConsole.clear_status
 
 let load_repo repo repo_root =
   let t = OpamConsole.timer () in

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -19,7 +19,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
 curl-or-wget -- "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
-Processing  1/1:
+Processing  1/1: [foo.1: extract]
 + tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
 Done.
 ### opam clean -c
@@ -34,7 +34,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
 + wget "--content-disposition" "-t" "3" "-O" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
-Processing  1/1:
+Processing  1/1: [foo.1: extract]
 + tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
 Done.
 ### opam clean -c
@@ -49,7 +49,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
 + curl "--write-out" "%{http_code}\n" "--retry" "3" "--retry-delay" "2" "--user-agent" "opam/current" "-L" "-o" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
-Processing  1/1:
+Processing  1/1: [foo.1: extract]
 + tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
 Done.
 ### opam clean -c
@@ -148,7 +148,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
 + wget "--content-disposition" "-t" "3" "-O" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
-Processing  1/1:
+Processing  1/1: [foo.1: extract]
 + tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
 Done.
 ### opam clean -c

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1416,6 +1416,24 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:update-upgrade.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-update)
+ (action
+  (diff update.test update.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-update)))
+
+(rule
+ (targets update.out)
+ (deps root-N0REP0)
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:update.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-upgrade-format)
  (action
   (diff upgrade-format.test upgrade-format.out)))

--- a/tests/reftests/update.test
+++ b/tests/reftests/update.test
@@ -6,4 +6,5 @@ opam-version: "2.0"
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [default: rsync]
 [default] synchronised from file://${BASEDIR}/REPO
+Processing: [default: loading data]
 Now run 'opam upgrade' to apply any package updates.

--- a/tests/reftests/update.test
+++ b/tests/reftests/update.test
@@ -1,0 +1,9 @@
+N0REP0
+### <REPO/packages/pkg/pkg.1/opam>
+opam-version: "2.0"
+### opam update --verbose
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+Processing  1/1: [default: rsync]
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.


### PR DESCRIPTION
First commit is extracted from https://github.com/ocaml/opam/pull/5883

This should at least mitigate the concerns from users thinking opam might have crashed while waiting for opam update/init to finish.

The second commit is temporary while https://github.com/ocaml/opam/issues/5741 is being fixed.