### PR TITLE
[2.2 backport] release: Fix the creation of the opam-full-<version>.tar.gz archive

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -72,6 +72,8 @@ users)
 ## Infrastructure
 
 ## Release scripts
+  * Add the missing mccs archive to the opam-full-<version>.tar.gz archive [#6067 @kit-ty-kate]
+  * Ensure the configure file stays as it is in the tag, in the opam-full-<version>.tar.gz archive [#6067 @kit-ty-kate]
 
 ## Install script
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -74,6 +74,7 @@ users)
 ## Release scripts
   * Add the missing mccs and dune archives to the opam-full-<version>.tar.gz archive [#6067 @kit-ty-kate]
   * Ensure the configure file stays as it is in the tag, in the opam-full-<version>.tar.gz archive [#6067 @kit-ty-kate]
+  * Exclude the .git directory from the release archive when using GNU tar [#6067 @kit-ty-kate]
 
 ## Install script
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -72,7 +72,7 @@ users)
 ## Infrastructure
 
 ## Release scripts
-  * Add the missing mccs archive to the opam-full-<version>.tar.gz archive [#6067 @kit-ty-kate]
+  * Add the missing mccs and dune archives to the opam-full-<version>.tar.gz archive [#6067 @kit-ty-kate]
   * Ensure the configure file stays as it is in the tag, in the opam-full-<version>.tar.gz archive [#6067 @kit-ty-kate]
 
 ## Install script

--- a/master_changes.md
+++ b/master_changes.md
@@ -75,6 +75,7 @@ users)
   * Add the missing mccs and dune archives to the opam-full-<version>.tar.gz archive [#6067 @kit-ty-kate]
   * Ensure the configure file stays as it is in the tag, in the opam-full-<version>.tar.gz archive [#6067 @kit-ty-kate]
   * Exclude the .git directory from the release archive when using GNU tar [#6067 @kit-ty-kate]
+  * Ensure non-existing %.cache target fail with a fatal error [#6067 @kit-ty-kate]
 
 ## Install script
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -26,11 +26,7 @@ s390x-linux: $(OUTDIR)/opam-$(VERSION)-s390x-linux
 $(OUTDIR)/opam-full-$(VERSION).tar.gz:
 	mkdir -p "$(OUTDIR)"
 	git clone $(GIT_URL) -b $(TAG) "$(OUTDIR)/opam-full-$(VERSION)"
-	sed 's/^AC_INIT(\[opam\],\[.*\])/AC_INIT([opam],[$(OPAM_VERSION)])/' "$(OUTDIR)/opam-full-$(VERSION)/configure.ac" > \
-	  "$(OUTDIR)/opam-full-$(VERSION)/configure.ac.tmp"
-	mv "$(OUTDIR)/opam-full-$(VERSION)/configure.ac.tmp" \
-	  "$(OUTDIR)/opam-full-$(VERSION)/configure.ac"
-	$(MAKE) -C "$(OUTDIR)/opam-full-$(VERSION)" OCAML=$(call pathsearch,ocaml) configure download-ext
+	$(MAKE) -C "$(OUTDIR)/opam-full-$(VERSION)" OCAML=$(call pathsearch,ocaml) MCCS_ENABLED=true download-ext
 	cd "$(OUTDIR)" && tar cz -f $(notdir $@) --exclude .git/ opam-full-$(VERSION)
 	rm -rf "$(OUTDIR)/opam-full-$(VERSION)"
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -27,7 +27,7 @@ $(OUTDIR)/opam-full-$(VERSION).tar.gz:
 	mkdir -p "$(OUTDIR)"
 	git clone $(GIT_URL) -b $(TAG) "$(OUTDIR)/opam-full-$(VERSION)"
 	$(MAKE) -C "$(OUTDIR)/opam-full-$(VERSION)" OCAML=$(call pathsearch,ocaml) download-ext
-	cd "$(OUTDIR)" && tar cz -f $(notdir $@) --exclude .git/ opam-full-$(VERSION)
+	cd "$(OUTDIR)" && tar cz -f $(notdir $@) --exclude .git opam-full-$(VERSION)
 	rm -rf "$(OUTDIR)/opam-full-$(VERSION)"
 
 build/Dockerfile.x86_64-linux: Dockerfile.in

--- a/release/Makefile
+++ b/release/Makefile
@@ -26,7 +26,7 @@ s390x-linux: $(OUTDIR)/opam-$(VERSION)-s390x-linux
 $(OUTDIR)/opam-full-$(VERSION).tar.gz:
 	mkdir -p "$(OUTDIR)"
 	git clone $(GIT_URL) -b $(TAG) "$(OUTDIR)/opam-full-$(VERSION)"
-	$(MAKE) -C "$(OUTDIR)/opam-full-$(VERSION)" OCAML=$(call pathsearch,ocaml) MCCS_ENABLED=true download-ext
+	$(MAKE) -C "$(OUTDIR)/opam-full-$(VERSION)" OCAML=$(call pathsearch,ocaml) download-ext
 	cd "$(OUTDIR)" && tar cz -f $(notdir $@) --exclude .git/ opam-full-$(VERSION)
 	rm -rf "$(OUTDIR)/opam-full-$(VERSION)"
 

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -114,7 +114,7 @@ GET_ARCHIVE=\
 
 %.cache:
 	@mkdir -p archives
-	@test -e archives/$(notdir $(URL_$*)) || \
+	@test -f archives/$(notdir $(URL_$*)) || \
           { $(call GET_ARCHIVE,$*) && mv $(call ARCHIVE_FILE,$*) archives/$(notdir $(URL_$*)); }
 
 .PRECIOUS: %.download

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -95,7 +95,7 @@ clone: $(DUNE_CLONE) $(SRC_EXTS:=.stamp) | ext-ignore
 archives: $(DUNE_CLONE:.stamp=.download) $(SRC_EXTS:=.download)
 	@true
 
-cache-archives: $(SRC_EXTS:=.cache) ocaml.cache flexdll.cache
+cache-archives: $(SRC_EXTS:=.cache) mccs.cache dune-local.cache ocaml.cache flexdll.cache
 	@
 
 has-archives: $(addprefix archives/, $(notdir $(URL_ocaml)) $(notdir $(URL_flexdll)) $(ARCHIVES))


### PR DESCRIPTION
Backport of https://github.com/ocaml/opam/pull/6066 for the 2.2 branch