### PR TITLE
Add an admin command to compare 2 package versions (named operators)

### DIFF
--- a/doc/man/opam-admin-topics.inc
+++ b/doc/man/opam-admin-topics.inc
@@ -61,6 +61,16 @@
   (package opam))
 
 (rule
+  (with-stdout-to opam-admin-compare-versions.0 (echo "")))
+(rule
+  (targets opam-admin-compare-versions.1 opam-admin-compare-versions.err)
+  (deps using-built-opam)
+  (action (progn (with-stderr-to opam-admin-compare-versions.err
+                   (with-stdout-to opam-admin-compare-versions.1 (run %{bin:opam} admin compare-versions --help=groff)))
+                 (diff opam-admin-compare-versions.err %{dep:opam-admin-compare-versions.0})))
+  (package opam))
+
+(rule
   (with-stdout-to opam-admin-check.0 (echo "")))
 (rule
   (targets opam-admin-check.1 opam-admin-check.err)
@@ -130,6 +140,7 @@
     opam-admin-add-constraint.1 
     opam-admin-filter.1 
     opam-admin-list.1 
+    opam-admin-compare-versions.1 
     opam-admin-check.1 
     opam-admin-lint.1 
     opam-admin-upgrade.1 

--- a/master_changes.md
+++ b/master_changes.md
@@ -145,6 +145,8 @@ users)
 ## opam-solver
 
 ## opam-format
+  * `OpamFormula.string_of_relop`: export function [#6197 @mbarbin]
+  * `OpamFormula.all_relop`: a list of all operators [#6197 @mbarbin]
 
 ## opam-core
   * `OpamStd.Sys.{get_terminal_columns,uname,getconf,guess_shell_compat}`: Harden the process calls to account for failures [#6230 @kit-ty-kate - fix #6215]

--- a/master_changes.md
+++ b/master_changes.md
@@ -92,6 +92,7 @@ users)
   * Add opam 2.3.0\~beta2 to the install scripts [#6262 @kit-ty-kate]
 
 ## Admin
+  * ◈ Add `opam admin compare-versions` to compare package versions for sanity checks [#6197 @mbarbin]
 
 ## Opam installer
 

--- a/src/format/opamFormula.ml
+++ b/src/format/opamFormula.ml
@@ -11,6 +11,8 @@
 
 type relop = [`Eq|`Neq|`Geq|`Gt|`Leq|`Lt]
 
+let all_relop = [ `Eq ; `Neq ; `Geq ; `Gt ; `Leq ; `Lt ]
+
 let neg_relop = function
   | `Eq -> `Neq
   | `Neq -> `Eq

--- a/src/format/opamFormula.mli
+++ b/src/format/opamFormula.mli
@@ -17,6 +17,13 @@ type relop = OpamParserTypes.FullPos.relop_kind (* = [ `Eq | `Neq | `Geq | `Gt |
 
 val compare_relop : relop -> relop -> int
 
+(** A list containing each available operator once. *)
+val all_relop : relop list
+
+(** Returns a string representing the operator in infix syntax, as
+    used in opam files (">", "=", etc.) *)
+val string_of_relop : relop -> string
+
 (** Version constraints for OPAM *)
 type version_constraint = relop * OpamPackage.Version.t
 

--- a/tests/reftests/admin.test
+++ b/tests/reftests/admin.test
@@ -654,9 +654,31 @@ opam-version: "2.0"
 ### ::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ### :: Cache is tested in admin-cache.test ::
 ### ::::::::::::::::::::::::::::::::::::::::::::::::::::::
-### :
+### :::::::::::::::::::::
+### :VII: compare-versions :
+### :::::::::::::::::::::
+### opam admin compare-versions 0.0.9 0.0.10
+0.0.9 < 0.0.10
+### opam admin compare-versions 1.2.3 1.2.3~preview
+1.2.3 > 1.2.3~preview
+### opam admin compare-versions 1.2.3 1.2.3-option
+1.2.3 < 1.2.3-option
+### opam admin compare-versions 0.1.0 0.01.0
+0.1.0 = 0.01.0
+### opam admin compare-versions 0.2.2 0.2.0
+0.2.2 > 0.2.0
+### opam admin compare-versions 0.0.9 --lt 0.0.10
+### opam admin compare-versions 1.2.3 --lt 1.2.3~preview
+# Return code 1 #
+### opam admin compare-versions 0.1.0 --eq 0.01.0
+### opam admin compare-versions 0.0.9 --eq 0.0.10
+# Return code 1 #
+### opam admin compare-versions 0.1.0 --le 0.1.0
+### opam admin compare-versions 0.0.9 --le 0.0.10
+### opam admin compare-versions 0.2.2 --le 0.2.1
+# Return code 1 #
 ### ::::::::::::::::::::::
-### :VII: Specific cases :
+### :C: Specific cases :
 ### ::::::::::::::::::::::
 ### : Package version comparison error (#5334)
 ### <packages/fail-5334/fail-5334.1/opam>


### PR DESCRIPTION
Add a new CLI `opam admin compare-versions` to compare package versions for sanity checks.

This command has 2 modes:

1. By default - user interactive.

In this mode, we provide two versions, and opam outputs a user-friendly expression with the result of the comparison, spelled out. For example:

```sh
$ opam admin compare-versions 0.0.9 0.0.10
 0.0.9 < 0.0.10
```

The command exits 0 regardless of the result of the comparison.

2. For use in scripts - if needed. Provide an optional operator { --eq, --geq, --gt, --leq, --lt, --neq }

In this mode, the output is suppressed (the command is silent). The result of the command will be encoded in the exit code, to be used in bash conditionals:

exit 0: the comparison holds
exit 1: it doesn't

For example:

```sh
$ opam admin compare-versions 0.0.9 --lt 0.0.10
[0]

$ opam admin compare-versions 0.0.9 --eq 0.0.10
[1]
```

This PR is an alternative to https://github.com/ocaml/opam/pull/6124 with a slightly different design to avoid quoted arguments.

* [ ] queued on #6268 