### PR TITLE
GHA: Add OCaml 5.3 to the build matrix

### DIFF
--- a/.github/scripts/main/ocaml-cache.sh
+++ b/.github/scripts/main/ocaml-cache.sh
@@ -45,10 +45,12 @@ case "$HOST" in
 esac
 
 FLEXDLL_VERSION=0.43
+MINGW_W64_VERSION=12.0.0
 
 curl -sLO "https://github.com/ocaml/ocaml/archive/refs/tags/${OCAML_VERSION}.tar.gz"
 if [[ $PLATFORM = 'Windows' ]] ; then
   curl -sLO "https://github.com/ocaml/flexdll/archive/refs/tags/$FLEXDLL_VERSION.tar.gz"
+  curl -sLO "https://github.com/mingw-w64/mingw-w64/archive/refs/tags/v${MINGW_W64_VERSION}.tar.gz"
 fi
 
 tar -xzf "$OCAML_VERSION.tar.gz"
@@ -72,6 +74,11 @@ if [[ $PLATFORM = 'Windows' ]] ; then
   tar -xzf ../$FLEXDLL_VERSION.tar.gz
   rm -rf flexdll
   mv "flexdll-$FLEXDLL_VERSION" flexdll
+
+  tar -xzf "../v${MINGW_W64_VERSION}.tar.gz"
+  rm -rf winpthreads
+  mv "mingw-w64-${MINGW_W64_VERSION}/mingw-w64-libraries/winpthreads" winpthreads
+  rm -rf "mingw-w64-${MINGW_W64_VERSION}"
 fi
 
 if [[ $PLATFORM = 'macOS' ]]; then
@@ -115,7 +122,7 @@ if [[ $OPAM_TEST -ne 1 ]] ; then
   fi
 fi
 
-if ! ./configure --prefix "$PREFIX"$HOST --with-vendored-deps ${CONFIGURE_SWITCHES:-} ; then
+if ! ./configure --prefix "$PREFIX"$HOST ${CONFIGURE_SWITCHES:-} ; then
   echo
   echo -e "[\e[31mERROR\e[0m] OCaml's configure script failed"
   (set +x ; echo -en "::group::config.log contents\r") 2>/dev/null

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -14,11 +14,11 @@
 open Lib
 
 let latest_ocaml4 = "4.14.2"
-let latest_ocaml5 = "5.2.0" (* Add this number to ocamls below when the next version comes out *)
+let latest_ocaml5 = "5.3.0" (* Add this number to ocamls below when the next version comes out *)
 let ocamls = [
   (* Fully supported versions *)
   "4.08.1"; "4.09.1"; "4.10.2"; "4.11.2"; "4.12.1"; "4.13.1";
-  "5.0.0"; "5.1.1";
+  "5.0.0"; "5.1.1"; "5.2.1";
 
   (* The last elements of the list after 4.14 will be used as default versions *)
   latest_ocaml4; latest_ocaml5;
@@ -312,8 +312,9 @@ let main_build_job ~analyse_job ~cygwin_job ?section runner start_version ~oc ~w
           "x86_64-pc-windows"
         ] in
         let ocaml5 = [
+          (* "x86_64-pc-cygwin"; *) (* TODO: Restore Cygwin + OCaml 5.3 when C++ support is fixed and released *)
           "x86_64-w64-mingw32";
-          (* "x86_64-pc-windows"; 5.3 needed *)
+          "x86_64-pc-windows";
         ] in
         let matrix_elem ocamlv hosts =
           let elem ocaml host =
@@ -525,8 +526,8 @@ let main oc : unit =
     ("OPAM12CACHE", "~/.cache/opam1.2/cache");
     (* These should be identical to the values in appveyor.yml *)
     ("OPAM_REPO", "https://github.com/ocaml/opam-repository.git");
-    ("OPAM_TEST_REPO_SHA", "dff745994c64d083a6ba3ddc5a9c28ed0ad0f40a");
-    ("OPAM_REPO_SHA", "6eee105e52e098e36949a584c053a18bcb9b2f6b");
+    ("OPAM_TEST_REPO_SHA", "67e940587b8aca227f511e1943bcd31eabe6b1db");
+    ("OPAM_REPO_SHA", "67e940587b8aca227f511e1943bcd31eabe6b1db");
     ("SOLVER", "");
     (* Cygwin configuration *)
     ("CYGWIN_MIRROR", "http://mirrors.kernel.org/sourceware/cygwin/");

--- a/.github/workflows/lib.ml
+++ b/.github/workflows/lib.ml
@@ -110,7 +110,7 @@ let find_need need = Hashtbl.find jobs need
 let emit_runs_on ~oc runs_on =
   let runner_of_platform (type a) (platform : a platform) =
     match platform with
-    | Windows -> "windows-2019"
+    | Windows -> "windows-2022"
     | MacOS
     | Linux as platform -> os_name_of_platform platform ^ "-latest"
     | Specific (platform, version) -> os_name_of_platform platform ^ "-" ^ version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,8 @@ env:
   OPAMBSROOT: ~/.cache/.opam.cached
   OPAM12CACHE: ~/.cache/opam1.2/cache
   OPAM_REPO: https://github.com/ocaml/opam-repository.git
-  OPAM_TEST_REPO_SHA: dff745994c64d083a6ba3ddc5a9c28ed0ad0f40a
-  OPAM_REPO_SHA: 6eee105e52e098e36949a584c053a18bcb9b2f6b
+  OPAM_TEST_REPO_SHA: 67e940587b8aca227f511e1943bcd31eabe6b1db
+  OPAM_REPO_SHA: 67e940587b8aca227f511e1943bcd31eabe6b1db
   SOLVER:
   CYGWIN_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
   CYGWIN_ROOT: D:\cygwin
@@ -79,7 +79,7 @@ jobs:
       run: bash -exu .github/scripts/main/archives-cache.sh
 
   Cygwin:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: Analyse
     steps:
     - name: Cygwin64 Cache
@@ -106,7 +106,7 @@ jobs:
     needs: Analyse
     strategy:
       matrix:
-        ocamlv: [ 4.08.1, 4.09.1, 4.10.2, 4.11.2, 4.12.1, 4.13.1, 5.0.0, 5.1.1, 4.14.2, 5.2.0 ]
+        ocamlv: [ 4.08.1, 4.09.1, 4.10.2, 4.11.2, 4.12.1, 4.13.1, 5.0.0, 5.1.1, 5.2.1, 4.14.2, 5.3.0 ]
       fail-fast: true
     steps:
     - name: Install bubblewrap
@@ -139,7 +139,7 @@ jobs:
       run: bash -exu .github/scripts/main/test.sh
 
   Build-Windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [ Analyse, Cygwin ]
     strategy:
       matrix:
@@ -161,7 +161,10 @@ jobs:
             ocamlv: 4.14.2
           - host: x86_64-w64-mingw32
             build: x86_64-pc-cygwin
-            ocamlv: 5.2.0
+            ocamlv: 5.3.0
+          - host: x86_64-pc-windows
+            build: x86_64-pc-cygwin
+            ocamlv: 5.3.0
       fail-fast: false
     defaults:
       run:
@@ -244,7 +247,7 @@ jobs:
     needs: Analyse
     strategy:
       matrix:
-        ocamlv: [ 4.14.2, 5.2.0 ]
+        ocamlv: [ 4.14.2, 5.3.0 ]
       fail-fast: true
     steps:
     - name: Install GNU patch
@@ -282,7 +285,7 @@ jobs:
     needs: [ Analyse, Build-Linux ]
     strategy:
       matrix:
-        ocamlv: [ 4.14.2, 5.2.0 ]
+        ocamlv: [ 4.14.2, 5.3.0 ]
       fail-fast: false
     env:
       OPAM_TEST: 1
@@ -339,7 +342,7 @@ jobs:
     needs: Analyse
     strategy:
       matrix:
-        ocamlv: [ 4.14.2, 5.2.0 ]
+        ocamlv: [ 4.14.2, 5.3.0 ]
       fail-fast: false
     env:
       OPAM_TEST: 1
@@ -428,7 +431,7 @@ jobs:
     needs: [ Analyse, Build-Linux ]
     strategy:
       matrix:
-        ocamlv: [ 4.14.2, 5.2.0 ]
+        ocamlv: [ 4.14.2, 5.3.0 ]
       fail-fast: false
     env:
       OPAM_DOC: 1
@@ -485,7 +488,7 @@ jobs:
     strategy:
       matrix:
         solver: [ z3, 0install ]
-        ocamlv: [ 4.14.2, 5.2.0 ]
+        ocamlv: [ 4.14.2, 5.3.0 ]
       fail-fast: false
     env:
       SOLVER: ${{ matrix.solver }}
@@ -535,7 +538,7 @@ jobs:
     strategy:
       matrix:
         solver: [ z3, 0install ]
-        ocamlv: [ 4.14.2, 5.2.0 ]
+        ocamlv: [ 4.14.2, 5.3.0 ]
       fail-fast: false
     env:
       SOLVER: ${{ matrix.solver }}
@@ -583,7 +586,7 @@ jobs:
     needs: [ Analyse, Build-Linux ]
     strategy:
       matrix:
-        ocamlv: [ 4.14.2, 5.2.0 ]
+        ocamlv: [ 4.14.2, 5.3.0 ]
       fail-fast: false
     steps:
     - name: Install bubblewrap
@@ -618,7 +621,7 @@ jobs:
     needs: [ Analyse, Build-macOS ]
     strategy:
       matrix:
-        ocamlv: [ 4.14.2, 5.2.0 ]
+        ocamlv: [ 4.14.2, 5.3.0 ]
       fail-fast: false
     steps:
     - name: Checkout tree

--- a/master_changes.md
+++ b/master_changes.md
@@ -101,6 +101,7 @@ users)
   * Add menhir to the list of vendored packages [#6321 @kit-ty-kate]
   * Upgrade the vendored spdx\_licenses to 1.3.0 [#6370 @kit-ty-kate - fix #6369]
   * Bump the vendored dune to 3.16.1 [#6192 @kit-ty-kate]
+  * Fix compilation on macOS with OCaml 5.3 by bumping the vendored mccs to 1.1+19 [#6192 @kit-ty-kate]
 
 ## Infrastructure
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -100,6 +100,7 @@ users)
   * Upgrade to opam-file-format 2.2.0~alpha1 [#6321 @kit-ty-kate]
   * Add menhir to the list of vendored packages [#6321 @kit-ty-kate]
   * Upgrade the vendored spdx\_licenses to 1.3.0 [#6370 @kit-ty-kate - fix #6369]
+  * Bump the vendored dune to 3.16.1 [#6192 @kit-ty-kate]
 
 ## Infrastructure
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -174,6 +174,8 @@ users)
   * Check `shell/install.sh` using `shellcheck` [#6313 @kit-ty-kate]
   * Fix the alpine depexts test [#6363 @kit-ty-kate]
   * Speedup the gentoo depexts test [#6363 @kit-ty-kate]
+  * Add OCaml 5.3 to the build matrix [#6192 @kit-ty-kate]
+  * Add OCaml 5.3/MSVC to the build matrix [#6192 @kit-ty-kate]
 
 ## Doc
   * Update the command to install opam to point to the new simplified url on opam.ocaml.org [#6226 @kit-ty-kate]

--- a/src_ext/Makefile.dune
+++ b/src_ext/Makefile.dune
@@ -1,3 +1,3 @@
 # NB If minimum OCaml version for Dune changes, update DUNE_SECONDARY in configure.ac
-URL_dune-local = https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz
-MD5_dune-local = 4605a1d9783a96a16cbec381cfbb3ac1
+URL_dune-local = https://github.com/ocaml/dune/releases/download/3.16.1/dune-3.16.1.tbz
+MD5_dune-local = c19a1bb71eb3510ca15ddcf9f875947a

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -22,8 +22,8 @@ MD5_cudf = ed8fea314d0c6dc0d8811ccf860c53dd
 URL_dose3 = https://gitlab.com/irill/dose3/-/archive/7.0.0/dose3-7.0.0.tar.gz
 MD5_dose3 = bc99cbcea8fca29dca3ebbee54be45e1
 
-URL_mccs = https://github.com/ocaml-opam/ocaml-mccs/releases/download/1.1+18/mccs-1.1+18.tar.gz
-MD5_mccs = 3fd6f609a02f3357f57570750fcacde0
+URL_mccs = https://github.com/ocaml-opam/ocaml-mccs/releases/download/1.1+19/mccs-1.1+19.tar.gz
+MD5_mccs = f852da188bf7de20e64be2fce0e48e0a
 
 URL_opam-0install-cudf = https://github.com/ocaml-opam/opam-0install-cudf/releases/download/v0.5.0/opam-0install-cudf-0.5.0.tar.gz
 MD5_opam-0install-cudf = 75419722aa839f518a25cae1b3c6efd4


### PR DESCRIPTION
Split off from https://github.com/ocaml/opam/pull/6189 as OCaml 5.3 is not released yet and contains several issues such as incompatibility with C++ (https://github.com/ocaml/ocaml/issues/13422) and Cygwin (https://github.com/ocaml/ocaml/issues/13421)