### PR TITLE
Do not special case the rewriting rule for the PKG_CONFIG_PATH environment variable

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -698,7 +698,7 @@ The `<path-format>` defines the way to handle variables path formatting:
   any entries which include the separator character.
 
 If a variable is not mentioned in `x-env-path-rewrite`, the separator is assumed to be `;` on Windows and `:` on all other systems; no slash or quoting transformations are performed. There are two special default cases:
-* `PKG_CONFIG_PATH` uses `:` separator and is `target-quoted`
+* `MANPATH` uses `:` separator and is `host`
 * `PATH` on Windows uses `;` separator and is `target-quoted`
 
 For example, on Windows:

--- a/master_changes.md
+++ b/master_changes.md
@@ -83,6 +83,7 @@ users)
   * [BUG] Fix incorrect reverting of `=+` and `=:` [#5935 @dra27 - fix #5926]
   * For the `Cygwin` internal operator, don't allow `make.exe` to become shadowed [#5996 @dra27]
   * [BUG] Fix incorrect quoting rule for `PKG_CONFIG_PATH` [#5972 @dra27 - partial fix for #5923]
+  * [BUG] Do not special case the rewriting rule for the PKG_CONFIG_PATH environment variable [#6002 @kit-ty-kate - fix #5923]
 
 ## Opamfile
 

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -28,7 +28,7 @@ let default_sep_fmt_str var =
   match String.uppercase_ascii var with
   | "PATH" when Sys.win32 ->
     SSemiColon, Target_quoted
-  | "PKG_CONFIG_PATH" | "MANPATH" ->
+  | "MANPATH" ->
     SColon, Host
   | _ -> default_separator, default_format
 


### PR DESCRIPTION
Fixes #5923 

The special casing of PKG_CONFIG_PATH was added in https://github.com/ocaml/opam/commit/fd429e33420cece92d82e803c26079185baafd74 but is not needed anymore since https://github.com/ocaml/opam/pull/5636