### PR TITLE
Don't allow make to become shadowed

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -80,6 +80,7 @@ users)
   * [BUG] Fix `x-env-path-rewrite` splitting of values when reverting [#5935 @dra27 - fix #5838]
   * [BUG] Rework the logic of := and =: so that an empty entry is correctly preserved on multiple updates [#5935 @dra27 - fix #5926]
   * [BUG] Fix incorrect reverting of `=+` and `=:` [#5935 @dra27 - fix #5926]
+  * For the `Cygwin` internal operator, don't allow `make.exe` to become shadowed [#5996 @dra27]
 
 ## Opamfile
 

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -315,7 +315,7 @@ let apply_op_zip ~sepfmt var op arg (rl1,l2 as zip) =
     in
     let shadow_list =
       List.filter (contains_in arg)
-        ["bash.exe"; "sort.exe"; "tar.exe"; "git.exe"]
+        ["bash.exe"; "make.exe"; "sort.exe"; "tar.exe"; "git.exe"]
     in
     let rec loop acc = function
       | [] -> acc, [arg]


### PR DESCRIPTION
This should deal with the problem being seen with flexdll on setup-ocaml. The issue there is that the Cygwin bin directory gets pushed past a manual installation of mingw-w64 installed on the GHA runners (in `C:\mingw64`) which includes gcc and which quite rightly confuses OCaml.