### PR TITLE
Adjust common flags passed to Cygwin setup

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -59,6 +59,7 @@ users)
 ## Opamfile
 
 ## External dependencies
+ * Always pass --no-version-check and --no-write-registry to Cygwin setup [#6046 @dra27]
 
 ## Format upgrade
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -60,6 +60,7 @@ users)
 
 ## External dependencies
  * Always pass --no-version-check and --no-write-registry to Cygwin setup [#6046 @dra27]
+ * Use --quiet-mode noinput for the internal Cygwin installation (which is definitely a fully-specified command line) and --quiet-mode unattended for external Cygwin installations (in case the user does need to select something, e.g. a mirror) [#6046 @dra27]
 
 ## Format upgrade
 

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -1026,9 +1026,10 @@ let install_packages_commands_t ?(env=OpamVariable.Map.empty) config sys_package
   | Cygwin ->
     (* We use setup_x86_64 to install package instead of `cygcheck` that is
        stored in `sys-pkg-manager-cmd` field *)
+    let is_internal = Cygwin.is_internal config in
     [`AsUser (OpamFilename.to_string (Cygwin.cygsetup ())),
      [ "--root"; (OpamFilename.Dir.to_string (Cygwin.cygroot config));
-       "--quiet-mode"; "noinput";
+       "--quiet-mode"; (if is_internal then "noinput" else "unattended");
        "--no-shortcuts";
        "--no-startmenu";
        "--no-desktop";
@@ -1037,7 +1038,7 @@ let install_packages_commands_t ?(env=OpamVariable.Map.empty) config sys_package
        "--no-write-registry";
        "--packages";
        String.concat "," packages;
-     ] @ (if Cygwin.is_internal config then
+     ] @ (if is_internal then
             let common =
               [ "--upgrade-also";
                 "--only-site";

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -1033,14 +1033,14 @@ let install_packages_commands_t ?(env=OpamVariable.Map.empty) config sys_package
        "--no-startmenu";
        "--no-desktop";
        "--no-admin";
+       "--no-version-check";
+       "--no-write-registry";
        "--packages";
        String.concat "," packages;
      ] @ (if Cygwin.is_internal config then
             let common =
               [ "--upgrade-also";
                 "--only-site";
-                "--no-write-registry";
-                "--no-version-check";
                 "--site"; Cygwin.mirror;
                 "--local-package-dir";
                 OpamFilename.Dir.to_string (Cygwin.internal_cygcache ());


### PR DESCRIPTION
Fixes #6041 - an additional option might be to explicitly abort when run non-interactively as well, but it's getting a bit niche because if you're non-interactive and expecting depext to work with an external Cygwin then clearly you must have specified `--confirm-level unsafe-yes`.

**Backport into 2.2 in #6057**