### PR TITLE
doc: add brief note about version ordering and OCaml REPL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,10 @@ that's not an option for you, you can use `git format-patch` and email us.
 
 ## Versioning
 
-The release cycle respects [Semantic Versioning](http://semver.org/).
+The release cycle of the opam binary respects [Semantic Versioning](http://semver.org/).
+Note however that the version ordering used for user packages managed by opam
+follows the Debian definition (more details in [this
+section](https://opam.ocaml.org/doc/Manual.html#version-ordering) of the user manual).
 
 ## Related Repositories
 

--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -320,6 +320,14 @@ relational operators are `=`, `!=`, `<`, `<=`, `>` and `>=`, and their meaning
 is defined by Version Ordering. They always have higher priority than logical
 operators.
 
+Here is a full example:
+
+```
+"foo" { >= "3.12" } & ("bar" | "baz" { !(> "2" & < "3.5") & != "5.1" })
+```
+
+#### Version-ordering
+
 > <a id="version-ordering">**Version Ordering**</a> follows the basics of the
 > [Debian definition](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version).
 >
@@ -351,10 +359,13 @@ operators.
 > Here is an example of an ordered sequence: `~~`, `~`, `~beta2`, `~beta10`,
 > `0.1`, `1.0~beta`, `1.0`, `1.0-test`, `1.0.1`, `1.0.10`, `dev`, `trunk`.
 
-Here is a full example:
+For quick sanity checks, you can compare package versions using the OCaml REPL:
 
 ```
-"foo" { >= "3.12" } & ("bar" | "baz" { !(> "2" & < "3.5") & != "5.1" })
+#use "topfind";;
+#require "opam-core";;
+# OpamVersionCompare.compare "1.2.10" "1.2.9";;
+- : int = 1
 ```
 
 ### Variables

--- a/master_changes.md
+++ b/master_changes.md
@@ -156,6 +156,7 @@ users)
 ## Doc
   * Remove the ppa from the installation instructions on Ubuntu [#5988 @kit-ty-kate - fix #5987]
   * Fix pinning instructions in readme [#5946 @rjbou - fix #5945]
+  * Add a brief note about version ordering and an OCaml REPL example [#6119 @mbarbin]
 
 ## Security fixes
 


### PR DESCRIPTION
Minor documentation update (README & User Manual) about version ordering in opam:

- Add a note to distinguish the version scheme used for the opam binary from that of user packages
- Add an example of how to execute the function implemented in opam for quick sanity checks

This follows a discussion in #6118 where I had some questions about this.

OCaml REPL snippet curtesy of @kit-ty-kate in https://github.com/ocaml/opam/issues/6118#issuecomment-2252387409_
