### PR TITLE
Documentation: Update the command to install opam to point to the new simplified url on opam.ocaml.org

### DIFF
--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -23,11 +23,11 @@ Then see the [Upgrade guide](Upgrade_guide.html) to check the changes.
 The quickest way to get the latest opam up and working is to run
 [this script](https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh):
 ```
-bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)"
+bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh)"
 ```
 or [this script](https://raw.githubusercontent.com/ocaml/opam/master/shell/install.ps1) on Windows using PowerShell:
 ```
-Invoke-Expression "& { $(Invoke-RestMethod https://raw.githubusercontent.com/ocaml/opam/master/shell/install.ps1) }"
+Invoke-Expression "& { $(Invoke-RestMethod https://opam.ocaml.org/install.ps1) }"
 ```
 
 This will simply check your architecture, download and install the proper

--- a/master_changes.md
+++ b/master_changes.md
@@ -113,6 +113,7 @@ users)
 ## Github Actions
 
 ## Doc
+  * Update the command to install opam to point to the new simplified url on opam.ocaml.org [#6226 @kit-ty-kate]
 
 ## Security fixes
 


### PR DESCRIPTION
At present this is a redirection to the same script on github

See https://github.com/ocaml-opam/opam2web/pull/241