### PR TITLE
Revert "[2.2 backport] Fix highly embarrassing mistake in patch transformation"

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -90,7 +90,6 @@ users)
 ## Shell
 
 ## Internal
-  * Fix error in `OpamSystem.transform_patch` - patches were only applied when debugging [#6182 @dra27 regression since #3449]
 
 ## Internal: Windows
 

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -1485,12 +1485,10 @@ let translate_patch ~dir orig corrected =
         process_state_transition `Header state transforms |> List.rev
   in
   let transforms = fold_lines `Header 1 [] in
-  if transforms = [] then begin
-    log ~level:1 "No patch translation needed for %s -> %s" orig corrected;
+  if transforms = [] then
     copy_file orig corrected
-  end else begin
+  else begin
     seek_in ch 0;
-    log ~level:1 "Transforming patch %s to %s" orig corrected;
     let ch_out =
       try open_out_bin corrected
       with Sys_error _ ->
@@ -1505,13 +1503,12 @@ let translate_patch ~dir orig corrected =
       else
         (id, (fun s -> s ^ "\r"), strip 1)
     in
-    if OpamConsole.debug () then begin
+    if OpamConsole.debug () then
       let log_transform (first_line, last_line, add_cr) =
          let indicator = if add_cr then '+' else '-' in
          log ~level:3 "Transform %d-%d %c\\r" first_line last_line indicator
       in
-      List.iter log_transform transforms
-    end;
+      List.iter log_transform transforms;
     let rec fold_lines n transforms =
       match input_line ch with
       | line ->

--- a/tests/lib/patcher.expected
+++ b/tests/lib/patcher.expected
@@ -7,7 +7,6 @@ PATCH                           No CRLF adaptation necessary for b/test1
 PATCH                           No CRLF adaptation necessary for b/test2
 PATCH                           No CRLF adaptation necessary for b/test3
 PATCH                           No CRLF adaptation necessary for b/will-null-file
-PATCH                           No patch translation needed for input.patch -> output.patch
 Before patch state of c:
   ./always-crlf: CRLF
   ./always-lf: LF
@@ -45,7 +44,6 @@ PATCH                           No CRLF adaptation necessary for b/test1
 PATCH                           Adding \r to patch chunks for b/test2
 PATCH                           No CRLF adaptation necessary for b/test3
 PATCH                           Adding \r to patch chunks for b/will-null-file
-PATCH                           Transforming patch input.patch to output.patch
 PATCH                           Transform 32-36 +\r
 PATCH                           Transform 62-67 +\r
 PATCH                           Transform 82-87 +\r


### PR DESCRIPTION
Reverts ocaml/opam#6183

After discussion, since the new release cycle is now shorter we would like to reserve the backports to regressions and security fixes.