### PR TITLE
Fix opam install on a local directory not updating pinned packages' metadata

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -29,6 +29,7 @@ users)
 ## Install
   * Do not keep the build directory of the pinned packages [#6436 @kit-ty-kate]
   * [BUG] Fix `opam install <local_dir>` not updating and storing pinned packages' metadata [#6209 @kit-ty-kate - fix #5567]
+  * [BUG] Fix `opam install --deps-only/--show-action <local_dir>` not updating (without storing) pinned packages' metadata [#6209 @kit-ty-kate - fix #5567]
 
 ## Build (package)
   * Patches are now applied using the `patch` OCaml library instead of GNU Patch [#5892 @kit-ty-kate - fix #6019 #6052]
@@ -251,6 +252,7 @@ users)
   * `OpamArg.InvalidCLI`: export exception [#6150 @rjbou]
   * `OpamArg`: export `require_checksums` and `no_checksums`, that are shared with `build_options` [#5563 @rjbou]
   * `OpamArg.hash_kinds`: was added [#5960 @kit-ty-kate]
+  * `OpamAuxCommands.{simulate_autopin,autopin ~simulate:true}`: now updates the `reinstall` field of the returned `switch_state` if necessary [#6209 @kit-ty-kate]
   * `OpamRepositoryCommand.switch_repos`: expose the function [#5014 @kit-ty-kate]
   * `OpamLockCommand.lock_opam`: add `~keep_local` argument to add local pins to pin-depends (and not resolve them) [#6411 @rjbou]
   * `OpamLockCommand.lock_opam`: make the `?only_direct` argument non-optional [#6411 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -28,6 +28,7 @@ users)
 
 ## Install
   * Do not keep the build directory of the pinned packages [#6436 @kit-ty-kate]
+  * [BUG] Fix `opam install <local_dir>` not updating and storing pinned packages' metadata [#6209 @kit-ty-kate - fix #5567]
 
 ## Build (package)
   * Patches are now applied using the `patch` OCaml library instead of GNU Patch [#5892 @kit-ty-kate - fix #6019 #6052]

--- a/master_changes.md
+++ b/master_changes.md
@@ -203,6 +203,7 @@ users)
   * Add admin filter subcommand test [#6166 @rjbou]
   * Add a test showing the behaviour of opam install when a local opam file changes while being pinned [#6209 @kit-ty-kate]
   * Add pin test to show stored overlay opam files [#6209 @rjbou]
+  * Add show test to highlight precedence of opam file selection and check that if an opam file is given it is always this one that is taken [#6209 @rjbou]
 
 ### Engine
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -202,6 +202,7 @@ users)
   * Add tests for `--keep-build-dir` and `OPAMKEEPBUILDDIR` [#6436 @rjbou @kit-ty-kate]
   * Add admin filter subcommand test [#6166 @rjbou]
   * Add a test showing the behaviour of opam install when a local opam file changes while being pinned [#6209 @kit-ty-kate]
+  * Add pin test to show stored overlay opam files [#6209 @rjbou]
 
 ### Engine
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -201,6 +201,7 @@ users)
   * Add a test for packages with subpath in a repository [#6439 @rjbou]
   * Add tests for `--keep-build-dir` and `OPAMKEEPBUILDDIR` [#6436 @rjbou @kit-ty-kate]
   * Add admin filter subcommand test [#6166 @rjbou]
+  * Add a test showing the behaviour of opam install when a local opam file changes while being pinned [#6209 @kit-ty-kate]
 
 ### Engine
 

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -2215,9 +2215,6 @@ let install_t t ?ask ?(ignore_conflicts=false) ?(depext_only=false)
   in
   let pkg_reinstall =
     if assume_built then OpamPackage.Set.of_list pkg_skip
-    else if deps_only then OpamPackage.Set.empty
-    (* NOTE: As we only install dependency packages, there are no intersections
-       between t.reinstall and pkg_skip *)
     else Lazy.force t.reinstall %% OpamPackage.Set.of_list pkg_skip
   in
   (* Add the packages to the list of package roots and display a

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3370,6 +3370,8 @@ module OPAMSyntax = struct
         OpamStd.Option.Op.(t.url >>= URL.subpath) = None)
       ~errmsg:"The url.subpath field is not allowed in files with \
                `opam-version` <= 2.0" -|
+    (* Fields added here are also added in [OpamAuxCommands.autopin_aux] to
+       check pin status. Keep synchronised. *)
     handle_subpath_2_0 -|
     handle_locked -|
     handle_env_paths

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1131,6 +1131,19 @@ depends: "dependency" {= "2"}
 ### opam install --deps-only ./pin-change
 [NOTE] Ignoring uncommitted changes in ${BASEDIR}/pin-change (`--working-dir' not specified or specified with no argument).
 [pin-change.dev] synchronised (no changes)
+The following actions will be performed:
+=== recompile 1 package
+  - recompile pin-change dev (pinned) [uses dependency]
+=== upgrade 1 package
+  - upgrade   dependency 1 to 2       [required by pin-change]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   dependency.1
+-> installed dependency.2
+-> retrieved pin-change.dev  (no changes)
+-> removed   pin-change.dev
+-> installed pin-change.dev
+Done.
 ### opam remove pin-change
 The following actions will be performed:
 === remove 1 package
@@ -1147,10 +1160,10 @@ depends: "dependency" {= "3"}
 [pin-change.dev] synchronised (no changes)
 The following actions will be performed:
 === upgrade 1 package
-  - upgrade dependency 1 to 3 [required by pin-change]
+  - upgrade dependency 2 to 3 [required by pin-change]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> removed   dependency.1
+-> removed   dependency.2
 -> installed dependency.3
 Done.
 ### opam pin | '\(at [a-f0-9]+\)' -> '(at HASH)'

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -819,10 +819,8 @@ Done.
 dev1
 ### sh add-pin.sh nip-of.dev2 git
 ### opam install ./nip-of
-[nip-of.dev1] synchronised (git+file://${BASEDIR}/nip-of#master)
-[nip-of] Conflicting update of the metadata from git+file://${BASEDIR}/nip-of#master.
-Override files in ${BASEDIR}/OPAM/opamfiles/.opam-switch/overlay/nip-of (there will be a backup)? [Y/n] y
-User metadata backed up in ${BASEDIR}/OPAM/backup/nip-of.bak
+nip-of is now pinned to git+file://${BASEDIR}/nip-of#master (version dev2)
+[nip-of.dev2] synchronised (git+file://${BASEDIR}/nip-of#master)
 The following actions will be performed:
 === upgrade 1 package
   - upgrade nip-of dev1 to dev2 (pinned)
@@ -870,10 +868,8 @@ Done.
 dev1
 ### sh add-pin.sh nip-fo.dev2 git
 ### opam install ./nip-fo
-[nip-fo.dev1] synchronised (git+file://${BASEDIR}/nip-fo#master)
-[nip-fo] Conflicting update of the metadata from git+file://${BASEDIR}/nip-fo#master.
-Override files in ${BASEDIR}/OPAM/opamfiles/.opam-switch/overlay/nip-fo (there will be a backup)? [Y/n] y
-User metadata backed up in ${BASEDIR}/OPAM/backup/nip-fo.bak
+nip-fo is now pinned to git+file://${BASEDIR}/nip-fo#master (version dev2)
+[nip-fo.dev2] synchronised (git+file://${BASEDIR}/nip-fo#master)
 The following actions will be performed:
 === upgrade 1 package
   - upgrade nip-fo dev1 to dev2 (pinned)
@@ -888,18 +884,20 @@ dev2
 ### git -C ./nip-fo add nip-fo.dev3.t
 ### git -C ./nip-fo commit -qm "add install file"
 ### opam install ./nip-fo
+nip-fo is now pinned to git+file://${BASEDIR}/nip-fo#master (version dev3)
 [NOTE] Ignoring uncommitted changes in ${BASEDIR}/nip-fo (`--working-dir' not specified or specified with no argument).
-[nip-fo.dev2] synchronised (git+file://${BASEDIR}/nip-fo#master)
+[nip-fo.dev3] synchronised (git+file://${BASEDIR}/nip-fo#master)
 The following actions will be performed:
-=== recompile 1 package
-  - recompile nip-fo dev2 (pinned)
+=== upgrade 1 package
+  - upgrade nip-fo dev2 to dev3 (pinned)
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved nip-fo.dev3  (no changes)
 -> removed   nip-fo.dev2
--> installed nip-fo.dev2
+-> installed nip-fo.dev3
 Done.
 ### opam show nip-fo --field=version
-dev2
+dev3
 ### :::::::::::::::::::::::
 ### :X: --current is in pin-legacy.test
 ### :::::::::::::::::::::::
@@ -1112,9 +1110,21 @@ opam-version: "2.0"
 depends: "dependency" {= "1"}
 ### :C:e:3: behaviour when the package is not pinned
 ### opam install ./pin-change
+pin-change is now pinned to git+file://${BASEDIR}/pin-change#master (version dev)
 [NOTE] Ignoring uncommitted changes in ${BASEDIR}/pin-change (`--working-dir' not specified or specified with no argument).
 [pin-change.dev] synchronised (no changes)
-[NOTE] Package pin-change is already installed (current version is dev).
+The following actions will be performed:
+=== recompile 1 package
+  - recompile pin-change dev (pinned)
+=== install 1 package
+  - install   dependency 1            [required by pin-change]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dependency.1
+-> retrieved pin-change.dev  (no changes)
+-> removed   pin-change.dev
+-> installed pin-change.dev
+Done.
 ### <pin:pin-change/opam>
 opam-version: "2.0"
 depends: "dependency" {= "2"}
@@ -1135,7 +1145,14 @@ depends: "dependency" {= "3"}
 ### opam install --deps-only ./pin-change/opam
 [NOTE] Ignoring uncommitted changes in ${BASEDIR}/pin-change (`--working-dir' not specified or specified with no argument).
 [pin-change.dev] synchronised (no changes)
-Nothing to do.
+The following actions will be performed:
+=== upgrade 1 package
+  - upgrade dependency 1 to 3 [required by pin-change]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   dependency.1
+-> installed dependency.3
+Done.
 ### opam pin | '\(at [a-f0-9]+\)' -> '(at HASH)'
 pin-change.dev  (uninstalled)  git  git+file://${BASEDIR}/pin-change#master  (at HASH)
 ### :C:f: stored overlay opam file

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1138,3 +1138,194 @@ depends: "dependency" {= "3"}
 Nothing to do.
 ### opam pin | '\(at [a-f0-9]+\)' -> '(at HASH)'
 pin-change.dev  (uninstalled)  git  git+file://${BASEDIR}/pin-change#master  (at HASH)
+### :C:f: stored overlay opam file
+### opam switch create --empty overlays
+### :C:f:1: Common case
+### <pkg:dep-over.1>
+opam-version: "2.0"
+### <pin:over/over.opam>
+opam-version: "2.0"
+depends: "dep-over"
+### opam pin ./over
+[NOTE] Package over does not exist in opam repositories registered in the current switch.
+over is now pinned to file://${BASEDIR}/over (version dev)
+
+The following actions will be performed:
+=== install 2 packages
+  - install dep-over 1            [required by over]
+  - install over     dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-over.1
+-> retrieved over.dev  (file://${BASEDIR}/over)
+-> installed over.dev
+Done.
+### opam-cat OPAM/overlays/.opam-switch/overlay/over/opam
+authors: "the testing team"
+bug-reports: "https://nobug"
+depends: "dep-over"
+description: "Two words."
+dev-repo: "hg+https://pkg@op.am"
+homepage: "egapemoh"
+license: "MIT"
+maintainer: "maint@tain.er"
+name: "over"
+opam-version: "2.0"
+synopsis: "A word"
+version: "dev"
+url {
+src: "file://${BASEDIR}/over"
+}
+### :C:f:2: Locked
+### <pkg:dep-over-locked.1>
+opam-version: "2.0"
+### <pkg:dep-over-locked.2>
+opam-version: "2.0"
+### <pin:over-locked/over-locked.opam>
+opam-version: "2.0"
+depends: "dep-over-locked"
+### opam install ./over-locked dep-over-locked.1
+[NOTE] Package over-locked does not exist in opam repositories registered in the current switch.
+over-locked is now pinned to file://${BASEDIR}/over-locked (version dev)
+The following actions will be performed:
+=== install 2 packages
+  - install dep-over-locked 1
+  - install over-locked     dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-over-locked.1
+-> retrieved over-locked.dev  (file://${BASEDIR}/over-locked)
+-> installed over-locked.dev
+Done.
+### opam lock over-locked
+Generated lock files for:
+  - over-locked.dev: ${BASEDIR}/over-locked.opam.locked
+### mv over-locked.opam.locked over-locked/over-locked.opam.locked
+### opam remove over-locked
+The following actions will be performed:
+=== remove 1 package
+  - remove over-locked dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   over-locked.dev
+Done.
+### opam install dep-over-locked.2
+The following actions will be performed:
+=== upgrade 1 package
+  - upgrade dep-over-locked 1 to 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   dep-over-locked.1
+-> installed dep-over-locked.2
+Done.
+### opam install over-locked --locked
+
+<><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
+[over-locked.dev] synchronised (file://${BASEDIR}/over-locked)
+[over-locked] Installing new package description from upstream file://${BASEDIR}/over-locked
+
+The following actions will be performed:
+=== downgrade 1 package
+  - downgrade dep-over-locked 2 to 1       [required by over-locked]
+=== install 1 package
+  - install   over-locked     dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   dep-over-locked.2
+-> installed dep-over-locked.1
+-> installed over-locked.dev
+Done.
+### opam-cat OPAM/overlays/.opam-switch/overlay/over-locked/opam
+authors: "the testing team"
+bug-reports: "https://nobug"
+depends: ["dep-over-locked" {= "1"}]
+description: "Two words."
+dev-repo: "hg+https://pkg@op.am"
+homepage: "egapemoh"
+license: "MIT"
+maintainer: "maint@tain.er"
+name: "over-locked"
+opam-version: "2.0"
+synopsis: "A word"
+version: "dev"
+x-locked: "locked"
+url {
+src: "file://${BASEDIR}/over-locked"
+}
+### :C:f:3: Subpath
+### <pkg:dep-over-subpath.1>
+opam-version: "2.0"
+### <pin:over-subpath/inner/over-subpath.opam>
+opam-version: "2.0"
+depends: "dep-over-subpath"
+### opam pin ./over-subpath --subpath inner
+[NOTE] Package over-subpath does not exist in opam repositories registered in the current switch.
+over-subpath is now subpath-pinned to directory /inner in file://${BASEDIR}/over-subpath (version dev)
+
+The following actions will be performed:
+=== install 2 packages
+  - install dep-over-subpath 1            [required by over-subpath]
+  - install over-subpath     dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-over-subpath.1
+-> retrieved over-subpath.dev  (directory /inner in file://${BASEDIR}/over-subpath)
+-> installed over-subpath.dev
+Done.
+### opam-cat OPAM/overlays/.opam-switch/overlay/over-subpath/opam
+authors: "the testing team"
+bug-reports: "https://nobug"
+depends: "dep-over-subpath"
+description: "Two words."
+dev-repo: "hg+https://pkg@op.am"
+homepage: "egapemoh"
+license: "MIT"
+maintainer: "maint@tain.er"
+name: "over-subpath"
+opam-version: "2.0"
+synopsis: "A word"
+version: "dev"
+x-subpath: "inner"
+url {
+src: "file://${BASEDIR}/over-subpath"
+}
+### :C:f:3: Env path rewrite
+### <pkg:dep-over-epr.1>
+opam-version: "2.0"
+### <pin:over-epr/over-epr.opam>
+opam-version: "2.0"
+depends: "dep-over-epr"
+x-env-path-rewrite: [
+  [ SOME_ENV ":" "target" ]
+]
+### opam pin ./over-epr
+[NOTE] Package over-epr does not exist in opam repositories registered in the current switch.
+over-epr is now pinned to file://${BASEDIR}/over-epr (version dev)
+
+The following actions will be performed:
+=== install 2 packages
+  - install dep-over-epr 1            [required by over-epr]
+  - install over-epr     dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-over-epr.1
+-> retrieved over-epr.dev  (file://${BASEDIR}/over-epr)
+-> installed over-epr.dev
+Done.
+### opam-cat OPAM/overlays/.opam-switch/overlay/over-epr/opam
+authors: "the testing team"
+bug-reports: "https://nobug"
+depends: "dep-over-epr"
+description: "Two words."
+dev-repo: "hg+https://pkg@op.am"
+homepage: "egapemoh"
+license: "MIT"
+maintainer: "maint@tain.er"
+name: "over-epr"
+opam-version: "2.0"
+synopsis: "A word"
+version: "dev"
+x-env-path-rewrite: [[SOME_ENV ":" "target"]]
+url {
+src: "file://${BASEDIR}/over-epr"
+}

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1035,7 +1035,7 @@ The following actions will be performed:
 -> installed dep2.2
 -> installed dep1.dev
 Done.
-### : opam install . --deps-only not selecting the good version
+### :C:d: opam install . --deps-only not selecting the good version
 ### <pkg:simcomp.1>
 opam-version: "2.0"
 flags: compiler
@@ -1068,3 +1068,73 @@ opam-version: "2.0"
 
 No solution found, exiting
 # Return code 20 #
+### :C:e: Make sure opam install works when the opam file changes and the package is pinned
+### opam switch create --empty local-pin-pinned-packages
+### <pkg:dependency.1>
+opam-version: "2.0"
+### <pkg:dependency.2>
+opam-version: "2.0"
+### <pkg:dependency.3>
+opam-version: "2.0"
+### mkdir pin-change
+### git -C pin-change init -q --initial-branch=master
+### git -C pin-change config core.autocrlf false
+### <pin:pin-change/opam>
+opam-version: "2.0"
+### git -C pin-change add opam
+### git -C pin-change commit -qm first-commit
+### :C:e:1: behaviour when the package is not pinned
+### opam install --deps-only --show ./pin-change
+Nothing to do.
+### <pin:pin-change/opam>
+opam-version: "2.0"
+depends: "dependency" {= "1"}
+### opam install --deps-only --show ./pin-change
+The following actions would be performed:
+=== install 1 package
+  - install dependency 1 [required by pin-change]
+### :C:e:2: behaviour when the package is pinned
+### <pin:pin-change/opam>
+opam-version: "2.0"
+### opam install ./pin-change
+[NOTE] Package pin-change does not exist in opam repositories registered in the current switch.
+pin-change is now pinned to git+file://${BASEDIR}/pin-change#master (version dev)
+The following actions will be performed:
+=== install 1 package
+  - install pin-change dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved pin-change.dev  (git+file://${BASEDIR}/pin-change#master)
+-> installed pin-change.dev
+Done.
+### <pin:pin-change/opam>
+opam-version: "2.0"
+depends: "dependency" {= "1"}
+### :C:e:3: behaviour when the package is not pinned
+### opam install ./pin-change
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/pin-change (`--working-dir' not specified or specified with no argument).
+[pin-change.dev] synchronised (no changes)
+[NOTE] Package pin-change is already installed (current version is dev).
+### <pin:pin-change/opam>
+opam-version: "2.0"
+depends: "dependency" {= "2"}
+### opam install --deps-only ./pin-change
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/pin-change (`--working-dir' not specified or specified with no argument).
+[pin-change.dev] synchronised (no changes)
+### opam remove pin-change
+The following actions will be performed:
+=== remove 1 package
+  - remove pin-change dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   pin-change.dev
+Done.
+### <pin:pin-change/opam>
+opam-version: "2.0"
+depends: "dependency" {= "3"}
+### opam install --deps-only ./pin-change/opam
+[NOTE] Ignoring uncommitted changes in ${BASEDIR}/pin-change (`--working-dir' not specified or specified with no argument).
+[pin-change.dev] synchronised (no changes)
+Nothing to do.
+### opam pin | '\(at [a-f0-9]+\)' -> '(at HASH)'
+pin-change.dev  (uninstalled)  git  git+file://${BASEDIR}/pin-change#master  (at HASH)

--- a/tests/reftests/show.test
+++ b/tests/reftests/show.test
@@ -402,3 +402,51 @@ url {
 url.src:     "https://an.arch/i/ve.tgz"
 url.swhid:   "swh:1:dir:309cf2674ee7a0749978cf8265ab91a60aea0f7d"
 url.mirrors: "https://a.mi/rror"
+### : Opam file information precedence :
+### mkdir -p REPO/packages
+### <REPO/repo>
+opam-version: "2.0"
+### opam switch create ordering --empty
+### opam repository add local ./REPO
+[local] Initialised
+[NOTE] Repository local has been added to the selections of switch ordering only.
+       Run `opam repository add local --all-switches|--set-default' to use it in all existing switches, or in newly created switches, respectively.
+
+### opam repository remove default --this-switch
+### <pkg:lorem.1>
+opam-version: "2.0"
+### <pkg:lorem.2>
+opam-version: "2.0"
+### opam update local
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[local] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### : first repo
+### opam show lorem --field version
+2
+### : then installed
+### opam install lorem.1
+The following actions will be performed:
+=== install 1 package
+  - install lorem 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed lorem.1
+Done.
+### opam show lorem --field version
+1
+### : then pinned
+### <pin:lorem/lorem.opam>
+opam-version: "2.0"
+version: "3"
+### opam pin ./lorem -n
+lorem is now pinned to file://${BASEDIR}/lorem (version 3)
+### opam show lorem --field version
+3
+### : and with all that, local file preceeds them all
+### <pin:lorem.opam>
+opam-version: "2.0"
+version: "4"
+### opam show ./lorem.opam --field version
+4

--- a/tests/reftests/working-dir.test
+++ b/tests/reftests/working-dir.test
@@ -256,7 +256,11 @@ Done.
 opam-version: "2.0"
 depends: ["qux" {= "1"}]
 ### opam install ./ongoing --working-dir --show-action
-[NOTE] Package ongoing is already installed (current version is dev).
+The following actions would be performed:
+=== downgrade 1 package
+  - downgrade qux     4 to 1       [required by ongoing]
+=== recompile 1 package
+  - recompile ongoing dev (pinned)
 ### opam reinstall ./ongoing --working-dir --show-action
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/5567
Fixes https://github.com/ocaml/opam/issues/4507
Queued on #6438 

I have no idea why `for_view` was introduced in https://github.com/ocaml/opam/commit/9b2a67f36d9d0e20b734ff85ddef470268aabb25 but i've tested `opam show` and i'm not seeing any breaking nor does the testsuite.

The bypass here was causing local packages to be put in the `already_pinned` set. However this set is only used to update the `<switch>/.opam-switch/sources/<pkg>` directory, not the `<...>/overlay` directory as the assumption with this set is that the package description hasn't change.
Removing that bypass makes the function much more consistent.

The `reinstall` bit is a bit easier to understand: when using `--deps-only` or `--show-action`, the codepath goes through `simulate_local_pinning` which didn't take into account that some packages being pinned are already pinned. In that case the `reinstall` field must be updated to ensure the rest of the code knows that package should be reinstalled.