### PR TITLE
Patch to move from caml.inria.fr to gitHub.com

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -70,6 +70,7 @@ users)
 
 ## Build
   * Fix the lower-bound constraint on ocaml-re (bump from >= 1.9.0 to >= 1.10.0) [#6016 @kit-ty-kate]
+  * Update source file location as caml.inria.fr is unavailable [#6032 @mtelvers]
 
 ## Infrastructure
 

--- a/shell/bootstrap-ocaml.sh
+++ b/shell/bootstrap-ocaml.sh
@@ -39,9 +39,9 @@ fi
 if [ ${GEN_CONFIG_ONLY} -eq 0 ] ; then
   tar -zxf ${V}.tar.gz
 else
-  mkdir -p ${V}
+  mkdir -p ocaml-${V}
 fi
-cd ${V}
+cd ocaml-${V}
 PATH_PREPEND=
 LIB_PREPEND=
 INC_PREPEND=
@@ -130,7 +130,7 @@ if [ -n "$1" -a -n "${COMSPEC}" -a -x "${COMSPEC}" ] ; then
   if [ ! -e ${FLEXDLL} ]; then
     cp $BOOTSTRAP_ROOT/src_ext/archives/${FLEXDLL} . 2>/dev/null || ${CURL} ${FV_URL}
   fi
-  cd ${V}
+  cd ocaml-${V}
   PREFIX=`cd .. ; pwd`/ocaml
   WINPREFIX=`echo ${PREFIX} | cygpath -f - -m`
   if [ ${GEN_CONFIG_ONLY} -eq 0 ] ; then

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -8,8 +8,8 @@ endif
 
 PATCH ?= patch
 
-URL_ocaml = https://caml.inria.fr/pub/distrib/ocaml-4.14/ocaml-4.14.2.tar.gz
-MD5_ocaml = f2fa20be4eea01f837b3556ff282d9b0
+URL_ocaml = https://github.com/ocaml/ocaml/archive/4.14.2.tar.gz
+MD5_ocaml = b28daefda803b5d5910cecf085b1451c
 
 URL_flexdll = https://github.com/ocaml/flexdll/archive/0.43.tar.gz
 MD5_flexdll = 6ce706f6c65b2c5adf5791fac678f090


### PR DESCRIPTION
This fix is necessary due to https://github.com/ocaml/ocaml/issues/13237 and allow us to build base images https://github.com/ocurrent/docker-base-images/issues/283 again.

I have tested this patch in the base image builder using this [commit](https://github.com/ocurrent/ocaml-dockerfile/commit/8600d2b94a92e526cfc84d18bfbda042a43942dc) and successfully built a base image with opam 2.0, 2.1 and dev.

