### PR TITLE
[2.3 backport] Update the vendored dependencies and unlock OCaml 5.3 compatibility

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -71,6 +71,8 @@ users)
 
 ## Build
   * Bump the requirement for dune to 2.8 [#6204 @kit-ty-kate]
+  * Bump the vendored version of dune to 3.16.0, cppo to 1.7.0 and extlib to 1.8.0 [#6223 @kit-ty-kate]
+  * Fix compilation with OCaml 5.3 when using the vendored extlib by updating to the 5.3 compatible version (e.g. `make cold` or `./configure --with-vendored-deps`) [#6223 @kit-ty-kate]
 
 ## Infrastructure
 

--- a/src_ext/Makefile.dune
+++ b/src_ext/Makefile.dune
@@ -1,3 +1,3 @@
 # NB If minimum OCaml version for Dune changes, update DUNE_SECONDARY in configure.ac
-URL_dune-local = https://github.com/ocaml/dune/releases/download/3.14.2/dune-3.14.2.tbz
-MD5_dune-local = 9496e02635c05a8288781b55fb837b6f
+URL_dune-local = https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz
+MD5_dune-local = 4605a1d9783a96a16cbec381cfbb3ac1

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -1,8 +1,8 @@
-URL_cppo = https://github.com/ocaml-community/cppo/archive/v1.6.9.tar.gz
-MD5_cppo = d23ffe85ac7dc8f0afd1ddf622770d09
+URL_cppo = https://github.com/ocaml-community/cppo/archive/refs/tags/v1.7.0.tar.gz
+MD5_cppo = 90f66810f73b115cc55e581a34bf7db9
 
-URL_extlib = https://github.com/ygrek/ocaml-extlib/releases/download/1.7.9/extlib-1.7.9.tar.gz
-MD5_extlib = f7ca7f1c82e15a99603b88f730fd7b8a
+URL_extlib = https://github.com/ygrek/ocaml-extlib/releases/download/1.8.0/extlib-1.8.0.tar.gz
+MD5_extlib = 43fb3bf2989671af1769147b1171d080
 
 URL_base64 = https://github.com/mirage/ocaml-base64/releases/download/v3.5.1/base64-3.5.1.tbz
 MD5_base64 = bfdd16aa8c136412878109df8791fc01

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -689,7 +689,7 @@ opam-version: "5.0"
 GARBAGE
 ### <VRS/packages/a/a.1/opam>
 opam-version: "2.0"
-### opam update -a --debug-level=-1
+### opam update -a --debug-level=-1 | unordered
 
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [repo] synchronised from file://${BASEDIR}/REPO


### PR DESCRIPTION
Backport of https://github.com/ocaml/opam/pull/6223