### PR TITLE
Return parse errors for 2.2/2.3 formats

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -93,6 +93,7 @@ users)
 
 ## Opamfile
   * Make all writes atomic [#5489 @kit-ty-kate]
+  * Propagate future opamfile parse errors correctly [#6199 @dra27]
 
 ## External dependencies
  * Always pass --no-version-check and --no-write-registry to Cygwin setup [#6046 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -206,6 +206,7 @@ users)
   * lint: add more test cases for E59: special cases (conf, git url), with and without option `--with-check-upstream` [#5561 @rjbou]
   * lint: add more test cases for W59: special cases (conf, git url), with and without `--with-check-upstream` [#5561 @rjbou]
   * Add a test showing an unhelpful conflict message [#5210 @kit-ty-kate]
+  * Add test in pin and lint for future opam version parse error [#6199 @dra27]
 
 ### Engine
   * Add a test filtering mechanism [#6105 @Keryan-dev]

--- a/master_changes.md
+++ b/master_changes.md
@@ -94,6 +94,7 @@ users)
 ## Opamfile
   * Make all writes atomic [#5489 @kit-ty-kate]
   * Propagate future opamfile parse errors correctly [#6199 @dra27]
+  * Ensure future syntax errors are only reported when the syntax version is greater than the client, not the format library [#6199 @dra27 - fix #6188]
 
 ## External dependencies
  * Always pass --no-version-check and --no-write-registry to Cygwin setup [#6046 @dra27]

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1171,7 +1171,8 @@ module SyntaxFile(X: SyntaxFileArg) : IO_FILE with type t := X.t = struct
     let catch_future_syntax_error = function
     | {file_contents = [{pelem = Variable({pelem = "opam-version"; _}, {pelem = String ver; _}); _ };
                         {pelem = Section {section_kind = {pelem = "#"; _}; _}; pos}]; _}
-      when OpamVersion.(compare (nopatch (of_string ver)) (nopatch X.format_version)) <= 0 ->
+      when OpamVersion.(compare (nopatch (of_string ver))
+                          (nopatch OpamVersion.current)) <= 0 ->
         raise (OpamPp.Bad_version (Some pos, "Parse error"))
     | opamfile -> opamfile
 

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -874,9 +874,17 @@ module Syntax = struct
     let filename = OpamFilename.to_string filename in
     lexbuf.Lexing.lex_curr_p <- { lexbuf.Lexing.lex_curr_p with
                                   Lexing.pos_fname = filename };
-    try OpamParser.main OpamLexer.token lexbuf filename with
-    | OpamLexer.Error msg -> error msg
-    | Parsing.Parse_error -> error "Parse error"
+    match OpamParser.main OpamLexer.token lexbuf filename with
+    | {file_contents =
+         [{pelem = Variable({pelem = "opam-version"; _},
+                            {pelem = String ver; _}); _ };
+          {pelem = Section {section_kind = {pelem = "#"; _}; _}; _}]; _}
+      when OpamVersion.(compare (nopatch (of_string ver))
+                          (nopatch OpamVersion.current)) <= 0 ->
+      error "Parse error"
+    | opamfile -> opamfile
+    | exception OpamLexer.Error msg -> error msg
+    | exception Parsing.Parse_error -> error "Parse error"
 
 
   let pp_channel filename ic oc =

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -1267,11 +1267,11 @@ ${BASEDIR}/future/pin-at-two-one.opam: Errors.
 # Return code 1 #
 ### opam lint future/pin-at-two-two.opam
 ${BASEDIR}/future/pin-at-two-two.opam: Errors.
-             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+             error  2: File format error at line 11, column 0: Parse error
 # Return code 1 #
 ### opam lint future/pin-at-two-three.opam
 ${BASEDIR}/future/pin-at-two-three.opam: Errors.
-             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+             error  2: File format error at line 11, column 0: Parse error
 # Return code 1 #
 ### opam lint future/pin-at-future.opam
 ${BASEDIR}/future/pin-at-future.opam: Errors.

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -1226,3 +1226,54 @@ ${BASEDIR}/lint.opam: Errors.
              error 53: Mismatching 'extra-files:' field: "./relative/path", "/absolute/../relative/path", "/absolute/path", "extra-files..patch.patch"
              error 73: Field 'extra-files' contains path with '..': "/absolute/../relative/path"
 # Return code 1 #
+### :::::::::::::::::::::
+### : Test parse errors :
+### :::::::::::::::::::::
+### :1: future opam versions
+### <pin:future/pin-at-two-one.opam>
+opam-version: "2.1"
+### <pin:future/pin-at-two-two.opam>
+opam-version: "2.2"
+### <pin:future/pin-at-two-three.opam>
+opam-version: "2.3"
+### <pin:future/pin-at-future.opam>
+opam-version: "50.0"
+### opam lint future/pin-at-two-one.opam
+${BASEDIR}/future/pin-at-two-one.opam: Errors.
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+# Return code 1 #
+### opam lint future/pin-at-two-two.opam
+${BASEDIR}/future/pin-at-two-two.opam: Errors.
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+# Return code 1 #
+### opam lint future/pin-at-two-three.opam
+${BASEDIR}/future/pin-at-two-three.opam: Errors.
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+# Return code 1 #
+### opam lint future/pin-at-future.opam
+${BASEDIR}/future/pin-at-future.opam: Errors.
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+# Return code 1 #
+### :2: future opam versions with parse error
+### <junk.sh>
+echo GARBAGE>>"$1"
+### sh junk.sh future/pin-at-two-one.opam
+### sh junk.sh future/pin-at-two-two.opam
+### sh junk.sh future/pin-at-two-three.opam
+### sh junk.sh future/pin-at-future.opam
+### opam lint future/pin-at-two-one.opam
+${BASEDIR}/future/pin-at-two-one.opam: Errors.
+             error  2: File format error at line 11, column 0: Parse error
+# Return code 1 #
+### opam lint future/pin-at-two-two.opam
+${BASEDIR}/future/pin-at-two-two.opam: Errors.
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+# Return code 1 #
+### opam lint future/pin-at-two-three.opam
+${BASEDIR}/future/pin-at-two-three.opam: Errors.
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+# Return code 1 #
+### opam lint future/pin-at-future.opam
+${BASEDIR}/future/pin-at-future.opam: Errors.
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+# Return code 1 #

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -353,7 +353,7 @@ echo GARBAGE>>"$1"
         Parse error [skipped]
 
 [ERROR] Invalid opam file in pin-at-two-two source from file://${BASEDIR}/pin-at-two-two:
-             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+             error  2: File format error at line 11, column 0: Parse error
 [ERROR] No package named pin-at-two-two found.
 # Return code 5 #
 ### sh junk.sh pin-at-two-three/pin-at-two-three.opam
@@ -367,7 +367,7 @@ echo GARBAGE>>"$1"
         Parse error [skipped]
 
 [ERROR] Invalid opam file in pin-at-two-three source from file://${BASEDIR}/pin-at-two-three:
-             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+             error  2: File format error at line 11, column 0: Parse error
 [ERROR] No package named pin-at-two-three found.
 # Return code 5 #
 ### sh junk.sh pin-at-future/pin-at-future.opam

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -344,13 +344,13 @@ echo GARBAGE>>"$1"
 # Return code 5 #
 ### sh junk.sh pin-at-two-two/pin-at-two-two.opam
 ### opam install ./pin-at-two-two
-[ERROR] In ${BASEDIR}/pin-at-two-two/pin-at-two-two.opam:
-        unsupported or missing file format version; should be 2.0 or older
+[ERROR] At ${BASEDIR}/pin-at-two-two/pin-at-two-two.opam:11:0-11:0::
+        Parse error
 [ERROR] Strict mode: aborting
 # Return code 30 #
 ### OPAMSTRICT=0 opam install ./pin-at-two-two
-[ERROR] In ${BASEDIR}/pin-at-two-two/pin-at-two-two.opam:
-        unsupported or missing file format version; should be 2.0 or older [skipped]
+[ERROR] At ${BASEDIR}/pin-at-two-two/pin-at-two-two.opam:11:0-11:0::
+        Parse error [skipped]
 
 [ERROR] Invalid opam file in pin-at-two-two source from file://${BASEDIR}/pin-at-two-two:
              error  2: File format error: unsupported or missing file format version; should be 2.0 or older
@@ -358,13 +358,13 @@ echo GARBAGE>>"$1"
 # Return code 5 #
 ### sh junk.sh pin-at-two-three/pin-at-two-three.opam
 ### opam install ./pin-at-two-three
-[ERROR] In ${BASEDIR}/pin-at-two-three/pin-at-two-three.opam:
-        unsupported or missing file format version; should be 2.0 or older
+[ERROR] At ${BASEDIR}/pin-at-two-three/pin-at-two-three.opam:11:0-11:0::
+        Parse error
 [ERROR] Strict mode: aborting
 # Return code 30 #
 ### OPAMSTRICT=0 opam install ./pin-at-two-three
-[ERROR] In ${BASEDIR}/pin-at-two-three/pin-at-two-three.opam:
-        unsupported or missing file format version; should be 2.0 or older [skipped]
+[ERROR] At ${BASEDIR}/pin-at-two-three/pin-at-two-three.opam:11:0-11:0::
+        Parse error [skipped]
 
 [ERROR] Invalid opam file in pin-at-two-three source from file://${BASEDIR}/pin-at-two-three:
              error  2: File format error: unsupported or missing file format version; should be 2.0 or older

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -263,3 +263,124 @@ Could not retrieve some package sources, they will not be pinned nor installed:
 
 Continue anyway? [y/n] y
 ### opam pin
+### : Parse error with future opam version field on pin
+### :: just the opam version that is a future
+### <pin:pin-at-two-one/pin-at-two-one.opam>
+opam-version: "2.1"
+### opam install ./pin-at-two-one
+[ERROR] In ${BASEDIR}/pin-at-two-one/pin-at-two-one.opam:
+        unsupported or missing file format version; should be 2.0 or older
+[ERROR] Strict mode: aborting
+# Return code 30 #
+### OPAMSTRICT=0 opam install ./pin-at-two-one
+[ERROR] In ${BASEDIR}/pin-at-two-one/pin-at-two-one.opam:
+        unsupported or missing file format version; should be 2.0 or older [skipped]
+
+[ERROR] Invalid opam file in pin-at-two-one source from file://${BASEDIR}/pin-at-two-one:
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+[ERROR] No package named pin-at-two-one found.
+# Return code 5 #
+### <pin:pin-at-two-two/pin-at-two-two.opam>
+opam-version: "2.2"
+### opam install ./pin-at-two-two
+[ERROR] In ${BASEDIR}/pin-at-two-two/pin-at-two-two.opam:
+        unsupported or missing file format version; should be 2.0 or older
+[ERROR] Strict mode: aborting
+# Return code 30 #
+### OPAMSTRICT=0 opam install ./pin-at-two-two
+[ERROR] In ${BASEDIR}/pin-at-two-two/pin-at-two-two.opam:
+        unsupported or missing file format version; should be 2.0 or older [skipped]
+
+[ERROR] Invalid opam file in pin-at-two-two source from file://${BASEDIR}/pin-at-two-two:
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+[ERROR] No package named pin-at-two-two found.
+# Return code 5 #
+### <pin:pin-at-two-three/pin-at-two-three.opam>
+opam-version: "2.3"
+### opam install ./pin-at-two-three
+[ERROR] In ${BASEDIR}/pin-at-two-three/pin-at-two-three.opam:
+        unsupported or missing file format version; should be 2.0 or older
+[ERROR] Strict mode: aborting
+# Return code 30 #
+### OPAMSTRICT=0 opam install ./pin-at-two-three
+[ERROR] In ${BASEDIR}/pin-at-two-three/pin-at-two-three.opam:
+        unsupported or missing file format version; should be 2.0 or older [skipped]
+
+[ERROR] Invalid opam file in pin-at-two-three source from file://${BASEDIR}/pin-at-two-three:
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+[ERROR] No package named pin-at-two-three found.
+# Return code 5 #
+### <pin:pin-at-future/pin-at-future.opam>
+opam-version: "50.0"
+### opam install ./pin-at-future
+[ERROR] In ${BASEDIR}/pin-at-future/pin-at-future.opam:
+        unsupported or missing file format version; should be 2.0 or older
+[ERROR] Strict mode: aborting
+# Return code 30 #
+### OPAMSTRICT=0 opam install ./pin-at-future
+[ERROR] In ${BASEDIR}/pin-at-future/pin-at-future.opam:
+        unsupported or missing file format version; should be 2.0 or older [skipped]
+
+[ERROR] Invalid opam file in pin-at-future source from file://${BASEDIR}/pin-at-future:
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+[ERROR] No package named pin-at-future found.
+# Return code 5 #
+### :: opam version is a future and there is a parse error
+### <junk.sh>
+echo GARBAGE>>"$1"
+### sh junk.sh pin-at-two-one/pin-at-two-one.opam
+### opam install ./pin-at-two-one
+[ERROR] At ${BASEDIR}/pin-at-two-one/pin-at-two-one.opam:11:0-11:0::
+        Parse error
+[ERROR] Strict mode: aborting
+# Return code 30 #
+### OPAMSTRICT=0 opam install ./pin-at-two-one
+[ERROR] At ${BASEDIR}/pin-at-two-one/pin-at-two-one.opam:11:0-11:0::
+        Parse error [skipped]
+
+[ERROR] Invalid opam file in pin-at-two-one source from file://${BASEDIR}/pin-at-two-one:
+             error  2: File format error at line 11, column 0: Parse error
+[ERROR] No package named pin-at-two-one found.
+# Return code 5 #
+### sh junk.sh pin-at-two-two/pin-at-two-two.opam
+### opam install ./pin-at-two-two
+[ERROR] In ${BASEDIR}/pin-at-two-two/pin-at-two-two.opam:
+        unsupported or missing file format version; should be 2.0 or older
+[ERROR] Strict mode: aborting
+# Return code 30 #
+### OPAMSTRICT=0 opam install ./pin-at-two-two
+[ERROR] In ${BASEDIR}/pin-at-two-two/pin-at-two-two.opam:
+        unsupported or missing file format version; should be 2.0 or older [skipped]
+
+[ERROR] Invalid opam file in pin-at-two-two source from file://${BASEDIR}/pin-at-two-two:
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+[ERROR] No package named pin-at-two-two found.
+# Return code 5 #
+### sh junk.sh pin-at-two-three/pin-at-two-three.opam
+### opam install ./pin-at-two-three
+[ERROR] In ${BASEDIR}/pin-at-two-three/pin-at-two-three.opam:
+        unsupported or missing file format version; should be 2.0 or older
+[ERROR] Strict mode: aborting
+# Return code 30 #
+### OPAMSTRICT=0 opam install ./pin-at-two-three
+[ERROR] In ${BASEDIR}/pin-at-two-three/pin-at-two-three.opam:
+        unsupported or missing file format version; should be 2.0 or older [skipped]
+
+[ERROR] Invalid opam file in pin-at-two-three source from file://${BASEDIR}/pin-at-two-three:
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+[ERROR] No package named pin-at-two-three found.
+# Return code 5 #
+### sh junk.sh pin-at-future/pin-at-future.opam
+### opam install ./pin-at-future
+[ERROR] In ${BASEDIR}/pin-at-future/pin-at-future.opam:
+        unsupported or missing file format version; should be 2.0 or older
+[ERROR] Strict mode: aborting
+# Return code 30 #
+### OPAMSTRICT=0 opam install ./pin-at-future
+[ERROR] In ${BASEDIR}/pin-at-future/pin-at-future.opam:
+        unsupported or missing file format version; should be 2.0 or older [skipped]
+
+[ERROR] Invalid opam file in pin-at-future source from file://${BASEDIR}/pin-at-future:
+             error  2: File format error: unsupported or missing file format version; should be 2.0 or older
+[ERROR] No package named pin-at-future found.
+# Return code 5 #


### PR DESCRIPTION
Fixes #6188 and addresses the note in https://github.com/ocaml/opam/pull/5665#discussion_r1742278703