### PR TITLE
Display an appropriate error message when the file given to opam init --config does not exist

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -127,6 +127,7 @@ users)
 ### Tests
   *  Add test cases to `update.test` for version-equivalent renames [#6774 @arozovyk fix #6754]
   * Fix a failure when two hashes start with the same two characters [#6793 @kit-ty-kate]
+  * Add a test showing the behaviour of `opam init --config` when the file given does not exist [#5979 @kit-ty-kate @rjbou]
 
 ### Engine
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -158,3 +158,4 @@ users)
 
 ## opam-core
   * `OpamCmdliner` was added. It is accessible through a new `opam-core.cmdliner` sub-library [#6755 @kit-ty-kate]
+  * `OpamUrl`: rename and expose `local_path` as `looks_like_local_path` [#5979 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -19,6 +19,7 @@ users)
 ## Plugins
 
 ## Init
+  * ✘ Display an appropriate error message when the file given to `opam init --config` does not exist or is in a VCS. This changes the behaviour for VCS local urls that was previously retrieved. [#5979 @kit-ty-kate - fix #5971]
 
 ## Config report
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -131,9 +131,27 @@ let get_init_config ~no_sandboxing ~no_default_config_file ~add_config_file =
     (if no_default_config_file then []
      else List.filter OpamFile.exists (OpamPath.init_config_files ()))
     @ List.map (fun url ->
-        match OpamUrl.local_file url with
-        | Some f -> OpamFile.make f
-        | None ->
+        match url.OpamUrl.backend with
+        | #OpamUrl.version_control ->
+          OpamConsole.error_and_exit `Bad_arguments
+            "Version control url not supported for %S"
+            (OpamUrl.to_string url);
+        | `rsync ->
+          begin match OpamUrl.looks_like_local_path url with
+          | Some path ->
+            let file = OpamFilename.of_string path in
+            if OpamFilename.exists file then
+              OpamFile.make file
+            else
+              OpamConsole.error_and_exit `Bad_arguments
+                "File does not exist: %s"
+                (OpamFilename.to_string file)
+          | None ->
+            OpamConsole.error_and_exit `Bad_arguments
+              "SSH url not supported for %S"
+              (OpamUrl.to_string url)
+          end
+        | `http ->
           let f = OpamFilename.of_string (OpamSystem.temp_file "conf") in
           OpamProcess.Job.run (OpamDownload.download_as ~overwrite:false url f);
           let hash = OpamHash.compute ~kind:`SHA256 (OpamFilename.to_string f) in

--- a/src/core/opamUrl.ml
+++ b/src/core/opamUrl.ml
@@ -209,7 +209,7 @@ let base_url url =
   | "" -> url.path
   | tr -> Printf.sprintf "%s://%s" tr url.path
 
-let local_path = function
+let looks_like_local_path = function
   | { transport = ("file"|"path"|"local"|"rsync"); path;
       hash = _; backend = (#version_control | `rsync); }
     when looks_like_ssh_path path = None ->
@@ -218,14 +218,14 @@ let local_path = function
 
 let local_dir url =
   let open OpamStd.Option.Op in
-  local_path url >>|
+  looks_like_local_path url >>|
   OpamFilename.Dir.of_string >>= fun d ->
   if OpamFilename.exists_dir d then Some d
   else None
 
 let local_file url =
   let open OpamStd.Option.Op in
-  local_path url >>|
+  looks_like_local_path url >>|
   OpamFilename.of_string >>= fun f ->
   if OpamFilename.exists f then Some f
   else None

--- a/src/core/opamUrl.mli
+++ b/src/core/opamUrl.mli
@@ -71,6 +71,10 @@ val root: t -> t
 
 val has_trailing_slash: t -> bool
 
+(** Check if the URL looks like a local path and returns [Some url.path]
+    if it does. Return [None] otherwise. *)
+val looks_like_local_path: t -> string option
+
 (** Check if the URL matches an existing local directory, and return it *)
 val local_dir: t -> OpamFilename.Dir.t option
 

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -328,15 +328,13 @@ Parse error
 ### :II:e:1: Non existing local file
 ### rm -rf $OPAMROOT
 ### opam init --bypass-checks --bare --no-setup --config some-non-existant-file
-Fatal error:
-File "src/repository/opamDownload.ml", line 198, characters 2-8: Assertion failed
-# Return code 99 #
+[ERROR] File does not exist: ${BASEDIR}/some-non-existant-file
+# Return code 2 #
 ### :II:e:2: Non existant vcs local file
 ### rm -rf $OPAMROOT
 ### opam init --bypass-checks --bare --no-setup --config git+file://$BASEDIR/config-files/config
-Fatal error:
-File "src/repository/opamDownload.ml", line 198, characters 2-8: Assertion failed
-# Return code 99 #
+[ERROR] Version control url not supported for "git+file://${BASEDIR}/config-files/config"
+# Return code 2 #
 ### :II:e:3: Existing VCS local file
 ### mkdir config-files
 ### <config-files/config>
@@ -351,12 +349,11 @@ repositories: "norepo" {"REPO/"}
 ### test -f config-files/config
 ### rm -rf $OPAMROOT
 ### opam init --bypass-checks --bare --no-setup --config git+file://$BASEDIR/config-files/config
-Configuring from ${BASEDIR}/config-files/config and then from built-in defaults.
-
-<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
-[norepo] Initialised
+[ERROR] Version control url not supported for "git+file://${BASEDIR}/config-files/config"
+# Return code 2 #
 ### opam option default-invariant
-["foo"]
+[ERROR] Opam has not been initialised, please run `opam init'
+# Return code 50 #
 ### :II:e:4: Existing VCS local file, url not specifyin VCS
 ### rm -rf $OPAMROOT
 ### opam init --bypass-checks --bare --no-setup --config $BASEDIR/config-files/config
@@ -376,15 +373,13 @@ rm 'config'
 # Return code 1 #
 ### rm -rf $OPAMROOT
 ### opam init --bypass-checks --bare --no-setup --config git+file://$BASEDIR/config-files/config#config
-Fatal error:
-File "src/repository/opamDownload.ml", line 198, characters 2-8: Assertion failed
-# Return code 99 #
+[ERROR] Version control url not supported for "git+file://${BASEDIR}/config-files/config#config"
+# Return code 2 #
 ### :II:e:6: Non existant distant VCS file
 ### rm -rf $OPAMROOT
 ### opam init --bypass-checks --bare --no-setup --config git+file://som.e/distant/config
-Fatal error:
-File "src/repository/opamDownload.ml", line 198, characters 2-8: Assertion failed
-# Return code 99 #
+[ERROR] Version control url not supported for "git+file://som.e/distant/config"
+# Return code 2 #
 ### :II:e:7: Non existant http file
 ### rm -rf $OPAMROOT
 ### opam --version >$ OPAMVERSION
@@ -399,13 +394,11 @@ this is not the content of a config file
 ### rm -rf $OPAMROOT
 ### opam --version >$ OPAMVERSION
 ### opam init --bypass-checks --bare --no-setup --config wrong-config --config non-existant
-Fatal error:
-File "src/repository/opamDownload.ml", line 198, characters 2-8: Assertion failed
-# Return code 99 #
+[ERROR] File does not exist: ${BASEDIR}/non-existant
+# Return code 2 #
 ### :II:f:2: 1 parse error, 1 non existant, 1 good
 ### rm -rf $OPAMROOT
 ### opam --version >$ OPAMVERSION
 ### opam init --bypass-checks --bare --no-setup --config wrong-config --config non-existant --config $BASEDIR/config-files/config
-Fatal error:
-File "src/repository/opamDownload.ml", line 198, characters 2-8: Assertion failed
-# Return code 99 #
+[ERROR] File does not exist: ${BASEDIR}/non-existant
+# Return code 2 #

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -251,7 +251,7 @@ opam-version: "2.0"
 repositories: "norepo" {"file://${BASEDIR}/REPO"}
 ### sh $OPAMROOT/opam-init/hooks/a-script.sh test
 script test launched STOP i repeat STOP script test launched
-### :: partially configured opamrc ::
+### :II:c: partially configured opamrc ::
 ### rm -rf $OPAMROOT
 ### <opamrc>
 opam-version: "2.0"
@@ -303,3 +303,109 @@ wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "ma
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
 repositories: "norepo" {"file://${BASEDIR}/REPO"}
+### :II:d: Parse error on config file
+### <wrong-config>
+this is not the content of a config file
+### :II:d:1: With strict mode
+### rm -rf $OPAMROOT
+### opam init --bypass-checks --bare --no-setup --config wrong-config
+Configuring from ${BASEDIR}/wrong-config and then from built-in defaults.
+[ERROR] At ${BASEDIR}/wrong-config:1:5-1:7::
+        Parse error
+[ERROR] Strict mode: aborting
+[ERROR] Error in configuration file, fix it, use '--no-opamrc', or check your '--config FILE' arguments:
+OpamStd.OpamSys.Exit(30)
+# Return code 50 #
+### :II:d:2: Without strict mode
+### rm -rf $OPAMROOT
+### OPAMSTRICT=0 opam init --bypass-checks --bare --no-setup --config wrong-config
+Configuring from ${BASEDIR}/wrong-config and then from built-in defaults.
+[ERROR] Error in configuration file, fix it, use '--no-opamrc', or check your '--config FILE' arguments:
+At ${BASEDIR}/wrong-config:1:5-1:7::
+Parse error
+# Return code 50 #
+### :II:e: Show a reasonable error message when the file given to --config does not exist ::
+### :II:e:1: Non existing local file
+### rm -rf $OPAMROOT
+### opam init --bypass-checks --bare --no-setup --config some-non-existant-file
+Fatal error:
+File "src/repository/opamDownload.ml", line 198, characters 2-8: Assertion failed
+# Return code 99 #
+### :II:e:2: Non existant vcs local file
+### rm -rf $OPAMROOT
+### opam init --bypass-checks --bare --no-setup --config git+file://$BASEDIR/config-files/config
+Fatal error:
+File "src/repository/opamDownload.ml", line 198, characters 2-8: Assertion failed
+# Return code 99 #
+### :II:e:3: Existing VCS local file
+### mkdir config-files
+### <config-files/config>
+opam-version: "2.0"
+default-invariant : "foo"
+repositories: "norepo" {"REPO/"}
+### git -C config-files init -q --initial-branch=master
+### git -C config-files config core.autocrlf false
+### git -C config-files commit -qm 'init' --allow-empty
+### git -C config-files add config
+### git -C config-files commit -qm 'config'
+### test -f config-files/config
+### rm -rf $OPAMROOT
+### opam init --bypass-checks --bare --no-setup --config git+file://$BASEDIR/config-files/config
+Configuring from ${BASEDIR}/config-files/config and then from built-in defaults.
+
+<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+[norepo] Initialised
+### opam option default-invariant
+["foo"]
+### :II:e:4: Existing VCS local file, url not specifyin VCS
+### rm -rf $OPAMROOT
+### opam init --bypass-checks --bare --no-setup --config $BASEDIR/config-files/config
+Configuring from ${BASEDIR}/config-files/config and then from built-in defaults.
+
+<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+[norepo] Initialised
+### opam option default-invariant
+["foo"]
+### :II:e:5: Existing VCS file but the branch is not the one on disk
+### git -C config-files checkout -b no-config
+Switched to a new branch 'no-config'
+### git -C config-files rm config
+rm 'config'
+### git -C config-files commit -qm 'no-config'
+### test -f config-files/config
+# Return code 1 #
+### rm -rf $OPAMROOT
+### opam init --bypass-checks --bare --no-setup --config git+file://$BASEDIR/config-files/config#config
+Fatal error:
+File "src/repository/opamDownload.ml", line 198, characters 2-8: Assertion failed
+# Return code 99 #
+### :II:e:6: Non existant distant VCS file
+### rm -rf $OPAMROOT
+### opam init --bypass-checks --bare --no-setup --config git+file://som.e/distant/config
+Fatal error:
+File "src/repository/opamDownload.ml", line 198, characters 2-8: Assertion failed
+# Return code 99 #
+### :II:e:7: Non existant http file
+### rm -rf $OPAMROOT
+### opam --version >$ OPAMVERSION
+### opam init --bypass-checks --bare --no-setup --config http://som.e/url/to/config | sed-cmd curl | "${OPAMVERSION}" -> "current" | "[^ ]*\.part" -> file.part
+Fatal error:
+OpamDownload.Download_fail(_, "curl failed: \"curl --write-out %{http_code}\\n --retry 3 --retry-delay 2 --user-agent opam/current -L -o file.part -- http://som.e/url/to/config\" exited with code 6")
+# Return code 99 #
+### :II:f: Several erroring files
+### :II:f:1: 1 parse error, 1 non existant
+### <wrong-config>
+this is not the content of a config file
+### rm -rf $OPAMROOT
+### opam --version >$ OPAMVERSION
+### opam init --bypass-checks --bare --no-setup --config wrong-config --config non-existant
+Fatal error:
+File "src/repository/opamDownload.ml", line 198, characters 2-8: Assertion failed
+# Return code 99 #
+### :II:f:2: 1 parse error, 1 non existant, 1 good
+### rm -rf $OPAMROOT
+### opam --version >$ OPAMVERSION
+### opam init --bypass-checks --bare --no-setup --config wrong-config --config non-existant --config $BASEDIR/config-files/config
+Fatal error:
+File "src/repository/opamDownload.ml", line 198, characters 2-8: Assertion failed
+# Return code 99 #


### PR DESCRIPTION
Fixes #5971 

This PR introduces `OpamUrl.kind` which i think is an improvement over `OpamUrl.local_{file,dir}` as way of detecting if a url is local or not. Most functions that use `OpamUrl.local_{file,dir}` already check later if the file exist and fail gracefully so there is no need to check twice.

I opened https://github.com/ocaml/opam/issues/5978 to think about removing `local_{file,dir}` in the future, but for now this would be a fairly intrusive change.