### PR TITLE
API: Allow explicit installation of system packages

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -158,6 +158,7 @@ users)
 # API updates
 ## opam-client
   * `OpamClient.init` and `OpamClient.reinit`: now can have additional cygwin packages to install [#5930 @moyodiallo]
+  * Expose `OpamSolution.print_depext_msg` [#5994 @dra27]
 
 ## opam-repository
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -159,6 +159,7 @@ users)
 ## opam-client
   * `OpamClient.init` and `OpamClient.reinit`: now can have additional cygwin packages to install [#5930 @moyodiallo]
   * Expose `OpamSolution.print_depext_msg` [#5994 @dra27]
+  * Extracted `OpamSolution.install_sys_packages` from `OpamSolution.install_depexts` [#5994 @dra27]
 
 ## opam-repository
 

--- a/src/client/opamSolution.mli
+++ b/src/client/opamSolution.mli
@@ -80,12 +80,17 @@ val dry_run: 'a switch_state -> OpamSolver.solution -> 'a switch_state
     non-empty. *)
 val print_depext_msg : OpamSysPkg.Set.t * OpamSysPkg.Set.t -> unit
 
+(** As {!install_depexts}, but supplied with a set of system packages to be
+    installed. *)
+val install_sys_packages: confirm:bool -> OpamStateTypes.gt_variables ->
+  OpamFile.Config.t -> OpamSysPkg.Set.t -> unit -> unit
+
 (* Install external dependencies of the given package set, according the depext
    configuration. If [confirm] is false, install commands are directly
    launched, without asking user (used by the `--depext-only` option). If
    [force_depext] is true, it overrides [OpamFile.Config.depext] value. *)
-val install_depexts:
-  ?force_depext:bool -> ?confirm:bool -> rw switch_state -> package_set -> rw switch_state
+val install_depexts: ?force_depext:bool -> ?confirm:bool -> rw switch_state ->
+  package_set -> rw switch_state
 
 (** {2 Atoms} *)
 

--- a/src/client/opamSolution.mli
+++ b/src/client/opamSolution.mli
@@ -75,6 +75,11 @@ val check_solution:
     without actually performing the action(s) on disk. *)
 val dry_run: 'a switch_state -> OpamSolver.solution -> 'a switch_state
 
+(** Given [(available, not_found)] (see {!OpamSysInteract.packages_status}),
+    displays appropriate warnings/messages on the console if either set is
+    non-empty. *)
+val print_depext_msg : OpamSysPkg.Set.t * OpamSysPkg.Set.t -> unit
+
 (* Install external dependencies of the given package set, according the depext
    configuration. If [confirm] is false, install commands are directly
    launched, without asking user (used by the `--depext-only` option). If


### PR DESCRIPTION
This is a refactoring in `OpamSolution` so that the depext menu can be displayed either with a list of opam packages (as `OpamSolution.install_depexts` presently does, or slightly lower-level where the set of system packages to install is already calculated by the caller (the new `OpamSolution.install_sys_packages`).

Additionally, the existing `OpamSolution.print_depext_msg` is exposed (ultimately to allow it be used by `OpamClient`).