### PR TITLE
[2.2 backport] Add curl to the list of required cygwin packages to avoid issues with Windows' curl

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -17,6 +17,7 @@ users)
 ## Plugins
 
 ## Init
+  * Add curl to the list of required cygwin packages to avoid issues with Windows' curl [#6142 @kit-ty-kate - fix #6120]
 
 ## Config report
 

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -154,6 +154,7 @@ let required_packages_for_cygwin =
     "tar";
     "unzip";
     "rsync";
+    "curl";
   ] |> List.map OpamSysPkg.of_string
 
 let init_scripts () = [


### PR DESCRIPTION
Backporting https://github.com/ocaml/opam/pull/6142 to the 2.2 branch