### PR TITLE
Mitigate problems with curl on Windows 11

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -71,6 +71,7 @@ users)
 ## Lint
 
 ## Repository
+ * Mitigate curl/curl#13845 by falling back from --write-out to --fail if exit code 43 is returned by curl [#6168 @dra27 - fix #6120]
 
 ## Lock
 

--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -20,19 +20,28 @@ let fail (s,l) = raise (Download_fail (s,l))
 let user_agent =
   CString (Printf.sprintf "opam/%s" (OpamVersion.(to_string current)))
 
-let curl_args = [
-  CString "--write-out", None;
-  CString "%%{http_code}\\n", None; (* 6.5 13-Mar-2000 *)
-  CString "--retry", None; CIdent "retry", None; (* 7.12.3 20-Dec-2004 *)
-  CString "--retry-delay", None; CString "2", None; (* 7.12.3 20-Dec-2004 *)
-  CString "--compressed",
-  Some (FIdent (OpamFilter.ident_of_string "compress")); (* 7.10 1-Oct-2002 *)
-  CString "--user-agent", None; user_agent, None; (* 4.5.1 12-Jun-1998 *)
-  CString "-L", None; (* 4.9 7-Oct-1998 *)
-  CString "-o", None; CIdent "out", None; (* 2.3 21-Aug-1997 *)
-  CString "--", None; (* End list of options; 5.0 1-Dec-1998 *)
-  CIdent "url", None;
-]
+let curl_args =
+  let main_args = [
+    CString "--retry", None; CIdent "retry", None; (* 7.12.3 20-Dec-2004 *)
+    CString "--retry-delay", None; CString "2", None; (* 7.12.3 20-Dec-2004 *)
+    CString "--compressed",
+    Some (FIdent (OpamFilter.ident_of_string "compress")); (* 7.10 1-Oct-2002 *)
+    CString "--user-agent", None; user_agent, None; (* 4.5.1 12-Jun-1998 *)
+    CString "-L", None; (* 4.9 7-Oct-1998 *)
+    CString "-o", None; CIdent "out", None; (* 2.3 21-Aug-1997 *)
+    CString "--", None; (* End list of options; 5.0 1-Dec-1998 *)
+    CIdent "url", None;
+  ] in
+  fun ~with_mitigation ->
+    if with_mitigation then
+      (* --fail is as old as curl; though the assumption that it leads to exit
+         code 22 when there's an error is probably 5.3 21-Dec-1998 (prior to
+         that it led to exit code 21) *)
+      (CString "--fail", None) :: main_args
+    else
+      (CString "--write-out", None) ::
+      (CString "%%{http_code}\\n", None) :: (* 6.5 13-Mar-2000 *)
+      main_args
 
 let wget_args = [
   CString "-t", None; CIdent "retry", None;
@@ -56,14 +65,16 @@ let ftp_args = [
   CIdent "url", None;
 ]
 
-let download_args ~url ~out ~retry ?checksum ~compress () =
+let download_args ~url ~out ~retry ?(with_curl_mitigation=false)
+                  ?checksum ~compress () =
   let cmd, _ = Lazy.force OpamRepositoryConfig.(!r.download_tool) in
   let cmd =
     match cmd with
     | [(CIdent "wget"), _] -> cmd @ wget_args
     | [(CIdent "fetch"), _] -> cmd @ fetch_args
     | [(CIdent "ftp"), _] -> cmd @ ftp_args
-    | [_] -> cmd @ curl_args (* Assume curl if the command is a single arg *)
+      (* Assume curl if the command is a single arg *)
+    | [_] -> cmd @ curl_args ~with_mitigation:with_curl_mitigation
     | _ -> cmd
   in
   OpamFilter.single_command (fun v ->
@@ -89,7 +100,28 @@ let download_args ~url ~out ~retry ?checksum ~compress () =
       | _ -> None)
     cmd
 
-let tool_return url ret =
+let download_command_t ~with_curl_mitigation ~compress ?checksum ~url ~dst c =
+  let cmd, args =
+    match
+      download_args
+        ~url
+        ~out:dst
+        ~retry:OpamRepositoryConfig.(!r.retries)
+        ~with_curl_mitigation
+        ?checksum
+        ~compress
+        ()
+    with
+    | cmd::args -> cmd, args
+    | [] ->
+      OpamConsole.error_and_exit `Configuration_error
+        "Empty custom download command"
+  in
+  let stdout = OpamSystem.temp_file ~auto_clean:false "dl" in
+  OpamProcess.Job.finally (fun () -> OpamSystem.remove_file stdout) @@ fun () ->
+  OpamSystem.make_command ~allow_stdin:false ~stdout cmd args @@> c
+
+let tool_return redownload_command url ret =
   match Lazy.force OpamRepositoryConfig.(!r.download_tool) with
   | _, `Default ->
     if OpamProcess.is_failure ret then
@@ -99,8 +131,28 @@ let tool_return url ret =
     else Done ()
   | _, `Curl ->
     if OpamProcess.is_failure ret then
-      fail (Some "Curl failed", Printf.sprintf "Curl failed: %s"
-              (OpamProcess.result_summary ret))
+      if ret.r_code = 43 then begin
+        (* Code 43 is CURLE_BAD_FUNCTION_ARGUMENT (7.1 7-Aug-2000). This should
+           never be encountered using the curl binary, so we assume that it's
+           a manifestation of curl/curl#13845 (see also #6120). *)
+        log "Attempting to mitigate curl/curl#13845";
+        redownload_command ~with_curl_mitigation:true @@ function ret ->
+          if OpamProcess.is_failure ret then
+            if ret.r_code = 22 then
+              (* If this broken version of curl persists for some time, it is
+                 relatively straightforward to parse the http response code from
+                 the message, as it hasn't changed. *)
+              fail (Some "curl failed owing to a server-side issue",
+                    Printf.sprintf "curl failed with server-side error: %s"
+                      (OpamProcess.result_summary ret))
+            else
+              fail (Some "curl failed",
+                    Printf.sprintf "curl failed: %s"
+                      (OpamProcess.result_summary ret))
+          else Done ()
+      end else
+        fail (Some "curl failed", Printf.sprintf "curl failed: %s"
+                (OpamProcess.result_summary ret))
     else
       match ret.OpamProcess.r_stdout with
       | [] ->
@@ -117,24 +169,9 @@ let tool_return url ret =
         else Done ()
 
 let download_command ~compress ?checksum ~url ~dst () =
-  let cmd, args =
-    match
-      download_args
-        ~url
-        ~out:dst
-        ~retry:OpamRepositoryConfig.(!r.retries)
-        ?checksum
-        ~compress
-        ()
-    with
-    | cmd::args -> cmd, args
-    | [] ->
-      OpamConsole.error_and_exit `Configuration_error
-        "Empty custom download command"
-  in
-  let stdout = OpamSystem.temp_file ~auto_clean:false "dl" in
-  OpamProcess.Job.finally (fun () -> OpamSystem.remove_file stdout) @@ fun () ->
-  OpamSystem.make_command ~allow_stdin:false ~stdout cmd args @@> tool_return url
+  let download_command = download_command_t ~compress ?checksum ~url ~dst in
+  download_command ~with_curl_mitigation:false
+  @@ tool_return download_command url
 
 let really_download
     ?(quiet=false) ~overwrite ?(compress=false) ?checksum ?(validate=true)

--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -100,20 +100,21 @@ let tool_return url ret =
   | _, `Curl ->
     if OpamProcess.is_failure ret then
       fail (Some "Curl failed", Printf.sprintf "Curl failed: %s"
-                  (OpamProcess.result_summary ret));
-    match ret.OpamProcess.r_stdout with
-    | [] ->
-      fail (Some "curl empty response",
-                Printf.sprintf "curl: empty response while downloading %s"
-                  (OpamUrl.to_string url))
-    | l  ->
-      let code = List.hd (List.rev l) in
-      let num = try int_of_string code with Failure _ -> 999 in
-      if num >= 400 then
-        fail (Some ("curl error code " ^ code),
-                  Printf.sprintf "curl: code %s while downloading %s"
-                    code (OpamUrl.to_string url))
-      else Done ()
+              (OpamProcess.result_summary ret))
+    else
+      match ret.OpamProcess.r_stdout with
+      | [] ->
+        fail (Some "curl empty response",
+              Printf.sprintf "curl: empty response while downloading %s"
+                (OpamUrl.to_string url))
+      | l  ->
+        let code = List.hd (List.rev l) in
+        let num = try int_of_string code with Failure _ -> 999 in
+        if num >= 400 then
+          fail (Some ("curl error code " ^ code),
+                Printf.sprintf "curl: code %s while downloading %s"
+                  code (OpamUrl.to_string url))
+        else Done ()
 
 let download_command ~compress ?checksum ~url ~dst () =
   let cmd, args =

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -64,9 +64,9 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
 + curl "--another-args" "3"
-[ERROR] Failed to get sources of foo.1: Curl failed
+[ERROR] Failed to get sources of foo.1: curl failed
 
-OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (Curl failed: \"curl --another-args 3\" exited with code 2)")
+OpamSolution.Fetch_fail("https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz (curl failed: \"curl --another-args 3\" exited with code 2)")
 
 
 <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>


### PR DESCRIPTION
Fixes #6120 by altering the call to curl. curl/curl#13845 can be mitigated by avoiding the use of `--write-out` so, having detected exit code 43 (which should never happen using the curl binary, as `curl` itself should normally know how to call its own functions!), a second call is made to call using `--fail` instead of `--write-out`. `--fail` was previously considered in https://github.com/ocaml/opam/issues/467#issuecomment-13881022. I've done some digging, and the semantics of `--fail` are good enough for what we're after, though using `--write-out` as in @samoht's f2ee0ec6e35196be2c57e8c32cb310cd942c771f is superior in general because it conveys more information to the user when an error occurs (which was the point).

The bug in cURL is causing enough issues elsewhere that I imagine Microsoft will update the `curl.exe` binary shipped with Windows before long - if they don't, it's easy to extend the mitigation further to extract the actual http response code from the error message, as the format of that message has never altered, from a look at cURL's sources.

There are three reasons to prefer this slightly more complicated fix to just adding the requirement for cURL from Cygwin/MSYS2 as in #6142:
1. We're getting away with the workaround of adding Cygwin's `curl` because Cygwin's SSL certificate doesn't contain the offending OIDS. If that were to change, the workaround would fail (because we have to download Cygwin's setup using `C:\Windows\System32\curl.exe`)
2. Cygwin's curl is (correctly) built with the wrong SSL stack, so the workaround has the potential to create problems for some users (same issue as Cygwin git vs Git-for-Windows)
3. The general direction of travel is supposed to be using fewer Cygwin/MSYS2 tools, so it's a shame to have to go in the opposite direction!

Running `opam init --debug -vv` on my Windows 11 laptop with this binary we can now see:

```
00:03.923  XSYS                   Downloading Cygwin setup checksums
Downloading Cygwin setup from cygwin.com
00:03.924  SYSTEM                 mkdir C:\Users\DRA\AppData\Local\Temp\opam-27848-4d3c3d
+ C:\Windows\system32\curl.exe "--write-out" "%{http_code}\\n" "--retry" "3" "--retry-delay" "2" "--user-agent" "opam/2.3.0~alpha~dev" "-L" "-o" "C:\\Users\\DRA\\AppData\\Local\\Temp\\opam-27848-4d3c3d\\sha512.sum.part" "--" "https://cygwin.com/sha512.sum"
- 200
-   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                  Dload  Upload   Total   Spent    Left  Speed
100   291  100   291    0     0    666      0 --:--:-- --:--:-- --:--:--   670
00:04.413  SYSTEM                 rm C:\Users\DRA\AppData\Local\Temp\opam-DRA-27848\dl-27848-2260b8
00:04.413  SYSTEM                 mv C:\Users\DRA\AppData\Local\Temp\opam-27848-4d3c3d\sha512.sum.part -> C:\Users\DRA\AppData\Local\Temp\opam-27848-4d3c3d\sha512.sum
00:04.422  XSYS                   Downloading setup-x86_64.exe
00:04.422  SYSTEM                 mkdir C:\Devel\Roots\broken-curl
00:04.422  SYSTEM                 mkdir C:\Devel\Roots\broken-curl\.cygwin
+ C:\Windows\system32\curl.exe "--write-out" "%{http_code}\\n" "--retry" "3" "--retry-delay" "2" "--user-agent" "opam/2.3.0~alpha~dev" "-L" "-o" "C:\\Devel\\Roots\\broken-curl\\.cygwin\\setup-x86_64.exe.part" "--" "https://cygwin.com/setup-x86_64.exe"
- 200
-   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                  Dload  Upload   Total   Spent    Left  Speed
100 1374k  100 1374k    0     0  1194k      0  0:00:01  0:00:01 --:--:-- 1196k
```

downloading Cygwin with no issues at all, but then mitigation kicking in for opam.ocaml.org:

```
00:44.717  PARALLEL               Next task in job 0: C:\Windows\system32\curl.exe --write-out %{http_code}\n --retry 3 --retry-delay 2 --user-agent opam/2.3.0~alpha~dev -L -o C:\Users\DRA\AppData\Local\Temp\opam-27848-a08201\index.tar.gz.part -- https://opam.ocaml.org/index.tar.gz
Processing  1/1: [default: http]
+ C:\Windows\system32\curl.exe "--write-out" "%{http_code}\\n" "--retry" "3" "--retry-delay" "2" "--user-agent" "opam/2.3.0~alpha~dev" "-L" "-o" "C:\\Users\\DRA\\AppData\\Local\\Temp\\opam-27848-a08201\\index.tar.gz.part" "--" "https://opam.ocaml.org/index.tar.gz"
- 000
-   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
- curl: (43) A libcurl function was given a bad argument
00:45.092  PARALLEL               Collected task for job 0 (ret:43)
00:45.092  CURL                   Attempting to mitigate curl/curl#13845
00:45.093  PARALLEL               Next task in job 0: C:\Windows\system32\curl.exe --fail --retry 3 --retry-delay 2 --user-agent opam/2.3.0~alpha~dev -L -o C:\Users\DRA\AppData\Local\Temp\opam-27848-a08201\index.tar.gz.part -- https://opam.ocaml.org/index.tar.gz
+ C:\Windows\system32\curl.exe "--fail" "--retry" "3" "--retry-delay" "2" "--user-agent" "opam/2.3.0~alpha~dev" "-L" "-o" "C:\\Users\\DRA\\AppData\\Local\\Temp\\opam-27848-a08201\\index.tar.gz.part" "--" "https://opam.ocaml.org/index.tar.gz"
-   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                  Dload  Upload   Total   Spent    Left  Speed
100 7223k  100 7223k    0     0  14.9M      0 --:--:-- --:--:-- --:--:-- 14.9M
00:45.610  PARALLEL               Collected task for job 0 (ret:0)
00:45.611  SYSTEM                 rm C:\Users\DRA\AppData\Local\Temp\opam-DRA-27848\dl-27848-5e0cc2
00:45.611  SYSTEM                 rm C:\Users\DRA\AppData\Local\Temp\opam-DRA-27848\dl-27848-f3db71
00:45.612  SYSTEM                 mv C:\Users\DRA\AppData\Local\Temp\opam-27848-a08201\index.tar.gz.part -> C:\Users\DRA\AppData\Local\Temp\opam-27848-a08201\index.tar.gz
```