### PR TITLE
Fix "opam install --check pkg" when pkg depends on a non-existing package

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -143,6 +143,7 @@ users)
   * clean: Add to check cleaning of sources directories [#5474 @rjbou]
   * Add reftest for `--verbose-on` option [#5682 @rjbou]
   * Add a test for --deps-only setting direct dependencies as root packages [#6125 @rjbou]
+  * Add a test file for `opam install --check` [#6121 @kit-ty-kate]
 
 ### Engine
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -32,6 +32,7 @@ users)
   * Fix package name display for no agreement conflicts [#6055 @rjbou - fix #6030]
   * Make fetching an archive from cache add missing symlinks [#6068 @kit-ty-kate - fix #6064]
   * [BUG] Fix `opam install --deps-only` set direct dependencies as root packages [#6125 @rjbou]
+  * [BUG] Fix `opam install --check pkg` when pkg depends on a non-existing package [#6121 @kit-ty-kate]
 
 ## Build (package)
   * ◈ Add `--verbose-on` option to enable verbose mode on specified package names [#5682 @desumn @rjbou]

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1946,7 +1946,6 @@ let init
 
 let check_installed ~build ~post t atoms =
   let available = (Lazy.force t.available_packages) in
-  let uninstalled = OpamPackage.Set.Op.(available -- t.installed) in
   let pkgs =
     OpamPackage.to_map
       (OpamFormula.packages_of_atoms available atoms)
@@ -1992,11 +1991,11 @@ let check_installed ~build ~post t atoms =
       | None -> assert false (* version set can't be empty *)
       | Some (pkg, missing_conj) ->
         OpamPackage.Map.add pkg
-          (OpamPackage.names_of_packages
-             (List.fold_left (fun names disj ->
-                  OpamPackage.Set.union names
-                    (OpamFormula.packages_of_atoms uninstalled disj))
-                 OpamPackage.Set.empty missing_conj))
+          (List.fold_left (fun names disj ->
+               List.fold_left (fun names (name, _) ->
+                   OpamPackage.Name.Set.add name names)
+                 names disj)
+              OpamPackage.Name.Set.empty missing_conj)
           map
     ) pkgs OpamPackage.Map.empty
 

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -813,6 +813,24 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:inplace.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-install-check)
+ (action
+  (diff install-check.test install-check.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-install-check)))
+
+(rule
+ (targets install-check.out)
+ (deps root-N0REP0)
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:install-check.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-install-formula)
  (action
   (diff install-formula.test install-formula.out)))

--- a/tests/reftests/install-check.test
+++ b/tests/reftests/install-check.test
@@ -1,0 +1,33 @@
+N0REP0
+### opam switch create test-switch --empty
+### ::: check that --check works correctly with non-registered packages
+### <pkg:test.1>
+opam-version: "2.0"
+depends: [
+  "a"
+  "does-no-exists"
+]
+### <pkg:a.1>
+opam-version: "2.0"
+### opam install --check test.1
+Missing dependencies:
+a
+# Return code 1 #
+### opam install --fake a
+The following actions will be faked:
+=== install 1 package
+  - install a 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Faking installation of a.1
+Done.
+### opam install --check test.1
+All dependencies installed
+### ::: check that --check works correctly with non-registered versions
+### <pkg:test.2>
+opam-version: "2.0"
+depends: [
+  "a" {= "2"}
+]
+### opam install --check test.2
+All dependencies installed

--- a/tests/reftests/install-check.test
+++ b/tests/reftests/install-check.test
@@ -11,7 +11,7 @@ depends: [
 opam-version: "2.0"
 ### opam install --check test.1
 Missing dependencies:
-a
+a does-no-exists
 # Return code 1 #
 ### opam install --fake a
 The following actions will be faked:
@@ -22,7 +22,9 @@ The following actions will be faked:
 Faking installation of a.1
 Done.
 ### opam install --check test.1
-All dependencies installed
+Missing dependencies:
+does-no-exists
+# Return code 1 #
 ### ::: check that --check works correctly with non-registered versions
 ### <pkg:test.2>
 opam-version: "2.0"
@@ -30,4 +32,6 @@ depends: [
   "a" {= "2"}
 ]
 ### opam install --check test.2
-All dependencies installed
+Missing dependencies:
+a
+# Return code 1 #


### PR DESCRIPTION
As the test show non-existing packages (or atoms requiring a version that does not exist yet for example) does not currently work when using `opam install --check`