### PR TITLE
[2.2 backport] Add every listed checksums of a given archive to the cache when fetching from it

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -76,6 +76,7 @@ users)
 ## Install script
 
 ## Admin
+  * Make opam admin cache store a symlink to every checksums, not just the best one [#6069 @kit-ty-kate]
 
 ## Opam installer
 

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -162,12 +162,13 @@ let package_files_to_cache repo_root cache_dir cache_urls
         OpamConsole.warning "[%s] no checksum, not caching"
           (OpamConsole.colorise `green label);
         Done errors
-      | best_chks :: _ ->
-        let cache_file =
-          OpamRepository.cache_file cache_dir best_chks
+      | _::_ ->
+        let cache_files =
+          List.map (OpamRepository.cache_file cache_dir) checksums
         in
         let error_opt =
-          if not recheck && OpamFilename.exists cache_file then Done None
+          if not recheck && List.for_all OpamFilename.exists cache_files then
+            Done None
           else
             OpamRepository.pull_file_to_cache label
               ~cache_urls ~cache_dir
@@ -190,7 +191,9 @@ let package_files_to_cache repo_root cache_dir cache_urls
               let link =
                 OpamFilename.Op.(link_dir / OpamPackage.to_string nv // name)
               in
-              OpamFilename.link ~relative:true ~target:cache_file ~link)
+              List.iter (fun cache_file ->
+                  OpamFilename.link ~relative:true ~target:cache_file ~link)
+                cache_files)
             link;
           errors
     in


### PR DESCRIPTION
Backport of #6068 in 2.2
The backport here is required to fix opam.ocaml.org together with https://github.com/ocaml-opam/opam2web/pull/238