### PR TITLE
Small refactoring and fixes to `opam init` on Windows.

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -28,6 +28,7 @@ users)
   * Skip Git-for-Windows menu if the Git binary resolved in PATH is Git-for-Windows [#5963 @dra27 - fix #5835]
   * Enhance the Git menu by warning if the user appears to need to restart the shell to pick up PATH changes [#5963 @dra27]
   * Include Git for Windows installations in the list of possibilities where the user instructed Git-for-Windows setup not to update PATH [#5963 @dra27]
+  * [BUG] Fail if `--git-location` points to a directory not containing git [#6000 @dra27]
 
 ## Config report
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -173,6 +173,7 @@ users)
   * `OpamClient.init` and `OpamClient.reinit`: now can have additional cygwin packages to install [#5930 @moyodiallo]
   * Expose `OpamSolution.print_depext_msg` [#5994 @dra27]
   * Extracted `OpamSolution.install_sys_packages` from `OpamSolution.install_depexts` [#5994 @dra27]
+  * `OpamInitDefaults.required_packages_for_cygwin`: no longer includes git; as the need to add that is computed in `OpamClient` [#6000 @dra27]
 
 ## opam-repository
   * `OpamDownload.download_command`: separate output from stdout and stderr [#5984 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -202,3 +202,4 @@ users)
   * [BUG]: fix incorrect recursion case in `OpamSystem.mk_temp_dir` [#6005 @dra27]
   * `OpamStubs.enumRegistry`: on Windows, retrieves all the values of a given type from a registry key, with their names [#6000 @dra27]
   * `OpamCompat`: add `Seq.find_map` from OCaml 4.14 [#6000 @dra27]
+  * `OpamStd.Sys.{get_windows_executable_variant,get_cygwin_variant,is_cygwin_variant}`: renamed `~cygbin` to `?search_in_path` with a change in semantics so that it acts as though the directory was simply the first entry in PATH [#6000 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -97,6 +97,7 @@ users)
   * Pass --no-version-check to Cygwin setup (suppresses a message box if setup needs updating) [#5830 @dra27]
   * Pass --quiet-mode noinput to stop the user interrupting the setup GUI [#5830 @dra27]
   * Always pass --no-write-registry to the Cygwin installer, not just on first installation [#5995 @dra27]
+  * os-distribution is now by default calculated from cygpath for Cygwin and MSYS2, instead of needing to be set by opam init [#6000 @dra27]
 
 ## Format upgrade
   * Handle init OCaml `sys-ocaml-*` eval variables during format upgrade from 2.0 -> 2.1 -> 2.2 [#5829 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -98,6 +98,7 @@ users)
   * Pass --quiet-mode noinput to stop the user interrupting the setup GUI [#5830 @dra27]
   * Always pass --no-write-registry to the Cygwin installer, not just on first installation [#5995 @dra27]
   * os-distribution is now by default calculated from cygpath for Cygwin and MSYS2, instead of needing to be set by opam init [#6000 @dra27]
+  * Cygwin setup is now always downloaded and updated both for internal and external Cygwin installations [#6000 @dra27]
 
 ## Format upgrade
   * Handle init OCaml `sys-ocaml-*` eval variables during format upgrade from 2.0 -> 2.1 -> 2.2 [#5829 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -201,3 +201,4 @@ users)
   * `OpamProcess.run_background`: name the stderr output file have the .err extension when cmd_stdout is given [#5984 @kit-ty-kate]
   * [BUG]: fix incorrect recursion case in `OpamSystem.mk_temp_dir` [#6005 @dra27]
   * `OpamStubs.enumRegistry`: on Windows, retrieves all the values of a given type from a registry key, with their names [#6000 @dra27]
+  * `OpamCompat`: add `Seq.find_map` from OCaml 4.14 [#6000 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -177,6 +177,7 @@ users)
   * `OpamDownload.download_command`: separate output from stdout and stderr [#5984 @kit-ty-kate]
 
 ## opam-state
+  * `OpamEnv.cygwin_non_shadowed_programs`: exposes the list of executables (not including git) which should always come from Cygwin [#6000 @dra27]
 
 ## opam-solver
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -133,6 +133,7 @@ users)
 
 ## Client
   * Fix rounding error when displaying the timestamp in debug mode [#5912 @kit-ty-kate - fix #5910]
+  * Overhaul Windows `opam init` to determine Unix and Git configuration simultaneously, and to detect from Cygwin, Git and MSYS2 from all the known package managers and shells [#6000 @dra27]
 
 ## Shell
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -199,3 +199,4 @@ users)
   * `OpamStd.Sys.resolve_in_path`: split the logic of `OpamStd.Sys.resolve_command` to allow searching for an arbitrary file in the search path [#5991 @dra27]
   * `OpamProcess.run_background`: name the stderr output file have the .err extension when cmd_stdout is given [#5984 @kit-ty-kate]
   * [BUG]: fix incorrect recursion case in `OpamSystem.mk_temp_dir` [#6005 @dra27]
+  * `OpamStubs.enumRegistry`: on Windows, retrieves all the values of a given type from a registry key, with their names [#6000 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -183,6 +183,7 @@ users)
 ## opam-state
   * `OpamEnv.cygwin_non_shadowed_programs`: exposes the list of executables (not including git) which should always come from Cygwin [#6000 @dra27]
   * `opamSysInteract.Cygwin.install`: de-label `packages` argument [#6000 @dra27]
+  * `OpamSysInteract.Cygwin.check_install` renamed to `analyse_install` which now also returns whether the installation found was MSYS2 or Cygwin [#6000 @dra27]
 
 ## opam-solver
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -182,6 +182,7 @@ users)
 
 ## opam-state
   * `OpamEnv.cygwin_non_shadowed_programs`: exposes the list of executables (not including git) which should always come from Cygwin [#6000 @dra27]
+  * `opamSysInteract.Cygwin.install`: de-label `packages` argument [#6000 @dra27]
 
 ## opam-solver
 

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -528,9 +528,8 @@ let compilation_env t opam =
       (OpamFile.OPAM.build_env opam)
   in
   let cygwin_env =
-    match OpamSysInteract.Cygwin.cygbin_opt t.switch_global.config with
+    match OpamCoreConfig.(!r.cygbin) with
     | Some cygbin ->
-      let cygbin = OpamFilename.Dir.to_string cygbin in
       [ OpamTypesBase.env_update_resolved "PATH" Cygwin cygbin
           ~comment:"Cygwin path"
       ] @ (match OpamCoreConfig.(!r.git_location) with

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1003,9 +1003,8 @@ let windows_checks ?cygwin_setup ?git_location config =
           in
           (* Check for default cygwin installation path *)
           let default =
-            match OpamSysInteract.Cygwin.(check_install
-                                            ~variant:true default_cygroot) with
-            | Ok cygcheck ->
+            match OpamSysInteract.Cygwin.(analyse_install default_cygroot) with
+            | Ok (_, cygcheck) ->
               let prompt_cygroot () =
                 let options = [
                   `manual,
@@ -1036,10 +1035,10 @@ let windows_checks ?cygwin_setup ?git_location config =
               | None -> None
               | Some entry ->
                 let cygcheck =
-                  OpamSysInteract.Cygwin.check_install ~variant:true entry
+                  OpamSysInteract.Cygwin.analyse_install entry
                 in
                 match cygcheck with
-                | Ok cygcheck -> Some cygcheck
+                | Ok (_, cygcheck) -> Some cygcheck
                 | Error msg -> OpamConsole.error "%s" msg; None
           in
           (* And finally ask for setup.exe *)
@@ -1113,9 +1112,8 @@ let windows_checks ?cygwin_setup ?git_location config =
                    | `default_location -> OpamSysInteract.Cygwin.default_cygroot
                    | `location dir -> OpamFilename.Dir.to_string dir
                  in
-                 (match OpamSysInteract.Cygwin.check_install ~variant:true
-                          cygroot with
-                 | Ok cygcheck -> cygcheck
+                 (match OpamSysInteract.Cygwin.analyse_install cygroot with
+                 | Ok (_, cygcheck) -> cygcheck
                  | Error msg ->
                    OpamConsole.error_and_exit `Not_found
                      "Error while checking %sCygwin install (%s): %s"
@@ -1131,9 +1129,9 @@ let windows_checks ?cygwin_setup ?git_location config =
           (* We check that current install is good *)
           (match OpamSysInteract.Cygwin.cygroot_opt config with
            | Some cygroot ->
-             (match OpamSysInteract.Cygwin.check_install ~variant:true
+             (match OpamSysInteract.Cygwin.analyse_install
                       (OpamFilename.Dir.to_string cygroot) with
-             | Ok cygcheck ->
+             | Ok (_, cygcheck) ->
                OpamSysInteract.Cygwin.check_setup None;
                success cygcheck
              | Error err -> OpamConsole.error "%s" err; get_cygwin None)

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -955,12 +955,12 @@ let windows_checks ?cygwin_setup ?git_location config =
     config
   in
   let install_cygwin_tools packages =
+    let default_packages = OpamInitDefaults.required_packages_for_cygwin in
     let default_packages =
-      match OpamSystem.resolve_command "git" with
-      | None -> OpamInitDefaults.required_packages_for_cygwin
-      | Some _ ->
-        List.filter (fun c -> not OpamSysPkg.(equal (of_string "git") c))
-          OpamInitDefaults.required_packages_for_cygwin
+      if OpamSystem.resolve_command "git" = None then
+        OpamSysPkg.of_string "git" :: default_packages
+      else
+        default_packages
     in
     (* packages comes last so that the user can override any potential version
        constraints in default_packages (although, with the current version of

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1096,7 +1096,10 @@ let windows_checks ?cygwin_setup ?git_location config =
              because there are commands opam requires which are only provided
              using it (patch, etc.). MSYS2 avoids this by requiring
              os-distribution to be set. *)
-          let cygcheck = OpamSysInteract.Cygwin.cygcheck_opt config in
+          let cygcheck =
+            OpamStd.String.Map.find_opt "cygwin"
+                    (OpamFile.Config.sys_pkg_manager_cmd config)
+          in
           (match cygwin_setup with
            | None -> get_cygwin cygcheck
            | Some setup  ->

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -840,16 +840,14 @@ let windows_checks ?cygwin_setup ?git_location config =
     | Some (Right ()), None -> Some (Right ())
     | Some (Right ()), Some _ ->
       OpamConsole.note
-        "As '--no-git-location' is given in argument, ignoring field \
-         'git-location' in opamrc";
+        "'--no-git-location' specified; field 'git-location' in opamrc \
+        has been ignored";
       Some (Right ())
     | Some (Left gl), None | None, Some gl -> Some (Left gl)
-    | Some (Left gl_cli), Some gl_config ->
+    | Some (Left gl_cli), Some _ ->
       OpamConsole.note
-        "Git location defined in opamrc '%s' and via CLI \
-         ('--git-location' option, %s). Keeping last one."
-        (OpamFilename.Dir.to_string gl_config)
-        (OpamFilename.Dir.to_string gl_cli) ;
+        "'--git-location' specified; field 'git-location' in opamrc \
+         has been ignored";
       Some (Left gl_cli)
   in
   let git_location =

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -966,7 +966,7 @@ let windows_checks ?cygwin_setup ?git_location config =
        constraints in default_packages (although, with the current version of
        setup, and with the list of default_packages in OpamInitDefaults, this at
        present doesn't matter too much). *)
-    OpamSysInteract.Cygwin.install ~packages:(default_packages @ packages)
+    OpamSysInteract.Cygwin.install (default_packages @ packages)
   in
   let header () = OpamConsole.header_msg "Unix support infrastructure" in
 

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -149,7 +149,6 @@ let required_tools ~sandboxing () =
 let required_packages_for_cygwin =
   [
     "diffutils";
-    "git"; (* XXX hg & mercurial ? *)
     "make";
     "patch";
     "tar";

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1189,6 +1189,8 @@ let install_sys_packages ~map_sysmap ~confirm env config sys_packages t =
     | `Ignore -> bypass t
     | `Quit -> give_up_msg (); OpamStd.Sys.exit_because `Aborted
   and print_command sys_packages =
+    if OpamSysPoll.os_distribution env = Some "cygwin" then
+      OpamSysInteract.Cygwin.check_setup None;
     let commands =
       OpamSysInteract.install_packages_commands ~env config sys_packages
       |> List.map (fun ((`AsAdmin c | `AsUser c), a) -> c::a)
@@ -1219,6 +1221,8 @@ let install_sys_packages ~map_sysmap ~confirm env config sys_packages t =
     | `Quit -> give_up ()
   and auto_install t sys_packages =
     try
+      if OpamSysPoll.os_distribution env = Some "cygwin" then
+        OpamSysInteract.Cygwin.check_setup None;
       OpamSysInteract.install ~env config sys_packages; (* handles dry_run *)
       map_sysmap (fun _ -> OpamSysPkg.Set.empty) t
     with Failure msg ->

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1189,8 +1189,10 @@ let install_sys_packages ~map_sysmap ~confirm env config sys_packages t =
     | `Ignore -> bypass t
     | `Quit -> give_up_msg (); OpamStd.Sys.exit_because `Aborted
   and print_command sys_packages =
+    (* Ensure that setup-x86_64.exe exists, so that an invalid command is not
+       displayed to the user. *)
     if OpamSysPoll.os_distribution env = Some "cygwin" then
-      OpamSysInteract.Cygwin.check_setup None;
+      OpamSysInteract.Cygwin.check_setup ~update:false;
     let commands =
       OpamSysInteract.install_packages_commands ~env config sys_packages
       |> List.map (fun ((`AsAdmin c | `AsUser c), a) -> c::a)
@@ -1222,7 +1224,7 @@ let install_sys_packages ~map_sysmap ~confirm env config sys_packages t =
   and auto_install t sys_packages =
     try
       if OpamSysPoll.os_distribution env = Some "cygwin" then
-        OpamSysInteract.Cygwin.check_setup None;
+        OpamSysInteract.Cygwin.check_setup ~update:true;
       OpamSysInteract.install ~env config sys_packages; (* handles dry_run *)
       map_sysmap (fun _ -> OpamSysPkg.Set.empty) t
     with Failure msg ->

--- a/src/core/opamCompat.ml
+++ b/src/core/opamCompat.ml
@@ -23,6 +23,24 @@ module String = struct
   include Stdlib.String
 end
 
+module Seq = struct
+  [@@@warning "-32"]
+
+  (** NOTE: OCaml >= 4.14 *)
+  let rec find_map f xs =
+    match xs() with
+    | Seq.Nil ->
+      None
+    | Seq.Cons (x, xs) ->
+      match f x with
+      | None ->
+          find_map f xs
+      | Some _ as result ->
+          result
+
+  include Seq
+end
+
 module Either = struct
   (** NOTE: OCaml >= 4.12 *)
   type ('a, 'b) t =

--- a/src/core/opamCompat.mli
+++ b/src/core/opamCompat.mli
@@ -13,6 +13,11 @@ module String : sig
   val exists: (char -> bool) -> string -> bool
 end
 
+module Seq : sig
+  (* NOTE: OCaml >= 4.14 *)
+  val find_map: ('a -> 'b option) -> 'a Seq.t -> 'b option
+end
+
 module Either : sig
   (* NOTE: OCaml >= 4.12 *)
   type ('a, 'b) t =

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -313,7 +313,7 @@ let create_process_env =
     fun cmd ->
       if OpamStd.Option.map_default
           (OpamStd.Sys.is_cygwin_variant
-             ~cygbin:(OpamCoreConfig.(!r.cygbin)))
+             ?search_in_first:(OpamCoreConfig.(!r.cygbin)))
              false
              (resolve_command cmd) then
         cygwin_create_process_env cmd

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1402,20 +1402,6 @@ module OpamSys = struct
   let is_cygwin_variant ?search_in_first cmd =
     get_cygwin_variant ?search_in_first cmd = `Cygwin
 
-  let is_cygwin_cygcheck_t ~variant ~cygbin =
-    match cygbin with
-    | Some cygbin ->
-      let cygpath = Filename.concat cygbin "cygpath.exe" in
-      Sys.file_exists cygpath
-      && (variant ?search_in_first:(Some cygbin) cygpath = `Cygwin)
-    | None -> false
-
-  let is_cygwin_variant_cygcheck ~cygbin =
-    is_cygwin_cygcheck_t ~variant:get_cygwin_variant ~cygbin
-
-  let is_cygwin_cygcheck ~cygbin =
-    is_cygwin_cygcheck_t ~variant:get_windows_executable_variant ~cygbin
-
   exception Exit of int
   exception Exec of string * string array * string array
 

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -565,11 +565,15 @@ module Sys : sig
       to a library which is itself Cygwin- or MSYS2-compiled, or [`Native]
       otherwise.
 
-      Note that this returns [`Native] on a Cygwin-build of opam!
+      If supplied, [~search_in_first] specifies a directory which should be
+      searched for cygcheck prior to searching the current PATH.
 
-      Both cygcheck and an unqualified command will be resolved if necessary
-      using the current PATH. *)
-  val get_windows_executable_variant: cygbin:string option ->
+      If the command given is not an absolute path, it too is resolved in the
+      current PATH.
+
+      If cygcheck cannot be resolved in PATH, or when running the Cygwin build
+      of opam, the function returns `Native. *)
+  val get_windows_executable_variant: ?search_in_first:string ->
     string -> [ `Native | `Cygwin | `Tainted of [ `Msys2 | `Cygwin] | `Msys2 ]
 
   (** Determines if cygcheck in given cygwin binary directory comes from a
@@ -581,18 +585,17 @@ module Sys : sig
       (Cygwin, Msys2). *)
   val is_cygwin_variant_cygcheck : cygbin:string option -> bool
 
-  (** For native Windows builds, returns [`Cygwin] if the command is a Cygwin-
+  (** Behaviour is largely as {!get_windows_executable_variant} but where MSYS2
+      and Cygwin are seen as equivalent.
+
+      For native Windows builds, returns [`Cygwin] if the command is a Cygwin-
       or Msys2- compiled executable, and [`CygLinked] if the command links to a
-      library which is itself Cygwin/Msys2-compiled, or [`Native] otherwise.
-
-      Note that this returns [`Native] on a Cygwin-build of opam!
-
-      Both cygcheck and an unqualified command will be resolved using the
-      current PATH. *)
-  val get_cygwin_variant: cygbin:string option -> string -> [ `Native | `Cygwin | `CygLinked ]
+      library which is itself Cygwin/Msys2-compiled, or [`Native] otherwise. *)
+  val get_cygwin_variant:
+    ?search_in_first:string -> string -> [ `Native | `Cygwin | `CygLinked ]
 
   (** Returns true if [get_cygwin_variant] is [`Cygwin] *)
-  val is_cygwin_variant: cygbin:string option -> string -> bool
+  val is_cygwin_variant: ?search_in_first:string -> string -> bool
 
   (** {3 Exit handling} *)
 

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -576,15 +576,6 @@ module Sys : sig
   val get_windows_executable_variant: ?search_in_first:string ->
     string -> [ `Native | `Cygwin | `Tainted of [ `Msys2 | `Cygwin] | `Msys2 ]
 
-  (** Determines if cygcheck in given cygwin binary directory comes from a
-      Cygwin installation. Determined by analysing the cygpath command
-      found with it. *)
-  val is_cygwin_cygcheck : cygbin:string option -> bool
-
-  (** As [is_cygwin_cygcheck], but returns true if it is a Cygwin variant
-      (Cygwin, Msys2). *)
-  val is_cygwin_variant_cygcheck : cygbin:string option -> bool
-
   (** Behaviour is largely as {!get_windows_executable_variant} but where MSYS2
       and Cygwin are seen as equivalent.
 

--- a/src/core/opamStubs.dummy.ml
+++ b/src/core/opamStubs.dummy.ml
@@ -24,6 +24,7 @@ let getWindowsVersion = that's_a_no_no
 let getArchitecture = that's_a_no_no
 let waitpids _ = that's_a_no_no
 let readRegistry _ _ _ = that's_a_no_no
+let enumRegistry _ _ = that's_a_no_no
 let writeRegistry _ _ _ = that's_a_no_no
 let getConsoleOutputCP = that's_a_no_no
 let getCurrentConsoleFontEx _ = that's_a_no_no

--- a/src/core/opamStubs.mli
+++ b/src/core/opamStubs.mli
@@ -70,6 +70,12 @@ val readRegistry : registry_root -> string -> string -> 'a registry_value -> 'a 
 
       @raise Failure If the value in the registry does not have [value_type] *)
 
+val enumRegistry : registry_root -> string -> 'a registry_value -> (string * 'a) list
+  (** Windows only. [enumRegistry root key value_type] reads all the values
+      from registry key [key] of [root] which have type [value_type].
+
+      Returns [[]] if the key is not found. *)
+
 val writeRegistry :
   registry_root -> string -> string -> 'a registry_value -> 'a -> unit
   (** Windows only. [writeRegistry root key name value_type value] sets the

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -444,7 +444,7 @@ let get_cygpath_function =
       lazy (
         if OpamStd.Option.map_default
             (OpamStd.Sys.is_cygwin_variant
-               ~cygbin:(OpamCoreConfig.(!r.cygbin)))
+               ?search_in_first:(OpamCoreConfig.(!r.cygbin)))
                false
                (resolve_command command) then
           apply_cygpath
@@ -794,7 +794,7 @@ let install ?(warning=default_install_warning) ?exec src dst =
       copy_file_aux ~src ~dst ();
       if cygcheck then
         match OpamStd.Sys.get_windows_executable_variant
-                ~cygbin:OpamCoreConfig.(!r.cygbin) dst with
+                ?search_in_first:OpamCoreConfig.(!r.cygbin) dst with
         | `Native -> ()
         | (`Cygwin | `Msys2 | `Tainted _) as code -> warning dst code
     end else

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -306,6 +306,9 @@ let rezip ?insert (l1, l2) =
 let rezip_to_string ?insert z =
   join_var (rezip ?insert z)
 
+let cygwin_non_shadowed_programs =
+  ["bash.exe"; "make.exe"; "sort.exe"; "tar.exe"]
+
 let apply_op_zip ~sepfmt var op arg (rl1,l2 as zip) =
   let arg = transform_format ~sepfmt var arg in
   let empty_tr = { tr_entry = ""; tr_raw = ""; tr_sep = arg.tr_sep } in
@@ -314,8 +317,7 @@ let apply_op_zip ~sepfmt var op arg (rl1,l2 as zip) =
       Sys.file_exists (Filename.concat dir item)
     in
     let shadow_list =
-      List.filter (contains_in arg)
-        ["bash.exe"; "make.exe"; "sort.exe"; "tar.exe"; "git.exe"]
+      List.filter (contains_in arg) ("git.exe" :: cygwin_non_shadowed_programs)
     in
     let rec loop acc = function
       | [] -> acc, [arg]

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -61,6 +61,12 @@ val hash_env_updates: ('a, euok_writeable) env_update list -> string
     and optionally the given updates *)
 val get_pure: ?updates:(spf_resolved, euok_internal) env_update list -> unit -> env
 
+(** The list of executables from Cygwin which must not be allowed to be shadowed
+    by other directories of PATH. This list must not contain git.exe - it is
+    added only if Cygwin's git is installed. The list is used to determine the
+    furthest point in PATH that Cygwin's bin directory can be placed. *)
+val cygwin_non_shadowed_programs : string list
+
 (** Update an environment, including reverting opam changes that could have been
     previously applied (therefore, don't apply to an already updated env as
     returned by e.g. [get_full]!) *)

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -41,17 +41,14 @@ let load_config lock_kind global_lock root =
   (* Update Cygwin variants cygbin *)
   let cygbin =
     let config = fst config in
-    match OpamSysInteract.Cygwin.cygbin_opt config with
-    | Some cygbin -> Some (OpamFilename.Dir.to_string cygbin)
-    | None ->
-      if List.exists (function
-          | (v, S "msys2", _) ->
-            String.equal (OpamVariable.to_string v) "os-distribution"
-          | _ -> false) (OpamFile.Config.global_variables config)
-      then
-        OpamStd.Option.map Filename.dirname
-          (OpamSystem.resolve_command "cygcheck")
-      else None
+    let cygwin = OpamSysInteract.Cygwin.cygbin_opt config in
+    let cygbin =
+      if cygwin = None then
+        OpamSysInteract.Cygwin.msys2bin_opt config
+      else
+        cygwin
+    in
+    Option.map OpamFilename.Dir.to_string cygbin
   in
   OpamCoreConfig.update ?cygbin ();
   config

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -320,7 +320,7 @@ module Cygwin = struct
       OpamFilename.with_open_out_bin_atomic fstab
         (fun oc -> Stdlib.output_string oc content)
 
-  let install ~packages =
+  let install packages =
     let open OpamProcess.Job.Op in
     let cygwin_root = internal_cygroot () in
     let cygwin_bin = cygwin_root / "bin" in

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -364,10 +364,7 @@ module Cygwin = struct
          args @@> fun r ->
        OpamSystem.raise_on_process_error r;
        set_fstab_noacl fstab;
-       Done ());
-    cygcheck
-
-  let default_cygroot = "C:\\cygwin64"
+       Done ())
 
   let analysis_cache = Hashtbl.create 17
 
@@ -440,11 +437,8 @@ module Cygwin = struct
               match r.OpamProcess.r_stdout with
               | [] ->
                 Error ("Unexpected error translating \"/\" with " ^ cygpath)
-              | _::_ ->
-                let cygcheck =
-                  OpamFilename.of_string (Filename.concat dir "cygpath.exe")
-                in
-                Ok (kind, cygcheck)
+              | l::_ ->
+                Ok (kind, OpamFilename.Dir.of_string l)
             else
               Error ("Could not determine the root for " ^ cygpath)
         in
@@ -452,6 +446,12 @@ module Cygwin = struct
         result
     in
     Result.bind cygbin identify
+
+  let bindir_for_root kind root =
+    let open OpamFilename.Op in
+    match kind with
+    | `Msys2 -> root / "usr" / "bin"
+    | `Cygwin -> root / "bin"
 
   (* Set setup.exe in the good place, ie in .opam/.cygwin/ *)
   let check_setup setup =

--- a/src/state/opamSysInteract.mli
+++ b/src/state/opamSysInteract.mli
@@ -69,10 +69,9 @@ module Cygwin : sig
   (* Return Cygwin binary path *)
   val cygbin_opt: OpamFile.Config.t -> OpamFilename.Dir.t option
 
-  (* Return Cygwin cygcheck.exe path *)
-  val cygcheck_opt: OpamFile.Config.t -> OpamFilename.t option
-
   (* Return Cygwin installation prefix *)
   val cygroot_opt: OpamFile.Config.t -> OpamFilename.Dir.t option
 
+  (* Return MSYS2 binary path *)
+  val msys2bin_opt: OpamFile.Config.t -> OpamFilename.Dir.t option
 end

--- a/src/state/opamSysInteract.mli
+++ b/src/state/opamSysInteract.mli
@@ -47,7 +47,7 @@ module Cygwin : sig
   val default_cygroot: string
 
   (* Install an internal Cygwin install, in <root>/.cygwin *)
-  val install: packages:OpamSysPkg.t list -> OpamFilename.t
+  val install: OpamSysPkg.t list -> OpamFilename.t
 
   (* [check_install ~variant path] checks a Cygwin install at [path]. It checks
      that 'path\cygcheck.exe', 'path\bin\cygcheck.exe', or

--- a/src/state/opamSysInteract.mli
+++ b/src/state/opamSysInteract.mli
@@ -49,21 +49,29 @@ module Cygwin : sig
   (* Install an internal Cygwin install, in <root>/.cygwin *)
   val install: OpamSysPkg.t list -> OpamFilename.t
 
-  (* [check_install ~variant path] checks a Cygwin install at [path]. It checks
-     that 'path\cygcheck.exe', 'path\bin\cygcheck.exe', or
-     'path\usr\bin\cygcheck.exe' exists.
-     If [~variant] is false, checks that it is strictly a Cygwin install,
-     otherwise a Cygwin-like install as MSYS2. *)
-  val check_install:
-    variant:bool -> string -> (OpamFilename.t, string) result
+  (* [analyse_install path] searches for and identifies Cygwin/MSYS2
+     installations. [path] may be able the location of cygcheck.exe itself
+     (with or without the .exe) or just a directory. If [path] is just a
+     directory, then the function searches for 'path\cygcheck.exe',
+     'path\bin\cygcheck.exe', or 'path\usr\bin\cygcheck.exe'. If exactly one
+     is found, and cygpath.exe is found with it, then cygpath is used both to
+     identify whether the installation is Cygwin or MSYS2 and to translate the
+     root directory [/] to its Windows path (i.e. to get the canonical root
+     directory of the installation). MSYS2 is additionally required to have
+     pacman.exe in the same directory as cygcheck.exe and cygpath.exe.
+
+     On success, the result is the kind of installation (Cygwin/MSYS2) along
+     with the full path to cygcheck.exe, otherwise a description of the problem
+     encountered is returned. *)
+  val analyse_install:
+    string -> ([ `Cygwin | `Msys2 ] * OpamFilename.t, string) result
 
   (* Returns true if Cygwin install is internal *)
   val is_internal: OpamFile.Config.t -> bool
 
   (* [check_setup path] checks and store Cygwin setup executable. Is [path] is
      [None], it downloads it, otherwise it copies it to
-     <opamroot>/.cygwin/setup-x86_64.exe. If the file is already existent, it
-     is a no-op. *)
+     <opamroot>/.cygwin/setup-x86_64.exe. *)
   val check_setup: OpamFilename.t option -> unit
 
   (* Return Cygwin binary path *)

--- a/src/state/opamSysInteract.mli
+++ b/src/state/opamSysInteract.mli
@@ -74,10 +74,11 @@ module Cygwin : sig
   (* Returns true if Cygwin install is internal *)
   val is_internal: OpamFile.Config.t -> bool
 
-  (* [check_setup path] checks and store Cygwin setup executable. Is [path] is
-     [None], it downloads it, otherwise it copies it to
-     <opamroot>/.cygwin/setup-x86_64.exe. *)
-  val check_setup: OpamFilename.t option -> unit
+  (* [check_setup ~update] downloads and stores a Cygwin setup executable to
+     <opamroot>/.cygwin/setup-x86_64.exe. If [~update = false], this only
+     happens if the setup executable does not already exist, otherwise it is.
+     updated. *)
+  val check_setup: update:bool -> unit
 
   (* Return Cygwin binary path *)
   val cygbin_opt: OpamFile.Config.t -> OpamFilename.Dir.t option

--- a/src/state/opamSysInteract.mli
+++ b/src/state/opamSysInteract.mli
@@ -43,11 +43,11 @@ val repo_enablers: ?env:gt_variables -> OpamFile.Config.t -> string option
 
 module Cygwin : sig
 
-  (* Default Cygwin installation prefix C:\cygwin64 *)
-  val default_cygroot: string
+  (* Location of the internal Cygwin installation *)
+  val internal_cygroot: unit -> OpamFilename.Dir.t
 
   (* Install an internal Cygwin install, in <root>/.cygwin *)
-  val install: OpamSysPkg.t list -> OpamFilename.t
+  val install: OpamSysPkg.t list -> unit
 
   (* [analyse_install path] searches for and identifies Cygwin/MSYS2
      installations. [path] may be able the location of cygcheck.exe itself
@@ -61,10 +61,15 @@ module Cygwin : sig
      pacman.exe in the same directory as cygcheck.exe and cygpath.exe.
 
      On success, the result is the kind of installation (Cygwin/MSYS2) along
-     with the full path to cygcheck.exe, otherwise a description of the problem
-     encountered is returned. *)
+     with the root directory (e.g. {v C:\cygwin64 v} or {v C:\msys64 v}),
+     otherwise a description of the problem encountered is returned. *)
   val analyse_install:
-    string -> ([ `Cygwin | `Msys2 ] * OpamFilename.t, string) result
+    string -> ([ `Cygwin | `Msys2 ] * OpamFilename.Dir.t, string) result
+
+  (* [bindir_for_root kind root] returns the bin directory for the given
+     installation root and [kind], as returned by {!analyse_install}. *)
+  val bindir_for_root:
+    [ `Cygwin | `Msys2 ] -> OpamFilename.Dir.t -> OpamFilename.Dir.t
 
   (* Returns true if Cygwin install is internal *)
   val is_internal: OpamFile.Config.t -> bool
@@ -76,9 +81,6 @@ module Cygwin : sig
 
   (* Return Cygwin binary path *)
   val cygbin_opt: OpamFile.Config.t -> OpamFilename.Dir.t option
-
-  (* Return Cygwin installation prefix *)
-  val cygroot_opt: OpamFile.Config.t -> OpamFilename.Dir.t option
 
   (* Return MSYS2 binary path *)
   val msys2bin_opt: OpamFile.Config.t -> OpamFilename.Dir.t option

--- a/src/state/opamSysPoll.ml
+++ b/src/state/opamSysPoll.ml
@@ -114,14 +114,15 @@ let poll_os_distribution () =
        try Scanf.sscanf s " %s " norm
        with Scanf.Scan_failure _ -> linux)
   | Some "win32" ->
-    (* If the user provides a Cygwin installation in PATH, by default we'll use
-       it. Note that this is _not_ done for MSYS2. *)
-    let cygwin =
-      OpamSystem.resolve_command "cygcheck"
-      >>| Filename.dirname
-      |> (fun cygbin -> OpamStd.Sys.is_cygwin_cygcheck ~cygbin)
+    let kind =
+      OpamStd.Sys.get_windows_executable_variant
+        ?search_in_first:(OpamCoreConfig.(!r.cygbin)) "cygpath.exe" 
     in
-    if cygwin then Some "cygwin" else os
+    begin match kind with
+    | `Msys2 -> Some "msys2"
+    | `Cygwin -> Some "cygwin"
+    | `Native | `Tainted _ -> os
+    end
   | os -> os
 let os_distribution = Lazy.from_fun poll_os_distribution
 

--- a/src/stubs/win32/opamWin32Stubs.ml
+++ b/src/stubs/win32/opamWin32Stubs.ml
@@ -23,6 +23,7 @@ external getWindowsVersion : unit -> int * int * int * int = "OPAMW_GetWindowsVe
 external getArchitecture : unit -> 'a = "OPAMW_GetArchitecture"
 external waitpids : int list -> int -> int * Unix.process_status = "OPAMW_waitpids"
 external readRegistry : 'a -> string -> string -> 'b -> 'c option = "OPAMW_ReadRegistry"
+external enumRegistry : 'a -> string -> 'b -> (string * 'c) list = "OPAMW_RegEnumValue"
 external writeRegistry : 'a -> string -> string -> 'b -> 'c -> unit = "OPAMW_WriteRegistry"
 external getConsoleOutputCP : unit -> int = "OPAMW_GetConsoleOutputCP"
 external getCurrentConsoleFontEx : 'a -> bool -> 'b = "OPAMW_GetCurrentConsoleFontEx"


### PR DESCRIPTION
At present includes #5991, #5994 and #5997. The diff becomes slightly less hideous with #5997 merged. The PR includes the behaviour of #5996 and may need #5998 for CI to pass properly.

This PR considerably extends the ideas from #5963. The primary goal is to extend `opam init` on Windows to recognise as many scenarios for getting either Cygwin or MSYS2 as we at present know to exist, so that users are presented with meaningful choices. In particular, this addresses running `opam init` from with a Cygwin or MSYS2 bash shell (in particular, #5952 is fixed).

I think it's helpful to start with some scenarios with beta2, and then explain the fixes from there:
1. From cmd/pwsh, with nothing other than `opam` installed, we already have an excellent experience which recommends pausing to install Git for Windows (with helpful advice on that added #5963) and which installs Cygwin.
2. If the user has installed Git for Windows using its (non-default) "Use Git and optional Unix tools from the Command Prompt" setting (or run `choco install git /GitAndUnixToolsOnPath`), then beta2 displays rather more Git options than might be nice, but #5963 also makes this a quite elegant experience by default (the `bash.exe` included on PATH is correctly shadowed by the internal Cygwin installation, which is recommended).
3. If the user installs things with [Scoop](https://scoop.sh/) - e.g. `scoop install cygwin msys2 git` - then `opam init` presently works, but neither Git for Windows, MSYS2 or Cygwin are recognised by opam.
4. Similarly, if the user installs with [Chocolatey](https://chocolatey.org/) - e.g. `choco install cyg-get msys2 git` - then `opam init` does detect Git for Windows, but does not detect either the MSYS2 or Cygwin installations.
5. Similarly, if the user installs with [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/) - e.g. `winget install Cygwin.Cygwin MSYS2.MSYS2 Git.Git` - then we have an experience similar to Chocolatey, although as Cygwin is installed to the default C:\cygwin64, that is recognised by opam.
6. If the user runs `opam init` from Git Bash (not a recommended thing to do), then we get hit by #5984, but if we work around that then the experience is OK. This is a scenario where there are tools on the PATH, and running with `--no-cygwin-setup` is not as OK - `opam var os-distribution` reporting `win32` instead of `msys2`. That said, using Git Bash to run `opam init` is never going to be a good idea (it has no package manager - it's intended for interaction with Git only).
7. If the user has elected to configure their `PATH` to have MSYS2's main bin directory permanently installed, then the default behaviour of `opam init` is pretty good, _unless_ MSYS2's `curl` shadows Windows `curl`.
8. If the user runs `opam init` from within MSYS2's `bash` the experience both with and without `--no-cygwin-setup` is pretty good.
9. If the user has elected to configure their `PATH` to have Cygwin's main bin directory permanently installed, then the default behaviour is affected by #5952.
10. Running `opam init` from within Cygwin's `bash` is similarly affected by #5952.

In all of these scenarios where the user has preinstalled either MSYS2 or Cygwin, we do have the issue that `opam init --no-cygwin-setup` (i.e. just using what's found) will typically fail because `patch`, `unzip` and so forth are not installed by default.

The changes here seek to make all of those scenarios as awesome as possible.

At a very high-level the changes are:
- MSYS2 and Cygwin are now treated equally where `sys-pkg-manager-cmd` is concerned (if both have been defined, Cygwin takes priority). In particular that means that MSYS2 gets added to PATH in exactly the same way as Cygwin.
- `os-distribution` is no longer explicitly set by `opam init`. Instead, `os-distribution` is always determined by looking at `cygpath.exe`. The internal or `--cygwin-location` treatment merely affects PATH resolution (i.e. the internal cygbin addition) - once cygpath.exe is resolved, it becomes the source of truth. Thus, from an MSYS2 shell, `opam var os-distribution` is now `msys2` _by default_.
- For now, I've removed the prompting for Cygwin setup. The idea here is that we treat Cygwin setup as being equal between both an internal and external installation of Cygwin. In particular, this fixes a bug in depext treatment when initialising with `--cygwin-location` as Cygwin setup was never downloaded.
- The final, somewhat horrific, refactor in OpamClient attempts to deal with the fact that the Git menu and the Unix tools decisions are not independent. The Unix tools are now determined first, and that feeds into the decision about what may need to be done for Git.
- Various tricks are now exploited to find Cygwin and MSYS2 installations:
  - Cygwin's two registry keys are inspected
  - The default locations of C:\cygwin64 and C:\msys64 are used
  - A path search for msys2.exe provides an heuristic for seeeking an MSYS2 installation
  - Special handling for Scoop is added, both to identify its Git for Windows and to identify its MSYS2 installation
- A key feature of all of these changes is that we only ever cygcheck and cygpath while inspecting things. In particular, we have to be very careful about running `bash` since we have no idea what it may do.
- Chocolatey and winget both correctly initialise their MSYS2 installations, but unfortunately Scoop leaves this as an instruction to the user. Again, I've added some special handling to detect this - but this is treated just as running a depext command, so opam asks about it first.
- The depext system is now integrated into `opam init` so opam will offer to add the required packages to both Cygwin and MSYS2 for existing installations, rather than simply erroring.

Put together, the changes mean that the user is presented with meaningful choices in all 10 of those scenarios and, in particular, they will see _all_ of the packages they have already installed. If they agree with everything opam suggests, they should then always end up with initialised opam with a compiler 🥳

On my system, when added to #5992, `opam init` run from Cygwin's bash now offers:

```
DRA@Tau /cygdrive/c/Devel/opam
$ ./opam init

<><> Unix support infrastructure ><><><><><><><><><><><><><><><><><><><><><>  🐫

opam and the OCaml ecosystem in general require various Unix tools in order to operate correctly. At present, this requires the installation of Cygwin to provide these tools.

How should opam obtain Unix tools?
> 1. Use tools found in PATH (Cygwin installation at C:\cygwin64)
  2. Automatically create an internal Cygwin installation that will be managed by opam (recommended)
  3. Use Cygwin installation found in C:\cygwin64
  4. Use Cygwin installation found in C:\OCaml64
  5. Use Cygwin installation found in C:\cygwin64-2
  6. Use Cygwin installation found in C:\Users\DRA\AppData\Local\opam\.cygwin\root
  7. Use Cygwin installation found in C:\Devel\Roots\beta2-testing\.cygwin\root
  8. Use Cygwin installation found in C:\Cygwin64-beta2-testing
  9. Use Cygwin installation found in C:\cygwin64-throw
  a. Use Cygwin installation found in C:\Devel\Roots\opam-testing\.cygwin\root
  b. Use Cygwin installation found in C:\Devel\Roots\final-test\.cygwin\root
  c. Use Cygwin installation found in C:\Devel\Roots\env-testing\.cygwin\root
  d. Use Cygwin installation found in C:\cygwin64-throw2
  e. Use Cygwin installation found in C:\Devel\Roots\msys2-native\.cygwin\root
  f. Use Cygwin installation found in C:\Devel\Roots\os-dist-cygwin\.cygwin\root
  g. Use MSYS2 installation found in C:\msys64
  h. Use another existing Cygwin/MSYS2 installation
  i. Abort initialisation

[1/2/3/4/5/6/7/8/9/a/b/c/d/e/f/g/h/i]
```