### PR TITLE
Fix the lower-bound constraint on ocaml-re

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -68,6 +68,7 @@ users)
 ## VCS
 
 ## Build
+  * Fix the lower-bound constraint on ocaml-re (bump from >= 1.9.0 to >= 1.10.0) [#6016 @kit-ty-kate]
 
 ## Infrastructure
 

--- a/opam-client.opam
+++ b/opam-client.opam
@@ -33,7 +33,7 @@ depends: [
   "opam-solver" {= version}
   "base64" {>= "3.1.0"}
   "opam-repository" {= version}
-  "re" {>= "1.9.0"}
+  "re" {>= "1.10.0"}
   "cmdliner" {>= "1.1.0"}
   "dune" {>= "2.0.0"}
 ]


### PR DESCRIPTION
Re.Group.get_opt was added in re 1.10.0

Noticed in https://github.com/ocaml/opam-repository/pull/26053

```
#=== ERROR while compiling opam-client.2.2.0~beta3 ============================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.08/.opam-switch/build/opam-client.2.2.0~beta3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p opam-client -j 255
# exit-code            1
# env-file             ~/.opam/log/opam-client-7-ac1441.env
# output-file          ~/.opam/log/opam-client-7-ac1441.out
### output ###
#       ocamlc src/client/.opam_client.objs/byte/opamClient.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.08/bin/ocamlc.opt -w -40 -w +a-4-40-42-44-48 -safe-string -g -bin-annot -I src/client/.opam_client.objs/byte -I /home/opam/.opam/4.08/lib/0install-solver -I /home/opam/.opam/4.08/lib/base64 -I /home/opam/.opam/4.08/lib/bytes -I /home/opam/.opam/4.08/lib/bz2 -I /home/opam/.opam/4.08/lib/cmdliner -I /home/opam/.opam/4.08/lib/cudf -I /home/opam/.opam/4.08/lib/dose3/algo -I /home/opam/.opam/4.08/lib/dose3/common -I /home/opam/.opam/4.08/lib/extlib -I /home/opam/.opam/4.08/lib/fmt -I /home/opam/.opam/4.08/lib/jsonm -I /home/opam/.opam/4.08/lib/mccs -I /home/opam/.opam/4.08/lib/mccs/glpk/internal -I /home/opam/.opam/4.08/lib/ocamlgraph -I /home/opam/.opam/4.08/lib/opam-0install-cudf -I /home/opam/.opam/4.08/lib/opam-core -I /home/opam/.opam/4.08/lib/opam-file-format -I /home/opam/.opam/4.08/lib/opam-format -I /home/opam/.opam/4.08/lib/opam-repository -I /home/opam/.opam/4.08/lib/opam-solver -I /home/opam/.opam/4.08/lib/opam-state -I /home/opam/.opam/4.08/lib/re -I /home/opam/.opam/4.08/lib/re/pcre -I /home/opam/.opam/4.08/lib/seq -I /home/opam/.opam/4.08/lib/sha -I /home/opam/.opam/4.08/lib/spdx_licenses -I /home/opam/.opam/4.08/lib/stdlib-shims -I /home/opam/.opam/4.08/lib/swhid_core -I /home/opam/.opam/4.08/lib/uchar -I /home/opam/.opam/4.08/lib/uutf -I /home/opam/.opam/4.08/lib/zip -intf-suffix .ml -no-alias-deps -o src/client/.opam_client.objs/byte/opamClient.cmo -c -impl src/client/opamClient.ml)
# File "src/client/opamClient.ml", line 980, characters 60-76:
# 980 |             Stdlib.Option.bind (Re.exec_opt re s) (Fun.flip Re.Group.get_opt 1)
#                                                                   ^^^^^^^^^^^^^^^^
# Error: Unbound value Re.Group.get_opt
```