### PR TITLE
ocp-indent: make sure 'begin match' doesn't add an extra indentation

### DIFF
--- a/.ocp-indent
+++ b/.ocp-indent
@@ -1,1 +1,2 @@
 normal
+strict_with=auto


### PR DESCRIPTION
Makes the indentation style switch from:
```ocaml
let () =
  begin match x with
    | Some _ -> ()
    | None -> ()
  end
```
to the more common:
```ocaml
let () =
  begin match x with
  | Some _ -> ()
  | None -> ()
  end
```
Some of our use of `begin match` already use this indentation style manually