### PR TITLE
Make the shell environment update hint easier to copy/paste

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -74,6 +74,7 @@ users)
 ## Clean
 
 ## Env
+  * Make the shell environment update hint easier to copy/paste [#6159 @kit-ty-kate - fix #6158]
 
 ## Opamfile
   * Make all writes atomic [#5489 @kit-ty-kate]

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -1277,7 +1277,7 @@ let check_and_print_env_warning st =
       OpamStateConfig.(!r.switch_from <> `Command_line))
   then
     OpamConsole.formatted_msg
-      "# Run %s to update the current shell environment\n"
+      "# To update the current shell environment, run: %s\n"
       (OpamConsole.colorise `bold (eval_string st.switch_global
                                      (Some st.switch)))
 

--- a/tests/reftests/env.unix.test
+++ b/tests/reftests/env.unix.test
@@ -19,7 +19,7 @@ Switch invariant: ["nv"]
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed nv.1
 Done.
-# Run eval $(opam env '--root=${BASEDIR}/root 2' '--switch=${BASEDIR}/switch w spaces') to update the current shell environment
+# To update the current shell environment, run: eval $(opam env '--root=${BASEDIR}/root 2' '--switch=${BASEDIR}/switch w spaces')
 ### opam env --root "$RT" --switch "./$SW" | grep "PREFIX" | ';' -> ':'
 OPAM_SWITCH_PREFIX='${BASEDIR}/switch w spaces/_opam': export OPAM_SWITCH_PREFIX:
 ### opam var root --root "$RT"


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/6158

I chose to keep in a single line instead of 2 just because we'd want to have it on a line starting with `# ` and i'm worried people would also copy the prefix when copy/pasting