### PR TITLE
Disentangle `OpamProcess.resolve_command` and `OpamSystem.resolve_command`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -184,3 +184,4 @@ users)
   * `OpamStubs.get_initial_environment`: on Windows, returns the pristine environment for new shells [#5963 @dra27]
   * `OpamConsole`: Add `formatted_errmsg` [#5999 @kit-ty-kate]
   * `OpamConsole.menu` now supports up to 35 menu items [#5992 @dra27]
+  * `OpamStd.Sys.resolve_command`: extracted the logic from `OpamSystem.resolve_command`, without the default environment handling from OpamProcess. [#5991 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -185,3 +185,4 @@ users)
   * `OpamConsole`: Add `formatted_errmsg` [#5999 @kit-ty-kate]
   * `OpamConsole.menu` now supports up to 35 menu items [#5992 @dra27]
   * `OpamStd.Sys.resolve_command`: extracted the logic from `OpamSystem.resolve_command`, without the default environment handling from OpamProcess. [#5991 @dra27]
+  * `OpamStd.Sys.resolve_in_path`: split the logic of `OpamStd.Sys.resolve_command` to allow searching for an arbitrary file in the search path [#5991 @dra27]

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -302,14 +302,11 @@ let string_of_info ?(color=`yellow) info =
         (OpamConsole.colorise color k) v) info;
   Buffer.contents b
 
-let resolve_command_fn = ref (fun ?env:_ ?dir:_ _ -> None)
-let set_resolve_command =
-  let called = ref false in
-  fun resolve_command ->
-    if !called then invalid_arg "Just what do you think you're doing, Dave?";
-    called := true;
-    resolve_command_fn := resolve_command
-let resolve_command cmd = !resolve_command_fn cmd
+let resolve_command ?env ?dir name =
+  let env = match env with None -> default_env () | Some e -> e in
+  match OpamStd.Sys.resolve_command ~env ?dir name with
+  | `Cmd cmd -> Some cmd
+  | `Denied | `Not_found -> None
 
 let create_process_env =
   if Sys.win32 then

--- a/src/core/opamProcess.mli
+++ b/src/core/opamProcess.mli
@@ -223,8 +223,9 @@ end
 type 'a job = 'a Job.Op.job
 
 (**/**)
-val set_resolve_command :
-  (?env:string array -> ?dir:string -> string -> string option) -> unit
+(** As {!OpamStd.Sys.resolve_command}, except the default for [~env] is
+    {!default_env}. *)
+val resolve_command: ?env:string array -> ?dir:string -> string -> string option
 
 (** Like Unix.create_process_env, but with correct escaping of arguments when
     invoking a cygwin executable from a native Windows executable. *)

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -553,6 +553,12 @@ module Sys : sig
   val resolve_command: ?env:string array -> ?dir:string -> string ->
     [ `Cmd of string | `Denied | `Not_found ]
 
+  (** Search for an arbitrary file in PATH. Unlike {!resolve_command}, no
+      transformations take place on the name in Windows (i.e. .exe, etc. is
+      never appended) and no executable check takes place. The name passed
+      must be a basename (no directory component). *)
+  val resolve_in_path: ?env:string array -> string -> string option
+
   (** For native Windows builds, returns [`Cygwin] if the command is a Cygwin-
       compiled executable, [`Msys2] if the command is a MSYS2-compiled
       executable, and [`Tainted of [ `Msys2 | `Cygwin ]] if the command links

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -548,6 +548,11 @@ module Sys : sig
       Optional argument [clean] permits to keep those empty strings. *)
   val split_path_variable: ?clean:bool -> string -> string list
 
+  (** Test whether a command exists in the environment, and returns it (resolved
+      if found in PATH). [~env] defaults to {!Env.raw_env}. *)
+  val resolve_command: ?env:string array -> ?dir:string -> string ->
+    [ `Cmd of string | `Denied | `Not_found ]
+
   (** For native Windows builds, returns [`Cygwin] if the command is a Cygwin-
       compiled executable, [`Msys2] if the command is a MSYS2-compiled
       executable, and [`Tainted of [ `Msys2 | `Cygwin ]] if the command links

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -181,8 +181,8 @@ val make_command:
 (** a command is a list of words *)
 type command = string list
 
-(** Test whether a command exists in the environment, and returns it (resolved
-    if found in PATH) *)
+(** As {!OpamStd.Sys.resolve_command}, except the default for [~env] is
+    {!OpamProcess.default_env}. *)
 val resolve_command: ?env:string array -> ?dir:string -> string -> string option
 
 val bin_contains_bash: string -> bool


### PR DESCRIPTION
The `opam init` menu overhaul wants to be able to use `resolve_command` from within `OpamStd.Sys` (to be used with some low-level functions), but this isn't possible at present because the default for `OpamSystem.resolve_command`'s `~env` argument is `OpamProcess.default_env`.

However, since #3348 there's already been a slightly unholy mess (added by me...) to allow OpamProcess to use `resolve_command`. This PR disentagles it slightly, by moving the bulk of the logic to `OpamStd.Sys` and leaving the default argument handling in `OpamProcess` and then simply making `OpamSystem.resolve_command` an alias for `OpamProcess.resolve_command`. Not totally sure why I didn't do that in 2018...