### PR TITLE
Add 2 admin commands to compare 2 package versions

### DIFF
--- a/doc/man/opam-admin-topics.inc
+++ b/doc/man/opam-admin-topics.inc
@@ -61,6 +61,26 @@
   (package opam))
 
 (rule
+  (with-stdout-to opam-admin-compare-versions.0 (echo "")))
+(rule
+  (targets opam-admin-compare-versions.1 opam-admin-compare-versions.err)
+  (deps using-built-opam)
+  (action (progn (with-stderr-to opam-admin-compare-versions.err
+                   (with-stdout-to opam-admin-compare-versions.1 (run %{bin:opam} admin compare-versions --help=groff)))
+                 (diff opam-admin-compare-versions.err %{dep:opam-admin-compare-versions.0})))
+  (package opam))
+
+(rule
+  (with-stdout-to opam-admin-assert-compare-versions.0 (echo "")))
+(rule
+  (targets opam-admin-assert-compare-versions.1 opam-admin-assert-compare-versions.err)
+  (deps using-built-opam)
+  (action (progn (with-stderr-to opam-admin-assert-compare-versions.err
+                   (with-stdout-to opam-admin-assert-compare-versions.1 (run %{bin:opam} admin assert-compare-versions --help=groff)))
+                 (diff opam-admin-assert-compare-versions.err %{dep:opam-admin-assert-compare-versions.0})))
+  (package opam))
+
+(rule
   (with-stdout-to opam-admin-check.0 (echo "")))
 (rule
   (targets opam-admin-check.1 opam-admin-check.err)
@@ -130,6 +150,8 @@
     opam-admin-add-constraint.1 
     opam-admin-filter.1 
     opam-admin-list.1 
+    opam-admin-compare-versions.1 
+    opam-admin-assert-compare-versions.1 
     opam-admin-check.1 
     opam-admin-lint.1 
     opam-admin-upgrade.1 

--- a/master_changes.md
+++ b/master_changes.md
@@ -15,6 +15,7 @@ users)
   * Bump opam-root-version to 2.2 [#5980 @kit-ty-kate]
 
 ## Global CLI
+  * ◈ Add `opam admin {compare-versions,assert-compare-versions}` to compare package versions for sanity checks [#6196 @mbarbin]
   * Add cli version 2.3 [#6045 #6151 @rjbou]
 
 ## Plugins

--- a/tests/reftests/compare-versions.test
+++ b/tests/reftests/compare-versions.test
@@ -1,0 +1,21 @@
+N0REP0
+### opam admin compare-versions 0.0.9 0.0.10
+0.0.9 < 0.0.10
+### opam admin compare-versions 1.2.3 1.2.3~preview
+1.2.3 > 1.2.3~preview
+### opam admin compare-versions 1.2.3 1.2.3-option
+1.2.3 < 1.2.3-option
+### opam admin compare-versions 0.1.0 0.01.0
+0.1.0 = 0.01.0
+### opam admin compare-versions 0.2.2 0.2.0
+0.2.2 > 0.2.0
+### opam admin assert-compare-versions 0.0.9 lt 0.0.10
+### opam admin assert-compare-versions 1.2.3 lt 1.2.3~preview
+# Return code 1 #
+### opam admin assert-compare-versions 0.1.0 eq 0.01.0
+### opam admin assert-compare-versions 0.0.9 eq 0.0.10
+# Return code 1 #
+### opam admin assert-compare-versions 0.1.0 le 0.1.0
+### opam admin assert-compare-versions 0.0.9 le 0.0.10
+### opam admin assert-compare-versions 0.2.2 le 0.2.1
+# Return code 1 #

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -189,6 +189,24 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:cli-versioning.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-compare-versions)
+ (action
+  (diff compare-versions.test compare-versions.out)))
+
+(alias
+ (name reftest)
+ (deps (alias reftest-compare-versions)))
+
+(rule
+ (targets compare-versions.out)
+ (deps root-N0REP0)
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:compare-versions.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-config)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action


### PR DESCRIPTION
Add 2 new commands `opam admin {assert-}compare-versions` to compare package versions for sanity checks.

1. `compare-versions` - User interactive.

In this command, we provide two versions, and opam outputs a user-friendly expression with the result of the comparison, spelled out. For example:

```sh
$ opam admin compare-versions 0.0.9 0.0.10
 0.0.9 < 0.0.10
```

The command exits 0 regardless of the result of the comparison.

2. `assert-compare-versions` - For use in scripts, if needed.

This command is silent, and requires an operator {lt,le,eq}. The result of the command will be encoded in the exit code, to be used in bash conditionals:

exit 0: the comparison holds
exit 1: it doesn't

For example:

```sh
$ opam admin assert-compare-versions 0.0.9 lt 0.0.10
[0]

$ opam admin assert-compare-versions 0.2.2 le 0.2.0
[1]
```

This PR is an alternative to #6124 trying to account for the various feedback received.
