### PR TITLE
Add benchmarks for opam show and String.split

### DIFF
--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -16,3 +16,4 @@ RUN opam init --bare -n --disable-sandboxing /rep/opam-repository
 RUN opam switch create --fake default 4.14.0
 RUN opam list --all -s --all-versions > /home/opam/all-packages
 RUN find /rep/opam-repository -name opam -type f > /home/opam/all-opam-files
+RUN cat /home/opam/all-opam-files | xargs -d '\n' cat > /home/opam/all-opam-content

--- a/master_changes.md
+++ b/master_changes.md
@@ -139,6 +139,7 @@ users)
 
 ## Benchmarks
   * Add benchmarks for `opam show` [#6212 @kit-ty-kate]
+  * Add benchmarks for `OpamStd.String.split` [#6212 @kit-ty-kate]
 
 ## Reftests
 ### Tests

--- a/master_changes.md
+++ b/master_changes.md
@@ -138,6 +138,7 @@ users)
 ## Test
 
 ## Benchmarks
+  * Add benchmarks for `opam show` [#6212 @kit-ty-kate]
 
 ## Reftests
 ### Tests

--- a/tests/bench/bench.ml
+++ b/tests/bench/bench.ml
@@ -99,6 +99,24 @@ let () =
     launch (fmt "%s switch create six --empty" bin);
     time_cmd ~exit:0 (fmt "%s list --installed --short --safe --color=never ocp-indent ocp-index merlin" bin)
   in
+  launch (fmt "%s switch create seven --empty" bin);
+  launch (fmt "%s install -y --fake dune" bin);
+  let time_show_installed =
+    Gc.compact ();
+    time_cmd ~exit:0 (fmt "%s show dune" bin)
+  in
+  let time_show_with_depexts =
+    Gc.compact ();
+    time_cmd ~exit:0 (fmt "%s show conf-llvm" bin)
+  in
+  let time_show_raw =
+    Gc.compact ();
+    time_cmd ~exit:0 (fmt "%s show --raw conf-llvm" bin)
+  in
+  let time_show_precise =
+    Gc.compact ();
+    time_cmd ~exit:0 (fmt "%s show --raw conf-llvm.14.0.6" bin)
+  in
   let json = fmt {|{
   "results": [
     {
@@ -148,6 +166,26 @@ let () =
           "name": "opam list --installed on non-installed packages",
           "value": %f,
           "units": "secs"
+        },
+        {
+          "name": "opam show of an installed package",
+          "value": %f,
+          "units": "secs"
+        },
+        {
+          "name": "opam show with depexts",
+          "value": %f,
+          "units": "secs"
+        },
+        {
+          "name": "opam show --raw pkgname",
+          "value": %f,
+          "units": "secs"
+        },
+        {
+          "name": "opam show --raw pkgname.version",
+          "value": %f,
+          "units": "secs"
         }
       ]
     },
@@ -172,6 +210,10 @@ let () =
       time_install_check_installed
       time_install_check_not_installed
       time_list_installed_noninstalled_packages
+      time_show_installed
+      time_show_with_depexts
+      time_show_raw
+      time_show_precise
       bin_size
   in
   print_endline json

--- a/tests/bench/bench.ml
+++ b/tests/bench/bench.ml
@@ -117,6 +117,25 @@ let () =
     Gc.compact ();
     time_cmd ~exit:0 (fmt "%s show --raw conf-llvm.14.0.6" bin)
   in
+  let time_OpamStd_String_split_10 =
+    Gc.compact ();
+    let lines =
+      let ic = Stdlib.open_in_bin "/home/opam/all-opam-content" in
+      let rec loop files =
+        match Stdlib.input_line ic with
+        | file -> loop (file :: files)
+        | exception End_of_file -> files
+      in
+      loop []
+    in
+    let n = 10 in
+    let l = List.init n (fun _ ->
+        let before = Unix.gettimeofday () in
+        List.iter (fun line -> ignore (OpamStd.String.split line ' ')) lines;
+        Unix.gettimeofday () -. before)
+    in
+    List.fold_left (+.) 0.0 l /. float_of_int n
+  in
   let json = fmt {|{
   "results": [
     {
@@ -186,6 +205,11 @@ let () =
           "name": "opam show --raw pkgname.version",
           "value": %f,
           "units": "secs"
+        },
+        {
+          "name": "OpamStd.String.split amortised over 10 runs",
+          "value": %f,
+          "units": "secs"
         }
       ]
     },
@@ -214,6 +238,7 @@ let () =
       time_show_with_depexts
       time_show_raw
       time_show_precise
+      time_OpamStd_String_split_10
       bin_size
   in
   print_endline json


### PR DESCRIPTION
This PR is meant to show the performance gain from https://github.com/ocaml/opam/pull/6210