### PR TITLE
Pin: fix first local vcs fetch rsyncing all source

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -34,6 +34,7 @@ users)
 ## Config
 
 ## Pin
+  * [BUG] Fix first retrieval of local VCS pin done as local path [#6221 @rjbou - fix #5809]
 
 ## List
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -109,6 +109,7 @@ users)
 ### Tests
   * Move pin test to pin-legacy [#6135 @rjbou]
   * More exhaustive test for pin command: test different behaviour and cli options [#6135 @rjbou]
+  * pin: add a test for erroneous first fetch done as local path on local VCS pinned packages [#6221 @rjbou]
 
 ### Engine
 

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -75,18 +75,15 @@ let get_source_definition ?version ?subpath ?locked st nv url =
     opam
   in
   let open OpamProcess.Job.Op in
-  let url =
-    let u = OpamFile.URL.url url in
-    match OpamUrl.local_dir u, u.OpamUrl.backend with
-    | Some dir, #OpamUrl.version_control ->
-      OpamFile.URL.with_url
-        (OpamUrl.of_string (OpamFilename.Dir.to_string dir))
-        url
-    | _, _ -> url
-  in
   OpamUpdate.fetch_dev_package url srcdir ?subpath nv @@| function
   | Not_available (_,s) -> raise (Fetch_Fail s)
   | Up_to_date _ | Result _ ->
+    let srcdir =
+      let u = OpamFile.URL.url url in
+      match OpamUrl.local_dir u, u.OpamUrl.backend with
+      | Some dir, #OpamUrl.version_control -> dir
+      | _, _ -> srcdir
+    in
     let srcdir = OpamFilename.SubPath.(srcdir /? subpath) in
     match OpamPinned.find_opam_file_in_source ?locked nv.name srcdir with
     | None -> None

--- a/tests/reftests/fetch-package.test
+++ b/tests/reftests/fetch-package.test
@@ -109,7 +109,7 @@ opam
 root.ml
 ### opam pin foo-git-pin ./a-dev -y
 Package foo-git-pin does not exist, create as a NEW package? [y/n] y
-[foo-git-pin.dev] synchronised (file://${BASEDIR}/a-dev)
+[foo-git-pin.dev] synchronised (git+file://${BASEDIR}/a-dev#master)
 foo-git-pin is now pinned to git+file://${BASEDIR}/a-dev#master (version dev)
 
 The following actions will be performed:
@@ -117,7 +117,7 @@ The following actions will be performed:
   - install foo-git-pin dev (pinned)
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved foo-git-pin.dev  (git+file://${BASEDIR}/a-dev#master)
+-> retrieved foo-git-pin.dev  (no changes)
 -> installed foo-git-pin.dev
 Done.
 ### cat OPAM/downloads-pin/lib/foo-git-pin-files | sort
@@ -128,7 +128,7 @@ root.ml
 ### :: dev-repo
 ### opam switch create downloads-devrepo --empty
 ### opam pin foo-git --dev-repo -y
-[foo-git.1] synchronised (file://${BASEDIR}/a-dev)
+[foo-git.1] synchronised (git+file://${BASEDIR}/a-dev)
 foo-git is now pinned to git+file://${BASEDIR}/a-dev (version 1)
 
 The following actions will be performed:
@@ -136,7 +136,7 @@ The following actions will be performed:
   - install foo-git 1 (pinned)
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved foo-git.1  (git+file://${BASEDIR}/a-dev)
+-> retrieved foo-git.1  (no changes)
 -> installed foo-git.1
 Done.
 ### cat OPAM/downloads-devrepo/lib/foo-git-files | sort

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -90,7 +90,7 @@ Now run 'opam upgrade' to apply any package updates.
 ### : pin with url
 ### opam pin add nip-git git+file://$BASEDIR/nip-git
 Package nip-git does not exist, create as a NEW package? [y/n] y
-[nip-git.dev] synchronised (file://${BASEDIR}/nip-git)
+[nip-git.dev] synchronised (git+file://${BASEDIR}/nip-git#master)
 nip-git is now pinned to git+file://${BASEDIR}/nip-git#master (version ved)
 
 The following actions will be performed:
@@ -936,9 +936,10 @@ opam-version: "2.0"
 build: "false"
 ### opam pin vcs-local ./vcs-local --no-action
 Package vcs-local does not exist, create as a NEW package? [y/n] y
-[vcs-local.dev] synchronised (file://${BASEDIR}/vcs-local)
+[vcs-local.dev] synchronised (git+file://${BASEDIR}/vcs-local#master)
 vcs-local is now pinned to git+file://${BASEDIR}/vcs-local#master (version dev)
 ### test -f OPAM/vcs-local/.opam-switch/sources/vcs-local/untracked
+# Return code 1 #
 ### opam show vcs-local --field build:,url.src:
 build:   "false"
 url.src: "git+file://${BASEDIR}/vcs-local#master"

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -909,3 +909,36 @@ dev2
 ### :::::::::::::::::::::::
 ### :X: --current is in pin-legacy.test
 ### :::::::::::::::::::::::
+### :::::::::::::::::::::::
+### :C: Specific tests
+### :::::::::::::::::::::::
+### : In pin-legacy, there is
+### :  - :2: check no repin in case of double 'install .'
+### :  - :3: depext update
+### :  - :4: Test opam pin remove <pkg>.<version>
+### :  - :5: Test opam pin remove --all
+### :  - :6: Error retrieving git pin :
+### :  - :7: Parse error with future opam version field on pin
+### :C:a: git pin first retrieved as local
+### opam switch create vcs-local --empty
+### <pin:vcs-local/vcs-local.opam>
+opam-version: "2.0"
+### git -C vcs-local init -q --initial-branch=master
+### git -C vcs-local config core.autocrlf false
+### git -C vcs-local add vcs-local.opam
+### git -C vcs-local commit -qm 'init'
+### git -C vcs-local ls-files
+vcs-local.opam
+### <vcs-local/untracked>
+i shouldn't be retrieved
+### <pin:vcs-local/vcs-local.opam>
+opam-version: "2.0"
+build: "false"
+### opam pin vcs-local ./vcs-local --no-action
+Package vcs-local does not exist, create as a NEW package? [y/n] y
+[vcs-local.dev] synchronised (file://${BASEDIR}/vcs-local)
+vcs-local is now pinned to git+file://${BASEDIR}/vcs-local#master (version dev)
+### test -f OPAM/vcs-local/.opam-switch/sources/vcs-local/untracked
+### opam show vcs-local --field build:,url.src:
+build:   "false"
+url.src: "git+file://${BASEDIR}/vcs-local#master"

--- a/tests/reftests/rec-pin.test
+++ b/tests/reftests/rec-pin.test
@@ -536,13 +536,13 @@ Package root-a-i-j_g does not exist, create as a NEW package? [y/n] y
 [root-a-i-j_g.3] synchronised (no changes)
 root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version 3)
 Package root-a-i_g does not exist, create as a NEW package? [y/n] y
-[root-a-i_g.3] synchronised (directory /a/i in file://${BASEDIR}/pinnes)
+[root-a-i_g.3] synchronised (no changes)
 root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version 3)
 Package root-a_p does not exist, create as a NEW package? [y/n] y
 [root-a_p.3] synchronised (no changes)
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version 3)
 Package root_g does not exist, create as a NEW package? [y/n] y
-[root_g.3] synchronised (file://${BASEDIR}/pinnes)
+[root_g.3] synchronised (no changes)
 root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version 3)
 Package root-a-k_p does not exist, create as a NEW package? [y/n] y
 [root-a-k_p.3] synchronised (no changes)
@@ -1052,13 +1052,13 @@ Package root-a-i-j_g does not exist, create as a NEW package? [y/n] y
 [root-a-i-j_g.3] synchronised (no changes)
 root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version 3)
 Package root-a-i_g does not exist, create as a NEW package? [y/n] y
-[root-a-i_g.3] synchronised (directory /a/i in file://${BASEDIR}/pinnes)
+[root-a-i_g.3] synchronised (no changes)
 root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version 3)
 Package root-a_p does not exist, create as a NEW package? [y/n] y
 [root-a_p.3] synchronised (no changes)
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version 3)
 Package root_g does not exist, create as a NEW package? [y/n] y
-[root_g.3] synchronised (file://${BASEDIR}/pinnes)
+[root_g.3] synchronised (no changes)
 root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version 3)
 Package root-a-k_p does not exist, create as a NEW package? [y/n] y
 [root-a-k_p.3] synchronised (no changes)


### PR DESCRIPTION
**Backported in 2.3 with  #6222**


The origin of the issue is from the magic to retrieve the opam file even if it is not committed added in #4300. To do that, the local vcs url was changed to local rsync, in order to get all source not only committed files. In the next synchronisation, as opam file contains the vcs url, the synchronisation fixed that anomaly.

Fix #5809
~~Queued on #6135~~
