### PR TITLE
Avoid head -c GNUism in reftests

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -108,6 +108,7 @@ users)
 ### Tests
   * cli versioning: untie output from current major version [#6045 @rjbou]
   * Set `opam-version` to 2.2 for some conflict message tests based on opam repository to stabilise their output [#6045 @rjbou]
+  * [BUG]: head -c is not posix compliant. Use cut -b instead. [#5989 @madroach]
 
 ### Engine
 

--- a/tests/reftests/legacy-git.test
+++ b/tests/reftests/legacy-git.test
@@ -19,7 +19,7 @@ ARCHIVE=$1; shift
 if [ ! -e "packages/${ARCHIVE}" ]; then ( cd packages && tar czf ${ARCHIVE} ${ARCHIVE%.tar.gz}; ) fi
 MD5=$(openssl md5 packages/${ARCHIVE} | cut -d' ' -f2)
 echo 'src: "http://dev.null" checksum: "'$MD5'"' > REPO/packages/${PKG}/url
-CACHEDIR=REPO/cache/md5/$(echo $MD5 |head -c2)
+CACHEDIR=REPO/cache/md5/$(echo $MD5 |cut -b -2)
 mkdir -p $CACHEDIR
 cp "packages/$ARCHIVE" "$CACHEDIR/$MD5"
 ### : INIT :

--- a/tests/reftests/legacy-local.test
+++ b/tests/reftests/legacy-local.test
@@ -7,7 +7,7 @@ ARCHIVE=$1; shift
 if [ ! -e "packages/${ARCHIVE}" ]; then ( cd packages && tar czf ${ARCHIVE} ${ARCHIVE%.tar.gz}; ) fi
 MD5=$(openssl md5 packages/${ARCHIVE} | cut -d' ' -f2)
 echo 'src: "http://dev.null" checksum: "'$MD5'"' > REPO/packages/${PKG}/url
-CACHEDIR=REPO/cache/md5/$(echo $MD5 |head -c2)
+CACHEDIR=REPO/cache/md5/$(echo $MD5 |cut -b -2)
 mkdir -p $CACHEDIR
 cp "packages/$ARCHIVE" "$CACHEDIR/$MD5"
 ### : INIT :


### PR DESCRIPTION
`head -c` is not posix-compliant, use `cut -b` instead.