### PR TITLE
Always list all the repositories in 'opam config report' regardless of whether or not a switch is currently set

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -23,6 +23,7 @@ users)
   * Suppress all the Windows menus when running with `opam init -ya` [#6034 @dra27]
 
 ## Config report
+  * Always list all the repositories regardless of whether or not a switch is currently set [#6116 @kit-ty-kate]
 
 ## Actions
   * Add support for wget2 [#6104 @kit-ty-kate]

--- a/tests/reftests/config.test
+++ b/tests/reftests/config.test
@@ -38,6 +38,7 @@ Set to '"-removed"' the field solver-upgrade-criteria in global configuration
 # install-criteria     -removed
 # upgrade-criteria     -removed
 # jobs                 1
+# repositories         1 (local)
 # current-switch       none set
 ### # empty switch
 ### opam switch create an-empty-switch --empty


### PR DESCRIPTION
Supersedes https://github.com/ocaml/opam/pull/5799 as it was its original intent behind that PR.
I don't see a reason why `repositories` should only be shown when a switch is set, so this PR makes it so that it is always displayed.