### PR TITLE
[2.2 backport] Fix highly embarrassing mistake in patch transformation

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -90,6 +90,7 @@ users)
 ## Shell
 
 ## Internal
+  * Fix error in `OpamSystem.transform_patch` - patches were only applied when debugging [#6182 @dra27 regression since #3449]
 
 ## Internal: Windows
 

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -1505,12 +1505,13 @@ let translate_patch ~dir orig corrected =
       else
         (id, (fun s -> s ^ "\r"), strip 1)
     in
-    if OpamConsole.debug () then
+    if OpamConsole.debug () then begin
       let log_transform (first_line, last_line, add_cr) =
          let indicator = if add_cr then '+' else '-' in
          log ~level:3 "Transform %d-%d %c\\r" first_line last_line indicator
       in
-      List.iter log_transform transforms;
+      List.iter log_transform transforms
+    end;
     let rec fold_lines n transforms =
       match input_line ch with
       | line ->

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -1485,10 +1485,12 @@ let translate_patch ~dir orig corrected =
         process_state_transition `Header state transforms |> List.rev
   in
   let transforms = fold_lines `Header 1 [] in
-  if transforms = [] then
+  if transforms = [] then begin
+    log ~level:1 "No patch translation needed for %s -> %s" orig corrected;
     copy_file orig corrected
-  else begin
+  end else begin
     seek_in ch 0;
+    log ~level:1 "Transforming patch %s to %s" orig corrected;
     let ch_out =
       try open_out_bin corrected
       with Sys_error _ ->

--- a/tests/lib/patcher.expected
+++ b/tests/lib/patcher.expected
@@ -7,6 +7,7 @@ PATCH                           No CRLF adaptation necessary for b/test1
 PATCH                           No CRLF adaptation necessary for b/test2
 PATCH                           No CRLF adaptation necessary for b/test3
 PATCH                           No CRLF adaptation necessary for b/will-null-file
+PATCH                           No patch translation needed for input.patch -> output.patch
 Before patch state of c:
   ./always-crlf: CRLF
   ./always-lf: LF
@@ -44,6 +45,7 @@ PATCH                           No CRLF adaptation necessary for b/test1
 PATCH                           Adding \r to patch chunks for b/test2
 PATCH                           No CRLF adaptation necessary for b/test3
 PATCH                           Adding \r to patch chunks for b/will-null-file
+PATCH                           Transforming patch input.patch to output.patch
 PATCH                           Transform 32-36 +\r
 PATCH                           Transform 62-67 +\r
 PATCH                           Transform 82-87 +\r


### PR DESCRIPTION
2.2 version of #6182. This code was supposed to have been quite battle-tested, but of course it hasn't been owing to this error.

~~The fix in #6182 is for everywhere - I propose limiting it slightly in 2.2.2 to be for Windows-only, to remove the risk of 2.2.2 causing unexpected regressions on non-Windows platforms.~~