### PR TITLE
Mechanism for reftests filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,11 @@ reftest-runner: $(DUNE_DEP) src/client/no-git-version
 	$(DUNE) build $(DUNE_ARGS) $(DUNE_PROFILE_ARG) --root . tests/reftests/run.exe
 
 reftests: $(DUNE_DEP) src/client/no-git-version
-	@$(DUNE) build $(DUNE_ARGS) $(DUNE_PROFILE_ARG) --root . @reftest; \
+	@ $(DUNE) build $(DUNE_ARGS) $(DUNE_PROFILE_ARG) --root . @reftest; \
+	$(tests-summary)
+
+quick-reftests: $(DUNE_DEP) src/client/no-git-version
+	@ TESTALL=0 TESTN0REP0=1 $(DUNE) build $(DUNE_ARGS) $(DUNE_PROFILE_ARG) --root . @reftest; \
 	$(tests-summary)
 
 reftest-%: $(DUNE_DEP) src/client/no-git-version

--- a/master_changes.md
+++ b/master_changes.md
@@ -153,9 +153,11 @@ users)
   * Add a test file for `opam install --check` [#6121 @kit-ty-kate]
   * Add reinstall test for delayed removal of packages [#6139 @rjbou]
   * Add a test showing the behaviour of `opam list --latests-only` [#5375 @kit-ty-kate]
+  * Add a test filtering mechanism [#6105 @Keryan-dev]
 
 ### Engine
   * Add a test filtering mechanism [#6105 @Keryan-dev]
+  * Add a test filter on N0REP0 first line [#6105 @Keryan-dev]
 
 ## Github Actions
   * Depexts: replace centos docker with almalinux to fake a centos [#6079 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -158,6 +158,7 @@ users)
 ### Engine
   * Add a test filtering mechanism [#6105 @Keryan-dev]
   * Add a test filter on N0REP0 first line [#6105 @Keryan-dev]
+  * Add a makefile target `quick-test` to launch only `N0REP0` tests [#6105 @Keryan-dev]
 
 ## Github Actions
   * Depexts: replace centos docker with almalinux to fake a centos [#6079 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -155,6 +155,7 @@ users)
   * Add a test showing the behaviour of `opam list --latests-only` [#5375 @kit-ty-kate]
 
 ### Engine
+  * Add a test filtering mechanism [#6105 @Keryan-dev]
 
 ## Github Actions
   * Depexts: replace centos docker with almalinux to fake a centos [#6079 @rjbou]

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -211,19 +211,19 @@
 
 (rule
  (alias reftest-conflict-4373)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1d23f0e=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff conflict-4373.test conflict-4373.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1d23f0e=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-conflict-4373)))
 
 (rule
  (targets conflict-4373.out)
  (deps root-c1d23f0e)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1d23f0e=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -232,19 +232,19 @@
 
 (rule
  (alias reftest-conflict-badversion)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff conflict-badversion.test conflict-badversion.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-conflict-badversion)))
 
 (rule
  (targets conflict-badversion.out)
  (deps root-f372039d)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -253,19 +253,19 @@
 
 (rule
  (alias reftest-conflict-camlp4)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff conflict-camlp4.test conflict-camlp4.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-conflict-camlp4)))
 
 (rule
  (targets conflict-camlp4.out)
  (deps root-f372039d)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -274,19 +274,19 @@
 
 (rule
  (alias reftest-conflict-core)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff conflict-core.test conflict-core.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-conflict-core)))
 
 (rule
  (targets conflict-core.out)
  (deps root-f372039d)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -295,19 +295,19 @@
 
 (rule
  (alias reftest-conflict-resto)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTa5d7cdc0=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff conflict-resto.test conflict-resto.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTa5d7cdc0=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-conflict-resto)))
 
 (rule
  (targets conflict-resto.out)
  (deps root-a5d7cdc0)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTa5d7cdc0=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -316,19 +316,19 @@
 
 (rule
  (alias reftest-conflict-solo5)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff conflict-solo5.test conflict-solo5.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-conflict-solo5)))
 
 (rule
  (targets conflict-solo5.out)
  (deps root-f372039d)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -379,19 +379,19 @@
 
 (rule
  (alias reftest-cudf-preprocess)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTad4dd344=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff cudf-preprocess.test cudf-preprocess.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTad4dd344=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-cudf-preprocess)))
 
 (rule
  (targets cudf-preprocess.out)
  (deps root-ad4dd344)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTad4dd344=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -526,19 +526,19 @@
 
 (rule
  (alias reftest-empty-conflicts-001)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST297366c=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff empty-conflicts-001.test empty-conflicts-001.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST297366c=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-empty-conflicts-001)))
 
 (rule
  (targets empty-conflicts-001.out)
  (deps root-297366c)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST297366c=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -547,19 +547,19 @@
 
 (rule
  (alias reftest-empty-conflicts-002)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST11ea1cb=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff empty-conflicts-002.test empty-conflicts-002.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST11ea1cb=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-empty-conflicts-002)))
 
 (rule
  (targets empty-conflicts-002.out)
  (deps root-11ea1cb)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST11ea1cb=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -568,19 +568,19 @@
 
 (rule
  (alias reftest-empty-conflicts-003)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST3235916=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff empty-conflicts-003.test empty-conflicts-003.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST3235916=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-empty-conflicts-003)))
 
 (rule
  (targets empty-conflicts-003.out)
  (deps root-3235916)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST3235916=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -589,19 +589,19 @@
 
 (rule
  (alias reftest-empty-conflicts-004)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST0070613707=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff empty-conflicts-004.test empty-conflicts-004.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST0070613707=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-empty-conflicts-004)))
 
 (rule
  (targets empty-conflicts-004.out)
  (deps root-0070613707)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST0070613707=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -610,19 +610,19 @@
 
 (rule
  (alias reftest-empty-conflicts-005)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTde897adf36c4230dfea812f40c98223b31c4521a=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff empty-conflicts-005.test empty-conflicts-005.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTde897adf36c4230dfea812f40c98223b31c4521a=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-empty-conflicts-005)))
 
 (rule
  (targets empty-conflicts-005.out)
  (deps root-de897adf36c4230dfea812f40c98223b31c4521a)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTde897adf36c4230dfea812f40c98223b31c4521a=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -631,19 +631,19 @@
 
 (rule
  (alias reftest-empty-conflicts-006)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1842d168d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff empty-conflicts-006.test empty-conflicts-006.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1842d168d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-empty-conflicts-006)))
 
 (rule
  (targets empty-conflicts-006.out)
  (deps root-c1842d168d)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1842d168d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -946,19 +946,19 @@
 
 (rule
  (alias reftest-install-formula)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff install-formula.test install-formula.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-install-formula)))
 
 (rule
  (targets install-formula.out)
  (deps root-f372039d)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -967,19 +967,19 @@
 
 (rule
  (alias reftest-install-pgocaml)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff install-pgocaml.test install-pgocaml.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-install-pgocaml)))
 
 (rule
  (targets install-pgocaml.out)
  (deps root-f372039d)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -1072,19 +1072,19 @@
 
 (rule
  (alias reftest-list-coinstallable)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7371c1d9=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff list-coinstallable.test list-coinstallable.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7371c1d9=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-list-coinstallable)))
 
 (rule
  (targets list-coinstallable.out)
  (deps root-7371c1d9)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7371c1d9=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -1093,19 +1093,19 @@
 
 (rule
  (alias reftest-list-large-dependencies)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7371c1d9=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff list-large-dependencies.test list-large-dependencies.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7371c1d9=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-list-large-dependencies)))
 
 (rule
  (targets list-large-dependencies.out)
  (deps root-7371c1d9)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7371c1d9=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -1135,19 +1135,19 @@
 
 (rule
  (alias reftest-list.unix)
- (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff list.unix.test list.unix.out)))
 
 (alias
  (name reftest)
- (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-list.unix)))
 
 (rule
  (targets list.unix.out)
  (deps root-f372039d)
- (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -1219,19 +1219,19 @@
 
 (rule
  (alias reftest-opamrt-big-upgrade)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7090735c=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff opamrt-big-upgrade.test opamrt-big-upgrade.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7090735c=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-opamrt-big-upgrade)))
 
 (rule
  (targets opamrt-big-upgrade.out)
  (deps root-7090735c)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7090735c=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -1513,19 +1513,19 @@
 
 (rule
  (alias reftest-show)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST009e00fa=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff show.test show.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST009e00fa=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-show)))
 
 (rule
  (targets show.out)
  (deps root-009e00fa)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST009e00fa=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -1702,19 +1702,19 @@
 
 (rule
  (alias reftest-unhelpful-conflicts-001)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff unhelpful-conflicts-001.test unhelpful-conflicts-001.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-unhelpful-conflicts-001)))
 
 (rule
  (targets unhelpful-conflicts-001.out)
  (deps root-c1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to
@@ -1765,19 +1765,19 @@
 
 (rule
  (alias reftest-upgrade-format)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST009e00fa=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (action
   (diff upgrade-format.test upgrade-format.out)))
 
 (alias
  (name reftest)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST009e00fa=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (deps (alias reftest-upgrade-format)))
 
 (rule
  (targets upgrade-format.out)
  (deps root-009e00fa)
- (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST009e00fa=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
   (with-stdout-to

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1,16 +1,19 @@
 
 (rule
  (alias reftest-admin-cache)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff admin-cache.test admin-cache.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-admin-cache)))
 
 (rule
  (targets admin-cache.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -19,16 +22,19 @@
 
 (rule
  (alias reftest-admin)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff admin.test admin.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-admin)))
 
 (rule
  (targets admin.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -37,16 +43,19 @@
 
 (rule
  (alias reftest-archive)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff archive.test archive.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-archive)))
 
 (rule
  (targets archive.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -55,16 +64,19 @@
 
 (rule
  (alias reftest-assume-built)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff assume-built.test assume-built.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-assume-built)))
 
 (rule
  (targets assume-built.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -73,16 +85,19 @@
 
 (rule
  (alias reftest-autopin)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff autopin.test autopin.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-autopin)))
 
 (rule
  (targets autopin.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -91,16 +106,19 @@
 
 (rule
  (alias reftest-avoid-version)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff avoid-version.test avoid-version.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-avoid-version)))
 
 (rule
  (targets avoid-version.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -109,16 +127,19 @@
 
 (rule
  (alias reftest-best-effort)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff best-effort.test best-effort.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-best-effort)))
 
 (rule
  (targets best-effort.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -127,16 +148,19 @@
 
 (rule
  (alias reftest-clean)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff clean.test clean.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-clean)))
 
 (rule
  (targets clean.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -145,16 +169,19 @@
 
 (rule
  (alias reftest-cli-versioning)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff cli-versioning.test cli-versioning.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-cli-versioning)))
 
 (rule
  (targets cli-versioning.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -163,16 +190,19 @@
 
 (rule
  (alias reftest-config)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff config.test config.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-config)))
 
 (rule
  (targets config.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -181,16 +211,19 @@
 
 (rule
  (alias reftest-conflict-4373)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1d23f0e=0} 1))))
  (action
   (diff conflict-4373.test conflict-4373.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1d23f0e=0} 1))))
  (deps (alias reftest-conflict-4373)))
 
 (rule
  (targets conflict-4373.out)
  (deps root-c1d23f0e)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1d23f0e=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -199,16 +232,19 @@
 
 (rule
  (alias reftest-conflict-badversion)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (action
   (diff conflict-badversion.test conflict-badversion.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (deps (alias reftest-conflict-badversion)))
 
 (rule
  (targets conflict-badversion.out)
  (deps root-f372039d)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -217,16 +253,19 @@
 
 (rule
  (alias reftest-conflict-camlp4)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (action
   (diff conflict-camlp4.test conflict-camlp4.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (deps (alias reftest-conflict-camlp4)))
 
 (rule
  (targets conflict-camlp4.out)
  (deps root-f372039d)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -235,16 +274,19 @@
 
 (rule
  (alias reftest-conflict-core)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (action
   (diff conflict-core.test conflict-core.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (deps (alias reftest-conflict-core)))
 
 (rule
  (targets conflict-core.out)
  (deps root-f372039d)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -253,16 +295,19 @@
 
 (rule
  (alias reftest-conflict-resto)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTa5d7cdc0=0} 1))))
  (action
   (diff conflict-resto.test conflict-resto.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTa5d7cdc0=0} 1))))
  (deps (alias reftest-conflict-resto)))
 
 (rule
  (targets conflict-resto.out)
  (deps root-a5d7cdc0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTa5d7cdc0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -271,16 +316,19 @@
 
 (rule
  (alias reftest-conflict-solo5)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (action
   (diff conflict-solo5.test conflict-solo5.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (deps (alias reftest-conflict-solo5)))
 
 (rule
  (targets conflict-solo5.out)
  (deps root-f372039d)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -289,16 +337,19 @@
 
 (rule
  (alias reftest-core-config)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff core-config.test core-config.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-core-config)))
 
 (rule
  (targets core-config.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -307,19 +358,19 @@
 
 (rule
  (alias reftest-core-system.unix)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff core-system.unix.test core-system.unix.out)))
 
 (alias
  (name reftest)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-core-system.unix)))
 
 (rule
  (targets core-system.unix.out)
  (deps root-N0REP0)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -328,16 +379,19 @@
 
 (rule
  (alias reftest-cudf-preprocess)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTad4dd344=0} 1))))
  (action
   (diff cudf-preprocess.test cudf-preprocess.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTad4dd344=0} 1))))
  (deps (alias reftest-cudf-preprocess)))
 
 (rule
  (targets cudf-preprocess.out)
  (deps root-ad4dd344)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTad4dd344=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -346,16 +400,19 @@
 
 (rule
  (alias reftest-depexts)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff depexts.test depexts.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-depexts)))
 
 (rule
  (targets depexts.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -364,16 +421,19 @@
 
 (rule
  (alias reftest-deprecated)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff deprecated.test deprecated.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-deprecated)))
 
 (rule
  (targets deprecated.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -382,16 +442,19 @@
 
 (rule
  (alias reftest-deps-only)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff deps-only.test deps-only.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-deps-only)))
 
 (rule
  (targets deps-only.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -400,16 +463,19 @@
 
 (rule
  (alias reftest-dot-install)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff dot-install.test dot-install.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-dot-install)))
 
 (rule
  (targets dot-install.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -418,16 +484,19 @@
 
 (rule
  (alias reftest-download)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff download.test download.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-download)))
 
 (rule
  (targets download.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -436,16 +505,19 @@
 
 (rule
  (alias reftest-effectively-equal)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff effectively-equal.test effectively-equal.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-effectively-equal)))
 
 (rule
  (targets effectively-equal.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -454,16 +526,19 @@
 
 (rule
  (alias reftest-empty-conflicts-001)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST297366c=0} 1))))
  (action
   (diff empty-conflicts-001.test empty-conflicts-001.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST297366c=0} 1))))
  (deps (alias reftest-empty-conflicts-001)))
 
 (rule
  (targets empty-conflicts-001.out)
  (deps root-297366c)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST297366c=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -472,16 +547,19 @@
 
 (rule
  (alias reftest-empty-conflicts-002)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST11ea1cb=0} 1))))
  (action
   (diff empty-conflicts-002.test empty-conflicts-002.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST11ea1cb=0} 1))))
  (deps (alias reftest-empty-conflicts-002)))
 
 (rule
  (targets empty-conflicts-002.out)
  (deps root-11ea1cb)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST11ea1cb=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -490,16 +568,19 @@
 
 (rule
  (alias reftest-empty-conflicts-003)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST3235916=0} 1))))
  (action
   (diff empty-conflicts-003.test empty-conflicts-003.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST3235916=0} 1))))
  (deps (alias reftest-empty-conflicts-003)))
 
 (rule
  (targets empty-conflicts-003.out)
  (deps root-3235916)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST3235916=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -508,16 +589,19 @@
 
 (rule
  (alias reftest-empty-conflicts-004)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST0070613707=0} 1))))
  (action
   (diff empty-conflicts-004.test empty-conflicts-004.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST0070613707=0} 1))))
  (deps (alias reftest-empty-conflicts-004)))
 
 (rule
  (targets empty-conflicts-004.out)
  (deps root-0070613707)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST0070613707=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -526,16 +610,19 @@
 
 (rule
  (alias reftest-empty-conflicts-005)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTde897adf36c4230dfea812f40c98223b31c4521a=0} 1))))
  (action
   (diff empty-conflicts-005.test empty-conflicts-005.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTde897adf36c4230dfea812f40c98223b31c4521a=0} 1))))
  (deps (alias reftest-empty-conflicts-005)))
 
 (rule
  (targets empty-conflicts-005.out)
  (deps root-de897adf36c4230dfea812f40c98223b31c4521a)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTde897adf36c4230dfea812f40c98223b31c4521a=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -544,16 +631,19 @@
 
 (rule
  (alias reftest-empty-conflicts-006)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1842d168d=0} 1))))
  (action
   (diff empty-conflicts-006.test empty-conflicts-006.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1842d168d=0} 1))))
  (deps (alias reftest-empty-conflicts-006)))
 
 (rule
  (targets empty-conflicts-006.out)
  (deps root-c1842d168d)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1842d168d=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -562,16 +652,19 @@
 
 (rule
  (alias reftest-empty-conflicts-007)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff empty-conflicts-007.test empty-conflicts-007.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-empty-conflicts-007)))
 
 (rule
  (targets empty-conflicts-007.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -580,16 +673,19 @@
 
 (rule
  (alias reftest-env)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff env.test env.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-env)))
 
 (rule
  (targets env.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -598,19 +694,19 @@
 
 (rule
  (alias reftest-env.unix)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff env.unix.test env.unix.out)))
 
 (alias
  (name reftest)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-env.unix)))
 
 (rule
  (targets env.unix.out)
  (deps root-N0REP0)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -619,19 +715,19 @@
 
 (rule
  (alias reftest-env.win32)
- (enabled_if (= %{os_type} "Win32"))
+ (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff env.win32.test env.win32.out)))
 
 (alias
  (name reftest)
- (enabled_if (= %{os_type} "Win32"))
+ (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-env.win32)))
 
 (rule
  (targets env.win32.out)
  (deps root-N0REP0)
- (enabled_if (= %{os_type} "Win32"))
+ (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -640,16 +736,19 @@
 
 (rule
  (alias reftest-extrafile)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff extrafile.test extrafile.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-extrafile)))
 
 (rule
  (targets extrafile.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -658,16 +757,19 @@
 
 (rule
  (alias reftest-extrasource)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff extrasource.test extrasource.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-extrasource)))
 
 (rule
  (targets extrasource.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -676,16 +778,19 @@
 
 (rule
  (alias reftest-filter-operators)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff filter-operators.test filter-operators.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-filter-operators)))
 
 (rule
  (targets filter-operators.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -694,19 +799,19 @@
 
 (rule
  (alias reftest-init-ocaml-eval-variables.unix)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff init-ocaml-eval-variables.unix.test init-ocaml-eval-variables.unix.out)))
 
 (alias
  (name reftest)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-init-ocaml-eval-variables.unix)))
 
 (rule
  (targets init-ocaml-eval-variables.unix.out)
  (deps root-N0REP0)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -715,19 +820,19 @@
 
 (rule
  (alias reftest-init-ocaml-eval-variables.win32)
- (enabled_if (= %{os_type} "Win32"))
+ (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff init-ocaml-eval-variables.win32.test init-ocaml-eval-variables.win32.out)))
 
 (alias
  (name reftest)
- (enabled_if (= %{os_type} "Win32"))
+ (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-init-ocaml-eval-variables.win32)))
 
 (rule
  (targets init-ocaml-eval-variables.win32.out)
  (deps root-N0REP0)
- (enabled_if (= %{os_type} "Win32"))
+ (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -736,19 +841,19 @@
 
 (rule
  (alias reftest-init-scripts.unix)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff init-scripts.unix.test init-scripts.unix.out)))
 
 (alias
  (name reftest)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-init-scripts.unix)))
 
 (rule
  (targets init-scripts.unix.out)
  (deps root-N0REP0)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -757,19 +862,19 @@
 
 (rule
  (alias reftest-init-scripts.win32)
- (enabled_if (= %{os_type} "Win32"))
+ (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff init-scripts.win32.test init-scripts.win32.out)))
 
 (alias
  (name reftest)
- (enabled_if (= %{os_type} "Win32"))
+ (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-init-scripts.win32)))
 
 (rule
  (targets init-scripts.win32.out)
  (deps root-N0REP0)
- (enabled_if (= %{os_type} "Win32"))
+ (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -778,16 +883,19 @@
 
 (rule
  (alias reftest-init)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff init.test init.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-init)))
 
 (rule
  (targets init.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -796,16 +904,19 @@
 
 (rule
  (alias reftest-inplace)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff inplace.test inplace.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-inplace)))
 
 (rule
  (targets inplace.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -814,16 +925,19 @@
 
 (rule
  (alias reftest-install-check)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff install-check.test install-check.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-install-check)))
 
 (rule
  (targets install-check.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -832,16 +946,19 @@
 
 (rule
  (alias reftest-install-formula)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (action
   (diff install-formula.test install-formula.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (deps (alias reftest-install-formula)))
 
 (rule
  (targets install-formula.out)
  (deps root-f372039d)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -850,16 +967,19 @@
 
 (rule
  (alias reftest-install-pgocaml)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (action
   (diff install-pgocaml.test install-pgocaml.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (deps (alias reftest-install-pgocaml)))
 
 (rule
  (targets install-pgocaml.out)
  (deps root-f372039d)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -868,19 +988,19 @@
 
 (rule
  (alias reftest-json.unix)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff json.unix.test json.unix.out)))
 
 (alias
  (name reftest)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-json.unix)))
 
 (rule
  (targets json.unix.out)
  (deps root-N0REP0)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -889,16 +1009,19 @@
 
 (rule
  (alias reftest-legacy-git)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff legacy-git.test legacy-git.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-legacy-git)))
 
 (rule
  (targets legacy-git.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -907,16 +1030,19 @@
 
 (rule
  (alias reftest-legacy-local)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff legacy-local.test legacy-local.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-legacy-local)))
 
 (rule
  (targets legacy-local.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -925,16 +1051,19 @@
 
 (rule
  (alias reftest-lint)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff lint.test lint.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-lint)))
 
 (rule
  (targets lint.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -943,16 +1072,19 @@
 
 (rule
  (alias reftest-list-coinstallable)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7371c1d9=0} 1))))
  (action
   (diff list-coinstallable.test list-coinstallable.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7371c1d9=0} 1))))
  (deps (alias reftest-list-coinstallable)))
 
 (rule
  (targets list-coinstallable.out)
  (deps root-7371c1d9)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7371c1d9=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -961,16 +1093,19 @@
 
 (rule
  (alias reftest-list-large-dependencies)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7371c1d9=0} 1))))
  (action
   (diff list-large-dependencies.test list-large-dependencies.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7371c1d9=0} 1))))
  (deps (alias reftest-list-large-dependencies)))
 
 (rule
  (targets list-large-dependencies.out)
  (deps root-7371c1d9)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7371c1d9=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -979,16 +1114,19 @@
 
 (rule
  (alias reftest-list)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff list.test list.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-list)))
 
 (rule
  (targets list.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -997,19 +1135,19 @@
 
 (rule
  (alias reftest-list.unix)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (action
   (diff list.unix.test list.unix.out)))
 
 (alias
  (name reftest)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (deps (alias reftest-list.unix)))
 
 (rule
  (targets list.unix.out)
  (deps root-f372039d)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTf372039d=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1018,16 +1156,19 @@
 
 (rule
  (alias reftest-lock)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff lock.test lock.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-lock)))
 
 (rule
  (targets lock.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1036,16 +1177,19 @@
 
 (rule
  (alias reftest-opam-pkgvar-with-plus)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff opam-pkgvar-with-plus.test opam-pkgvar-with-plus.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-opam-pkgvar-with-plus)))
 
 (rule
  (targets opam-pkgvar-with-plus.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1054,16 +1198,19 @@
 
 (rule
  (alias reftest-opamroot-versions)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff opamroot-versions.test opamroot-versions.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-opamroot-versions)))
 
 (rule
  (targets opamroot-versions.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1072,16 +1219,19 @@
 
 (rule
  (alias reftest-opamrt-big-upgrade)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7090735c=0} 1))))
  (action
   (diff opamrt-big-upgrade.test opamrt-big-upgrade.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7090735c=0} 1))))
  (deps (alias reftest-opamrt-big-upgrade)))
 
 (rule
  (targets opamrt-big-upgrade.out)
  (deps root-7090735c)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST7090735c=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1090,16 +1240,19 @@
 
 (rule
  (alias reftest-opamrt-dep-cycle)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff opamrt-dep-cycle.test opamrt-dep-cycle.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-opamrt-dep-cycle)))
 
 (rule
  (targets opamrt-dep-cycle.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1108,16 +1261,19 @@
 
 (rule
  (alias reftest-opamrt-reinstall)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff opamrt-reinstall.test opamrt-reinstall.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-opamrt-reinstall)))
 
 (rule
  (targets opamrt-reinstall.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1126,16 +1282,19 @@
 
 (rule
  (alias reftest-orphans)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff orphans.test orphans.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-orphans)))
 
 (rule
  (targets orphans.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1144,16 +1303,19 @@
 
 (rule
  (alias reftest-parallel)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff parallel.test parallel.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-parallel)))
 
 (rule
  (targets parallel.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1162,16 +1324,19 @@
 
 (rule
  (alias reftest-pat-sub)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff pat-sub.test pat-sub.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-pat-sub)))
 
 (rule
  (targets pat-sub.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1180,16 +1345,19 @@
 
 (rule
  (alias reftest-pin)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff pin.test pin.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-pin)))
 
 (rule
  (targets pin.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1198,16 +1366,19 @@
 
 (rule
  (alias reftest-rebuild)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff rebuild.test rebuild.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-rebuild)))
 
 (rule
  (targets rebuild.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1216,16 +1387,19 @@
 
 (rule
  (alias reftest-rec-pin)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff rec-pin.test rec-pin.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-rec-pin)))
 
 (rule
  (targets rec-pin.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1234,16 +1408,19 @@
 
 (rule
  (alias reftest-reinstall)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff reinstall.test reinstall.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-reinstall)))
 
 (rule
  (targets reinstall.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1252,16 +1429,19 @@
 
 (rule
  (alias reftest-remove)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff remove.test remove.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-remove)))
 
 (rule
  (targets remove.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1270,16 +1450,19 @@
 
 (rule
  (alias reftest-repository)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff repository.test repository.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-repository)))
 
 (rule
  (targets repository.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1288,16 +1471,19 @@
 
 (rule
  (alias reftest-resolve-variables)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff resolve-variables.test resolve-variables.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-resolve-variables)))
 
 (rule
  (targets resolve-variables.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1306,16 +1492,19 @@
 
 (rule
  (alias reftest-shared-fetch)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff shared-fetch.test shared-fetch.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-shared-fetch)))
 
 (rule
  (targets shared-fetch.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1324,16 +1513,19 @@
 
 (rule
  (alias reftest-show)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST009e00fa=0} 1))))
  (action
   (diff show.test show.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST009e00fa=0} 1))))
  (deps (alias reftest-show)))
 
 (rule
  (targets show.out)
  (deps root-009e00fa)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST009e00fa=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1342,16 +1534,19 @@
 
 (rule
  (alias reftest-source)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff source.test source.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-source)))
 
 (rule
  (targets source.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1360,19 +1555,19 @@
 
 (rule
  (alias reftest-swhid.unix)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff swhid.unix.test swhid.unix.out)))
 
 (alias
  (name reftest)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-swhid.unix)))
 
 (rule
  (targets swhid.unix.out)
  (deps root-N0REP0)
- (enabled_if (= %{os_type} "Unix"))
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1381,16 +1576,19 @@
 
 (rule
  (alias reftest-switch-creation)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff switch-creation.test switch-creation.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-switch-creation)))
 
 (rule
  (targets switch-creation.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1399,16 +1597,19 @@
 
 (rule
  (alias reftest-switch-import)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff switch-import.test switch-import.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-switch-import)))
 
 (rule
  (targets switch-import.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1417,16 +1618,19 @@
 
 (rule
  (alias reftest-switch-invariant)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff switch-invariant.test switch-invariant.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-switch-invariant)))
 
 (rule
  (targets switch-invariant.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1435,16 +1639,19 @@
 
 (rule
  (alias reftest-switch-list)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff switch-list.test switch-list.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-switch-list)))
 
 (rule
  (targets switch-list.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1453,16 +1660,19 @@
 
 (rule
  (alias reftest-switch-set)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff switch-set.test switch-set.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-switch-set)))
 
 (rule
  (targets switch-set.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1471,16 +1681,19 @@
 
 (rule
  (alias reftest-tree)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff tree.test tree.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-tree)))
 
 (rule
  (targets tree.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1489,16 +1702,19 @@
 
 (rule
  (alias reftest-unhelpful-conflicts-001)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a=0} 1))))
  (action
   (diff unhelpful-conflicts-001.test unhelpful-conflicts-001.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a=0} 1))))
  (deps (alias reftest-unhelpful-conflicts-001)))
 
 (rule
  (targets unhelpful-conflicts-001.out)
  (deps root-c1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTc1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1507,16 +1723,19 @@
 
 (rule
  (alias reftest-update-upgrade)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff update-upgrade.test update-upgrade.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-update-upgrade)))
 
 (rule
  (targets update-upgrade.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1525,16 +1744,19 @@
 
 (rule
  (alias reftest-update)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff update.test update.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-update)))
 
 (rule
  (targets update.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1543,16 +1765,19 @@
 
 (rule
  (alias reftest-upgrade-format)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST009e00fa=0} 1))))
  (action
   (diff upgrade-format.test upgrade-format.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST009e00fa=0} 1))))
  (deps (alias reftest-upgrade-format)))
 
 (rule
  (targets upgrade-format.out)
  (deps root-009e00fa)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TEST009e00fa=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1561,16 +1786,19 @@
 
 (rule
  (alias reftest-upgrade-two-point-o)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff upgrade-two-point-o.test upgrade-two-point-o.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-upgrade-two-point-o)))
 
 (rule
  (targets upgrade-two-point-o.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1579,16 +1807,19 @@
 
 (rule
  (alias reftest-upgrade)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff upgrade.test upgrade.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-upgrade)))
 
 (rule
  (targets upgrade.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1597,16 +1828,19 @@
 
 (rule
  (alias reftest-var-option)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff var-option.test var-option.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-var-option)))
 
 (rule
  (targets var-option.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1615,16 +1849,19 @@
 
 (rule
  (alias reftest-verbose-on)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff verbose-on.test verbose-on.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-verbose-on)))
 
 (rule
  (targets verbose-on.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1633,16 +1870,19 @@
 
 (rule
  (alias reftest-with-dev-setup)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff with-dev-setup.test with-dev-setup.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-with-dev-setup)))
 
 (rule
  (targets with-dev-setup.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
@@ -1651,16 +1891,19 @@
 
 (rule
  (alias reftest-working-dir)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
   (diff working-dir.test working-dir.out)))
 
 (alias
  (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (deps (alias reftest-working-dir)))
 
 (rule
  (targets working-dir.out)
  (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to

--- a/tests/reftests/gen.ml
+++ b/tests/reftests/gen.ml
@@ -1,8 +1,8 @@
-let first_line ~path =
+let first_line_tags ~path =
   let ic = open_in path in
   let s = input_line ic in
   close_in ic;
-  s
+  String.split_on_char ' ' s
 
 let null_hash= "N0REP0"
 let default_repo = "opam-repo-"^null_hash
@@ -95,15 +95,32 @@ let () =
   in
   let process archive_hashes filename =
     let base_name = OpamStd.String.remove_suffix ~suffix:".test" filename in
-    let condition = match Filename.extension base_name with
-      | "" -> ""
-      | os ->
-        Printf.sprintf "\n (enabled_if (= %%{os_type} %S))"
-          String.(capitalize_ascii (sub os 1 (length os - 1)))
-    in
     if base_name = filename then archive_hashes else
+      let archive_hash, tags =
+        match first_line_tags ~path:filename with
+        | [] -> "", []
+        | ar::_ as tags -> ar, tags
+      in
+      let os_condition =
+        match Filename.extension base_name with
+        | "" -> ""
+        | os ->
+          Printf.sprintf "(= %%{os_type} %S)"
+            String.(capitalize_ascii (sub os 1 (length os - 1)))
+      in
+      let tags_conditions =
+        List.map (fun tag ->
+            Printf.sprintf
+              "(= %%{env:TEST%s=0} 1)"
+              tag)
+          tags
+      in
+      let condition =
+        Printf.sprintf
+          "\n (enabled_if (and %s (or (<> %%{env:TESTALL=1} 0) %s)))"
+          os_condition (String.concat "\n   " tags_conditions)
+      in
       (print_string (diff_rule base_name ~condition);
-       let archive_hash = first_line ~path:filename in
        if archive_hash = null_hash then
          (print_string (run_rule ~base_name ~archive_hash:null_hash ~condition);
           archive_hashes)


### PR DESCRIPTION
This is an attempt to have a generalization to filter arbitrarily reftests, with the main objective being having a command that run quickly locally.

The approach is to use custom-defined tags in the testfiles and injecting corresponding variable in the dune command environment (in a way that doesn't affect exisiting behavior). The lack of expressivity in dune files limits filter expressivity but I think this is good enough as a first step toward something we'd want to use more systematically.

Also, this makes tests summary more broadly available to other rules