### PR TITLE
[2.3 backport] Fix the detection of the current terminal size

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -29,6 +29,10 @@ users)
 
 ## Remove
 
+## UI
+  * [BUG] Fix the detection of the current terminal size [#6244 @kit-ty-kate - fix #6243]
+  * [BUG] Ensure the output of opam commands using a column style UI stay consistent accross environment by setting the number of columns to 80 if stdout is not a tty and if the `COLUMNS` env variable is not set [#6244 @kit-ty-kate]
+
 ## Switch
 
 ## Config
@@ -122,3 +126,4 @@ users)
 ## opam-format
 
 ## opam-core
+  * `OpamStubs.get_stdout_ws_col`: new Unix-only function returning the number of columns of the current terminal window [#6244 @kit-ty-kate]

--- a/src/core/dune
+++ b/src/core/dune
@@ -19,7 +19,7 @@
   (wrapped     false))
 
 (rule
-  (deps opamWindows.c opamInject.c)
+  (deps opamWindows.c opamInject.c opamUnix.c)
   (action (copy# opamCommonStubs.c opam_stubs.c)))
 
 (rule

--- a/src/core/opamCommonStubs.c
+++ b/src/core/opamCommonStubs.c
@@ -63,4 +63,6 @@ CAMLprim value opam_is_executable(value path)
 #ifdef _WIN32
 #include "opamInject.c"
 #include "opamWindows.c"
+#else
+#include "opamUnix.c"
 #endif

--- a/src/core/opamStubs.mli
+++ b/src/core/opamStubs.mli
@@ -165,3 +165,9 @@ val getVersionInfo : string -> win32_version_info option
 
 val get_initial_environment : unit -> string list
 (** Windows only. Returns the environment which new processes would receive. *)
+
+val get_stdout_ws_col : unit -> int
+(** Unix only. Returns the number of columns of the current terminal window
+    linked with stdout. If stdout isn't linked to any terminal
+    (e.g. redirection), then this function will return 0. A valid number
+    of columns should be strictly above 0. *)

--- a/src/core/opamStubs.unix.ml
+++ b/src/core/opamStubs.unix.ml
@@ -46,3 +46,5 @@ let getErrorMode = that's_a_no_no
 let setConsoleToUTF8 = that's_a_no_no
 let getVersionInfo = that's_a_no_no
 let get_initial_environment = that's_a_no_no
+
+external get_stdout_ws_col : unit -> int = "opam_stdout_ws_col"

--- a/src/core/opamUnix.c
+++ b/src/core/opamUnix.c
@@ -1,0 +1,20 @@
+/**************************************************************************/
+/*                                                                        */
+/*    Copyright 2024 Kate Deplaix                                         */
+/*                                                                        */
+/*  All rights reserved. This file is distributed under the terms of the  */
+/*  GNU Lesser General Public License version 2.1, with the special       */
+/*  exception on linking described in the file LICENSE.                   */
+/*                                                                        */
+/**************************************************************************/
+
+#include <sys/ioctl.h>
+
+CAMLprim value opam_stdout_ws_col(value _unit) {
+    struct winsize win;
+
+    if (-1 == ioctl(STDOUT_FILENO, TIOCGWINSZ, &win)) {
+        return Val_int(0);
+    }
+    return Val_int(win.ws_col);
+}

--- a/src/core/opamWin32Stubs.win32.ml
+++ b/src/core/opamWin32Stubs.win32.ml
@@ -47,3 +47,7 @@ external getErrorMode : unit -> int = "OPAMW_GetErrorMode"
 external setConsoleToUTF8 : unit -> unit = "OPAMW_SetConsoleToUTF8"
 external getVersionInfo : string -> 'a option = "OPAMW_GetVersionInfo"
 external get_initial_environment : unit -> string list = "OPAMW_CreateEnvironmentBlock"
+
+let that's_a_no_no _ = failwith "Unix only. This function isn't implemented."
+
+let get_stdout_ws_col = that's_a_no_no


### PR DESCRIPTION
Backport of https://github.com/ocaml/opam/pull/6244