### PR TITLE
Fix a wrong use of OpamFilename.of_string

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -90,6 +90,7 @@ users)
 ## Shell
 
 ## Internal
+  * Fix a wrong use of `OpamFilename.of_string` [#6024 @kit-ty-kate]
 
 ## Internal: Windows
 

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -358,7 +358,7 @@ module LinesBase = struct
       ) lines;
     Buffer.contents buf
 
-  let file_none = OpamFilename.of_string "<none>"
+  let file_none = OpamFilename.raw "<none>"
 
   let pp_string =
     Pp.pp


### PR DESCRIPTION
Related to https://github.com/ocaml/opam/pull/5822

This line of code defines a dummy default value to pass to the two pretty-printers below.
However the `OpamFilename.of_string` function is going to try to expend this path as much as possible, which it should not do.