### PR TITLE
Remove opam 2.1 support from the release script

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -85,6 +85,7 @@ users)
   * Ensure the configure file stays as it is in the tag, in the opam-full-<version>.tar.gz archive [#6066 @kit-ty-kate]
   * Exclude the .git directory from the release archive when using GNU tar [#6066 @kit-ty-kate]
   * Ensure non-existing %.cache target fail with a fatal error [#6066 @kit-ty-kate]
+  * Remove opam 2.1 support from the release script [#6084 @kit-ty-kate]
 
 ## Install script
   * Provide a shell/install.ps1 PowerShell script to install opam on Windows [#5906 @kit-ty-kate @dra27]

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -25,8 +25,7 @@ USER opam
 WORKDIR /home/opam/
 CMD tar xz >&2 && \
     cd opam-full-${VERSION} >&2 && \
-    { { ./configure --with-mccs >&2 && make lib-ext >&2 ; } || \
-      ./configure --with-vendored-deps >&2 ; } && \
+    ./configure --with-vendored-deps --with-mccs && \
     echo "(${LINKING})" > src/client/linking.sexp && \
     make opam >&2 && \
     strip opam >&2 && \

--- a/release/Makefile
+++ b/release/Makefile
@@ -50,26 +50,24 @@ build/%.image: build/Dockerfile.%
 	docker build -t opam-build-$* -f $^ build
 	touch $@
 
-SHA_LINK = $(if $(shell mkdir -p build/tmp_extract && tar xzf "$(OUTDIR)/opam-full-$(VERSION).tar.gz" -C build/tmp_extract && grep -F URL_sha build/tmp_extract/opam-full-$(VERSION)/src_ext/Makefile.sources),-lsha_stubs)
-
 # Actually, this is for alpine 3.13, and varies
 CLINKING_linux = \
 -Wl,-Bstatic \
--lunix -lmccs_stubs -lmccs_glpk_stubs $(SHA_LINK) \
+-lunix -lmccs_stubs -lmccs_glpk_stubs -lsha_stubs \
 -lstdc++ \
 -static-libgcc \
 -static
 # -Wl,-Bdynamic
 
 CLINKING_macos = \
--lunix -lmccs_stubs -lmccs_glpk_stubs $(SHA_LINK) \
+-lunix -lmccs_stubs -lmccs_glpk_stubs -lsha_stubs \
 -lstdc++
 
 CLINKING_openbsd = $(CLINKING_macos)
 CLINKING_freebsd = $(CLINKING_macos)
 
 CLINKING_windows = \
--lunix -lmccs_stubs -lmccs_glpk_stubs $(SHA_LINK) \
+-lunix -lmccs_stubs -lmccs_glpk_stubs -lsha_stubs \
 -lopam_stubs_win32_stubs \
 -l:libstdc++.a -l:libpthread.a \
 -Wl,-static \
@@ -122,8 +120,7 @@ host: $(OUTDIR)/opam-full-$(VERSION).tar.gz build/$(HOST).env
 	    MAKE=$(MAKE) \
 	    $(EXPORTS_$(HOST_OS)); \
 	  cd build/opam-full-$(VERSION) && \
-	  { { ./configure --with-mccs >&2 && $(MAKE) lib-ext >&2 ; } || \
-	    ./configure --with-vendored-deps >&2 ; } && \
+	  ./configure --with-vendored-deps --with-mccs && \
 	  echo "$(call LINKING,$(HOST_OS))" >src/client/linking.sexp && \
 	  $(MAKE) opam; \
 	)

--- a/release/readme.md
+++ b/release/readme.md
@@ -56,7 +56,7 @@
 * tag the release (git tag -am 2.2.0 2.2.0; git push origin 2.2.0)
 * /!\ Once the tag pushed, it can be updated [different commit] only in case of severe issue
 * create a release (or prerelease if intermediate release) draft on github based on your tag (https://github.com/ocaml/opam/releases/new)
-* fetch locally the tag
+* Make sure the repository is in the correct state: `git switch --detach <tag>`
 * launch docker using the Docker GUI macOS app
 * generate opam artifacts, using `release/release.sh <tag>` from a macOS/arm64 machine, it requires to have Docker and QEMU installed (see below device requirements)
 * generate the signatures using `release/sign.sh <tag>`
@@ -92,6 +92,6 @@
 ## Device requirements
 * Mac M1 or above with Rosetta2
 * >=70GB of disk space free
-* brew dependencies: git, gpg, qemu>=8.1.0, docker>=24.0.0, md5sha1sum (only when releasing on the 2.1 branch)
+* brew dependencies: git, gpg, qemu>=8.1.0, docker>=24.0.0
 * opam repo with the tag fetched
 * Have the secret key available


### PR DESCRIPTION
Simplifies the release script and makes it less likely to have errors
Related to https://github.com/ocaml/opam/pull/6082 and https://github.com/ocaml/opam/pull/6083

Backported to 2.2 in https://github.com/ocaml/opam/pull/6085