### PR TITLE
Various fixes

### DIFF
--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -969,7 +969,7 @@ let menu ?default ?unsafe_yes ?yes ~no ~options fmt =
   let options_nums =
     let option_of_index n =
       (* NOTE: 1..9 (starts at ASCII 49) & a..z (starts at ASCII 97) *)
-      (String.make 1 (char_of_int (if n < 9 then n+49 else n+97)))
+      (String.make 1 (char_of_int (if n < 9 then n+49 else (n-9)+97)))
     in
     List.mapi (fun n (ans, _) -> ans, option_of_index n) options
   in

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -168,9 +168,9 @@ module B = struct
          else
            OpamFilename.mkdir quarantine;
          pull_dir_quiet quarantine url) @@+ function
-    | Not_available _ ->
+    | Not_available (_, msg) ->
       finalise ();
-      Done (OpamRepositoryBackend.Update_err (Failure "rsync failed"))
+      Done (OpamRepositoryBackend.Update_err (Failure ("Not available: " ^ msg)))
     | Up_to_date _ ->
       finalise (); Done OpamRepositoryBackend.Update_empty
     | Result _ ->


### PR DESCRIPTION
Noticed when debugging https://github.com/kit-ty-kate/opam-repository/pull/26

The first commit is my fault from #6000. I noticed it when running opam locally on Windows and saw the choices `1/2/3/4/5/6/7/8/9/j` instead of the expected `1/2/3/4/5/6/7/8/9/a`.

The second commit helped to locate the issue i was having as `[ERROR] Could not update repository "default": rsync failed` was not very helpful. With this change I now get `Error:  Could not update repository "default": Not available: Directory D:/a/opam-repository/opam-repository/opam-repository/ does not exist`