### PR TITLE
Remove dealing with descr and url files

### DIFF
--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -335,15 +335,16 @@ let packages_with_prefixes repo_root packages =
 let check_opam_file_version_url has_error repo_root prefix nv opam =
   let min_opam_version = OpamVersion.of_string "2.0" in
   let url_file =
-    let ( // ) = OpamFilename.Op.( // ) in
-    OpamFile.(make
-                (OpamRepositoryPath.packages repo_root prefix nv // "url"))
+    let open OpamFilename.Op in
+    OpamFile.make
+      (OpamRepositoryPath.packages repo_root prefix nv // "url")
   in
+  let opam_version = opam.OpamFile.OPAM.opam_version in
   if OpamFile.exists url_file then
     (OpamConsole.warning "Not updating external URL file at %s"
        (OpamFile.to_string url_file);
      true)
-  else if OpamVersion.compare opam.OpamFile.OPAM.opam_version min_opam_version < 0 then
+  else if OpamVersion.compare opam_version min_opam_version < 0 then
     (OpamConsole.warning "OPAM version must be >= 2.0 at %s"
        (OpamFile.to_string (OpamRepositoryPath.opam repo_root prefix nv));
      true)

--- a/src/client/opamAdminRepoUpgrade.ml
+++ b/src/client/opamAdminRepoUpgrade.ml
@@ -428,11 +428,12 @@ let do_upgrade repo_root =
         in
         if opam <> opam0 then
           (OpamFile.OPAM.write_with_preserved_format opam_file opam;
+           let ( // ) = OpamFilename.Op.( // ) in
            List.iter OpamFilename.remove [
-             OpamFile.filename
-               (OpamRepositoryPath.descr repo_root prefix package);
-             OpamFile.filename
-               (OpamRepositoryPath.url repo_root prefix package);
+             OpamFile.(filename (make
+                                   (OpamRepositoryPath.packages repo_root prefix package // "descr")));
+             OpamFile.(filename (make
+                                   (OpamRepositoryPath.packages repo_root prefix package // "url")));
            ];
            OpamConsole.status_line "Updated %s" (OpamFile.to_string opam_file))
     )

--- a/src/client/opamAdminRepoUpgrade.ml
+++ b/src/client/opamAdminRepoUpgrade.ml
@@ -428,12 +428,11 @@ let do_upgrade repo_root =
         in
         if opam <> opam0 then
           (OpamFile.OPAM.write_with_preserved_format opam_file opam;
-           let ( // ) = OpamFilename.Op.( // ) in
+           let open OpamFilename.Op in
+           let path = OpamRepositoryPath.packages repo_root prefix package in
            List.iter OpamFilename.remove [
-             OpamFile.(filename (make
-                                   (OpamRepositoryPath.packages repo_root prefix package // "descr")));
-             OpamFile.(filename (make
-                                   (OpamRepositoryPath.packages repo_root prefix package // "url")));
+             OpamFile.filename (OpamFile.make (path // "descr"));
+             OpamFile.filename (OpamFile.make (path // "url"));
            ];
            OpamConsole.status_line "Updated %s" (OpamFile.to_string opam_file))
     )

--- a/src/client/opamAdminRepoUpgrade.ml
+++ b/src/client/opamAdminRepoUpgrade.ml
@@ -217,7 +217,9 @@ let do_upgrade repo_root =
       let descr_file =
         OpamFilename.(opt_file (add_extension (chop_extension comp_file) "descr"))
       in
-      let descr = descr_file >>| fun f -> OpamFile.Descr.read (OpamFile.make f) in
+      let descr =
+        descr_file >>| fun f -> OpamFile.Descr.create (OpamFilename.read f)
+      in
       let nv, ocaml_version, variant =
         match OpamStd.String.cut_at c '+' with
         | None ->

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -259,12 +259,6 @@ let edit st ?version name =
     |  Some o when OpamFile.OPAM.equal opam o ->
       (OpamConsole.msg "Package metadata unchanged.\n"; st)
     | _ ->
-      (* Remove obsolete auxiliary files, in case *)
-      OpamFilename.remove
-        (OpamFile.filename (path OpamPath.Switch.Overlay.url));
-      OpamFilename.remove
-        (OpamFile.filename (path OpamPath.Switch.Overlay.descr));
-
       let opam_extra =
         OpamStd.Option.default [] @@ OpamFile.OPAM.extra_files opam
       in

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -186,10 +186,7 @@ end
     content. Formerly, (<repo>/packages/.../descr,
     <repo>/compilers/.../<v>.descr) *)
 
-module DescrIO = struct
-
-  let internal = "descr"
-  let format_version = OpamVersion.of_string "0"
+module Descr = struct
 
   type t = string * string
 
@@ -203,24 +200,6 @@ module DescrIO = struct
     | "" -> x ^ "\n"
     | y -> String.concat "" [x; "\n\n"; y; "\n"]
 
-  let of_channel _ ic =
-    let x =
-      try OpamStd.String.strip (input_line ic)
-      with End_of_file | Sys_error _ -> "" in
-    let y =
-      try OpamStd.String.strip (OpamSystem.string_of_channel ic)
-      with End_of_file | Sys_error _ -> ""
-    in
-    x, y
-
-  let to_channel _ oc (x,y) =
-    output_string oc x;
-    output_char oc '\n';
-    if y <> "" then
-      (output_char oc '\n';
-       output_string oc y;
-       output_char oc '\n')
-
   let create str =
     let head, tail =
       match OpamStd.String.cut_at str '\n' with
@@ -228,14 +207,6 @@ module DescrIO = struct
       | Some (h,t) -> h, t in
     OpamStd.String.strip head, OpamStd.String.strip tail
 
-  let of_string _ = create
-
-  let to_string _ = full
-
-end
-module Descr = struct
-  include DescrIO
-  include MakeIO(DescrIO)
 end
 
 (* module Comp_descr = Descr *)
@@ -3182,7 +3153,7 @@ module OPAMSyntax = struct
         Pp.V.os_constraint;
       "descr", no_cleanup Pp.ppacc_opt with_descr OpamStd.Option.none
         (Pp.V.string_tr -|
-         Pp.of_pair "descr" Descr.(of_string (), to_string ()));
+         Pp.of_pair "descr" Descr.(create, full));
       "extra-sources", no_cleanup Pp.ppacc_opt
         with_extra_sources OpamStd.Option.none
         (Pp.V.map_list ~depth:2 @@

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -298,12 +298,11 @@ end
 (** Package descriptions: [$opam/descr/] *)
 module Descr: sig
 
-  include IO_FILE
+  type t
+
+  val empty : t
 
   val create: string -> t
-
-  (** Create an abstract description file from a string *)
-  val of_string: t typed_file -> string -> t
 
   (** Return the first line *)
   val synopsis: t -> string

--- a/src/format/opamPath.ml
+++ b/src/format/opamPath.ml
@@ -270,10 +270,6 @@ module Switch = struct
 
     let tmp_opam t a n = package t a n /- "opam_"
 
-    let url t a n = package t a n /- "url"
-
-    let descr t a n = package t a n /- "descr"
-
     let files t a n = package t a n / "files"
 
   end

--- a/src/format/opamPath.mli
+++ b/src/format/opamPath.mli
@@ -362,13 +362,6 @@ module Switch: sig
         $meta/overlay/$name.$version/opam_} *)
     val tmp_opam: t -> switch -> name -> OpamFile.OPAM.t OpamFile.t
 
-    (** URL overlay: {i
-        $meta/overlay/$name.$version/url} *)
-    val url: t -> switch -> name -> OpamFile.URL.t OpamFile.t
-
-    (** Descr orverlay *)
-    val descr: t -> switch -> name -> OpamFile.Descr.t OpamFile.t
-
     (** Files overlay *)
     val files: t -> switch -> name -> dirname
   end

--- a/src/repository/opamRepositoryPath.ml
+++ b/src/repository/opamRepositoryPath.ml
@@ -44,12 +44,6 @@ let packages repo_root prefix nv =
 let opam repo_root prefix nv =
   packages repo_root prefix nv // "opam" |> OpamFile.make
 
-let descr repo_root prefix nv =
-  packages repo_root prefix nv // "descr" |> OpamFile.make
-
-let url repo_root prefix nv =
-  packages repo_root prefix nv // "url" |> OpamFile.make
-
 let files repo_root prefix nv =
   packages repo_root prefix nv / "files"
 

--- a/src/repository/opamRepositoryPath.mli
+++ b/src/repository/opamRepositoryPath.mli
@@ -41,13 +41,6 @@ val packages: dirname -> string option -> package -> dirname
     {i $repo/packages/XXX/$NAME.$VERSION/opam} *)
 val opam: dirname -> string option -> package -> OpamFile.OPAM.t OpamFile.t
 
-(** Return the description file for a given package:
-    {i $repo/packages/XXX/$NAME.VERSION/descr} *)
-val descr: dirname -> string option -> package -> OpamFile.Descr.t OpamFile.t
-
-(** urls {i $repo/package/XXX/$NAME.$VERSION/url} *)
-val url: dirname -> string option -> package -> OpamFile.URL.t OpamFile.t
-
 (** files {i $repo/packages/XXX/$NAME.$VERSION/files} *)
 val files: dirname -> string option -> package -> dirname
 

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -1297,43 +1297,8 @@ let add_aux_files ?dir ?(files_subdir_hashes=false) opam =
   match dir with
   | None -> opam
   | Some dir ->
-    let (url_file: OpamFile.URL.t OpamFile.t) =
-      OpamFile.make (dir // "url")
-    in
-    let (descr_file: OpamFile.Descr.t OpamFile.t)  =
-      OpamFile.make (dir // "descr")
-    in
     let files_dir =
       OpamFilename.Op.(dir / "files")
-    in
-    let opam =
-      match OpamFile.OPAM.url opam, try_read OpamFile.URL.read_opt url_file with
-      | None, (Some url, None) -> OpamFile.OPAM.with_url url opam
-      | Some opam_url, (Some url, errs) ->
-        if url = opam_url && errs = None then
-          log "Duplicate definition of url in '%s' and opam file"
-            (OpamFile.to_string url_file)
-        else
-          OpamConsole.warning
-            "File '%s' ignored (conflicting url already specified in the \
-             'opam' file)"
-            (OpamFile.to_string url_file);
-        opam
-      | _, (_, Some err) ->
-        OpamFile.OPAM.with_format_errors (err :: opam.format_errors) opam
-      | _, (None, None) -> opam
-    in
-    let opam =
-      match OpamFile.OPAM.descr opam,
-            try_read OpamFile.Descr.read_opt descr_file with
-      | None, (Some descr, None) -> OpamFile.OPAM.with_descr descr opam
-      | Some _, (Some _, _) ->
-        log "Duplicate descr in '%s' and opam file"
-          (OpamFile.to_string descr_file);
-        opam
-      | _, (_, Some err) ->
-        OpamFile.OPAM.with_format_errors (err :: opam.format_errors) opam
-      | _, (None, None)  -> opam
     in
     let opam =
       let extra_files =

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -563,7 +563,11 @@ let from_1_3_dev2_to_1_3_dev5 ~on_the_fly:_ root conf =
             OpamStd.Option.default
               (OpamFile.Descr.create
                  "Switch relying on a system-wide installation of OCaml")
-              (OpamFile.Descr.read_opt descr_f)
+              (if OpamFile.exists descr_f then
+                 Some (OpamFile.Descr.create
+                         (OpamSystem.read (OpamFile.to_string descr_f)))
+               else
+                 None)
           in
           let comp_opam =
             OpamFile.Comp.to_package comp (Some descr)

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -331,12 +331,7 @@ let pinned_package st ?version ?(autolock=false) ?(working_dir=false) name =
     let save_overlay opam =
       OpamFilename.mkdir overlay_dir;
       let opam_file = OpamPath.Switch.Overlay.opam root st.switch name in
-      List.iter OpamFilename.remove
-        OpamPath.Switch.Overlay.([
-            OpamFile.filename opam_file;
-            OpamFile.filename (url root st.switch name);
-            OpamFile.filename (descr root st.switch name);
-          ]);
+      OpamFilename.remove (OpamFile.filename opam_file);
       let files_dir = OpamPath.Switch.Overlay.files root st.switch name in
       OpamFilename.rmdir files_dir;
       let opam =

--- a/src/tools/opam_admin_top.mli
+++ b/src/tools/opam_admin_top.mli
@@ -28,10 +28,8 @@ val iter_packages_gen:
   (OpamPackage.t ->
    prefix:string option ->
    opam:OPAM.t ->
-   descr:Descr.t option ->
-   url:URL.t option ->
    dot_install:Dot_install.t option ->
-   OPAM.t * Descr.t action * URL.t action * Dot_install.t action)
+   OPAM.t * Dot_install.t action)
   -> unit
 
 (** Turn a list of glob patterns into a proper filtering function on
@@ -44,7 +42,5 @@ val iter_packages:
   ?filter:(OpamPackage.t -> bool) ->
   ?f:(OpamPackage.t -> string option -> OPAM.t -> unit) ->
   ?opam:(OpamPackage.t -> OPAM.t -> OPAM.t) ->
-  ?descr:(OpamPackage.t -> Descr.t -> Descr.t) ->
-  ?url:(OpamPackage.t -> URL.t -> URL.t) ->
   ?dot_install:(OpamPackage.t -> Dot_install.t -> Dot_install.t) ->
   unit -> unit


### PR DESCRIPTION
They have been deprecated since quite some time. I suspect this PR could go further, and remove the OpamFile.DescrIO module - but I failed to understand what to replace it with.

Please let me know whether this direction is the right one. I'm especially unsure whether there need to be more guards checking that url / descr do not exist.

Fixes https://github.com/ocaml/opam/issues/5086
Queued on https://github.com/ocaml/opam/pull/6827