### PR TITLE
depext: fix Debian/apt lookup for installed packages

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -66,6 +66,7 @@ users)
 ## External dependencies
  * Always pass --no-version-check and --no-write-registry to Cygwin setup [#6046 @dra27]
  * Use --quiet-mode noinput for the internal Cygwin installation (which is definitely a fully-specified command line) and --quiet-mode unattended for external Cygwin installations (in case the user does need to select something, e.g. a mirror) [#6046 @dra27]
+  * [BUG] Fix apt/debian lookup for installed packages [#6054 @rjbou]
 
 ## Format upgrade
 

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -774,12 +774,24 @@ let packages_status ?(env=OpamVariable.Map.empty) config packages =
     let get_installed str_pkgs =
       (* ouput:
          >ii  uim-gtk3                 1:1.8.8-6.1  amd64    Universal ...
-         >ii  uim-gtk3-immodule:amd64  1:1.8.8-6.1  amd64    Universal ...
+         >ri  uim-gtk3-immodule:amd64  1:1.8.8-6.1  amd64    Universal ...
+
+         First column is <desired action><package status>
+         * Desired action:
+           u = Unknown           h = Hold             p = Purge
+           i = Install           r = Remove
+         * Package status:
+           n = Not-installed    U = Unpacked          t = Triggers-pending
+           c = Config-files     F = Half-configured   i = Installed
+           H = Half-installed   W = Triggers-awaiting
+
+         We focus on the second element of the column
       *)
       let re_pkg =
         Re.(compile @@ seq
               [ bol;
-                str "ii";
+                alpha;
+                char 'i';
                 rep1 @@ space;
                 group @@ rep1 @@ diff (alt [alnum; punct]) (char ':');
                 (* pkg:arch convention *)


### PR DESCRIPTION
dpkg-query output have the information in the first column, but only the second character needed to be looked up.


