### PR TITLE
Change example of non-letter in version ordering

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -299,7 +299,7 @@ packages.
                     | "(" <version-formula> ")"
                     | <relop> <version>
 <relop>           ::= "=" | "!=" | "<" | "<=" | ">" | ">="
-<version>         ::= (") { <identchar> | "+" | "." | "~" }+ (")
+<version>         ::= (") { <identchar> | "." | "~" }+ (")
 ```
 
 Package names have the same restrictions as idents — only letter, digits, dash

--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -350,7 +350,7 @@ Here is a full example:
 >   1, which is the empty string `""`, is smaller than `"a"`.
 >
 > - For non-digit components, the ordering used is that letters are
->   always smaller than non-letters (for example `z` < `"#"`), while
+>   always smaller than non-letters (for example `z` < `"+"`), while
 >   non-letters are compared by ASCII order.
 >
 > - The `~` character is special as it sorts even before the end of sequence

--- a/master_changes.md
+++ b/master_changes.md
@@ -117,6 +117,7 @@ users)
 ## Doc
   * Update the command to install opam to point to the new simplified url on opam.ocaml.org [#6226 @kit-ty-kate]
   * Fix debian manual url fragment [#6231 @RyanGibb]
+  * Change example of non-letter in version ordering [#6252 @gridbugs]
 
 ## Security fixes
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -118,6 +118,7 @@ users)
   * Update the command to install opam to point to the new simplified url on opam.ocaml.org [#6226 @kit-ty-kate]
   * Fix debian manual url fragment [#6231 @RyanGibb]
   * Change example of non-letter in version ordering [#6252 @gridbugs]
+  * Remove redundant `+` in version BNF definition (it is already present in `identchar`) [#6252 @rjbou]
 
 ## Security fixes
 


### PR DESCRIPTION
The "Package Formulas" grammar in the manual says that valid characters for version numbers are `<identchar> | "+" | "." | "~"`. Notably this does not include the "#" character. This change updates the example of a comparing a letter to a non-letter character to use a non-letter character that may appear in a version number.

Please update `master_changes.md` file with your changes.
