### PR TITLE
Restore signature of OpamStateConfig.opamroot

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -114,6 +114,7 @@ users)
 ## opam-repository
 
 ## opam-state
+ * `OpamStateConfig.opamroot_with_provenance`: restore previous behaviour to `OpamStateConfig.opamroot` for compatibility with third party code [#6047 @dra27]
 
 ## opam-solver
 

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -181,7 +181,7 @@ let check_and_run_external_commands () =
     let yes = if yes then Some (Some true) else None in
     OpamCoreConfig.init ?yes ?confirm_level ();
     OpamFormatConfig.init ();
-    let root_from, root_dir = OpamStateConfig.opamroot () in
+    let root_from, root_dir = OpamStateConfig.opamroot_with_provenance () in
     let has_init, root_upgraded =
       match OpamStateConfig.load_defaults ~lock_kind:`Lock_read root_dir with
       | None -> (false, false)

--- a/src/client/opamClientConfig.ml
+++ b/src/client/opamClientConfig.ml
@@ -209,7 +209,7 @@ let opam_init ?root_dir ?strict ?solver =
   let open OpamStd.Option.Op in
 
   (* (i) get root dir *)
-  let root_from, root = OpamStateConfig.opamroot ?root_dir () in
+  let root_from, root = OpamStateConfig.opamroot_with_provenance ?root_dir () in
 
   (* (ii) load conf file and set defaults *)
   (* the init for OpamFormat is done in advance since (a) it has an effect on

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -94,7 +94,7 @@ let global_options cli =
       switch_to_updated_self
         OpamStd.Option.Op.(options.debug_level ++
                            OpamCoreConfig.E.debug () +! 0 |> abs > 0)
-        (snd (OpamStateConfig.opamroot ?root_dir:options.opt_root ()));
+        (OpamStateConfig.opamroot ?root_dir:options.opt_root ());
     let root_is_ok =
       OpamStd.Option.default false (OpamClientConfig.E.rootisok ())
     in

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -223,7 +223,7 @@ let initk k =
 
 let init ?noop:_ = initk (fun () -> ())
 
-let opamroot ?root_dir () =
+let opamroot_with_provenance ?root_dir () =
   match root_dir with
   | Some root -> `Command_line, win_space_redirection root
   | None ->
@@ -232,6 +232,8 @@ let opamroot ?root_dir () =
       `Env, win_space_redirection (OpamFilename.Dir.of_string root)
     | None ->
       `Default, default.root_dir
+
+let opamroot ?root_dir () = snd (opamroot_with_provenance ?root_dir ())
 
 let is_newer_raw = function
   | Some v ->

--- a/src/state/opamStateConfig.mli
+++ b/src/state/opamStateConfig.mli
@@ -86,7 +86,10 @@ val default : t
 (** Get the initial opam root value (from default, env or optional argument).
     This allows one to get it before doing the init, which is useful to get the
     configuration file used to fill some options to init() *)
-val opamroot: ?root_dir:dirname -> unit -> provenance * dirname
+val opamroot_with_provenance: ?root_dir:dirname -> unit -> provenance * dirname
+
+(** [opamroot ?root_dir () = snd (opamroot_with_provenance ?root_dir ()] *)
+val opamroot: ?root_dir:dirname -> unit -> dirname
 
 (** Loads the global configuration file, protecting against concurrent writes *)
 val load: ?lock_kind: 'a lock -> dirname -> OpamFile.Config.t option


### PR DESCRIPTION
#5457 changed the signature of `OpamStateConfig.opamroot` between beta2 and beta3 which has broken the opam-dune-lint plugin along with a few other packages. This seems a shame, given that it's quite trivial and indeed natural to have two functions and simply have the provenance-returning version have a new name.

Given that ~~it looks like we'll need an rc2 to deal with the Cygwin hang~~it's a demonstrably safe internal API restoration, I'm hoping we can slip this API change in ~~at the same time~~to the final release. If we do, https://github.com/ocaml/opam-repository/pull/26066 can be reverted.

**Backported into 2.2 in #6058**