### PR TITLE
Fix highly embarrassing mistake in patch transformation

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -144,6 +144,7 @@ users)
   * Remove the meta opam packages opam and opam-admin [#6115 @kit-ty-kate]
   * Reduce allocations in OpamVersionCompare [#6144 @talex5]
   * Speedup OpamVersionCompare by 25% by removing the unused handling of epoch [#5518 @kit-ty-kate]
+  * Fix error in `OpamSystem.transform_patch` - patches were only applied when debugging [#6182 @dra27 regression since #3449]
 
 ## Internal: Windows
 

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -1505,12 +1505,13 @@ let translate_patch ~dir orig corrected =
       else
         (id, (fun s -> s ^ "\r"), strip 1)
     in
-    if OpamConsole.debug () then
+    if OpamConsole.debug () then begin
       let log_transform (first_line, last_line, add_cr) =
          let indicator = if add_cr then '+' else '-' in
          log ~level:3 "Transform %d-%d %c\\r" first_line last_line indicator
       in
-      List.iter log_transform transforms;
+      List.iter log_transform transforms
+    end;
     let rec fold_lines n transforms =
       match input_line ch with
       | line ->

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -1485,10 +1485,12 @@ let translate_patch ~dir orig corrected =
         process_state_transition `Header state transforms |> List.rev
   in
   let transforms = fold_lines `Header 1 [] in
-  if transforms = [] then
+  if transforms = [] then begin
+    log ~level:1 "No patch translation needed for %s -> %s" orig corrected;
     copy_file orig corrected
-  else begin
+  end else begin
     seek_in ch 0;
+    log ~level:1 "Transforming patch %s to %s" orig corrected;
     let ch_out =
       try open_out_bin corrected
       with Sys_error _ ->

--- a/tests/lib/patcher.expected
+++ b/tests/lib/patcher.expected
@@ -7,6 +7,7 @@ PATCH                           No CRLF adaptation necessary for b/test1
 PATCH                           No CRLF adaptation necessary for b/test2
 PATCH                           No CRLF adaptation necessary for b/test3
 PATCH                           No CRLF adaptation necessary for b/will-null-file
+PATCH                           No patch translation needed for input.patch -> output.patch
 Before patch state of c:
   ./always-crlf: CRLF
   ./always-lf: LF
@@ -44,6 +45,7 @@ PATCH                           No CRLF adaptation necessary for b/test1
 PATCH                           Adding \r to patch chunks for b/test2
 PATCH                           No CRLF adaptation necessary for b/test3
 PATCH                           Adding \r to patch chunks for b/will-null-file
+PATCH                           Transforming patch input.patch to output.patch
 PATCH                           Transform 32-36 +\r
 PATCH                           Transform 62-67 +\r
 PATCH                           Transform 82-87 +\r


### PR DESCRIPTION
This has sadly been wrong since #3349 was fixed in #3449 (which equates to "it's always been wrong", as that was during 2.0.0's dev cycle).

Patches require transformation to deal with line-endings - patch can cope with patching CRLF files, but the diff needs to have the same line-endings as the files. Prior to applying a patch, `OpamSystem.translate_patch` checks the files to which the diff is being applied and transforms the patch. If no transformations are needed (which is pretty much always - most release tarballs use Unix line-endings, even on Windows), then the patch is simply copied.

The process works fine, except for a teeny detail. Owing to a badly made logging transformation in #3449, the transformation was only written to the patch file if debugging mode was enabled 🤦

On Windows, while working on compiler packaging, this manifested itself as:

```
∗ installed ocaml-env-mingw64.1
∗ installed system-mingw.1
⬇ retrieved ocaml-compiler.4.08.1  (cached)
∗ installed mingw-w64-shims.0.2.0

#=== ERROR while compiling ocaml-compiler.4.08.1 ==============================#
Sys_error("C:\\Users\\DRA\\AppData\\Local\\opam\\log\\processed-patch-25204-bf7b21: Permission denied")


<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
┌─ The following actions failed
│ λ build ocaml-compiler 4.08.1
```

but the patch is successfully transformed when running with `--debug`. What was happening was the the patch file is opened (`ch_out`); nothing is written to it so the patch of course "applies" perfectly but because `ch_out` was never closed, the removal fails after trying to apply the patch (as it happens, the removal is skipped when debugging, but would in fact succeed).