### PR TITLE
Lookup at gpatch before patch on macOS now that both homebrew and macports expose gpatch as gpatch

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -334,6 +334,7 @@ let main_build_job ~analyse_job ~cygwin_job ?section runner start_version ~oc ~w
   job ~oc ~workflow ~runs_on:(Runner [runner]) ?shell ?section ~needs ~matrix ("Build-" ^ name_of_platform platform)
     ++ only_on Linux (run "Install bubblewrap" ["sudo apt install bubblewrap"])
     ++ only_on Linux (run "Disable AppArmor" ["echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns"])
+    ++ only_on MacOS (run "Install GNU patch" ["brew install gpatch"])
     ++ only_on Windows (git_lf_checkouts ~cond:(Predicate(true, EndsWith("matrix.host", "-pc-cygwin"))) ~shell:"cmd" ~title:"Configure LF checkout for Cygwin" ())
     ++ checkout ()
     ++ only_on Windows (cache ~cond:(Predicate(true, Compare("matrix.build", "x86_64-pc-cygwin"))) Cygwin)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -247,6 +247,8 @@ jobs:
         ocamlv: [ 4.14.2, 5.2.0 ]
       fail-fast: true
     steps:
+    - name: Install GNU patch
+      run: brew install gpatch
     - name: Checkout tree
       uses: actions/checkout@v4
     - name: src_ext/archives and opam-repository Cache

--- a/master_changes.md
+++ b/master_changes.md
@@ -81,6 +81,7 @@ users)
 
 ## External dependencies
   * Add apt-rpm/ALTLinux family support for depext [#6207 @RiderALT]
+  * Lookup at `gpatch` before `patch` on macOS now that both homebrew and macports expose `gpatch` as `gpatch` since Homebrew/homebrew-core#174687 [#6255 @kit-ty-kate]
 
 ## Format upgrade
 

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -58,7 +58,7 @@ let sandbox_filter = FOr (linux_filter, macos_filter)
 
 let gpatch_filter =
   FOr (FOr (openbsd_filter, netbsd_filter),
-       FOr (freebsd_filter, dragonflybsd_filter))
+       FOr (freebsd_filter, FOr (dragonflybsd_filter, macos_filter)))
 let patch_filter = FNot gpatch_filter
 
 let gtar_filter = openbsd_filter

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -1604,12 +1604,12 @@ let gpatch = lazy begin
   in
   let default_cmd, other_cmds =
     match OpamStd.Sys.os () with
+    | Darwin
     | DragonFly
     | FreeBSD
     | NetBSD
     | OpenBSD -> ("gpatch", ["patch"])
     | Cygwin
-    | Darwin
     | Linux
     | Unix
     | Win32

--- a/tests/lib/patcher.ml
+++ b/tests/lib/patcher.ml
@@ -82,7 +82,13 @@ let generate_patch () =
   Printf.eprintf "Before patch state of c:\n";
   print_directory ".";
   flush stdout;
-  if Sys.command "patch -p1 -i ../output.patch" <> 0 then (Printf.eprintf "patch application failed\n%!"; exit 2);
+  let gpatch =
+    if Sys.command "sh -c \"command -v gpatch > /dev/null 2> /dev/null\"" = 0 then
+      "gpatch"
+    else
+      "patch"
+  in
+  if Sys.command (gpatch^" -p1 -i ../output.patch") <> 0 then (Printf.eprintf "patch application failed\n%!"; exit 2);
   Printf.eprintf "After patch state of c:\n";
   print_directory ".";
   OpamSystem.chdir Filename.parent_dir_name

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -18,7 +18,7 @@ some content
 ### sh hash.sh REPO foo.1
 ### : Internal repository storage as archive or plain directory :
 ### opam switch create tarring --empty
-### opam update -vv | grep '^\+' | sed-cmd diff | sed-cmd patch | 'patch-[^"]+' -> 'patch'
+### opam update -vv | grep '^\+' | sed-cmd diff | sed-cmd patch | sed-cmd gpatch | '\+ gpatch ' -> '+ patch ' | 'patch-[^"]+' -> 'patch'
 + diff "-ruaN" "default" "default.new" (CWD=${BASEDIR}/OPAM/repo)
 + patch "--version"
 + patch "-p1" "-i" "${BASEDIR}/OPAM/log/patch" (CWD=${BASEDIR}/OPAM/repo/default)
@@ -38,7 +38,7 @@ build: ["test" "-f" "baz"]
 ### <REPO/packages/foo/foo.2/files/baz>
 some content
 ### sh hash.sh REPO foo.2
-### opam update default -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd patch | 'patch-[^"]+' -> 'patch'
+### opam update default -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd patch | sed-cmd gpatch | '\+ gpatch ' -> '+ patch ' | 'patch-[^"]+' -> 'patch'
 + diff "-ruaN" "default" "default.new" (CWD=${BASEDIR}/OPAM/repo)
 + patch "--version"
 + patch "-p1" "-i" "${BASEDIR}/OPAM/log/patch" (CWD=${BASEDIR}/OPAM/repo/default)
@@ -78,7 +78,7 @@ build: ["test" "-f" "baz"]
 ### <REPO/packages/foo/foo.4/files/baz>
 some content
 ### sh hash.sh REPO foo.4
-### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd patch | 'patch-[^"]+' -> 'patch'
+### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd patch | sed-cmd gpatch | '\+ gpatch ' -> '+ patch ' | 'patch-[^"]+' -> 'patch'
 + tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
 + diff "-ruaN" "tarred" "tarred.new" (CWD=${OPAMTMP})
 + patch "--version"
@@ -102,7 +102,7 @@ build: ["test" "-f" "quux"]
 ### <REPO/packages/foo/foo.5/files/quux>
 some content
 ### sh hash.sh REPO foo.5
-### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd patch | 'patch-[^"]+' -> 'patch'
+### opam update -vv | grep '^\+' | sed-cmd tar | sed-cmd diff | sed-cmd patch | sed-cmd gpatch | '\+ gpatch ' -> '+ patch ' | 'patch-[^"]+' -> 'patch'
 + tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
 + diff "-ruaN" "tarred" "tarred.new" (CWD=${OPAMTMP})
 + patch "--version"


### PR DESCRIPTION
Homebrew changed behaviour in Homebrew/homebrew-core#174687

~This is only an optimization (avoids the (probably) unnecessary `patch --version`), this doesn't change the general behaviour at all.~
EDIT: actually nevermind, this changes the behaviour in case, neither `patch` or `gpatch` are available and GNU patch. In that case, it would default to use `patch`, but now it will use `gpatch` by default. Which means that if someone hasn't installed gpatch, previously it would show a warning and used `patch` anyway, but now it will show a warning and fail to execute `gpatch`.