### PR TITLE
Reduce allocations in opamVersionCompare

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -121,6 +121,7 @@ users)
 ## Internal
   * Stop using polymorphic comparison when comparing `OpamTypes.switch_selections` [#6102 @kit-ty-kate]
   * Remove the meta opam packages opam and opam-admin [#6115 @kit-ty-kate]
+  * Reduce allocations in OpamVersionCompare [#6144 @talex5]
 
 ## Internal: Windows
 

--- a/src/core/opamVersionCompare.ml
+++ b/src/core/opamVersionCompare.ml
@@ -20,11 +20,9 @@ let is_digit = function
 (* [skip_while_from i f w m] yields the index of the leftmost character
  * in the string [s], starting from [i], and ending at [m], that does
  * not satisfy the predicate [f], or [length w] if no such index exists.  *)
-let skip_while_from i f w m =
-  let rec loop i =
-    if i = m then i
-    else if f w.[i] then loop (i + 1) else i
-  in loop i
+let rec skip_while_from i f w m =
+  if i = m then i
+  else if f w.[i] then skip_while_from (i + 1) f w m else i
 ;;
 
 (* splits a version into (epoch,rest), without the separating ':'. The


### PR DESCRIPTION
Test-case:

```ocaml
let ()
  let x0 = Gc.stat () in
  assert (OpamVersionCompare.compare "1.2.3" "1.02.3" == 0);
  let x1 = Gc.stat () in
  Printf.printf "minor_words: %.0f\n" (x1.minor_words -. x0.minor_words)
```

Before: minor_words: 156
After:  minor_words: 84

This just passes all the parameters to `loop` rather than getting them from the context. Then `loop` itself isn't needed.

Ideally, there would be no allocations at all. However, removing the others makes the code quite messy so I just did the easy change here.

See https://roscidus.com/blog/blog/2024/07/22/performance-2/#statmemprof for some real-world profiling of the CI solver service, showing this to be a problem.