### PR TITLE
Don't display undefined variable warnings when evaluating the `?` operator

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -51,6 +51,7 @@ users)
 ## Var/Option
 
 ## Update / Upgrade
+  * [BUG] Stop triggering "Undefined filter variable variable" warning for `?variable` [#5983 @dra27]
 
 ## Tree
   * [BUG] Fix `opam tree --with-*` assigning the `with-*` variables to unrequested packages [#5919 @kit-ty-kate @rjbou - fix #5755]

--- a/tests/reftests/resolve-variables.test
+++ b/tests/reftests/resolve-variables.test
@@ -81,3 +81,16 @@ The following actions will be performed:
 -> installed d.4
 -> installed foo.1
 Done.
+### OPAMYES=1 OPAMSTRICT=1
+### <REPO2/packages/undef/undef.1/opam>
+opam-version: "2.0"
+depends: "d" {?undefined-global & undefined-global != ""}
+### <REPO2/repo>
+opam-version: "2.0"
+### opam switch create undefined-globals --empty
+### opam repository add second ./REPO2 --this-switch
+[second] Initialised
+### opam repo remove default --this-switch
+### opam install undef
+[ERROR] Undefined filter variable undefined-global in dependencies of undef.1
+# Return code 30 #

--- a/tests/reftests/resolve-variables.test
+++ b/tests/reftests/resolve-variables.test
@@ -92,5 +92,10 @@ opam-version: "2.0"
 [second] Initialised
 ### opam repo remove default --this-switch
 ### opam install undef
-[ERROR] Undefined filter variable undefined-global in dependencies of undef.1
-# Return code 30 #
+The following actions will be performed:
+=== install 1 package
+  - install undef 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed undef.1
+Done.


### PR DESCRIPTION
#2921 added the `?` operator to allow filters to have expressions like `?foo & foo = "foo"`, where `?foo` is true if and only if `foo` is a defined variable (or an expression where all the variables have been successfully resolved).

However, it doesn't seem to have been working, which I'd spotted in the ocaml-system updates in https://github.com/ocaml/opam-repository/pull/25861. Unfortunately, the failure means that the repository can't be used with `--strict`.

The fundamental problem is that the warning about undefined variables is displayed when the variables are being resolved, which sadly includes the moment they are being tested with the `?` operator. However, when a filter is partially evaluated, the resulting filter will only contain undefined variables (and the `post` variable), which allows the check added in #5141 to be co-opted to display the unresolved variables _after_ the filter has been reduced, rather than during the reducing.