### PR TITLE
Use a C stub to call the uname function from the C standard library instead of calling the uname POSIX command

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -100,6 +100,9 @@ users)
 
 ## Internal
 
+## Internal: Unix
+  * Use a C stub to call the `uname` function from the C standard library instead of calling the `uname` POSIX command [#6217 @kit-ty-kate]
+
 ## Internal: Windows
 
 ## Test
@@ -132,6 +135,9 @@ users)
 
 ## opam-core
   * `OpamStd.Sys.{get_terminal_columns,uname,getconf,guess_shell_compat}`: Harden the process calls to account for failures [#6230 @kit-ty-kate - fix #6215]
-  * `OpamStd.Sys.{uname,getconf}`: now accepts only one argument as parameter, as per their documentation [#6230 @kit-ty-kate]
+  * `OpamStd.Sys.getconf`: was removed, replaced by `get_long_bit` [#6217 @kit-ty-kate]
+  * `OpamStd.Sys.get_long_bit`: was added, which returns the output of the `getconf LONG_BIT` command [#6217 @kit-ty-kate]
+  * `OpamStd.Sys.uname`: now returns the memoized result of the `uname` function from the C standard library [#6217 @kit-ty-kate]
+  * `OpamStd.Sys.get_freebsd_version`: was added, which returns the output of the `uname -U` command [#6217 @kit-ty-kate]
   * `OpamStubs.get_stdout_ws_col`: new Unix-only function returning the number of columns of the current terminal window [#6244 @kit-ty-kate]
   * `OpamSystem`: add `is_archive_from_string` that does the same than `is_archive` but without looking at the file, only analysing the string (extension) [#6219 @rjbou]

--- a/src/core/opamCommonStubs.c
+++ b/src/core/opamCommonStubs.c
@@ -37,6 +37,7 @@
 
 #if OCAML_VERSION < 50000
 #define caml_unix_access unix_access
+#define caml_uerror uerror
 #endif
 
 CAMLprim value opam_is_executable(value path)

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -510,11 +510,15 @@ module Sys : sig
   (** Queried lazily *)
   val os: unit -> os
 
-  (** The output of the command "uname", with the given argument. Memoised. *)
-  val uname: string -> string option
+  (** The output of the command "uname -U". FreeBSD only. Reasoning:
+      https://github.com/ocaml/opam/pull/4274#issuecomment-659280485 *)
+  val get_freebsd_version: unit -> string option
 
-  (** The output of the command "getconf", with the given argument. Memoised. *)
-  val getconf: string -> string option
+  (** The output of the command "getconf LONG_BIT". *)
+  val get_long_bit: unit -> string option
+
+  (** The memoized result of the uname function from the C standard library *)
+  val uname : unit -> OpamStubs.uname
 
   (** Append .exe (only if missing) to executable filenames on Windows *)
   val executable_name : string -> string

--- a/src/core/opamStubs.mli
+++ b/src/core/opamStubs.mli
@@ -171,3 +171,14 @@ val get_stdout_ws_col : unit -> int
     linked with stdout. If stdout isn't linked to any terminal
     (e.g. redirection), then this function will return 0. A valid number
     of columns should be strictly above 0. *)
+
+type uname = {
+  sysname : string; (** uname -s *)
+  release : string; (** uname -r *)
+  machine : string; (** uname -m *)
+}
+(** A subset of the [struct utsname] C structure, as modified by uname(2),
+    converted to OCaml datatypes. *)
+
+val uname : unit -> uname
+(** Unix only. Returns info from uname(2) *)

--- a/src/core/opamStubs.unix.ml
+++ b/src/core/opamStubs.unix.ml
@@ -48,3 +48,4 @@ let getVersionInfo = that's_a_no_no
 let get_initial_environment = that's_a_no_no
 
 external get_stdout_ws_col : unit -> int = "opam_stdout_ws_col"
+external uname : unit -> uname = "opam_uname"

--- a/src/core/opamStubsTypes.ml
+++ b/src/core/opamStubsTypes.ml
@@ -114,6 +114,12 @@ type win32_version_info = {
     (** Non-fixed string table. First field is a pair of Language and Codepage ID. *)
 }
 
+type uname = {
+  sysname : string;
+  release : string;
+  machine : string;
+}
+
 external is_executable : string -> bool = "opam_is_executable"
 (** faccessat on Unix; _waccess on Windows. Checks whether a path is executable
     for the current process. On Unix, unlike Unix.access, this is checked using

--- a/src/core/opamUnix.c
+++ b/src/core/opamUnix.c
@@ -18,3 +18,20 @@ CAMLprim value opam_stdout_ws_col(value _unit) {
     }
     return Val_int(win.ws_col);
 }
+
+#include <sys/utsname.h>
+
+CAMLprim value opam_uname(value _unit) {
+  struct utsname buf;
+  value ret;
+
+  if (-1 == uname(&buf)) {
+    caml_uerror("uname", Nothing);
+  }
+  ret = caml_alloc(3, 0);
+  Store_field(ret, 0, caml_copy_string(buf.sysname));
+  Store_field(ret, 1, caml_copy_string(buf.release));
+  Store_field(ret, 2, caml_copy_string(buf.machine));
+
+  return ret;
+}

--- a/src/core/opamWin32Stubs.win32.ml
+++ b/src/core/opamWin32Stubs.win32.ml
@@ -51,3 +51,4 @@ external get_initial_environment : unit -> string list = "OPAMW_CreateEnvironmen
 let that's_a_no_no _ = failwith "Unix only. This function isn't implemented."
 
 let get_stdout_ws_col = that's_a_no_no
+let uname = that's_a_no_no


### PR DESCRIPTION
~Queued on top of #6216~
~F.i.x.e.s #6215~

~For the backport to 2.3, do we want to backport the entire PR or just the OpenBSD fix?~
~Partially backported to 2.3 in https://github.com/ocaml/opam/pull/6228~

~Queued on #6230~ merged