### PR TITLE
Add a benchmark showing the current performance of OpamVersionCompare

### DIFF
--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -14,4 +14,5 @@ RUN install ./opam /usr/local/bin/
 USER opam
 RUN opam init --bare -n --disable-sandboxing /rep/opam-repository
 RUN opam switch create --fake default 4.14.0
+RUN opam list --all -s --all-versions > /home/opam/all-packages
 RUN find /rep/opam-repository -name opam -type f > /home/opam/all-opam-files

--- a/master_changes.md
+++ b/master_changes.md
@@ -118,6 +118,7 @@ users)
 
 ## Benchmarks
   * Make the benchmark setup process faster and the benchmark itself more stable [#6094 @kit-ty-kate]
+  * Add a benchmark showing the current performance of OpamVersionCompare [#6078 @kit-ty-kate]
 
 ## Reftests
 ### Tests

--- a/tests/bench/dune
+++ b/tests/bench/dune
@@ -1,3 +1,3 @@
 (executable
  (name bench)
- (libraries unix opam-core))
+ (libraries unix opam-core opam-format))


### PR DESCRIPTION
This PR aims at showing whether or not https://github.com/ocaml/opam/pull/5518 actually improves performance.
The idea is similar to https://github.com/ocaml/opam/pull/5900