### PR TITLE
[2.2 backport] Disable shallow clone by default except for opam repositories

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -24,6 +24,7 @@ users)
 
 ## Install
   * [BUG] Fix `opam install --deps-only` set direct dependencies as root packages [#6125 @rjbou]
+  * Disable shallow clone by default except for opam repositories [#6146 @kit-ty-kate - fix #6145]
 
 ## Remove
 
@@ -132,6 +133,7 @@ users)
 ## opam-client
 
 ## opam-repository
+ * `?full_fetch` is now `true` by default instead of `false` [#6146 @kit-ty-kate - fix #6145]
 
 ## opam-state
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -106,6 +106,7 @@ users)
 ## Reftests
 ### Tests
   * Add a test for --deps-only setting direct dependencies as root packages [#6125 @rjbou]
+  * Add a package fetching test [#6146 @rjbou]
 
 ### Engine
 

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -62,7 +62,7 @@ module VCS : OpamVCS.VCS = struct
     | Some h -> "refs/remotes/opam-ref-"^h
     | None -> "refs/remotes/opam-ref"
 
-  let fetch ?(full_fetch = false) ?cache_dir ?subpath repo_root repo_url =
+  let fetch ?(full_fetch = true) ?cache_dir ?subpath repo_root repo_url =
     (match subpath with
      | Some sp ->
        git repo_root [ "config"; "--local"; "core.sparseCheckout"; "true" ]

--- a/src/repository/opamRepository.mli
+++ b/src/repository/opamRepository.mli
@@ -43,8 +43,8 @@ val pull_shared_tree:
   url list -> string download OpamProcess.job
 
 (* Same as [pull_shared_tree], but for a unique label/dirname.
-   If [full_fetch] is true, VCS repository is retrieved with full history (by
-   default, no history). *)
+   If [full_fetch] is set to false, VCS repository is retrieved with shallow
+   history (by default, full history). *)
 val pull_tree:
   string -> ?full_fetch:bool -> ?cache_dir:dirname -> ?cache_urls:url list ->
   ?working_dir:bool -> ?subpath:subpath ->

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -45,8 +45,8 @@ module type S = sig
       [checksum] can be used for retrieval but is NOT checked by this
       function.
 
-      If [full_fetch] is set to true, VCS repository is retrieved with full
-      history (by default, no history).
+      If [full_fetch] is set to false, VCS repository is retrieved with shallow
+      history (by default, full history).
       If [cache_dir] is given, the directory is used by VCS tool as a its cache
       directory.
       If [subpath] is given, only that [subpath] of the url is retrieved. *)

--- a/src/repository/opamVCS.mli
+++ b/src/repository/opamVCS.mli
@@ -29,8 +29,8 @@ module type VCS = sig
       Be aware that the remote URL might have been changed, so make sure
       to update accordingly.
 
-      If [full_fetch] is set to true, VCS repository is retrieved with full
-      history (by default, no history).
+      If [full_fetch] is set to false, VCS repository is retrieved with shallow
+      history (by default, full history).
       If [cache_dir] is given, the directory is used by VCS tool as a its cache
       directory.
       If [subpath] is given, only that [subpath] of the url is retrieved. *)

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -639,6 +639,24 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:extrasource.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-fetch-package)
+ (action
+  (diff fetch-package.test fetch-package.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-fetch-package)))
+
+(rule
+ (targets fetch-package.out)
+ (deps root-N0REP0)
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:fetch-package.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-init-ocaml-eval-variables.unix)
  (enabled_if (= %{os_type} "Unix"))
  (action

--- a/tests/reftests/fetch-package.test
+++ b/tests/reftests/fetch-package.test
@@ -1,0 +1,146 @@
+N0REP0
+### <a-dev/root.ml>
+print_endline "i'm root file"
+### <pin:a-dev/opam>
+opam-version: "2.0"
+build: [
+  [ "sh" "-c" "git ls-files > files || ls > files" ]
+  [ "sh" "-c" "git rev-list --all --count > hist || echo > hist" ]
+]
+install: [
+  [ "cp" "files" "%{lib}%/%{name}%-files" ]
+  [ "cp" "hist" "%{lib}%/%{name}%-hist" ]
+]
+### tar czf arch.tgz a-dev
+### git -C ./a-dev init -q --initial-branch=master
+### git -C ./a-dev config core.autocrlf false
+### git -C ./a-dev add opam
+### git -C ./a-dev commit -qm "init"
+### git -C ./a-dev add root.ml
+### git -C ./a-dev commit -qm "i'm empty"
+### <pkg:foo-arch.1>
+opam-version: "2.0"
+build: [ "sh" "-c" "ls > files" ]
+install: [ "cp" "files" "%{lib}%/%{name}%-files" ]
+### <pkg:foo-git.1>
+opam-version: "2.0"
+build: [
+  [ "sh" "-c" "git ls-files > files" ]
+  [ "sh" "-c" "git rev-list --all --count > hist" ]
+]
+install: [
+  [ "cp" "files" "%{lib}%/%{name}%-files" ]
+  [ "cp" "hist" "%{lib}%/%{name}%-hist" ]
+]
+### <mkurl.sh>
+p=foo-arch.1
+arch=arch
+file="REPO/packages/${p%.*}/$p/opam"
+basedir=`echo "$BASEDIR" | sed "s/\\\\\\\\/\\\\\\\\\\\\\\\\/g"`
+MD5=$(openssl md5 "$arch.tgz" | cut -d' ' -f2)
+cat << EOF >> "$file"
+url {
+  src: "$arch.tgz"
+  checksum: "md5=$MD5"
+}
+dev-repo: "git+file://${basedir}/a-dev"
+EOF
+
+p=foo-git.1
+file="REPO/packages/${p%.*}/$p/opam"
+cat << EOF >> "$file"
+url {
+  src: "git+file://${basedir}/a-dev"
+}
+dev-repo: "git+file://${basedir}/a-dev"
+EOF
+### sh mkurl.sh
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### opam switch create downloads-repo --empty
+### opam install foo-arch
+The following actions will be performed:
+=== install 1 package
+  - install foo-arch 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved foo-arch.1  (file://${BASEDIR}/arch.tgz)
+-> installed foo-arch.1
+Done.
+### cat OPAM/downloads-repo/lib/foo-arch-files | sort
+files
+opam
+root.ml
+### opam install foo-git
+The following actions will be performed:
+=== install 1 package
+  - install foo-git 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved foo-git.1  (git+file://${BASEDIR}/a-dev)
+-> installed foo-git.1
+Done.
+### cat OPAM/downloads-repo/lib/foo-git-files | sort
+opam
+root.ml
+### cat OPAM/downloads-repo/lib/foo-git-hist
+1
+### :: pinning
+### opam switch create downloads-pin --empty
+### opam pin foo-arch-pin arch.tgz -y
+Package foo-arch-pin does not exist, create as a NEW package? [y/n] y
+[foo-arch-pin.dev] synchronised (file://${BASEDIR}/arch.tgz)
+foo-arch-pin is now pinned to file://${BASEDIR}/arch.tgz (version dev)
+
+The following actions will be performed:
+=== install 1 package
+  - install foo-arch-pin dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved foo-arch-pin.dev  (file://${BASEDIR}/arch.tgz)
+-> installed foo-arch-pin.dev
+Done.
+### cat OPAM/downloads-pin/lib/foo-arch-pin-files | sort
+files
+opam
+root.ml
+### opam pin foo-git-pin ./a-dev -y
+Package foo-git-pin does not exist, create as a NEW package? [y/n] y
+[foo-git-pin.dev] synchronised (file://${BASEDIR}/a-dev)
+foo-git-pin is now pinned to git+file://${BASEDIR}/a-dev#master (version dev)
+
+The following actions will be performed:
+=== install 1 package
+  - install foo-git-pin dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved foo-git-pin.dev  (git+file://${BASEDIR}/a-dev#master)
+-> installed foo-git-pin.dev
+Done.
+### cat OPAM/downloads-pin/lib/foo-git-pin-files | sort
+opam
+root.ml
+### cat OPAM/downloads-pin/lib/foo-git-pin-hist
+1
+### :: dev-repo
+### opam switch create downloads-devrepo --empty
+### opam pin foo-git --dev-repo -y
+[foo-git.1] synchronised (file://${BASEDIR}/a-dev)
+foo-git is now pinned to git+file://${BASEDIR}/a-dev (version 1)
+
+The following actions will be performed:
+=== install 1 package
+  - install foo-git 1 (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved foo-git.1  (git+file://${BASEDIR}/a-dev)
+-> installed foo-git.1
+Done.
+### cat OPAM/downloads-devrepo/lib/foo-git-files | sort
+opam
+root.ml
+### cat OPAM/downloads-devrepo/lib/foo-git-hist
+1

--- a/tests/reftests/fetch-package.test
+++ b/tests/reftests/fetch-package.test
@@ -87,7 +87,7 @@ Done.
 opam
 root.ml
 ### cat OPAM/downloads-repo/lib/foo-git-hist
-1
+2
 ### :: pinning
 ### opam switch create downloads-pin --empty
 ### opam pin foo-arch-pin arch.tgz -y
@@ -124,7 +124,7 @@ Done.
 opam
 root.ml
 ### cat OPAM/downloads-pin/lib/foo-git-pin-hist
-1
+2
 ### :: dev-repo
 ### opam switch create downloads-devrepo --empty
 ### opam pin foo-git --dev-repo -y
@@ -143,4 +143,4 @@ Done.
 opam
 root.ml
 ### cat OPAM/downloads-devrepo/lib/foo-git-hist
-1
+2

--- a/tests/reftests/source.test
+++ b/tests/reftests/source.test
@@ -132,7 +132,7 @@ Now run 'opam upgrade' to apply any package updates.
 ### opam source pandore.4 --dir pandore5
 Successfully extracted to ${BASEDIR}/pandore5
 ### git -C pandore5 rev-list --all --count
-1
+2
 ### opam source pandore.4 --dev --dir pandore6
 Successfully fetched pandore development repo to ${BASEDIR}/pandore6
 ### git -C pandore6 rev-list --all --count


### PR DESCRIPTION
Backport of https://github.com/ocaml/opam/pull/6146 to the `2.2` branch