### PR TITLE
Fix OpamFilter map/fold functions

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -160,6 +160,8 @@ users)
 
 ## opam-format
   * `OpamPath`: remove `OpamPath.Switch.last_env` function in favor to `OpamPath.last_env` as the files are no more stored in switch directory [#5962 @moyodiallo - fix #5823]
+  * `OpamFilter.map_up`: correct handling of FDefined [#5983 @dra27]
+  * `OpamFilter.fold_down_left`: correct handling of FDefined and FUndef [#5983 @dra27]
 
 ## opam-core
   * `OpamStd.String`: add `split_quoted` that preserves quoted separator [#5935 @dra27]

--- a/src/format/opamFilter.ml
+++ b/src/format/opamFilter.ml
@@ -74,8 +74,14 @@ let to_string ?custom t =
 let rec fold_down_left f acc filter = match filter with
   | FOp(l,_,r) | FAnd(l,r) | FOr(l,r) ->
     fold_down_left f (fold_down_left f (f acc filter) l) r
-  | FNot(x) -> fold_down_left f (f acc filter) x
-  | x -> f acc x
+  | FNot x
+  | FUndef x
+  | FDefined x ->
+    fold_down_left f (f acc filter) x
+  | FBool _
+  | FString _
+  | FIdent _ ->
+    f acc filter
 
 let rec map_up f = function
   | FOp (l, op, r) -> f (FOp (map_up f l, op, map_up f r))
@@ -83,7 +89,8 @@ let rec map_up f = function
   | FOr (l, r) -> f (FOr (map_up f l, map_up f r))
   | FNot x -> f (FNot (map_up f x))
   | FUndef x -> f (FUndef (map_up f x))
-  | (FBool _ | FString _ | FIdent _ | FDefined _) as flt -> f flt
+  | FDefined x -> f (FDefined (map_up f x))
+  | (FBool _ | FString _ | FIdent _) as flt -> f flt
 
 (* ["%%"], ["%{xxx}%"], or ["%{xxx"] if unclosed *)
 let string_interp_regex =


### PR DESCRIPTION
 - Incorrect handling of `FDefined` and `FUndef`
 - harden `fold_down_left` against future changes

@dra27 PR, extracted from #5983, @rjbou reviewed :heavy_check_mark: 