### PR TITLE
Add an admin command to compare 2 package versions

### DIFF
--- a/doc/man/opam-admin-topics.inc
+++ b/doc/man/opam-admin-topics.inc
@@ -61,6 +61,16 @@
   (package opam))
 
 (rule
+  (with-stdout-to opam-admin-compare-package-versions.0 (echo "")))
+(rule
+  (targets opam-admin-compare-package-versions.1 opam-admin-compare-package-versions.err)
+  (deps using-built-opam)
+  (action (progn (with-stderr-to opam-admin-compare-package-versions.err
+                   (with-stdout-to opam-admin-compare-package-versions.1 (run %{bin:opam} admin compare-package-versions --help=groff)))
+                 (diff opam-admin-compare-package-versions.err %{dep:opam-admin-compare-package-versions.0})))
+  (package opam))
+
+(rule
   (with-stdout-to opam-admin-check.0 (echo "")))
 (rule
   (targets opam-admin-check.1 opam-admin-check.err)
@@ -130,6 +140,7 @@
     opam-admin-add-constraint.1 
     opam-admin-filter.1 
     opam-admin-list.1 
+    opam-admin-compare-package-versions.1 
     opam-admin-check.1 
     opam-admin-lint.1 
     opam-admin-upgrade.1 

--- a/doc/man/opam-admin-topics.inc
+++ b/doc/man/opam-admin-topics.inc
@@ -61,13 +61,13 @@
   (package opam))
 
 (rule
-  (with-stdout-to opam-admin-compare-package-versions.0 (echo "")))
+  (with-stdout-to opam-admin-compare-versions.0 (echo "")))
 (rule
-  (targets opam-admin-compare-package-versions.1 opam-admin-compare-package-versions.err)
+  (targets opam-admin-compare-versions.1 opam-admin-compare-versions.err)
   (deps using-built-opam)
-  (action (progn (with-stderr-to opam-admin-compare-package-versions.err
-                   (with-stdout-to opam-admin-compare-package-versions.1 (run %{bin:opam} admin compare-package-versions --help=groff)))
-                 (diff opam-admin-compare-package-versions.err %{dep:opam-admin-compare-package-versions.0})))
+  (action (progn (with-stderr-to opam-admin-compare-versions.err
+                   (with-stdout-to opam-admin-compare-versions.1 (run %{bin:opam} admin compare-versions --help=groff)))
+                 (diff opam-admin-compare-versions.err %{dep:opam-admin-compare-versions.0})))
   (package opam))
 
 (rule
@@ -140,7 +140,7 @@
     opam-admin-add-constraint.1 
     opam-admin-filter.1 
     opam-admin-list.1 
-    opam-admin-compare-package-versions.1 
+    opam-admin-compare-versions.1 
     opam-admin-check.1 
     opam-admin-lint.1 
     opam-admin-upgrade.1 

--- a/master_changes.md
+++ b/master_changes.md
@@ -15,10 +15,8 @@ users)
   * Bump opam-root-version to 2.2 [#5980 @kit-ty-kate]
 
 ## Global CLI
-  * Add cli version 2.3 [#6045 #6151 @rjbou]
-  * ◈ Add `opam admin compare-package-versions` to compare package versions for sanity checks [#6124 @mbarbin]
   * ◈ Add `opam admin compare-versions` to compare package versions for sanity checks [#6124 @mbarbin]
-  * Add cli version 2.3 [#6045 @rjbou]
+  * Add cli version 2.3 [#6045 #6151 @rjbou]
 
 ## Plugins
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -17,6 +17,7 @@ users)
 ## Global CLI
   * Add cli version 2.3 [#6045 #6151 @rjbou]
   * ◈ Add `opam admin compare-package-versions` to compare package versions for sanity checks [#6124 @mbarbin]
+  * ◈ Add `opam admin compare-versions` to compare package versions for sanity checks [#6124 @mbarbin]
   * Add cli version 2.3 [#6045 @rjbou]
 
 ## Plugins

--- a/master_changes.md
+++ b/master_changes.md
@@ -16,6 +16,8 @@ users)
 
 ## Global CLI
   * Add cli version 2.3 [#6045 #6151 @rjbou]
+  * ◈ Add `opam admin compare-package-versions` to compare package versions for sanity checks [#6124 @mbarbin]
+  * Add cli version 2.3 [#6045 @rjbou]
 
 ## Plugins
 

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -830,8 +830,8 @@ let check_command cli =
   Term.(const cmd $ global_options cli $ ignore_test_arg $ print_short_arg
         $ installability_arg $ cycles_arg $ obsolete_arg)
 
-let compare_package_versions_command_doc = "Compare 2 package versions"
-let compare_package_versions_command cli =
+let compare_versions_command_doc = "Compare 2 package versions"
+let compare_versions_command cli =
   let version_arg n =
     let doc =
       Arg.info
@@ -840,12 +840,12 @@ let compare_package_versions_command cli =
     in
     Arg.(required & pos n (Arg.some' OpamArg.package_version) None & doc)
   in
-  let command = "compare-package-versions" in
-  let doc = compare_package_versions_command_doc in
+  let command = "compare-versions" in
+  let doc = compare_versions_command_doc in
   let man = [
     `S Manpage.s_description;
     `P "This command compares 2 package versions for quick sanity checks, and prints the result of the comparison to the console. For example:";
-    `I ("For example:", "opam admin compare-package-versions 0.0.9 0.0.10");
+    `I ("For example:", "opam admin compare-versions 0.0.9 0.0.10");
     `I ("outputs:", "0.0.9 < 0.0.10");
     `S Manpage.s_arguments;
     `S Manpage.s_options;
@@ -1259,7 +1259,7 @@ let admin_subcommands cli =
     upgrade_command cli;
     lint_command cli;
     check_command cli;
-    compare_package_versions_command cli;
+    compare_versions_command cli;
     list_command cli;
     filter_command cli;
     add_constraint_command cli;

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -854,8 +854,7 @@ let compare_package_versions_command cli =
   let cmd global_options v1 v2 () =
     OpamArg.apply_global_options cli global_options;
     let result = OpamPackage.Version.compare v1 v2 in
-    OpamConsole.formatted_msg "%d (%s %s %s)\n"
-      result
+    OpamConsole.formatted_msg "%s %s %s\n"
       (OpamPackage.Version.to_string v1)
       (if result < 0 then "<" else if result = 0 then "=" else ">")
       (OpamPackage.Version.to_string v2);

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -889,8 +889,8 @@ let compare_versions_command cli =
   let doc = compare_versions_command_doc in
   let man = [
     `S Manpage.s_description;
-    `P "This command compares 2 package versions for quick sanity checks, \
-        and by default prints the result of the comparison to the console. \
+    `P "This command compares 2 package versions for quick sanity checks. \
+        By default it prints the result of the comparison to the console. \
         You may optionally control the exit-code with '--assert=OP'. \
         For example:";
     `Pre "\n\

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -846,7 +846,7 @@ let compare_package_versions_command cli =
     `S Manpage.s_description;
     `P "This command compares 2 package versions for quick sanity checks, and prints the result of the comparison to the console. For example:";
     `I ("For example:", "opam admin compare-package-versions 0.0.9 0.0.10");
-    `I ("outputs:", "-1 (0.0.9 < 0.0.10)");
+    `I ("outputs:", "0.0.9 < 0.0.10");
     `S Manpage.s_arguments;
     `S Manpage.s_options;
   ]

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -869,10 +869,10 @@ let compare_versions_command cli =
       Arg.info
         ~docv:"OP"
         ~doc:(Printf.sprintf
-             "When supplied, the output is suppressed and the result of the \
-              comparison is checked againts the provided operator. The command exits 0 \
-              if the comparison holds, and 1 otherwise. \
-              $(docv) must be %s.\n" (Arg.doc_alts_enum ~quoted:true operators))
+                "When supplied, the output is suppressed and the result of \
+                 the comparison is checked againts the provided operator. \
+                 The command exits 0 if the comparison holds, and 1 otherwise. \
+                 $(docv) must be %s.\n" (Arg.doc_alts_enum ~quoted:true operators))
         [ "assert" ]
     in
     let op_conv = Arg.enum operators in
@@ -895,14 +895,14 @@ let compare_versions_command cli =
         You may optionally control the exit-code with '--assert=OP'. \
         For example:";
     `Pre "\n\
-       \\$ opam admin compare-versions 0.0.9 0.0.10\n\
-       0.0.9 < 0.0.10\n\
-       \n\
-       \\$ opam admin compare-versions 0.0.9 0.0.10 --assert='<'\n\
-       [0]\n\
-       \n\
-       \\$ opam admin compare-versions 0.0.9 0.0.10 --assert='>='\n\
-       [1]";
+          \\$ opam admin compare-versions 0.0.9 0.0.10\n\
+          0.0.9 < 0.0.10\n\
+          \n\
+          \\$ opam admin compare-versions 0.0.9 0.0.10 --assert='<'\n\
+          [0]\n\
+          \n\
+          \\$ opam admin compare-versions 0.0.9 0.0.10 --assert='>='\n\
+          [1]";
     `S Manpage.s_arguments;
     `S Manpage.s_options;
   ]
@@ -923,7 +923,7 @@ let compare_versions_command cli =
          else `False)
   in
   OpamArg.mk_command  ~cli OpamArg.cli_original command ~doc ~man
-  Term.(const cmd $ global_options cli $ version_arg 0 $ version_arg 1 $ assert_result)
+    Term.(const cmd $ global_options cli $ version_arg 0 $ version_arg 1 $ assert_result)
 
 let pattern_list_arg =
   OpamArg.arg_list "PATTERNS"

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -830,6 +830,39 @@ let check_command cli =
   Term.(const cmd $ global_options cli $ ignore_test_arg $ print_short_arg
         $ installability_arg $ cycles_arg $ obsolete_arg)
 
+let compare_package_versions_command_doc = "Compare 2 package versions"
+let compare_package_versions_command cli =
+  let version_arg n =
+    let doc =
+      Arg.info
+        ~docv:"VERSION"
+        ~doc:"Package version to compare" []
+    in
+    Arg.(required & pos n (Arg.some' OpamArg.package_version) None & doc)
+  in
+  let command = "compare-package-versions" in
+  let doc = compare_package_versions_command_doc in
+  let man = [
+    `S Manpage.s_description;
+    `P "This command compares 2 package versions for quick sanity checks, and prints the result of the comparison to the console. For example:";
+    `I ("For example:", "opam admin compare-package-versions 0.0.9 0.0.10");
+    `I ("outputs:", "-1 (0.0.9 < 0.0.10)");
+    `S Manpage.s_arguments;
+    `S Manpage.s_options;
+  ]
+  in
+  let cmd global_options v1 v2 () =
+    OpamArg.apply_global_options cli global_options;
+    let result = OpamPackage.Version.compare v1 v2 in
+    OpamConsole.formatted_msg "%d (%s %s %s)\n"
+      result
+      (OpamPackage.Version.to_string v1)
+      (if result < 0 then "<" else if result = 0 then "=" else ">")
+      (OpamPackage.Version.to_string v2);
+  in
+  OpamArg.mk_command  ~cli OpamArg.cli_original command ~doc ~man
+  Term.(const cmd $ global_options cli $ version_arg 0 $ version_arg 1)
+
 let pattern_list_arg =
   OpamArg.arg_list "PATTERNS"
     "Package patterns with globs. matching against $(b,NAME) or \
@@ -1227,6 +1260,7 @@ let admin_subcommands cli =
     upgrade_command cli;
     lint_command cli;
     check_command cli;
+    compare_package_versions_command cli;
     list_command cli;
     filter_command cli;
     add_constraint_command cli;

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -875,8 +875,7 @@ let compare_versions_command cli =
                  $(docv) must be %s.\n" (Arg.doc_alts_enum ~quoted:true operators))
         [ "assert" ]
     in
-    let op_conv = Arg.enum operators in
-    Arg.(value & opt (Arg.some' op_conv) None doc)
+    Arg.(value & opt (some (enum operators)) None doc)
   in
   let version_arg n =
     let doc =
@@ -884,7 +883,7 @@ let compare_versions_command cli =
         ~docv:(Printf.sprintf "VERSION%d" (n+1))
         ~doc:"Package version to compare" []
     in
-    Arg.(required & pos n (Arg.some' OpamArg.package_version) None & doc)
+    Arg.(required & pos n (some OpamArg.package_version) None & doc)
   in
   let command = "compare-versions" in
   let doc = compare_versions_command_doc in

--- a/src/format/opamFormula.ml
+++ b/src/format/opamFormula.ml
@@ -21,6 +21,8 @@ let neg_relop = function
 
 let string_of_relop = OpamPrinter.FullPos.relop_kind
 
+let all_relop = [ `Eq ; `Neq ; `Geq ; `Gt ; `Leq ; `Lt ]
+
 type version_constraint = relop * OpamPackage.Version.t
 
 type atom = OpamPackage.Name.t * version_constraint option

--- a/src/format/opamFormula.mli
+++ b/src/format/opamFormula.mli
@@ -17,6 +17,13 @@ type relop = OpamParserTypes.FullPos.relop_kind (* = [ `Eq | `Neq | `Geq | `Gt |
 
 val compare_relop : relop -> relop -> int
 
+(** A list containing each available operator once. *)
+val all_relop : relop list
+
+(** Returns a string representing the operator in infix syntax, as
+    used in opam files (">", "=", etc.) *)
+val string_of_relop : relop -> string
+
 (** Version constraints for OPAM *)
 type version_constraint = relop * OpamPackage.Version.t
 

--- a/tests/reftests/compare-package-versions.test
+++ b/tests/reftests/compare-package-versions.test
@@ -1,7 +1,0 @@
-N0REP0
-### opam admin compare-package-versions 0.0.9 0.0.10
-0.0.9 < 0.0.10
-### opam admin compare-package-versions 1.2.3 1.2.3~preview
-1.2.3 > 1.2.3~preview
-### opam admin compare-package-versions 0.1.0 0.01.0
-0.1.0 = 0.01.0

--- a/tests/reftests/compare-package-versions.test
+++ b/tests/reftests/compare-package-versions.test
@@ -1,0 +1,7 @@
+N0REP0
+### opam admin compare-package-versions 0.0.9 0.0.10
+-1 (0.0.9 < 0.0.10)
+### opam admin compare-package-versions 1.2.3 1.2.3~preview
+1 (1.2.3 > 1.2.3~preview)
+### opam admin compare-package-versions 0.1.0 0.01.0
+0 (0.1.0 = 0.01.0)

--- a/tests/reftests/compare-package-versions.test
+++ b/tests/reftests/compare-package-versions.test
@@ -1,7 +1,7 @@
 N0REP0
 ### opam admin compare-package-versions 0.0.9 0.0.10
--1 (0.0.9 < 0.0.10)
+0.0.9 < 0.0.10
 ### opam admin compare-package-versions 1.2.3 1.2.3~preview
-1 (1.2.3 > 1.2.3~preview)
+1.2.3 > 1.2.3~preview
 ### opam admin compare-package-versions 0.1.0 0.01.0
-0 (0.1.0 = 0.01.0)
+0.1.0 = 0.01.0

--- a/tests/reftests/compare-versions.test
+++ b/tests/reftests/compare-versions.test
@@ -5,9 +5,16 @@ N0REP0
 1.2.3 > 1.2.3~preview
 ### opam admin compare-versions 0.1.0 0.01.0
 0.1.0 = 0.01.0
+### opam admin compare-versions 0.1.0 0.01.0 --assert '='
 ### opam admin compare-versions 0.0.9 0.0.10 --assert '<'
 ### opam admin compare-versions 0.0.9 0.0.10 --assert '<='
+### opam admin compare-versions 1.2.3 1.2.3~preview --assert '>'
+### opam admin compare-versions 1.2.3 1.2.3~preview --assert '>='
 ### opam admin compare-versions 0.0.9 0.0.10 --assert '='
+# Return code 1 #
+### opam admin compare-versions 1.2.3 1.2.3~preview --assert '<'
+# Return code 1 #
+### opam admin compare-versions 1.2.3-option 1.2.3 --assert '<='
 # Return code 1 #
 ### opam admin compare-versions 0.0.9 0.0.10 --assert '>'
 # Return code 1 #

--- a/tests/reftests/compare-versions.test
+++ b/tests/reftests/compare-versions.test
@@ -5,3 +5,11 @@ N0REP0
 1.2.3 > 1.2.3~preview
 ### opam admin compare-versions 0.1.0 0.01.0
 0.1.0 = 0.01.0
+### opam admin compare-versions 0.0.9 0.0.10 --assert '<'
+### opam admin compare-versions 0.0.9 0.0.10 --assert '<='
+### opam admin compare-versions 0.0.9 0.0.10 --assert '='
+# Return code 1 #
+### opam admin compare-versions 0.0.9 0.0.10 --assert '>'
+# Return code 1 #
+### opam admin compare-versions 0.0.9 0.0.10 --assert '>='
+# Return code 1 #

--- a/tests/reftests/compare-versions.test
+++ b/tests/reftests/compare-versions.test
@@ -1,0 +1,7 @@
+N0REP0
+### opam admin compare-versions 0.0.9 0.0.10
+0.0.9 < 0.0.10
+### opam admin compare-versions 1.2.3 1.2.3~preview
+1.2.3 > 1.2.3~preview
+### opam admin compare-versions 0.1.0 0.01.0
+0.1.0 = 0.01.0

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -189,6 +189,24 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:cli-versioning.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-compare-package-versions)
+ (action
+  (diff compare-package-versions.test compare-package-versions.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-compare-package-versions)))
+
+(rule
+ (targets compare-package-versions.out)
+ (deps root-N0REP0)
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:compare-package-versions.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-config)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -189,22 +189,22 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:cli-versioning.test} %{read-lines:testing-env}))))
 
 (rule
- (alias reftest-compare-package-versions)
+ (alias reftest-compare-versions)
  (action
-  (diff compare-package-versions.test compare-package-versions.out)))
+  (diff compare-versions.test compare-versions.out)))
 
 (alias
  (name reftest)
- (deps (alias reftest-compare-package-versions)))
+ (deps (alias reftest-compare-versions)))
 
 (rule
- (targets compare-package-versions.out)
+ (targets compare-versions.out)
  (deps root-N0REP0)
  (package opam)
  (action
   (with-stdout-to
    %{targets}
-   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:compare-package-versions.test} %{read-lines:testing-env}))))
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:compare-versions.test} %{read-lines:testing-env}))))
 
 (rule
  (alias reftest-config)


### PR DESCRIPTION
Add a new CLI `opam admin compare-versions` to compare package versions for sanity checks.

This command has 2 modes:

1. By default - user interactive.

In this mode, we provide two versions, and opam outputs a user-friendly expression with the result of the comparison, spelled out. For example:

```sh
$ opam admin compare-versions 0.0.9 0.0.10
 0.0.9 < 0.0.10
```

The command exits 0 regardless of the result of the comparison.

2. For use in scripts - if needed. Adding the argument `--assert=OP`.

In this mode, the output is suppressed (the command is silent). The result of the command will be encoded in the exit code, to be used in bash conditionals:

exit 0: the comparison holds
exit 1: it doesn't

For example:

```sh
$ opam admin compare-versions 0.0.9 0.0.10 --assert='<'
[0]

$ opam admin compare-versions 0.0.9 0.0.10 --assert='>='
[1]
```

### Original notes

This is meant for quick sanity checks for example.

- Added some basic tests to cover the command. The tests I added do not duplicate the tests for the actual comparison function, rather that meant to cover the basic cases encountered by the command.

- [x] Please update `master_changes.md` file with your changes.

This is following a discussion with @kit-ty-kate in #6118.

Note to reviewers:

I wasn't too sure where to expose the new command. It's not really an admin command, but I couldn't find another suitable section.

This is my first PR on opam and I am not familiar with the code base, as well as some dependencies (e.g. cmdliner). Please feel free to request for as many changes as you like. Thank you!