### PR TITLE
Consistent accepted repository links 

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -42,6 +42,7 @@ users)
 
 ## Switch
   * ◈ Add `opam switch import --deps-only` option to install only dependencies of root package at import [#5388 @rjbou - fix #5200]
+  * [BUG] Make accepted `--repos` URLs on creation consistent with `opam repository` [#6091 @Keryan-dev - fix #4673]
 
 ## Config
 

--- a/tests/reftests/switch-creation.test
+++ b/tests/reftests/switch-creation.test
@@ -47,3 +47,10 @@ The following actions will be performed:
 Done.
 ### cat $OPAMROOT/undef-switch/lib/prefix
 ${BASEDIR}/OPAM/undef-switch
+### # switch with repo link
+### # expects a warning, useful to check chosen backend
+### opam switch create w-repo --repositories=from-link=https://github.com/ocaml/opam-repository.git --dry-run --empty
+Creating repository from-link...
+[ERROR] Could not update repository "from-link": OpamDownload.Download_fail(_, "curl: empty response while downloading https://github.com/ocaml/opam-repository.git/index.tar.gz")
+[ERROR] Initial fetch of these repositories failed: from-link
+# Return code 40 #

--- a/tests/reftests/switch-creation.test
+++ b/tests/reftests/switch-creation.test
@@ -51,6 +51,9 @@ ${BASEDIR}/OPAM/undef-switch
 ### # expects a warning, useful to check chosen backend
 ### opam switch create w-repo --repositories=from-link=https://github.com/ocaml/opam-repository.git --dry-run --empty
 Creating repository from-link...
-[ERROR] Could not update repository "from-link": OpamDownload.Download_fail(_, "curl: empty response while downloading https://github.com/ocaml/opam-repository.git/index.tar.gz")
-[ERROR] Initial fetch of these repositories failed: from-link
-# Return code 40 #
+[from-link] Initialised
+[WARNING] The repository 'from-link' at git+https://github.com/ocaml/opam-repository.git doesn't have a 'repo' file, and might not be compatible with this version of opam.
+[NOTE] Repository at git+https://github.com/ocaml/opam-repository.git doesn't define its version, assuming it's 1.2.
+
+<><> Upgrading repositories from older opam format ><><><><><><><><><><><><><><>
+Upgrading repository "from-link"...


### PR DESCRIPTION
`opam switch create foo --repos bar=[url]` should no longer require `git+` to be accepted. Consistent with `opam repository add`.

fixes #4673 