### PR TITLE
Fix bug in recursion case in `OpamSystem.mk_temp_dir`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -194,3 +194,4 @@ users)
   * `OpamStd.Sys.resolve_command`: extracted the logic from `OpamSystem.resolve_command`, without the default environment handling from OpamProcess. [#5991 @dra27]
   * `OpamStd.Sys.resolve_in_path`: split the logic of `OpamStd.Sys.resolve_command` to allow searching for an arbitrary file in the search path [#5991 @dra27]
   * `OpamProcess.run_background`: name the stderr output file have the .err extension when cmd_stdout is given [#5984 @kit-ty-kate]
+  * [BUG]: fix incorrect recursion case in `OpamSystem.mk_temp_dir` [#6005 @dra27]

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -84,7 +84,7 @@ let temp_basename prefix =
 let rec mk_temp_dir ?(prefix="opam") () =
   let s = Filename.get_temp_dir_name () / temp_basename prefix in
   if Sys.file_exists s then
-    mk_temp_dir ()
+    mk_temp_dir ~prefix ()
   else
     real_path s
 


### PR DESCRIPTION
The `~prefix` argument wasn't passed when recursing. Very niche failure mode, but having spotted it...