### PR TITLE
Add OCaml 5.2.0 to the build matrix and update the vendored dependencies to fix compilation with OCaml 5.3

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -15,7 +15,11 @@ open Lib
 
 let ocamls = [
   (* Fully supported versions *)
-   "4.08.1"; "4.09.1"; "4.10.2"; "4.11.2"; "4.12.1"; "4.13.1"; "5.0.0"; "5.1.1"; "4.14.1";
+  "4.08.1"; "4.09.1"; "4.10.2"; "4.11.2"; "4.12.1"; "4.13.1";
+  "5.0.0"; "5.1.1"; "5.2.0";
+
+  (* The last elements of the list after 4.14 will be used as default versions *)
+  "4.14.1";
 ]
 
 (* Entry point for the workflow. Workflows are specified as continuations where
@@ -65,7 +69,7 @@ let end_workflow ~oc:_ ~workflow:_ = ()
 let ocamls =
   List.map (fun v -> Scanf.sscanf v "%u.%u.%u" (fun major minor _ -> ((major, minor), v))) ocamls
 
-let latest_ocaml = List.fold_left (fun _ (v, _) -> v) (0, 0) ocamls
+let latest_ocaml = (4, 14)
 
 let platform_ocaml_matrix ?(dir=List.drop_while) ~fail_fast start_version =
   (fail_fast,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,7 @@ jobs:
     needs: Analyse
     strategy:
       matrix:
-        ocamlv: [ 4.08.1, 4.09.1, 4.10.2, 4.11.2, 4.12.1, 4.13.1, 5.0.0, 5.1.1, 4.14.1 ]
+        ocamlv: [ 4.08.1, 4.09.1, 4.10.2, 4.11.2, 4.12.1, 4.13.1, 5.0.0, 5.1.1, 5.2.0, 4.14.1 ]
       fail-fast: true
     steps:
     - name: Install bubblewrap

--- a/master_changes.md
+++ b/master_changes.md
@@ -112,6 +112,8 @@ users)
 ### Engine
 
 ## Github Actions
+  * Add OCaml 5.2.0 to the build matrix [#6211 @kit-ty-kate]
+  * Allow to have more than one default version [#6211 @kit-ty-kate]
 
 ## Doc
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -71,6 +71,8 @@ users)
 
 ## Build
   * Bump the requirement for dune to 2.8 [#6204 @kit-ty-kate]
+  * Bump the vendored version of dune to 3.16.0, cppo to 1.7.0 and extlib to 1.8.0 [#6211 @kit-ty-kate]
+  * Fix compilation with OCaml 5.3 when using the vendored extlib (e.g. `make cold` or `./configure --with-vendored-deps`) [#6211 @kit-ty-kate]
 
 ## Infrastructure
 

--- a/src_ext/Makefile.dune
+++ b/src_ext/Makefile.dune
@@ -1,3 +1,3 @@
 # NB If minimum OCaml version for Dune changes, update DUNE_SECONDARY in configure.ac
-URL_dune-local = https://github.com/ocaml/dune/releases/download/3.14.2/dune-3.14.2.tbz
-MD5_dune-local = 9496e02635c05a8288781b55fb837b6f
+URL_dune-local = https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz
+MD5_dune-local = 4605a1d9783a96a16cbec381cfbb3ac1

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -1,8 +1,8 @@
-URL_cppo = https://github.com/ocaml-community/cppo/archive/v1.6.9.tar.gz
-MD5_cppo = d23ffe85ac7dc8f0afd1ddf622770d09
+URL_cppo = https://github.com/ocaml-community/cppo/archive/refs/tags/v1.7.0.tar.gz
+MD5_cppo = 90f66810f73b115cc55e581a34bf7db9
 
-URL_extlib = https://github.com/ygrek/ocaml-extlib/releases/download/1.7.9/extlib-1.7.9.tar.gz
-MD5_extlib = f7ca7f1c82e15a99603b88f730fd7b8a
+URL_extlib = https://github.com/ygrek/ocaml-extlib/releases/download/1.8.0/extlib-1.8.0.tar.gz
+MD5_extlib = 43fb3bf2989671af1769147b1171d080
 
 URL_base64 = https://github.com/mirage/ocaml-base64/releases/download/v3.5.1/base64-3.5.1.tbz
 MD5_base64 = bfdd16aa8c136412878109df8791fc01


### PR DESCRIPTION
All the vendored dependencies were updated except `re` while https://github.com/ocaml/ocaml-re/issues/411 is being delt with.

This PR is a split from https://github.com/ocaml/opam/pull/6192 while i'm trying to figure out why the Github Action scripts do not like OCaml 5.3.0~alpha1