### PR TITLE
Avoid double symlink in archive cache

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -28,6 +28,7 @@ users)
 
 ## Install
   * Fix package name display for no agreement conflicts [#6055 @rjbou - fix #6030]
+  * Make fetching an archive from cache add missing symlinks [#6068 @kit-ty-kate - fix #6064]
 
 ## Remove
 
@@ -93,6 +94,7 @@ users)
   * Add opam 2.2.0 to the install scripts [#6062 @kit-ty-kate]
 
 ## Admin
+  * Make `opam admin cache` add missing symlinks [#6068 @kit-ty-kate - fix #6064]
 
 ## Opam installer
 
@@ -145,6 +147,7 @@ users)
 ## opam-client
 
 ## opam-repository
+ * `OpamRepository.fetch_from_cache`: when an archive is found, add a symlink (or copy) for the ones found in opam file but not in cache [#6068 @kit-ty-kate]
 
 ## opam-state
  * `OpamStateConfig.opamroot_with_provenance`: restore previous behaviour to `OpamStateConfig.opamroot` for compatibility with third party code [#6047 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -122,6 +122,7 @@ users)
   * Add bad cudf package name encoding (dose3 lib) [#6055 @rjbou]
   * Add test for filter operators in opam file [#5642 @rjbou]
   * Update init test to make it no repo [#5327 @rjbou]
+  * Add admin cache test on windows and linux/macos [#6068 @rjbou]
 
 ### Engine
 

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -162,12 +162,13 @@ let package_files_to_cache repo_root cache_dir cache_urls
         OpamConsole.warning "[%s] no checksum, not caching"
           (OpamConsole.colorise `green label);
         Done errors
-      | best_chks :: _ ->
-        let cache_file =
-          OpamRepository.cache_file cache_dir best_chks
+      | _::_ ->
+        let cache_files =
+          List.map (OpamRepository.cache_file cache_dir) checksums
         in
         let error_opt =
-          if not recheck && OpamFilename.exists cache_file then Done None
+          if not recheck && List.for_all OpamFilename.exists cache_files then
+            Done None
           else
             OpamRepository.pull_file_to_cache label
               ~cache_urls ~cache_dir
@@ -190,7 +191,7 @@ let package_files_to_cache repo_root cache_dir cache_urls
               let link =
                 OpamFilename.Op.(link_dir / OpamPackage.to_string nv // name)
               in
-              OpamFilename.link ~relative:true ~target:cache_file ~link)
+              OpamFilename.link ~relative:true ~target:(List.hd cache_files) ~link)
             link;
           errors
     in

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -101,7 +101,7 @@ let fetch_from_cache =
     match
       List.fold_left (fun (hit, misses) ck ->
           let f = cache_file cache_dir ck in
-          if OpamFilename.exists f
+          if OpamFilename.exists f && not (OpamFilename.is_symlink f)
           then (Some f, misses)
           else (hit, f :: misses))
         (None, []) checksums

--- a/tests/reftests/admin-cache.unix.test
+++ b/tests/reftests/admin-cache.unix.test
@@ -147,40 +147,44 @@ amet : sha512 : exists
 ### # in cache, the archiv is the strongest one
 ### rm -rf cache/md5 cache/sha256
 ### opam admin cache | unordered
+[dolor.1] synchronised (cached)
+[ipsum.1] synchronised (cached)
+[sit.1] synchronised (cached)
+[amet.1] synchronised (cached)
 Done.
 ### sh cache-analysi.sh
-ipsum : md5 : not found
-ipsum : sha256 : not found
+ipsum : md5 : exists, link to sha512
+ipsum : sha256 : exists, link to sha512
 ipsum : sha512 : exists
 --
-dolor : md5 : not found
-dolor : sha256 : not found
+dolor : md5 : exists, link to sha512
+dolor : sha256 : exists, link to sha512
 dolor : sha512 : exists
 --
-sit : md5 : not found
-sit : sha256 : not found
+sit : md5 : exists, link to sha512
+sit : sha256 : exists, link to sha512
 sit : sha512 : exists
 --
-amet : md5 : not found
-amet : sha256 : not found
+amet : md5 : exists, link to sha512
+amet : sha256 : exists, link to sha512
 amet : sha512 : exists
 ### opam admin cache | unordered
 Done.
 ### sh cache-analysi.sh
-ipsum : md5 : not found
-ipsum : sha256 : not found
+ipsum : md5 : exists, link to sha512
+ipsum : sha256 : exists, link to sha512
 ipsum : sha512 : exists
 --
-dolor : md5 : not found
-dolor : sha256 : not found
+dolor : md5 : exists, link to sha512
+dolor : sha256 : exists, link to sha512
 dolor : sha512 : exists
 --
-sit : md5 : not found
-sit : sha256 : not found
+sit : md5 : exists, link to sha512
+sit : sha256 : exists, link to sha512
 sit : sha512 : exists
 --
-amet : md5 : not found
-amet : sha256 : not found
+amet : md5 : exists, link to sha512
+amet : sha256 : exists, link to sha512
 amet : sha512 : exists
 ### :::::::::::::::::::::::::::::::::::::::::::
 ### :III: remove strongest hash and recompute :
@@ -258,13 +262,13 @@ amet : sha512 : exists
 ### sed -i '/"sha512=.*/d' packages/dolor/dolor.1/opam
 ### sed -i '/"md5=.*/d' packages/sit/sit.1/opam
 ### sed -i '/"sha512=.*/d' packages/sit/sit.1/opam
-### opam show --just-file ./packages/ipsum/ipsum.1/opam --field url.src,url.checksum | "${IP_MD5}" -> IP_MD5 | "${IP_SHA512}" -> IP_SHA512
+### opam show --just-file ./packages/ipsum/ipsum.1/opam --field url.src,url.checksum | "${IP_MD5}" -> IP_MD5
 url.src:      file://${BASEDIR}/arch-ipsum.tgz
 url.checksum: md5=IP_MD5
-### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | "${DL_MD5}" -> DL_MD5 | "${DL_SHA256}" -> DL_SHA256 | "${DL_SHA512}" -> DL_SHA512
+### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | "${DL_MD5}" -> DL_MD5 | "${DL_SHA256}" -> DL_SHA256
 url.src:      file://${BASEDIR}/arch-dolor.tgz
 url.checksum: md5=DL_MD5, sha256=DL_SHA256
-### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | "${ST_MD5}" -> ST_MD5 | "${ST_SHA256}" -> ST_SHA256 | "${ST_SHA512}" -> ST_SHA512
+### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | "${ST_SHA256}" -> ST_SHA256
 url.src:      file://${BASEDIR}/arch-sit.tgz
 url.checksum: sha256=ST_SHA256
 ### rm -rf cache
@@ -294,7 +298,7 @@ amet : sha512 : exists
 ### opam admin add-hashes sha512 --package ipsum
 ### opam admin add-hashes sha512 --package dolor
 ### opam admin add-hashes md5    --package sit
-[file://${BASEDIR}/arch-sit.tgz] downloaded from file://${BASEDIR}/cache
+[file://${BASEDIR}/arch-sit.tgz] found in cache
 ### opam admin add-hashes sha512 --package sit
 ### opam show --just-file ./packages/ipsum/ipsum.1/opam --field url.src,url.checksum | "${IP_MD5}" -> IP_MD5 | "${IP_SHA512}" -> IP_SHA512
 url.src:      file://${BASEDIR}/arch-ipsum.tgz
@@ -330,15 +334,15 @@ Done.
 ### sh cache-analysi.sh
 ipsum : md5 : exists
 ipsum : sha256 : not found
-ipsum : sha512 : not found
+ipsum : sha512 : exists, link to md5
 --
 dolor : md5 : exists, link to sha256
 dolor : sha256 : exists
-dolor : sha512 : not found
+dolor : sha512 : exists, link to md5
 --
-sit : md5 : not found
+sit : md5 : exists, link to sha256
 sit : sha256 : exists
-sit : sha512 : not found
+sit : sha512 : exists, link to sha256
 --
 amet : md5 : exists, link to sha512
 amet : sha256 : exists, link to sha512
@@ -364,9 +368,6 @@ opam-version: "2.0"
 MD5(arch-evil.tgz)= LR_MD5
 ### sh add-urls.sh lorem
 ### opam admin cache | unordered
-[dolor.1] synchronised (cached)
-[ipsum.1] synchronised (cached)
-[sit.1] synchronised (cached)
 [lorem.1] synchronised (file://${BASEDIR}/arch-lorem.tgz)
 Done.
 ### opam admin add-hashes sha256 --package lorem
@@ -380,19 +381,16 @@ lorem : sha256 : not found
 lorem : sha512 : not found
 ### opam admin cache | unordered
 [lorem.1] synchronised (cached)
-[dolor.1] synchronised (cached)
-[ipsum.1] synchronised (cached)
-[sit.1] synchronised (cached)
 Done.
 ### sh cache-analysi.sh
 lorem : md5 : exists
-lorem : sha256 : not found
+lorem : sha256 : exists, link to md5
 lorem : sha512 : not found
 ### mv arch-evil.tgz cache/md5/$PRE_LR_MD5/$LR_MD5
 ### opam admin add-hashes sha512 --package lorem
 ### sh cache-analysi.sh
 lorem : md5 : exists
-lorem : sha256 : not found
+lorem : sha256 : exists, link to md5
 lorem : sha512 : not found
 ### opam admin cache | "${LR_MD5}" -> LR_MD5 | "${LR_SHA256}" -> LR_SHA256 | "${LR_SHA512}" -> LR_SHA512
 [ERROR] Conflicting file hashes, or broken or compromised cache!
@@ -400,9 +398,6 @@ lorem : sha512 : not found
           - sha256=LR_SHA256 (MISMATCH)
           - md5=LR_MD5 (match)
 
-[dolor.1] synchronised (cached)
-[ipsum.1] synchronised (cached)
-[sit.1] synchronised (cached)
 [lorem.1] synchronised (file://${BASEDIR}/arch-lorem.tgz)
 Done.
 ### sh cache-analysi.sh

--- a/tests/reftests/admin-cache.unix.test
+++ b/tests/reftests/admin-cache.unix.test
@@ -298,7 +298,7 @@ amet : sha512 : exists
 ### opam admin add-hashes sha512 --package ipsum
 ### opam admin add-hashes sha512 --package dolor
 ### opam admin add-hashes md5    --package sit
-[file://${BASEDIR}/arch-sit.tgz] found in cache
+[file://${BASEDIR}/arch-sit.tgz] downloaded from file://${BASEDIR}/cache
 ### opam admin add-hashes sha512 --package sit
 ### opam show --just-file ./packages/ipsum/ipsum.1/opam --field url.src,url.checksum | "${IP_MD5}" -> IP_MD5 | "${IP_SHA512}" -> IP_SHA512
 url.src:      file://${BASEDIR}/arch-ipsum.tgz
@@ -338,7 +338,7 @@ ipsum : sha512 : exists, link to md5
 --
 dolor : md5 : exists, link to sha256
 dolor : sha256 : exists
-dolor : sha512 : exists, link to md5
+dolor : sha512 : exists, link to sha256
 --
 sit : md5 : exists, link to sha256
 sit : sha256 : exists

--- a/tests/reftests/admin-cache.unix.test
+++ b/tests/reftests/admin-cache.unix.test
@@ -1,0 +1,411 @@
+N0REP0
+### mv REPO OPER
+### opam repository set-url default OPER/ --set-default
+[default] Initialised
+### : create repo
+### <repo>
+opam-version: "1.2"
+### <packages/ipsum/ipsum.1/opam>
+opam-version: "2.0"
+### <packages/dolor/dolor.1/opam>
+opam-version: "2.0"
+### <packages/sit/sit.1/opam>
+opam-version: "2.0"
+### <packages/amet/amet.1/opam>
+opam-version: "2.0"
+### <add-content.sh>
+for op in `ls packages/*/*/opam`; do
+  grep -q synopsis $op || echo 'synopsis: "A word"' >> $op
+  grep -q description $op || echo 'description: "Two words."' >> $op
+  grep -q authors $op || echo 'authors: "the testing team"' >> $op
+  grep -q homepage $op || echo 'homepage: "egapemoh"' >> $op
+  grep -q maintainer $op || echo 'maintainer: "maint@tain.er"' >> $op
+  grep -q license $op || echo 'license: "MIT"' >> $op
+  grep -q dev-repo $op || echo 'dev-repo: "hg+https://pkg@op.am"' >> $op
+  grep -q bug-reports $op || echo 'bug-reports: "https://nobug"' >> $op
+done
+### sh add-content.sh
+### : add archives
+### tar czf arch-ipsum.tgz add-content.sh
+### tar czf arch-dolor.tgz repo
+### tar czf arch-sit.tgz OPAM/config
+### tar czf arch-amet.tgz OPAM/repo/repos-config
+### <add-urls.sh>
+for n in $@; do
+  nv=$n.1
+  arch=arch-$n.tgz
+  file="packages/$n/$nv/opam"
+  echo "url {" >> $file
+  echo "src: \"$arch\"" >> $file
+  MD5=$(openssl md5 $arch | cut -d' ' -f2)
+  echo "checksum: \"md5=$MD5\"" >> $file
+  echo "}" >> $file
+done
+### sh add-urls.sh ipsum dolor sit amet
+### opam admin add-hashes sha256
+### opam admin add-hashes sha512
+[file://${BASEDIR}/arch-amet.tgz] found in cache
+[file://${BASEDIR}/arch-dolor.tgz] found in cache
+[file://${BASEDIR}/arch-ipsum.tgz] found in cache
+[file://${BASEDIR}/arch-sit.tgz] found in cache
+### rm -rf cache
+### : computes hashes
+### openssl md5 arch-ipsum.tgz | '.*= ' -> '' >$ IP_MD5
+### sh -c "echo '$IP_MD5' | cut -c 1-2" >$ PRE_IP_MD5
+### openssl sha256 arch-ipsum.tgz | '.*= ' -> '' >$ IP_SHA256
+### sh -c "echo '$IP_SHA256' | cut -c 1-2" >$ PRE_IP_SHA256
+### openssl sha512 arch-ipsum.tgz | '.*= ' -> '' >$ IP_SHA512
+### sh -c "echo '$IP_SHA512' | cut -c 1-2" >$ PRE_IP_SHA512
+### openssl md5 arch-dolor.tgz | '.*= ' -> '' >$ DL_MD5
+### sh -c "echo '$DL_MD5' | cut -c 1-2" >$ PRE_DL_MD5
+### openssl sha256 arch-dolor.tgz | '.*= ' -> '' >$ DL_SHA256
+### sh -c "echo '$DL_SHA256' | cut -c 1-2" >$ PRE_DL_SHA256
+### openssl sha512 arch-dolor.tgz | '.*= ' -> '' >$ DL_SHA512
+### sh -c "echo '$DL_SHA512' | cut -c 1-2" >$ PRE_DL_SHA512
+### openssl md5 arch-sit.tgz | '.*= ' -> '' >$ ST_MD5
+### sh -c "echo '$ST_MD5' | cut -c 1-2" >$ PRE_ST_MD5
+### openssl sha256 arch-sit.tgz | '.*= ' -> '' >$ ST_SHA256
+### sh -c "echo '$ST_SHA256' | cut -c 1-2" >$ PRE_ST_SHA256
+### openssl sha512 arch-sit.tgz | '.*= ' -> '' >$ ST_SHA512
+### sh -c "echo '$ST_SHA512' | cut -c 1-2" >$ PRE_ST_SHA512
+### openssl md5 arch-amet.tgz | '.*= ' -> '' >$ MT_MD5
+### sh -c "echo '$MT_MD5' | cut -c 1-2" >$ PRE_MT_MD5
+### openssl sha256 arch-amet.tgz | '.*= ' -> '' >$ MT_SHA256
+### sh -c "echo '$MT_SHA256' | cut -c 1-2" >$ PRE_MT_SHA256
+### openssl sha512 arch-amet.tgz | '.*= ' -> '' >$ MT_SHA512
+### sh -c "echo '$MT_SHA512' | cut -c 1-2" >$ PRE_MT_SHA512
+### <analysi.sh>
+pkg=$1
+kind=$2
+hash=$3
+
+pre=`echo $hash | cut -c 1-2`
+arch=cache/$kind/$pre/$hash
+msg="$pkg : $kind :"
+
+if [ -L $arch ]; then
+  link=`readlink "$arch"`
+  hash=$(basename $(dirname $(dirname $link)))
+  real=`realpath -mLP $arch`
+  if [ -f $real ]; then
+    abs=""
+  else
+    abs=" (absent)"
+  fi
+  echo "$msg exists, link to $hash$abs"
+elif [ -f "$arch" ] ; then
+  echo "$msg exists"
+else
+  echo "$msg not found"
+fi
+### <cache-analysi.sh>
+sh analysi.sh ipsum md5    $IP_MD5
+sh analysi.sh ipsum sha256 $IP_SHA256
+sh analysi.sh ipsum sha512 $IP_SHA512
+echo --
+sh analysi.sh dolor md5    $DL_MD5
+sh analysi.sh dolor sha256 $DL_SHA256
+sh analysi.sh dolor sha512 $DL_SHA512
+echo --
+sh analysi.sh sit   md5    $ST_MD5
+sh analysi.sh sit   sha256 $ST_SHA256
+sh analysi.sh sit   sha512 $ST_SHA512
+echo --
+sh analysi.sh amet  md5    $MT_MD5
+sh analysi.sh amet  sha256 $MT_SHA256
+sh analysi.sh amet  sha512 $MT_SHA512
+### : create cache :
+### opam admin cache | unordered
+[dolor.1] synchronised (file://${BASEDIR}/arch-dolor.tgz)
+[ipsum.1] synchronised (file://${BASEDIR}/arch-ipsum.tgz)
+[sit.1] synchronised (file://${BASEDIR}/arch-sit.tgz)
+[amet.1] synchronised (file://${BASEDIR}/arch-amet.tgz)
+Adding cache to ${BASEDIR}/repo...
+Done.
+### :::::::::::::::::::::::::::
+### :I: check hashes presence :
+### :::::::::::::::::::::::::::
+### sh cache-analysi.sh
+ipsum : md5 : exists, link to sha512
+ipsum : sha256 : exists, link to sha512
+ipsum : sha512 : exists
+--
+dolor : md5 : exists, link to sha512
+dolor : sha256 : exists, link to sha512
+dolor : sha512 : exists
+--
+sit : md5 : exists, link to sha512
+sit : sha256 : exists, link to sha512
+sit : sha512 : exists
+--
+amet : md5 : exists, link to sha512
+amet : sha256 : exists, link to sha512
+amet : sha512 : exists
+### ::::::::::::::::::::::::::::::::::::::::::
+### :II: remove weakest hashes and recompute :
+### ::::::::::::::::::::::::::::::::::::::::::
+### # in cache, the archiv is the strongest one
+### rm -rf cache/md5 cache/sha256
+### opam admin cache | unordered
+Done.
+### sh cache-analysi.sh
+ipsum : md5 : not found
+ipsum : sha256 : not found
+ipsum : sha512 : exists
+--
+dolor : md5 : not found
+dolor : sha256 : not found
+dolor : sha512 : exists
+--
+sit : md5 : not found
+sit : sha256 : not found
+sit : sha512 : exists
+--
+amet : md5 : not found
+amet : sha256 : not found
+amet : sha512 : exists
+### opam admin cache | unordered
+Done.
+### sh cache-analysi.sh
+ipsum : md5 : not found
+ipsum : sha256 : not found
+ipsum : sha512 : exists
+--
+dolor : md5 : not found
+dolor : sha256 : not found
+dolor : sha512 : exists
+--
+sit : md5 : not found
+sit : sha256 : not found
+sit : sha512 : exists
+--
+amet : md5 : not found
+amet : sha256 : not found
+amet : sha512 : exists
+### :::::::::::::::::::::::::::::::::::::::::::
+### :III: remove strongest hash and recompute :
+### :::::::::::::::::::::::::::::::::::::::::::
+### rm -rf cache
+### opam admin cache | unordered
+[ipsum.1] synchronised (file://${BASEDIR}/arch-ipsum.tgz)
+[dolor.1] synchronised (file://${BASEDIR}/arch-dolor.tgz)
+[sit.1] synchronised (file://${BASEDIR}/arch-sit.tgz)
+[amet.1] synchronised (file://${BASEDIR}/arch-amet.tgz)
+Done.
+### sh cache-analysi.sh
+ipsum : md5 : exists, link to sha512
+ipsum : sha256 : exists, link to sha512
+ipsum : sha512 : exists
+--
+dolor : md5 : exists, link to sha512
+dolor : sha256 : exists, link to sha512
+dolor : sha512 : exists
+--
+sit : md5 : exists, link to sha512
+sit : sha256 : exists, link to sha512
+sit : sha512 : exists
+--
+amet : md5 : exists, link to sha512
+amet : sha256 : exists, link to sha512
+amet : sha512 : exists
+### rm -rf cache/sha512
+### sh cache-analysi.sh
+ipsum : md5 : exists, link to sha512 (absent)
+ipsum : sha256 : exists, link to sha512 (absent)
+ipsum : sha512 : not found
+--
+dolor : md5 : exists, link to sha512 (absent)
+dolor : sha256 : exists, link to sha512 (absent)
+dolor : sha512 : not found
+--
+sit : md5 : exists, link to sha512 (absent)
+sit : sha256 : exists, link to sha512 (absent)
+sit : sha512 : not found
+--
+amet : md5 : exists, link to sha512 (absent)
+amet : sha256 : exists, link to sha512 (absent)
+amet : sha512 : not found
+### opam admin cache | unordered
+[dolor.1] synchronised (file://${BASEDIR}/arch-dolor.tgz)
+[ipsum.1] synchronised (file://${BASEDIR}/arch-ipsum.tgz)
+[sit.1] synchronised (file://${BASEDIR}/arch-sit.tgz)
+[amet.1] synchronised (file://${BASEDIR}/arch-amet.tgz)
+Done.
+### sh cache-analysi.sh
+ipsum : md5 : exists, link to sha512
+ipsum : sha256 : exists, link to sha512
+ipsum : sha512 : exists
+--
+dolor : md5 : exists, link to sha512
+dolor : sha256 : exists, link to sha512
+dolor : sha512 : exists
+--
+sit : md5 : exists, link to sha512
+sit : sha256 : exists, link to sha512
+sit : sha512 : exists
+--
+amet : md5 : exists, link to sha512
+amet : sha256 : exists, link to sha512
+amet : sha512 : exists
+### ::::::::::::::::::::::::::::::::::::
+### :IV: add a other hashes afterwards :
+### ::::::::::::::::::::::::::::::::::::
+### : ipsum : only md5 then adding sha512
+### : dolor : md5 & sha256 then adding sha512
+### : sit   : sha256 then adding md5 & sha512
+### sed -i '/"sha512=.*/d' packages/ipsum/ipsum.1/opam
+### sed -i '/"sha256=.*/d' packages/ipsum/ipsum.1/opam
+### sed -i '/"sha512=.*/d' packages/dolor/dolor.1/opam
+### sed -i '/"md5=.*/d' packages/sit/sit.1/opam
+### sed -i '/"sha512=.*/d' packages/sit/sit.1/opam
+### opam show --just-file ./packages/ipsum/ipsum.1/opam --field url.src,url.checksum | "${IP_MD5}" -> IP_MD5 | "${IP_SHA512}" -> IP_SHA512
+url.src:      file://${BASEDIR}/arch-ipsum.tgz
+url.checksum: md5=IP_MD5
+### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | "${DL_MD5}" -> DL_MD5 | "${DL_SHA256}" -> DL_SHA256 | "${DL_SHA512}" -> DL_SHA512
+url.src:      file://${BASEDIR}/arch-dolor.tgz
+url.checksum: md5=DL_MD5, sha256=DL_SHA256
+### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | "${ST_MD5}" -> ST_MD5 | "${ST_SHA256}" -> ST_SHA256 | "${ST_SHA512}" -> ST_SHA512
+url.src:      file://${BASEDIR}/arch-sit.tgz
+url.checksum: sha256=ST_SHA256
+### rm -rf cache
+### opam admin cache | unordered
+[dolor.1] synchronised (file://${BASEDIR}/arch-dolor.tgz)
+[ipsum.1] synchronised (file://${BASEDIR}/arch-ipsum.tgz)
+[sit.1] synchronised (file://${BASEDIR}/arch-sit.tgz)
+[amet.1] synchronised (file://${BASEDIR}/arch-amet.tgz)
+Done.
+### sh cache-analysi.sh
+ipsum : md5 : exists
+ipsum : sha256 : not found
+ipsum : sha512 : not found
+--
+dolor : md5 : exists, link to sha256
+dolor : sha256 : exists
+dolor : sha512 : not found
+--
+sit : md5 : not found
+sit : sha256 : exists
+sit : sha512 : not found
+--
+amet : md5 : exists, link to sha512
+amet : sha256 : exists, link to sha512
+amet : sha512 : exists
+### : add hashes
+### opam admin add-hashes sha512 --package ipsum
+### opam admin add-hashes sha512 --package dolor
+### opam admin add-hashes md5    --package sit
+[file://${BASEDIR}/arch-sit.tgz] downloaded from file://${BASEDIR}/cache
+### opam admin add-hashes sha512 --package sit
+### opam show --just-file ./packages/ipsum/ipsum.1/opam --field url.src,url.checksum | "${IP_MD5}" -> IP_MD5 | "${IP_SHA512}" -> IP_SHA512
+url.src:      file://${BASEDIR}/arch-ipsum.tgz
+url.checksum: md5=IP_MD5, sha512=IP_SHA512
+### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | "${DL_MD5}" -> DL_MD5 | "${DL_SHA256}" -> DL_SHA256 | "${DL_SHA512}" -> DL_SHA512
+url.src:      file://${BASEDIR}/arch-dolor.tgz
+url.checksum: md5=DL_MD5, sha256=DL_SHA256, sha512=DL_SHA512
+### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | "${ST_MD5}" -> ST_MD5 | "${ST_SHA256}" -> ST_SHA256 | "${ST_SHA512}" -> ST_SHA512
+url.src:      file://${BASEDIR}/arch-sit.tgz
+url.checksum: sha256=ST_SHA256, md5=ST_MD5, sha512=ST_SHA512
+### sh cache-analysi.sh
+ipsum : md5 : exists
+ipsum : sha256 : not found
+ipsum : sha512 : not found
+--
+dolor : md5 : exists, link to sha256
+dolor : sha256 : exists
+dolor : sha512 : not found
+--
+sit : md5 : not found
+sit : sha256 : exists
+sit : sha512 : not found
+--
+amet : md5 : exists, link to sha512
+amet : sha256 : exists, link to sha512
+amet : sha512 : exists
+### : cache
+### opam admin cache | unordered
+[dolor.1] synchronised (cached)
+[ipsum.1] synchronised (cached)
+[sit.1] synchronised (cached)
+Done.
+### sh cache-analysi.sh
+ipsum : md5 : exists
+ipsum : sha256 : not found
+ipsum : sha512 : not found
+--
+dolor : md5 : exists, link to sha256
+dolor : sha256 : exists
+dolor : sha512 : not found
+--
+sit : md5 : not found
+sit : sha256 : exists
+sit : sha512 : not found
+--
+amet : md5 : exists, link to sha512
+amet : sha256 : exists, link to sha512
+amet : sha512 : exists
+### ::::::::::::::::::
+### :V: corrupted md5:
+### ::::::::::::::::::
+### <packages/lorem/lorem.1/opam>
+opam-version: "2.0"
+### <hex1>
+4dc968ff0ee35c209572d4777b721587d36fa7b21bdc56b74a3dc0783e7b9518afbfa200a8284bf36e8e4b55b35f427593d849676da0d1555d8360fb5f07fea2
+### <hex2>
+4dc968ff0ee35c209572d4777b721587d36fa7b21bdc56b74a3dc0783e7b9518afbfa202a8284bf36e8e4b55b35f427593d849676da0d1d55d8360fb5f07fea2
+### xxd -r -p hex1 arch-lorem.tgz
+### xxd -r -p hex2 arch-evil.tgz
+### openssl md5 arch-lorem.tgz | '.*= ' -> '' >$ LR_MD5
+### sh -c "echo '$LR_MD5' | cut -c 1-2" >$ PRE_LR_MD5
+### openssl sha256 arch-lorem.tgz | '.*= ' -> '' >$ LR_SHA256
+### sh -c "echo '$LR_SHA256' | cut -c 1-2" >$ PRE_LR_SHA256
+### openssl sha512 arch-lorem.tgz | '.*= ' -> '' >$ LR_SHA512
+### sh -c "echo '$LR_SHA512' | cut -c 1-2" >$ PRE_LR_SHA512
+### openssl md5 arch-evil.tgz | "${LR_MD5}" -> LR_MD5
+MD5(arch-evil.tgz)= LR_MD5
+### sh add-urls.sh lorem
+### opam admin cache | unordered
+[dolor.1] synchronised (cached)
+[ipsum.1] synchronised (cached)
+[sit.1] synchronised (cached)
+[lorem.1] synchronised (file://${BASEDIR}/arch-lorem.tgz)
+Done.
+### opam admin add-hashes sha256 --package lorem
+### <cache-analysi.sh>
+sh analysi.sh lorem md5    $LR_MD5
+sh analysi.sh lorem sha256 $LR_SHA256
+sh analysi.sh lorem sha512 $LR_SHA512
+### sh cache-analysi.sh
+lorem : md5 : exists
+lorem : sha256 : not found
+lorem : sha512 : not found
+### opam admin cache | unordered
+[lorem.1] synchronised (cached)
+[dolor.1] synchronised (cached)
+[ipsum.1] synchronised (cached)
+[sit.1] synchronised (cached)
+Done.
+### sh cache-analysi.sh
+lorem : md5 : exists
+lorem : sha256 : not found
+lorem : sha512 : not found
+### mv arch-evil.tgz cache/md5/$PRE_LR_MD5/$LR_MD5
+### opam admin add-hashes sha512 --package lorem
+### sh cache-analysi.sh
+lorem : md5 : exists
+lorem : sha256 : not found
+lorem : sha512 : not found
+### opam admin cache | "${LR_MD5}" -> LR_MD5 | "${LR_SHA256}" -> LR_SHA256 | "${LR_SHA512}" -> LR_SHA512
+[ERROR] Conflicting file hashes, or broken or compromised cache!
+          - sha512=LR_SHA512 (MISMATCH)
+          - sha256=LR_SHA256 (MISMATCH)
+          - md5=LR_MD5 (match)
+
+[dolor.1] synchronised (cached)
+[ipsum.1] synchronised (cached)
+[sit.1] synchronised (cached)
+[lorem.1] synchronised (file://${BASEDIR}/arch-lorem.tgz)
+Done.
+### sh cache-analysi.sh
+lorem : md5 : exists, link to sha512
+lorem : sha256 : exists, link to sha512
+lorem : sha512 : exists

--- a/tests/reftests/admin-cache.win32.test
+++ b/tests/reftests/admin-cache.win32.test
@@ -1,0 +1,413 @@
+N0REP0
+### mv REPO OPER
+### opam repository set-url default OPER/ --set-default
+[default] Initialised
+### : create repo
+### <repo>
+opam-version: "1.2"
+### <packages/ipsum/ipsum.1/opam>
+opam-version: "2.0"
+### <packages/dolor/dolor.1/opam>
+opam-version: "2.0"
+### <packages/sit/sit.1/opam>
+opam-version: "2.0"
+### <packages/amet/amet.1/opam>
+opam-version: "2.0"
+### <add-content.sh>
+for op in `ls packages/*/*/opam`; do
+  grep -q synopsis $op || echo 'synopsis: "A word"' >> $op
+  grep -q description $op || echo 'description: "Two words."' >> $op
+  grep -q authors $op || echo 'authors: "the testing team"' >> $op
+  grep -q homepage $op || echo 'homepage: "egapemoh"' >> $op
+  grep -q maintainer $op || echo 'maintainer: "maint@tain.er"' >> $op
+  grep -q license $op || echo 'license: "MIT"' >> $op
+  grep -q dev-repo $op || echo 'dev-repo: "hg+https://pkg@op.am"' >> $op
+  grep -q bug-reports $op || echo 'bug-reports: "https://nobug"' >> $op
+done
+### sh add-content.sh
+### : add archives
+### tar czf arch-ipsum.tgz add-content.sh
+### tar czf arch-dolor.tgz repo
+### tar czf arch-sit.tgz OPAM/config
+### tar czf arch-amet.tgz OPAM/repo/repos-config
+### <add-urls.sh>
+for n in $@; do
+  nv=$n.1
+  arch=arch-$n.tgz
+  file="packages/$n/$nv/opam"
+  echo "url {" >> $file
+  echo "src: \"$arch\"" >> $file
+  MD5=$(openssl md5 $arch | cut -d' ' -f2)
+  echo "checksum: \"md5=$MD5\"" >> $file
+  echo "}" >> $file
+done
+### sh add-urls.sh ipsum dolor sit amet
+### opam admin add-hashes sha256
+### opam admin add-hashes sha512
+[file://${BASEDIR}/arch-amet.tgz] found in cache
+[file://${BASEDIR}/arch-dolor.tgz] found in cache
+[file://${BASEDIR}/arch-ipsum.tgz] found in cache
+[file://${BASEDIR}/arch-sit.tgz] found in cache
+### rm -rf cache
+### : computes hashes
+### openssl md5 arch-ipsum.tgz | '.*= ' -> '' >$ IP_MD5
+### sh -c "echo '$IP_MD5' | cut -c 1-2" >$ PRE_IP_MD5
+### openssl sha256 arch-ipsum.tgz | '.*= ' -> '' >$ IP_SHA256
+### sh -c "echo '$IP_SHA256' | cut -c 1-2" >$ PRE_IP_SHA256
+### openssl sha512 arch-ipsum.tgz | '.*= ' -> '' >$ IP_SHA512
+### sh -c "echo '$IP_SHA512' | cut -c 1-2" >$ PRE_IP_SHA512
+### openssl md5 arch-dolor.tgz | '.*= ' -> '' >$ DL_MD5
+### sh -c "echo '$DL_MD5' | cut -c 1-2" >$ PRE_DL_MD5
+### openssl sha256 arch-dolor.tgz | '.*= ' -> '' >$ DL_SHA256
+### sh -c "echo '$DL_SHA256' | cut -c 1-2" >$ PRE_DL_SHA256
+### openssl sha512 arch-dolor.tgz | '.*= ' -> '' >$ DL_SHA512
+### sh -c "echo '$DL_SHA512' | cut -c 1-2" >$ PRE_DL_SHA512
+### openssl md5 arch-sit.tgz | '.*= ' -> '' >$ ST_MD5
+### sh -c "echo '$ST_MD5' | cut -c 1-2" >$ PRE_ST_MD5
+### openssl sha256 arch-sit.tgz | '.*= ' -> '' >$ ST_SHA256
+### sh -c "echo '$ST_SHA256' | cut -c 1-2" >$ PRE_ST_SHA256
+### openssl sha512 arch-sit.tgz | '.*= ' -> '' >$ ST_SHA512
+### sh -c "echo '$ST_SHA512' | cut -c 1-2" >$ PRE_ST_SHA512
+### openssl md5 arch-amet.tgz | '.*= ' -> '' >$ MT_MD5
+### sh -c "echo '$MT_MD5' | cut -c 1-2" >$ PRE_MT_MD5
+### openssl sha256 arch-amet.tgz | '.*= ' -> '' >$ MT_SHA256
+### sh -c "echo '$MT_SHA256' | cut -c 1-2" >$ PRE_MT_SHA256
+### openssl sha512 arch-amet.tgz | '.*= ' -> '' >$ MT_SHA512
+### sh -c "echo '$MT_SHA512' | cut -c 1-2" >$ PRE_MT_SHA512
+### <analysi.sh>
+pkg=$1
+kind=$2
+hash=$3
+
+pre=`echo $hash | cut -c 1-2`
+arch=cache/$kind/$pre/$hash
+msg="$pkg : $kind :"
+
+if [ -L $arch ]; then
+  link=`readlink "$arch"`
+  hash=$(basename $(dirname $(dirname $link)))
+  real=`realpath -mLP $arch`
+  if [ -f $real ]; then
+    abs=""
+  else
+    abs=" (absent)"
+  fi
+  echo "$msg exists, link to $hash$abs"
+elif [ -f "$arch" ] ; then
+  echo "$msg exists"
+else
+  echo "$msg not found"
+fi
+### <cache-analysi.sh>
+sh analysi.sh ipsum md5    $IP_MD5
+sh analysi.sh ipsum sha256 $IP_SHA256
+sh analysi.sh ipsum sha512 $IP_SHA512
+echo --
+sh analysi.sh dolor md5    $DL_MD5
+sh analysi.sh dolor sha256 $DL_SHA256
+sh analysi.sh dolor sha512 $DL_SHA512
+echo --
+sh analysi.sh sit   md5    $ST_MD5
+sh analysi.sh sit   sha256 $ST_SHA256
+sh analysi.sh sit   sha512 $ST_SHA512
+echo --
+sh analysi.sh amet  md5    $MT_MD5
+sh analysi.sh amet  sha256 $MT_SHA256
+sh analysi.sh amet  sha512 $MT_SHA512
+### : create cache :
+### opam admin cache | unordered
+[dolor.1] synchronised (file://${BASEDIR}/arch-dolor.tgz)
+[ipsum.1] synchronised (file://${BASEDIR}/arch-ipsum.tgz)
+[sit.1] synchronised (file://${BASEDIR}/arch-sit.tgz)
+[amet.1] synchronised (file://${BASEDIR}/arch-amet.tgz)
+Adding cache to ${BASEDIR}/repo...
+Done.
+### :::::::::::::::::::::::::::
+### :I: check hashes presence :
+### :::::::::::::::::::::::::::
+### sh cache-analysi.sh
+ipsum : md5 : exists
+ipsum : sha256 : exists
+ipsum : sha512 : exists
+--
+dolor : md5 : exists
+dolor : sha256 : exists
+dolor : sha512 : exists
+--
+sit : md5 : exists
+sit : sha256 : exists
+sit : sha512 : exists
+--
+amet : md5 : exists
+amet : sha256 : exists
+amet : sha512 : exists
+### ::::::::::::::::::::::::::::::::::::::::::
+### :II: remove weakest hashes and recompute :
+### ::::::::::::::::::::::::::::::::::::::::::
+### # in cache, the archiv is the strongest one
+### rm -rf cache/md5 cache/sha256
+### opam admin cache | unordered
+Done.
+### sh cache-analysi.sh
+ipsum : md5 : not found
+ipsum : sha256 : not found
+ipsum : sha512 : exists
+--
+dolor : md5 : not found
+dolor : sha256 : not found
+dolor : sha512 : exists
+--
+sit : md5 : not found
+sit : sha256 : not found
+sit : sha512 : exists
+--
+amet : md5 : not found
+amet : sha256 : not found
+amet : sha512 : exists
+### opam admin cache | unordered
+Done.
+### sh cache-analysi.sh
+ipsum : md5 : not found
+ipsum : sha256 : not found
+ipsum : sha512 : exists
+--
+dolor : md5 : not found
+dolor : sha256 : not found
+dolor : sha512 : exists
+--
+sit : md5 : not found
+sit : sha256 : not found
+sit : sha512 : exists
+--
+amet : md5 : not found
+amet : sha256 : not found
+amet : sha512 : exists
+### :::::::::::::::::::::::::::::::::::::::::::
+### :III: remove strongest hash and recompute :
+### :::::::::::::::::::::::::::::::::::::::::::
+### rm -rf cache
+### opam admin cache | unordered
+[ipsum.1] synchronised (file://${BASEDIR}/arch-ipsum.tgz)
+[dolor.1] synchronised (file://${BASEDIR}/arch-dolor.tgz)
+[sit.1] synchronised (file://${BASEDIR}/arch-sit.tgz)
+[amet.1] synchronised (file://${BASEDIR}/arch-amet.tgz)
+Done.
+### sh cache-analysi.sh
+ipsum : md5 : exists
+ipsum : sha256 : exists
+ipsum : sha512 : exists
+--
+dolor : md5 : exists
+dolor : sha256 : exists
+dolor : sha512 : exists
+--
+sit : md5 : exists
+sit : sha256 : exists
+sit : sha512 : exists
+--
+amet : md5 : exists
+amet : sha256 : exists
+amet : sha512 : exists
+### rm -rf cache/sha512
+### sh cache-analysi.sh
+ipsum : md5 : exists
+ipsum : sha256 : exists
+ipsum : sha512 : not found
+--
+dolor : md5 : exists
+dolor : sha256 : exists
+dolor : sha512 : not found
+--
+sit : md5 : exists
+sit : sha256 : exists
+sit : sha512 : not found
+--
+amet : md5 : exists
+amet : sha256 : exists
+amet : sha512 : not found
+### opam admin cache | unordered
+[dolor.1] synchronised (cached)
+[ipsum.1] synchronised (cached)
+[sit.1] synchronised (cached)
+[amet.1] synchronised (cached)
+Done.
+### sh cache-analysi.sh
+ipsum : md5 : exists
+ipsum : sha256 : exists
+ipsum : sha512 : not found
+--
+dolor : md5 : exists
+dolor : sha256 : exists
+dolor : sha512 : not found
+--
+sit : md5 : exists
+sit : sha256 : exists
+sit : sha512 : not found
+--
+amet : md5 : exists
+amet : sha256 : exists
+amet : sha512 : not found
+### ::::::::::::::::::::::::::::::::::::
+### :IV: add a other hashes afterwards :
+### ::::::::::::::::::::::::::::::::::::
+### : ipsum : only md5 then adding sha512
+### : dolor : md5 & sha256 then adding sha512
+### : sit   : sha256 then adding md5 & sha512
+### sed -i '/"sha512=.*/d' packages/ipsum/ipsum.1/opam
+### sed -i '/"sha256=.*/d' packages/ipsum/ipsum.1/opam
+### sed -i '/"sha512=.*/d' packages/dolor/dolor.1/opam
+### sed -i '/"md5=.*/d' packages/sit/sit.1/opam
+### sed -i '/"sha512=.*/d' packages/sit/sit.1/opam
+### opam show --just-file ./packages/ipsum/ipsum.1/opam --field url.src,url.checksum | "${IP_MD5}" -> IP_MD5 | "${IP_SHA512}" -> IP_SHA512
+url.src:      file://${BASEDIR}/arch-ipsum.tgz
+url.checksum: md5=IP_MD5
+### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | "${DL_MD5}" -> DL_MD5 | "${DL_SHA256}" -> DL_SHA256 | "${DL_SHA512}" -> DL_SHA512
+url.src:      file://${BASEDIR}/arch-dolor.tgz
+url.checksum: md5=DL_MD5, sha256=DL_SHA256
+### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | "${ST_MD5}" -> ST_MD5 | "${ST_SHA256}" -> ST_SHA256 | "${ST_SHA512}" -> ST_SHA512
+url.src:      file://${BASEDIR}/arch-sit.tgz
+url.checksum: sha256=ST_SHA256
+### rm -rf cache
+### opam admin cache | unordered
+[dolor.1] synchronised (file://${BASEDIR}/arch-dolor.tgz)
+[ipsum.1] synchronised (file://${BASEDIR}/arch-ipsum.tgz)
+[sit.1] synchronised (file://${BASEDIR}/arch-sit.tgz)
+[amet.1] synchronised (file://${BASEDIR}/arch-amet.tgz)
+Done.
+### sh cache-analysi.sh
+ipsum : md5 : exists
+ipsum : sha256 : not found
+ipsum : sha512 : not found
+--
+dolor : md5 : exists
+dolor : sha256 : exists
+dolor : sha512 : not found
+--
+sit : md5 : not found
+sit : sha256 : exists
+sit : sha512 : not found
+--
+amet : md5 : exists
+amet : sha256 : exists
+amet : sha512 : exists
+### : add hashes
+### opam admin add-hashes sha512 --package ipsum
+### opam admin add-hashes sha512 --package dolor
+### opam admin add-hashes md5    --package sit
+[file://${BASEDIR}/arch-sit.tgz] downloaded from file://${BASEDIR}/cache
+### opam admin add-hashes sha512 --package sit
+### opam show --just-file ./packages/ipsum/ipsum.1/opam --field url.src,url.checksum | "${IP_MD5}" -> IP_MD5 | "${IP_SHA512}" -> IP_SHA512
+url.src:      file://${BASEDIR}/arch-ipsum.tgz
+url.checksum: md5=IP_MD5, sha512=IP_SHA512
+### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | "${DL_MD5}" -> DL_MD5 | "${DL_SHA256}" -> DL_SHA256 | "${DL_SHA512}" -> DL_SHA512
+url.src:      file://${BASEDIR}/arch-dolor.tgz
+url.checksum: md5=DL_MD5, sha256=DL_SHA256, sha512=DL_SHA512
+### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | "${ST_MD5}" -> ST_MD5 | "${ST_SHA256}" -> ST_SHA256 | "${ST_SHA512}" -> ST_SHA512
+url.src:      file://${BASEDIR}/arch-sit.tgz
+url.checksum: sha256=ST_SHA256, md5=ST_MD5, sha512=ST_SHA512
+### sh cache-analysi.sh
+ipsum : md5 : exists
+ipsum : sha256 : not found
+ipsum : sha512 : not found
+--
+dolor : md5 : exists
+dolor : sha256 : exists
+dolor : sha512 : not found
+--
+sit : md5 : not found
+sit : sha256 : exists
+sit : sha512 : not found
+--
+amet : md5 : exists
+amet : sha256 : exists
+amet : sha512 : exists
+### : cache
+### opam admin cache | unordered
+[dolor.1] synchronised (cached)
+[ipsum.1] synchronised (cached)
+[sit.1] synchronised (cached)
+Done.
+### sh cache-analysi.sh
+ipsum : md5 : exists
+ipsum : sha256 : not found
+ipsum : sha512 : not found
+--
+dolor : md5 : exists
+dolor : sha256 : exists
+dolor : sha512 : not found
+--
+sit : md5 : not found
+sit : sha256 : exists
+sit : sha512 : not found
+--
+amet : md5 : exists
+amet : sha256 : exists
+amet : sha512 : exists
+### ::::::::::::::::::
+### :V: corrupted md5:
+### ::::::::::::::::::
+### <packages/lorem/lorem.1/opam>
+opam-version: "2.0"
+### <hex1>
+4dc968ff0ee35c209572d4777b721587d36fa7b21bdc56b74a3dc0783e7b9518afbfa200a8284bf36e8e4b55b35f427593d849676da0d1555d8360fb5f07fea2
+### <hex2>
+4dc968ff0ee35c209572d4777b721587d36fa7b21bdc56b74a3dc0783e7b9518afbfa202a8284bf36e8e4b55b35f427593d849676da0d1d55d8360fb5f07fea2
+### xxd -r -p hex1 arch-lorem.tgz
+### xxd -r -p hex2 arch-evil.tgz
+### openssl md5 arch-lorem.tgz | '.*= ' -> '' >$ LR_MD5
+### sh -c "echo '$LR_MD5' | cut -c 1-2" >$ PRE_LR_MD5
+### openssl sha256 arch-lorem.tgz | '.*= ' -> '' >$ LR_SHA256
+### sh -c "echo '$LR_SHA256' | cut -c 1-2" >$ PRE_LR_SHA256
+### openssl sha512 arch-lorem.tgz | '.*= ' -> '' >$ LR_SHA512
+### sh -c "echo '$LR_SHA512' | cut -c 1-2" >$ PRE_LR_SHA512
+### openssl md5 arch-evil.tgz | "${LR_MD5}" -> LR_MD5
+MD5(arch-evil.tgz)= LR_MD5
+### sh add-urls.sh lorem
+### opam admin cache | unordered
+[dolor.1] synchronised (cached)
+[ipsum.1] synchronised (cached)
+[sit.1] synchronised (cached)
+[lorem.1] synchronised (file://${BASEDIR}/arch-lorem.tgz)
+Done.
+### opam admin add-hashes sha256 --package lorem
+[file://${BASEDIR}/arch-lorem.tgz] downloaded from file://${BASEDIR}/cache
+### <cache-analysi.sh>
+sh analysi.sh lorem md5    $LR_MD5
+sh analysi.sh lorem sha256 $LR_SHA256
+sh analysi.sh lorem sha512 $LR_SHA512
+### sh cache-analysi.sh
+lorem : md5 : exists
+lorem : sha256 : not found
+lorem : sha512 : not found
+### opam admin cache | unordered
+[lorem.1] synchronised (cached)
+[dolor.1] synchronised (cached)
+[ipsum.1] synchronised (cached)
+[sit.1] synchronised (cached)
+Done.
+### sh cache-analysi.sh
+lorem : md5 : exists
+lorem : sha256 : not found
+lorem : sha512 : not found
+### mv arch-evil.tgz cache/md5/$PRE_LR_MD5/$LR_MD5
+### opam admin add-hashes sha512 --package lorem
+[file://${BASEDIR}/arch-lorem.tgz] found in cache
+### sh cache-analysi.sh
+lorem : md5 : exists
+lorem : sha256 : not found
+lorem : sha512 : not found
+### opam admin cache | "${LR_MD5}" -> LR_MD5 | "${LR_SHA256}" -> LR_SHA256 | "${LR_SHA512}" -> LR_SHA512
+[ERROR] Conflicting file hashes, or broken or compromised cache!
+          - sha512=LR_SHA512 (MISMATCH)
+          - sha256=LR_SHA256 (MISMATCH)
+          - md5=LR_MD5 (match)
+
+[dolor.1] synchronised (cached)
+[ipsum.1] synchronised (cached)
+[sit.1] synchronised (cached)
+[lorem.1] synchronised (file://${BASEDIR}/arch-lorem.tgz)
+Done.
+### sh cache-analysi.sh
+lorem : md5 : exists
+lorem : sha256 : exists
+lorem : sha512 : exists

--- a/tests/reftests/admin-cache.win32.test
+++ b/tests/reftests/admin-cache.win32.test
@@ -147,40 +147,44 @@ amet : sha512 : exists
 ### # in cache, the archiv is the strongest one
 ### rm -rf cache/md5 cache/sha256
 ### opam admin cache | unordered
+[dolor.1] synchronised (cached)
+[ipsum.1] synchronised (cached)
+[sit.1] synchronised (cached)
+[amet.1] synchronised (cached)
 Done.
 ### sh cache-analysi.sh
-ipsum : md5 : not found
-ipsum : sha256 : not found
+ipsum : md5 : exists
+ipsum : sha256 : exists
 ipsum : sha512 : exists
 --
-dolor : md5 : not found
-dolor : sha256 : not found
+dolor : md5 : exists
+dolor : sha256 : exists
 dolor : sha512 : exists
 --
-sit : md5 : not found
-sit : sha256 : not found
+sit : md5 : exists
+sit : sha256 : exists
 sit : sha512 : exists
 --
-amet : md5 : not found
-amet : sha256 : not found
+amet : md5 : exists
+amet : sha256 : exists
 amet : sha512 : exists
 ### opam admin cache | unordered
 Done.
 ### sh cache-analysi.sh
-ipsum : md5 : not found
-ipsum : sha256 : not found
+ipsum : md5 : exists
+ipsum : sha256 : exists
 ipsum : sha512 : exists
 --
-dolor : md5 : not found
-dolor : sha256 : not found
+dolor : md5 : exists
+dolor : sha256 : exists
 dolor : sha512 : exists
 --
-sit : md5 : not found
-sit : sha256 : not found
+sit : md5 : exists
+sit : sha256 : exists
 sit : sha512 : exists
 --
-amet : md5 : not found
-amet : sha256 : not found
+amet : md5 : exists
+amet : sha256 : exists
 amet : sha512 : exists
 ### :::::::::::::::::::::::::::::::::::::::::::
 ### :III: remove strongest hash and recompute :
@@ -234,19 +238,19 @@ Done.
 ### sh cache-analysi.sh
 ipsum : md5 : exists
 ipsum : sha256 : exists
-ipsum : sha512 : not found
+ipsum : sha512 : exists
 --
 dolor : md5 : exists
 dolor : sha256 : exists
-dolor : sha512 : not found
+dolor : sha512 : exists
 --
 sit : md5 : exists
 sit : sha256 : exists
-sit : sha512 : not found
+sit : sha512 : exists
 --
 amet : md5 : exists
 amet : sha256 : exists
-amet : sha512 : not found
+amet : sha512 : exists
 ### ::::::::::::::::::::::::::::::::::::
 ### :IV: add a other hashes afterwards :
 ### ::::::::::::::::::::::::::::::::::::
@@ -294,7 +298,7 @@ amet : sha512 : exists
 ### opam admin add-hashes sha512 --package ipsum
 ### opam admin add-hashes sha512 --package dolor
 ### opam admin add-hashes md5    --package sit
-[file://${BASEDIR}/arch-sit.tgz] downloaded from file://${BASEDIR}/cache
+[file://${BASEDIR}/arch-sit.tgz] found in cache
 ### opam admin add-hashes sha512 --package sit
 ### opam show --just-file ./packages/ipsum/ipsum.1/opam --field url.src,url.checksum | "${IP_MD5}" -> IP_MD5 | "${IP_SHA512}" -> IP_SHA512
 url.src:      file://${BASEDIR}/arch-ipsum.tgz
@@ -330,15 +334,15 @@ Done.
 ### sh cache-analysi.sh
 ipsum : md5 : exists
 ipsum : sha256 : not found
-ipsum : sha512 : not found
+ipsum : sha512 : exists
 --
 dolor : md5 : exists
 dolor : sha256 : exists
-dolor : sha512 : not found
+dolor : sha512 : exists
 --
-sit : md5 : not found
+sit : md5 : exists
 sit : sha256 : exists
-sit : sha512 : not found
+sit : sha512 : exists
 --
 amet : md5 : exists
 amet : sha256 : exists
@@ -364,9 +368,6 @@ opam-version: "2.0"
 MD5(arch-evil.tgz)= LR_MD5
 ### sh add-urls.sh lorem
 ### opam admin cache | unordered
-[dolor.1] synchronised (cached)
-[ipsum.1] synchronised (cached)
-[sit.1] synchronised (cached)
 [lorem.1] synchronised (file://${BASEDIR}/arch-lorem.tgz)
 Done.
 ### opam admin add-hashes sha256 --package lorem
@@ -381,20 +382,17 @@ lorem : sha256 : not found
 lorem : sha512 : not found
 ### opam admin cache | unordered
 [lorem.1] synchronised (cached)
-[dolor.1] synchronised (cached)
-[ipsum.1] synchronised (cached)
-[sit.1] synchronised (cached)
 Done.
 ### sh cache-analysi.sh
 lorem : md5 : exists
-lorem : sha256 : not found
+lorem : sha256 : exists
 lorem : sha512 : not found
 ### mv arch-evil.tgz cache/md5/$PRE_LR_MD5/$LR_MD5
 ### opam admin add-hashes sha512 --package lorem
 [file://${BASEDIR}/arch-lorem.tgz] found in cache
 ### sh cache-analysi.sh
 lorem : md5 : exists
-lorem : sha256 : not found
+lorem : sha256 : exists
 lorem : sha512 : not found
 ### opam admin cache | "${LR_MD5}" -> LR_MD5 | "${LR_SHA256}" -> LR_SHA256 | "${LR_SHA512}" -> LR_SHA512
 [ERROR] Conflicting file hashes, or broken or compromised cache!
@@ -402,9 +400,6 @@ lorem : sha512 : not found
           - sha256=LR_SHA256 (MISMATCH)
           - md5=LR_MD5 (match)
 
-[dolor.1] synchronised (cached)
-[ipsum.1] synchronised (cached)
-[sit.1] synchronised (cached)
 [lorem.1] synchronised (file://${BASEDIR}/arch-lorem.tgz)
 Done.
 ### sh cache-analysi.sh

--- a/tests/reftests/admin.test
+++ b/tests/reftests/admin.test
@@ -600,6 +600,10 @@ opam-version: "2.0"
 ### opam-cat packages/with-xf/with-xf.2/opam | "${XF_MD5}" -> "good-md5" | "${XF_SHA256}" -> "good-sha"
 extra-files: ["missing-hash" "md5=good-md5"]
 opam-version: "2.0"
+### ::::::::::::::::::::::::::::::::::::::::::::::::::::::
+### :: Cache is tested in admin-cache.{unix,win32}.test ::
+### ::::::::::::::::::::::::::::::::::::::::::::::::::::::
+### :
 ### ::::::::::::::::::::::
 ### :VII: Specific cases :
 ### ::::::::::::::::::::::

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1,5 +1,47 @@
 
 (rule
+ (alias reftest-admin-cache.unix)
+ (enabled_if (= %{os_type} "Unix"))
+ (action
+  (diff admin-cache.unix.test admin-cache.unix.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (= %{os_type} "Unix"))
+ (deps (alias reftest-admin-cache.unix)))
+
+(rule
+ (targets admin-cache.unix.out)
+ (deps root-N0REP0)
+ (enabled_if (= %{os_type} "Unix"))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:admin-cache.unix.test} %{read-lines:testing-env}))))
+
+(rule
+ (alias reftest-admin-cache.win32)
+ (enabled_if (= %{os_type} "Win32"))
+ (action
+  (diff admin-cache.win32.test admin-cache.win32.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (= %{os_type} "Win32"))
+ (deps (alias reftest-admin-cache.win32)))
+
+(rule
+ (targets admin-cache.win32.out)
+ (deps root-N0REP0)
+ (enabled_if (= %{os_type} "Win32"))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:admin-cache.win32.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-admin)
  (action
   (diff admin.test admin.out)))


### PR DESCRIPTION
pro: have a cleaner cache by avoiding double symlinks (e.g. `md5 -> sha512` & `sha256 -> sha512` instead of `md5 -> sha256 -> sha512`)
cons: when the cache contains a `sha256 -> md5` link, installing 2 packages that refer to the same archive but one with an md5 and the other with a sha256 ; the one with a sha256 won't be found in cache and redownloaded.

Another solution is to have opam always compute and store all checksums linked (from sha*'s), like proposed by @kit-ty-kate. 


* [ ] add a test
* [ ] update master changes
* [ ] queued on #6068
