### PR TITLE
Extend OpamConsole.menu to support 35 options

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -182,3 +182,4 @@ users)
   * `OpamStubs.readRegistry`: on Windows, complements `OpamStubs.writeRegistry` [#5963 @dra27]
   * `OpamStubs.get_initial_environment`: on Windows, returns the pristine environment for new shells [#5963 @dra27]
   * `OpamConsole`: Add `formatted_errmsg` [#5999 @kit-ty-kate]
+  * `OpamConsole.menu` now supports up to 35 menu items [#5992 @dra27]

--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -964,9 +964,13 @@ let print_table ?cut oc ~sep table =
   List.iter (fun l -> print_line (cleanup_trailing l)) table
 
 let menu ?default ?unsafe_yes ?yes ~no ~options fmt =
-  assert (List.length options < 10);
+  assert (List.length options < 36);
   let options_nums =
-    List.mapi (fun n (ans, _) -> ans, string_of_int (n+1)) options
+    let option_of_index n =
+      (* NOTE: 1..9 (starts at ASCII 49) & a..z (starts at ASCII 97) *)
+      (String.make 1 (char_of_int (if n < 9 then n+49 else n+97)))
+    in
+    List.mapi (fun n (ans, _) -> ans, option_of_index n) options
   in
   let nums_options = List.map (fun (a, n) -> n, a) options_nums in
   let rec prev_option a0 = function

--- a/src/core/opamConsole.mli
+++ b/src/core/opamConsole.mli
@@ -133,7 +133,7 @@ val confirm:
     options are set.
     [no] is the option to choose otherwise, when non interactive, on [escape].
     [default] is the option to choose on an active empty input ("\n").
-    Max 9 options. *)
+    Max 35 options. *)
 val menu:
   ?default:'a -> ?unsafe_yes:'a -> ?yes:'a -> no:'a ->
   options:('a * string) list ->


### PR DESCRIPTION
The Git-for-Windows and Cygwin options mean at least one Windows user is capable of blowing the previous limit of 9 menu items quite trivally. 1-9 used as before with a-z used for the remaining items.