### PR TITLE
Env: Add install.exe to the shadow program list

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -88,6 +88,7 @@ users)
 
 ## Env
   * Make the shell environment update hint easier to copy/paste [#6159 @kit-ty-kate - fix #6158]
+  * Add install.exe to the list of non-shadowed programs when adding Cygwin's bin directory to PATH (ocamlfind et al can be affected by Vim for Windows) [#6190 @dra27]
 
 ## Opamfile
   * Make all writes atomic [#5489 @kit-ty-kate]

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -307,7 +307,9 @@ let rezip_to_string ?insert z =
   join_var (rezip ?insert z)
 
 let cygwin_non_shadowed_programs =
-  ["bash.exe"; "make.exe"; "sort.exe"; "tar.exe"]
+  [ "bash.exe"; "make.exe"; "sort.exe"; "tar.exe";
+    "install.exe"; (* from Vim for Windows *)
+  ]
 
 let apply_op_zip ~sepfmt var op arg (rl1,l2 as zip) =
   let arg = transform_format ~sepfmt var arg in


### PR DESCRIPTION
install.exe is installed by Vim for Windows, which can result in the install command being shadowed, e.g. for ocamlfind.