### PR TITLE
Make the benchmark setup process faster and the benchmark itself more stable

### DIFF
--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,6 +1,10 @@
 FROM debian:bullseye
 RUN apt-get update -qq && apt-get install -qq -yy make curl gcc g++ patch bzip2 git unzip
 RUN adduser --disabled-password --gecos '' --shell /bin/bash opam
+ENV OPAMREPOSHA 26770281fa1ea8b13aab979c1dfbd326e9ab512c
+RUN git clone https://github.com/ocaml/opam-repository --depth 1 /rep/opam-repository
+RUN git -C /rep/opam-repository fetch origin $OPAMREPOSHA
+RUN git -C /rep/opam-repository checkout $OPAMREPOSHA
 USER opam
 COPY --chown=opam:opam . /src
 WORKDIR /src
@@ -8,9 +12,6 @@ RUN make cold
 USER root
 RUN install ./opam /usr/local/bin/
 USER opam
-ENV OPAMREPOSHA 26770281fa1ea8b13aab979c1dfbd326e9ab512c
-RUN git clone https://github.com/ocaml/opam-repository --depth 1
-RUN git -C opam-repository fetch origin $OPAMREPOSHA
-RUN git -C opam-repository checkout $OPAMREPOSHA
-RUN opam init -n --disable-sandboxing ./opam-repository
-RUN find "$(pwd)/opam-repository" -name opam -type f > /home/opam/all-opam-files
+RUN opam init --bare -n --disable-sandboxing /rep/opam-repository
+RUN opam switch create --fake default 4.14.0
+RUN find /rep/opam-repository -name opam -type f > /home/opam/all-opam-files

--- a/master_changes.md
+++ b/master_changes.md
@@ -113,6 +113,7 @@ users)
 ## Test
 
 ## Benchmarks
+  * Make the benchmark setup process faster and the benchmark itself more stable [#6094 @kit-ty-kate]
 
 ## Reftests
 ### Tests


### PR DESCRIPTION
Required for https://github.com/ocaml/opam/pull/6078 as it makes the new benchmarks stable enough to be merged.