### PR TITLE
Always pass `--no-write-registry` to Cygwin setup

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -87,6 +87,7 @@ users)
   * Pass --symlink-type native to Cygwin setup if symlinks are available [#5830 @dra27]
   * Pass --no-version-check to Cygwin setup (suppresses a message box if setup needs updating) [#5830 @dra27]
   * Pass --quiet-mode noinput to stop the user interrupting the setup GUI [#5830 @dra27]
+  * Always pass --no-write-registry to the Cygwin installer, not just on first installation [#5995 @dra27]
 
 ## Format upgrade
   * Handle init OCaml `sys-ocaml-*` eval variables during format upgrade from 2.0 -> 2.1 -> 2.2 [#5829 @dra27]

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -984,6 +984,7 @@ let install_packages_commands_t ?(env=OpamVariable.Map.empty) config sys_package
             let common =
               [ "--upgrade-also";
                 "--only-site";
+                "--no-write-registry";
                 "--no-version-check";
                 "--site"; Cygwin.mirror;
                 "--local-package-dir";


### PR DESCRIPTION
This flag is already passed when initially installing Cygwin, but any subsequent depext installs which don't have it cause the internal installations to be put in the registry (when possible).

From my testing so far, including it with an existing registered installation does not cause Cygwin to _delete_ the existing registration.