### PR TITLE
reftest: add a test showing root redirection on Windows when OPAMROOT contains spaces

### DIFF
--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -723,6 +723,27 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:init.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-init.win32)
+ (enabled_if (= %{os_type} "Win32"))
+ (action
+  (diff init.win32.test init.win32.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (= %{os_type} "Win32"))
+ (deps (alias reftest-init.win32)))
+
+(rule
+ (targets init.win32.out)
+ (deps root-N0REP0)
+ (enabled_if (= %{os_type} "Win32"))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:init.win32.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-inplace)
  (action
   (diff inplace.test inplace.out)))

--- a/tests/reftests/init.win32.test
+++ b/tests/reftests/init.win32.test
@@ -1,0 +1,28 @@
+N0REP0
+### : Redirection :
+### rm -rf $OPAMROOT
+### OPAMROOT="roots/with path"
+### opam init --no-setup --bare --bypass-checks default REPO/ | grep -v Cygwin
+[ERROR] You opam root directory contains a space, this may lead to several malfunction... bzzz.... nooo
+No configuration file found, using built-in defaults.
+Your opam root path '${BASEDIR}/roots/with path' contains a space, we'll redirect to 'C:\opamroot'.
+Do you want to choose and enter another spaceless folder? [y/n] n
+
+<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+[default] Initialised
+### opam var root --debug --debug-level=-1
+CLI                             Parsing CLI version 2.2
+GSTATE                          LOAD-GLOBAL-STATE @ C:\opamroot
+C:\opamroot
+### cat 'roots/with path/redirected-opamroot'
+C:\opamroot
+### opam switch create --empty test
+### opam switch --debug --debug-level=-1
+CLI                             Parsing CLI version 2.2
+GSTATE                          LOAD-GLOBAL-STATE @ C:\opamroot
+SWITCH                          list
+#   switch  compiler  description
+->  test              test
+### echo $OPAMROOT
+roots/with path
+### rm -rf 'C:\opamroot'


### PR DESCRIPTION
Split off from #5457 as we're not yet sure how to properly test this