### PR TITLE
Doc: point users to ways to override the default opam root location in the opam init manpage

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -132,6 +132,7 @@ users)
   * mli documentation: fix code blocks, references, add `@raise` tags [#6150 @rjbou]
   * Unhide `OpamProcess` functions [#6150 @rjbou]
   * Fix a typo in the default man page [#6267 @fccm2]
+  * Point users to ways to override the default opam root location in the opam init manpage [#6251 @kit-ty-kate]
 
 ## Security fixes
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -178,7 +178,8 @@ let init cli =
     `P "Initialise the opam state, or update opam init options";
     `P (Printf.sprintf
          "The $(b,init) command initialises a local \"opam root\" (by default, \
-          $(i,~%s.opam%s)) that holds opam's data and packages. This is a \
+          $(i,~%s.opam%s) unless overriden by $(i,--root) or the $(i,OPAMROOT) \
+          environment variable) that holds opam's data and packages. This is a \
           necessary step for normal operation of opam. The initial software \
           repositories are fetched, and an initial 'switch' can also be \
           installed, according to the configuration and options. These can be \


### PR DESCRIPTION
Might have helped https://github.com/ocaml/opam/issues/6250.

`--root` and `$OPAMROOT` aren't very well documented in `opam init`. The concept of an "opam root" is mentioned but the option is very far down the man page and the environment variable even more.
So i feel like, for such a useful command, it should be mentioned in the top summary.