### PR TITLE
GHA: Remove centos when testing depexts as the docker images no longer work

### DIFF
--- a/.github/scripts/depexts/generate-actions.sh
+++ b/.github/scripts/depexts/generate-actions.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-#for target in alpine archlinux centos debian fedora gentoo opensuse oraclelinux ubuntu; do
+#for target in alpine archlinux debian fedora gentoo opensuse oraclelinux ubuntu; do
 target=$1
 dir=.github/actions/$target
 
@@ -36,15 +36,6 @@ EOF
     cat >$dir/Dockerfile << EOF
 FROM archlinux
 RUN pacman -Syu --noconfirm $mainlibs $ocaml gcc diffutils
-EOF
-    ;;
- centos)
-   # CentOS 7 doesn't support OCaml 5 (GCC is too old)
-   OCAML_CONSTRAINT=' & < "5.0"'
-    cat >$dir/Dockerfile << EOF
-FROM centos:7
-RUN yum install -y $mainlibs $ocaml
-RUN yum install -y gcc-c++
 EOF
     ;;
   debian)
@@ -160,8 +151,7 @@ test_depext () {
 
 test_depext conf-gmp conf-which conf-autoconf
 
-# disable automake for centos, as os-family returns rhel
-if [ $target != "centos" ] && [ $target != "opensuse" ]; then
+if [ $target != "opensuse" ]; then
   test_depext conf-automake
 fi
 

--- a/.github/workflows/depexts.yml
+++ b/.github/workflows/depexts.yml
@@ -74,24 +74,6 @@ jobs:
       uses: ./.github/actions/archlinux
       id: depexts-archlinux
 
-  depexts-centos:
-    needs: opam-cache
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: opam binary cache
-      uses: actions/cache@v3
-      with:
-        path: binary/opam
-        key: binary-${{ env.OPAMVERSION }}
-    - name: generate action
-      run: |
-        bash .github/scripts/depexts/generate-actions.sh centos
-    - name: depexts actions centos
-      uses: ./.github/actions/centos
-      id: depexts-centos
-
   depexts-debian:
     needs: opam-cache
     runs-on: ubuntu-latest

--- a/master_changes.md
+++ b/master_changes.md
@@ -112,6 +112,7 @@ users)
 ### Engine
 
 ## Github Actions
+  * Remove centos when testing depexts as the docker images no longer work [#6063 @kit-ty-kate]
 
 ## Doc
 


### PR DESCRIPTION
Should fix the Github Action issues we've seen recently