### PR TITLE
Allowing packages to override default environment updates

### DIFF
--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -743,7 +743,7 @@ let get_full
   let u =
     (List.map resolve_separator_and_format u) in
   let updates =
-    u @ updates ~set_opamroot ~set_opamswitch ~force_path st in
+    updates ~set_opamroot ~set_opamswitch ~force_path st @ u in
   add env0 updates
 
 let is_up_to_date_raw ?(skip=OpamStateConfig.(!r.no_env_notice)) updates =


### PR DESCRIPTION
Opening this is as a draft PR so it doesn't get forgotten. This has come up in the context of https://github.com/ocaml/opam-repository/pull/25928.

The problem is that it is not possible for a package to prepend a directory before opam's `bin` directory in PATH and this feels like a mistake. Given, say, `/usr/local/bin:/usr/bin:/bin` etc. in a standard posix PATH, it feels reasonable that opam prepends the switch `bin` directory _before_ packages - i.e. we have `<package-PATH-directory>:<switch-PATH-directory>:/usr/local/bin:/usr/bin:/bin`. This is also mildly more coherent with other environment variable updates in build-env, which the manual explicitly states can be overridden.

In the context of the opam-repository PR above, it means that

```
build-env: PATH += "%{some-package:share}%/bin"
```

doesn't allow binaries in the additional directory to override those in the switch directory, which seems incorrect.