### PR TITLE
Remove the getgroups workaround allowing users belonging to more than 32 groups

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -125,6 +125,7 @@ users)
   * Exclude the .git directory from the release archive when using GNU tar [#6066 @kit-ty-kate]
   * Ensure non-existing %.cache target fail with a fatal error [#6066 @kit-ty-kate]
   * Remove opam 2.1 support from the release script [#6084 #6175 @kit-ty-kate]
+  * Remove the getgroups workaround allowing users belonging to more than 32 groups [#6200 @dra27 @kit-ty-kate]
 
 ## Install script
   * Provide a shell/install.ps1 PowerShell script to install opam on Windows [#5906 @kit-ty-kate @dra27]

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -14,7 +14,6 @@ RUN tar xzf %OCAMLV%.tar.gz
 WORKDIR ocaml-%OCAMLV%
 RUN sed -i 's/gnueabi/*eabi/' configure
 RUN sed -i 's/musl/musl*/' configure
-RUN sed -i -e 's/NGROUPS_MAX/65536/' otherlibs/unix/getgroups.c
 RUN ./configure %CONF% -prefix /usr/local
 RUN make "-j$(nproc)" && make install && rm -rf /root/ocaml-%OCAMLV% /root/ocaml-%OCAMLV%.tar.gz
 


### PR DESCRIPTION
~Follow-on from #5381 - it can't actually be removed until the release scripts stop being used for 2.2 and older.~

Following the merge of https://github.com/ocaml/opam/pull/5381 this workaround is no longer needed