### PR TITLE
opam switch list-available will not display compilers flagged with avoid-version/deprecated unless --all is given

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -44,6 +44,7 @@ users)
 ## Switch
   * ◈ Add `opam switch import --deps-only` option to install only dependencies of root package at import [#5388 @rjbou - fix #5200]
   * [BUG] Make accepted `--repos` URLs on creation consistent with `opam repository` [#6091 @Keryan-dev - fix #4673]
+  * ◈ opam switch list-available will not display compilers flagged with avoid-version/deprecated unless --all is given [#6098 @kit-ty-kate - fix #6089]
 
 ## Config
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -194,6 +194,7 @@ users)
   * `OpamArg.build_options`: add `--verbose-on` flag [#5682 @desumn @rjbou]
   * `OpamClientConfig.build_options`: add `verbose_on` field [#5682 @desumn]
   * `OpamClientConfig.E`, `OpamArg.environment_variables`: and `OPAMVERBOSEON` support [#5682 @desumn @rjbou]
+  * `OpamListCommand.selector`: Add `NotFlag` selector [#6098 @kit-ty-kate]
 
 ## opam-repository
  * `OpamRepository.fetch_from_cache`: when an archive is found, add a symlink (or copy) for the ones found in opam file but not in cache [#6068 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -157,6 +157,7 @@ users)
   * Add a test showing the behaviour of `opam list --latests-only` [#5375 @kit-ty-kate]
   * Add a test filtering mechanism [#6105 @Keryan-dev]
   * Add a package fetching test [#6146 @rjbou]
+  * Add a test showing the behaviour of `opam switch list-available` [#6098 @kit-ty-kate]
 
 ### Engine
   * Add a test filtering mechanism [#6105 @Keryan-dev]

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2651,7 +2651,9 @@ let switch cli =
     cli_original, "list-available", `list_available, ["[PATTERN]"],
     "Lists all the possible packages that are advised for installation when \
      creating a new switch, i.e. packages with the $(i,compiler) flag set. If \
-     no pattern is supplied, all versions are shown.";
+     no pattern is supplied, all versions are shown. By default, packages \
+     flagged with $(i,avoid-version) or $(i,deprecated) will not appear \
+     unless $(b,--all) is given.";
     cli_original, "show", `current, [],
     "Prints the name of the current switch.";
     cli_from cli2_1, "invariant", `show_invariant, [],
@@ -2807,6 +2809,12 @@ let switch cli =
        right away: wait for the next $(i,install), $(i,upgrade) or similar \
        command."
   in
+  let all =
+    mk_flag ~cli (cli_from cli2_3) ["all"]
+      "Only for $(i,list-available): show all available compilers, \
+       regardless of whether they are flagged with $(i,avoid-version) \
+       or $(i,deprecated)."
+  in
   (* Deprecated options *)
   let d_alias_of =
     mk_opt ~cli (cli_between cli2_0 cli2_1)
@@ -2818,7 +2826,7 @@ let switch cli =
   let switch
       global_options build_options command print_short
       no_switch packages formula empty descr full freeze no_install deps_only repos
-      force no_action
+      force no_action all
       d_alias_of d_no_autoinstall params () =
     if d_alias_of <> None then
       OpamConsole.warning
@@ -2828,6 +2836,10 @@ let switch cli =
     if d_no_autoinstall then
       OpamConsole.warning "Option %s is deprecated, ignoring it."
         (OpamConsole.colorise `bold "--no-autoinstall");
+    if all && command <> Some `list_available then
+      OpamConsole.warning
+        "Option %s must be used with $(i,list-available), ignoring it"
+        (OpamConsole.colorise `bold "--all");
     apply_global_options cli global_options;
     apply_build_options cli build_options;
     let invariant_arg ?repos rt args =
@@ -2871,6 +2883,7 @@ let switch cli =
       OpamSwitchCommand.list gt ~print_short;
       `Ok ()
     | Some `list_available, pattlist ->
+      let all = all || OpamCLIVersion.Op.(cli @< OpamArg.cli2_3) in
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
       with_repos_rt gt cli repos @@ fun (repos, rt) ->
       let compilers = OpamSwitchCommand.get_compiler_packages ?repos rt in
@@ -2886,16 +2899,26 @@ let switch cli =
                patt))
           pattlist
       in
-      let compilers =
+      let all_compilers =
         OpamListCommand.filter ~base:compilers st
           (OpamFormula.ands (List.map (fun f -> OpamFormula.Atom f) filters))
+      in
+      let compilers =
+        if all then
+          all_compilers
+        else
+          OpamListCommand.filter ~base:all_compilers st
+            (OpamFormula.ands [
+                OpamFormula.Atom (OpamListCommand.NotFlag Pkgflag_AvoidVersion);
+                OpamFormula.Atom (OpamListCommand.NotFlag Pkgflag_Deprecated);
+              ])
       in
       let format =
         if print_short then OpamListCommand.([ Package ])
         else OpamListCommand.([ Name; Version; Synopsis; ])
       in
       let order nv1 nv2 =
-        if nv1.version = nv2.version
+        if OpamPackage.Version.equal nv1.version nv2.version
         then OpamPackage.Name.compare nv1.name nv2.name
         else OpamPackage.Version.compare nv1.version nv2.version
       in
@@ -2909,6 +2932,10 @@ let switch cli =
            order = `Custom order;
         }
         compilers;
+      if not all && not (OpamPackage.Set.equal all_compilers compilers) then
+        OpamConsole.note
+          "Some compilers have been hidden (e.g. pre-releases). \
+           If you want to display them, run: 'opam switch list-available --all'";
       `Ok ()
     | Some `install, switch_arg::params ->
       OpamGlobalState.with_ `Lock_write @@ fun gt ->
@@ -3161,7 +3188,7 @@ let switch cli =
           $print_short_flag cli cli_original
           $no_switch
           $packages $formula $empty $descr $full $freeze $no_install
-          $deps_only $repos $force $no_action $d_alias_of $d_no_autoinstall
+          $deps_only $repos $force $no_action $all $d_alias_of $d_no_autoinstall
           $params)
 
 (* PIN *)

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3148,7 +3148,12 @@ let switch cli =
       in
       OpamSwitchAction.install_switch_config gt.root st.switch config;
       `Ok ()
-    | command, params -> bad_subcommand ~cli commands ("switch", command, params)
+    (* NOTE: The explicit pattern ensures there hasn't been any typos in
+       the polymorphic variant *)
+    | ((None | Some (`list | `current | `default _ | `show_invariant)), (_::_ as params))
+    | Some `install, ([] as params)
+    | Some (`import | `export | `set), ((_::_::_ | []) as params) ->
+      bad_subcommand ~cli commands ("switch", command, params)
   in
   mk_command_ret  ~cli cli_original "switch" ~doc ~man
     Term.(const switch

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -73,6 +73,7 @@ type selector =
   | Pattern of pattern_selector * string
   | Atoms of atom list
   | Flag of package_flag
+  | NotFlag of package_flag
   | Tag of string
   | From_repository of repository_name list
   | Owns_file of filename
@@ -126,6 +127,9 @@ let string_of_selector =
       (fun a -> OpamFormula.short_string_of_atom a % `bold) atoms
   | Flag fl ->
     Printf.sprintf "%s(%s)" ("has-flag" % `green)
+      (OpamTypesBase.string_of_pkg_flag fl % `bold)
+  | NotFlag fl ->
+    Printf.sprintf "%s(%s)" ("not-has-flag" % `green)
       (OpamTypesBase.string_of_pkg_flag fl % `bold)
   | Tag t ->
     Printf.sprintf "%s(%s)" ("has-tag" % `green) (t % `bold)
@@ -313,6 +317,10 @@ let apply_selector ~base st = function
   | Flag f ->
     OpamPackage.Set.filter (fun nv ->
         get_opam st nv |> OpamFile.OPAM.has_flag f)
+      base
+  | NotFlag f ->
+    OpamPackage.Set.filter (fun nv ->
+        not (get_opam st nv |> OpamFile.OPAM.has_flag f))
       base
   | Tag t ->
     OpamPackage.Set.filter (fun nv ->

--- a/src/client/opamListCommand.mli
+++ b/src/client/opamListCommand.mli
@@ -58,6 +58,7 @@ type selector =
   | Pattern of pattern_selector * string
   | Atoms of atom list
   | Flag of package_flag
+  | NotFlag of package_flag
   | Tag of string
   | From_repository of repository_name list
   | Owns_file of filename

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1659,6 +1659,27 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:switch-invariant.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-switch-list-available)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (action
+  (diff switch-list-available.test switch-list-available.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (deps (alias reftest-switch-list-available)))
+
+(rule
+ (targets switch-list-available.out)
+ (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:switch-list-available.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-switch-list)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action

--- a/tests/reftests/switch-list-available.test
+++ b/tests/reftests/switch-list-available.test
@@ -1,0 +1,92 @@
+N0REP0
+### <pkg:comp-a.1>
+opam-version: "2.0"
+flags: compiler
+### <pkg:comp-a.2>
+opam-version: "2.0"
+flags: compiler
+### <pkg:comp-a.3>
+opam-version: "2.0"
+flags: compiler
+### <pkg:comp-a.4>
+opam-version: "2.0"
+flags: compiler
+### <pkg:comp-b.1>
+opam-version: "2.0"
+flags: compiler
+### <pkg:pkg-1.1>
+opam-version: "2.0"
+### <pkg:pkg-1.2>
+opam-version: "2.0"
+### <pkg:pkg-2.1>
+opam-version: "2.0"
+### opam switch list-available
+# Listing available compilers from repositories: default
+# Name # Version # Synopsis
+comp-a 1
+comp-b 1
+comp-a 2
+comp-a 3
+comp-a 4
+### <pkg:comp-b.2>
+opam-version: "2.0"
+flags: [compiler avoid-version]
+### <pkg:comp-b.3>
+opam-version: "2.0"
+flags: [compiler deprecated]
+### <pkg:comp-b.4>
+opam-version: "2.0"
+flags: compiler
+### opam switch list-available
+# Listing available compilers from repositories: default
+# Name # Version # Synopsis
+comp-a 1
+comp-b 1
+comp-a 2
+comp-b 2
+comp-a 3
+comp-b 3
+comp-a 4
+comp-b 4
+### :: patterns selectors
+### opam switch list-available pkg-1
+# Listing available compilers from repositories: default
+# No matches found
+### opam switch list-available comp-b
+# Listing available compilers from repositories: default
+# Name # Version # Synopsis
+comp-b 1
+comp-b 2
+comp-b 3
+comp-b 4
+### opam switch list-available comp-b.1
+# Listing available compilers from repositories: default
+# No matches found
+### opam switch list-available comp-b.2
+# Listing available compilers from repositories: default
+# No matches found
+### <pkg:comp_c.1>
+opam-version: "2.0"
+flags: compiler
+### <pkg:comp_c.2>
+opam-version: "2.0"
+flags: [compiler avoid-version]
+### opam switch list-available "pkg-*"
+# Listing available compilers from repositories: default
+# No matches found
+### opam switch list-available "comp-*"
+# Listing available compilers from repositories: default
+# Name # Version # Synopsis
+comp-a 1
+comp-b 1
+comp-a 2
+comp-b 2
+comp-a 3
+comp-b 3
+comp-a 4
+comp-b 4
+### opam switch list-available "comp_*"
+# Listing available compilers from repositories: default
+# Name # Version # Synopsis
+comp_c 1
+comp_c 2

--- a/tests/reftests/switch-list-available.test
+++ b/tests/reftests/switch-list-available.test
@@ -28,6 +28,14 @@ comp-b 1
 comp-a 2
 comp-a 3
 comp-a 4
+### opam switch list-available --all
+# Listing available compilers from repositories: default
+# Name # Version # Synopsis
+comp-a 1
+comp-b 1
+comp-a 2
+comp-a 3
+comp-a 4
 ### <pkg:comp-b.2>
 opam-version: "2.0"
 flags: [compiler avoid-version]
@@ -43,6 +51,27 @@ flags: compiler
 comp-a 1
 comp-b 1
 comp-a 2
+comp-a 3
+comp-a 4
+comp-b 4
+[NOTE] Some compilers have been hidden (e.g. pre-releases). If you want to display them, run: 'opam switch list-available --all'
+### opam switch list-available --all
+# Listing available compilers from repositories: default
+# Name # Version # Synopsis
+comp-a 1
+comp-b 1
+comp-a 2
+comp-b 2
+comp-a 3
+comp-b 3
+comp-a 4
+comp-b 4
+### opam switch list-available --cli 2.2
+# Listing available compilers from repositories: default
+# Name # Version # Synopsis
+comp-a 1
+comp-b 1
+comp-a 2
 comp-b 2
 comp-a 3
 comp-b 3
@@ -52,7 +81,16 @@ comp-b 4
 ### opam switch list-available pkg-1
 # Listing available compilers from repositories: default
 # No matches found
+### opam switch list-available pkg-1 --all
+# Listing available compilers from repositories: default
+# No matches found
 ### opam switch list-available comp-b
+# Listing available compilers from repositories: default
+# Name # Version # Synopsis
+comp-b 1
+comp-b 4
+[NOTE] Some compilers have been hidden (e.g. pre-releases). If you want to display them, run: 'opam switch list-available --all'
+### opam switch list-available comp-b --all
 # Listing available compilers from repositories: default
 # Name # Version # Synopsis
 comp-b 1
@@ -62,7 +100,13 @@ comp-b 4
 ### opam switch list-available comp-b.1
 # Listing available compilers from repositories: default
 # No matches found
+### opam switch list-available comp-b.1 --all
+# Listing available compilers from repositories: default
+# No matches found
 ### opam switch list-available comp-b.2
+# Listing available compilers from repositories: default
+# No matches found
+### opam switch list-available comp-b.2 --all
 # Listing available compilers from repositories: default
 # No matches found
 ### <pkg:comp_c.1>
@@ -80,12 +124,27 @@ flags: [compiler avoid-version]
 comp-a 1
 comp-b 1
 comp-a 2
+comp-a 3
+comp-a 4
+comp-b 4
+[NOTE] Some compilers have been hidden (e.g. pre-releases). If you want to display them, run: 'opam switch list-available --all'
+### opam switch list-available "comp-*" --all
+# Listing available compilers from repositories: default
+# Name # Version # Synopsis
+comp-a 1
+comp-b 1
+comp-a 2
 comp-b 2
 comp-a 3
 comp-b 3
 comp-a 4
 comp-b 4
 ### opam switch list-available "comp_*"
+# Listing available compilers from repositories: default
+# Name # Version # Synopsis
+comp_c 1
+[NOTE] Some compilers have been hidden (e.g. pre-releases). If you want to display them, run: 'opam switch list-available --all'
+### opam switch list-available "comp_*" --all
 # Listing available compilers from repositories: default
 # Name # Version # Synopsis
 comp_c 1


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/6089