### PR TITLE
Add support for wget2

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -25,6 +25,7 @@ users)
 ## Config report
 
 ## Actions
+  * Add support for wget2 [#6104 @kit-ty-kate]
 
 ## Install
   * Fix package name display for no agreement conflicts [#6055 @rjbou - fix #6030]

--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -35,7 +35,6 @@ let curl_args = [
 ]
 
 let wget_args = [
-  CString "--content-disposition", None;
   CString "-t", None; CIdent "retry", None;
   CString "-O", None; CIdent "out", None;
   CString "-U", None; user_agent, None;

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -33,15 +33,10 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
-+ wget "--content-disposition" "-t" "3" "-O" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
-[ERROR] Failed to get sources of foo.1: Downloaded file not found
-
-OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (Download command succeeded, but resulting file not found)")
-
-
-<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-'${OPAM} install foo --download-only' failed.
-# Return code 40 #
++ wget "-t" "3" "-O" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
+Processing  1/1: [foo.1: extract]
++ tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
+Done.
 ### opam clean -c
 Clearing cache of downloaded files
 ### :I:b: FETCH curl
@@ -152,14 +147,9 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
-+ wget "--content-disposition" "-t" "3" "-O" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
-[ERROR] Failed to get sources of foo.1: Downloaded file not found
-
-OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (Download command succeeded, but resulting file not found)")
-
-
-<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-'${OPAM} install foo --download-only' failed.
-# Return code 40 #
++ wget "-t" "3" "-O" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
+Processing  1/1: [foo.1: extract]
++ tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
+Done.
 ### opam clean -c
 Clearing cache of downloaded files

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -34,9 +34,14 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
 + wget "--content-disposition" "-t" "3" "-O" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
-Processing  1/1: [foo.1: extract]
-+ tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
-Done.
+[ERROR] Failed to get sources of foo.1: Downloaded file not found
+
+OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (Download command succeeded, but resulting file not found)")
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+'${OPAM} install foo --download-only' failed.
+# Return code 40 #
 ### opam clean -c
 Clearing cache of downloaded files
 ### :I:b: FETCH curl
@@ -148,8 +153,13 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
 + wget "--content-disposition" "-t" "3" "-O" "${BASEDIR}/OPAM/download/.opam-switch/sources/foo.1/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
-Processing  1/1: [foo.1: extract]
-+ tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
-Done.
+[ERROR] Failed to get sources of foo.1: Downloaded file not found
+
+OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (Download command succeeded, but resulting file not found)")
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+'${OPAM} install foo --download-only' failed.
+# Return code 40 #
 ### opam clean -c
 Clearing cache of downloaded files


### PR DESCRIPTION
Currently on system that have wget2 (e.g. Fedora 40), downloading archives do not work if wget is used.
Per wget2's man page:
```
   --content-disposition
       If this is set to on, experimental (not fully-functional) support for “Content-Disposition” headers is enabled.  This can currently result in extra round-trips to the server for a “HEAD” request, and is
       known to suffer from a few bugs, which is why it is not currently enabled by default.

       This option is useful for some file-downloading CGI programs that use “Content-Disposition” headers to describe what the name of a downloaded file should be.
```
I don't think we want to enable an experimental argument. Given we use `-O` already I'm not sure what the goal of it was.
This was original added 9 years ago in https://github.com/ocaml/opam/commit/c49430d79cffc0180e2d125456f1360bdc894884