### PR TITLE
ocp-indent: disable unindented else block

### DIFF
--- a/.ocp-indent
+++ b/.ocp-indent
@@ -1,2 +1,1 @@
 normal
-strict_else=auto


### PR DESCRIPTION
```
if ... then a else
b
```
A good portion of the code are indented to use this code pattern and this makes reading that code really hard to me. Forcing the indentation of `b` in the example above makes it much more readable, especially for large functions.
New indented code would look like:
```
if ... then a else
  b
```