### PR TITLE
Reftest: add `opam-cache` printing command

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -116,6 +116,7 @@ users)
   * pin: add a test for erroneous first fetch done as local path on local VCS pinned packages [#6221 @rjbou]
 
 ### Engine
+  * Update print file function [#6233 @rjbou]
 
 ## Github Actions
   * Add OCaml 5.2.0 to the build matrix [#6216 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -117,6 +117,7 @@ users)
 
 ### Engine
   * Update print file function [#6233 @rjbou]
+  * Add `opam-cache` command, to display internal cache content in reftest [#6233 @rjbou]
 
 ## Github Actions
   * Add OCaml 5.2.0 to the build matrix [#6216 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -135,6 +135,7 @@ users)
 ## opam-repository
 
 ## opam-state
+  * `OpamSwitchState.Installed_cache`: export `load` function [#6233 @rjbou]
 
 ## opam-solver
 

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -297,6 +297,7 @@ val avoid_version : 'a switch_state -> package -> bool
 (** Handle a cache of the opam files of installed packages *)
 module Installed_cache: sig
   type t = OpamFile.OPAM.t OpamPackage.Map.t
+  val load: OpamFilename.t -> t option
   val save: OpamFilename.t -> t -> unit
   val remove: OpamFilename.t -> unit
 end

--- a/tests/reftests/dune
+++ b/tests/reftests/dune
@@ -6,7 +6,7 @@
 
 (executable
  (name run)
- (libraries opam-core re opam-file-format)
+ (libraries opam-core re opam-file-format opam-state)
  (modules run))
 
 (executable

--- a/tests/reftests/readme.md
+++ b/tests/reftests/readme.md
@@ -70,6 +70,11 @@ output...
   * `json-cat file`: print a human readable opam output json file, with
     replacement of some duration and temporary files names. meant to be used
     on opam generated json files.
+  * `opam-cache installed <switch> [nvs]`: print the content of installed
+    packages cache for switch `<switch>`. If `[nvs]` is specified, filter over
+    these package names or packages.
+  * `opam-cache repo [nvs]`: print the content of repository cache. If
+    `[nvs]` is specified, filter over these package names or packages.
 
 - if you need more shell power, create a script using <FILENAME> then run it.
   Or just use `sh -c`... but beware for compatibility.

--- a/tests/reftests/reftests.test
+++ b/tests/reftests/reftests.test
@@ -363,3 +363,149 @@ Done.
     }
   ]
 }
+### :V:3: Cache cat
+### <OPER/repo>
+opam-version: "2.0"
+### <OPER/packages/foo/foo.2/opam>
+opam-version: "2.0"
+### <OPER/packages/un/un.2/opam>
+opam-version: "2.0"
+### <OPER/packages/deux/deux.2/opam>
+opam-version: "2.0"
+### opam switch create cache --empty
+### opam repository add oper ./OPER
+[oper] Initialised
+[NOTE] Repository oper has been added to the selections of switch cache only.
+       Run `opam repository add oper --all-switches|--set-default' to use it in all existing switches, or in newly created switches, respectively.
+
+### opam install bar baz foo un deux
+The following actions will be performed:
+=== install 5 packages
+  - install bar  1
+  - install baz  1
+  - install deux 2
+  - install foo  2
+  - install un   2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed bar.1
+-> installed baz.1
+-> installed deux.2
+-> installed foo.2
+-> installed un.2
+Done.
+### :V:3: installed packages cache
+### opam-cache installed cache
+=> un.2 <=
+opam-version: "2.0"
+name: "un"
+version: "2"
+=> foo.2 <=
+opam-version: "2.0"
+name: "foo"
+version: "2"
+=> deux.2 <=
+opam-version: "2.0"
+name: "deux"
+version: "2"
+=> baz.1 <=
+opam-version: "2.0"
+name: "baz"
+version: "1"
+extra-files: ["xf-baz" "md5=9ac116bceba2bdf45065df19d26a6b64"]
+=> bar.1 <=
+opam-version: "2.0"
+name: "bar"
+version: "1"
+extra-files: ["xf-bar" "md5=dbaf1ea561686374373dc7d154f3a0ff"]
+### opam-cache installed cache foo
+=> foo.2 <=
+opam-version: "2.0"
+name: "foo"
+version: "2"
+### opam-cache installed cache foo un
+=> un.2 <=
+opam-version: "2.0"
+name: "un"
+version: "2"
+=> foo.2 <=
+opam-version: "2.0"
+name: "foo"
+version: "2"
+### opam-cache installed cache inexistent
+### opam switch create cache2 --empty
+### opam-cache installed cache2
+Empty cache
+### opam-cache installed cache2 foo
+Empty cache
+### opam-cache installed cache3
+No cache
+### :V:3:b: repo cache
+### opam-cache repo
+=> oper:un.2 <=
+opam-version: "2.0"
+name: "un"
+version: "2"
+=> oper:foo.2 <=
+opam-version: "2.0"
+name: "foo"
+version: "2"
+=> oper:deux.2 <=
+opam-version: "2.0"
+name: "deux"
+version: "2"
+=> default:qux.1 <=
+opam-version: "2.0"
+name: "qux"
+version: "1"
+extra-files: ["xf-qux" "md5=ccacf3e9d1e3f473e093042aa309e9da"]
+=> default:grault.1 <=
+opam-version: "2.0"
+name: "grault"
+version: "1"
+extra-files: [
+  ["file" "md5=00000000000000000000000000000000"]
+  ["xf-grault" "md5=9fd8d4d58e5fd899478b03ab24a11d00"]
+  ["xf-grault2" "md5=5c1ff559ac6490338d362978c058f44a"]
+]
+=> default:foo.1 <=
+opam-version: "2.0"
+name: "foo"
+version: "1"
+extra-files: ["xfile" "md5=f343d90d29f2632b7e5fcf8ee249d1b5"]
+=> default:corge.1 <=
+opam-version: "2.0"
+name: "corge"
+version: "1"
+extra-files: ["xf-corge" "md5=71e14bfb95ec10cb60f3b6cafd908a08"]
+=> default:baz.1 <=
+opam-version: "2.0"
+name: "baz"
+version: "1"
+extra-files: ["xf-baz" "md5=9ac116bceba2bdf45065df19d26a6b64"]
+=> default:bar.1 <=
+opam-version: "2.0"
+name: "bar"
+version: "1"
+extra-files: ["xf-bar" "md5=dbaf1ea561686374373dc7d154f3a0ff"]
+### opam-cache repo foo
+=> oper:foo.2 <=
+opam-version: "2.0"
+name: "foo"
+version: "2"
+=> default:foo.1 <=
+opam-version: "2.0"
+name: "foo"
+version: "1"
+extra-files: ["xfile" "md5=f343d90d29f2632b7e5fcf8ee249d1b5"]
+### opam-cache repo un baz
+=> oper:un.2 <=
+opam-version: "2.0"
+name: "un"
+version: "2"
+=> default:baz.1 <=
+opam-version: "2.0"
+name: "baz"
+version: "1"
+extra-files: ["xf-baz" "md5=9ac116bceba2bdf45065df19d26a6b64"]
+### opam-cache repo inexistent


### PR DESCRIPTION
**Backported in 2.3 in #6234**

It displays the content of opam internal caches: switch installed packages and repository.

* `opam-cache installed <switch>`: Switch `<switch>` installed packages
* `opam-cache installed <switch> foo bar.1 `: Switch `<switch>` installed packages, selecting only packages `foo` and `bar.1`
* `opam-cache repo`: all repositories cache
* `opam-cache repo foo bar.1`: all repositories cache, selecting packages `foo` and `bar.1` over repositories