### PR TITLE
Speedup "make reftest-gen"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,6 @@ tests-%: $(DUNE_DEP) src/client/no-git-version
 	$(DUNE) build $(DUNE_ARGS) $(DUNE_PROFILE_ARG) --root . @reftest-legacy-$* --force
 
 reftest-gen: src/client/no-git-version
-	echo >tests/reftests/dune.inc
 	$(DUNE) build $(DUNE_ARGS) $(DUNE_PROFILE_ARG) --root . @reftest-gen --auto-promote --force
 
 reftest-runner: $(DUNE_DEP) src/client/no-git-version

--- a/master_changes.md
+++ b/master_changes.md
@@ -164,6 +164,7 @@ users)
   * Add a test filtering mechanism [#6105 @Keryan-dev]
   * Add a test filter on N0REP0 first line [#6105 @Keryan-dev]
   * Add a makefile target `quick-test` to launch only `N0REP0` tests [#6105 @Keryan-dev]
+  * Speedup `make reftest-gen` [#6155 @kit-ty-kate]
 
 ## Github Actions
   * Depexts: replace centos docker with almalinux to fake a centos [#6079 @rjbou]


### PR DESCRIPTION
Opening https://github.com/ocaml/opam/pull/6154 made me realised that the reason `make reftest-gen` is slow is that we're removing `tests/reftests/dune.inc` which lists all the opam roots/opam repositories and tar.gz targets, so dune build will scan the directory and remove everything that it doesn't know about and given those targets are not defined anymore it will then remove everything.

Simply not emptying that file fixes the issue. If in the future we need to upgrade the syntax or whatever we can always remove that file manually and the error message should make it obvious. But in the meantime this change is extremely beneficial to the day-to-day development setup by not having to remove then re-download, unpack and recreate 5GB everytime that rule is called