### PR TITLE
Suppress Windows-specific menus with `opam init -ya`

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -20,6 +20,7 @@ users)
 ## Plugins
 
 ## Init
+  * Suppress all the Windows menus when running with `opam init -ya` [#6034 @dra27]
 
 ## Config report
 


### PR DESCRIPTION
This at the moment sits on top of #6033. #6033 is a bug-fix and needs to go in 2.2.0 - the extra commit here follows a discussion last week with @kayceesrk regarding making `opam init -ya` to be potentially less confusing for students. In this mode, `opam init` looks more like:

```
C:\Users\David Allsopp>\\tau\devel\opam\opam init -ya
No configuration file found, using built-in defaults.
[NOTE] opam is storing files in C:\opamroot

<><> Windows Developer Mode <><><><><><><><><><><><><><><><><><><><><><><><>  🐫
opam does not require Developer Mode to be enabled on Windows, but it is
recommended, in particular because it enables support for symlinks without
requiring opam to be run elevated (which we do not recommend doing).

More information on enabling Developer Mode may be obtained from
https://learn.microsoft.com/en-gb/windows/apps/get-started/enable-your-device-for-development
[NOTE] opam will maintain an internal Cygwin installation
[NOTE] opam will add Git to Cygwin
```

Note (!) that each NOTE would otherwise be an entire menu. The change is quite noisy, and I'm not totally sure that we should do this for 2.2.0, just given the late hour.