### PR TITLE
Ensure the right versions of packages are used when simulating pinning

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -180,6 +180,7 @@ users)
   * Add a test showing the behaviour when a pin depend is unpinned [#6380 @rjbou]
   * Add a test to ensure `opam upgrade <pkg>` will not upgrade unrelated things [#6373 @kit-ty-kate]
   * Add a test in init to show ocaml system compiler selection behaviour [#6307 @kit-ty-kate @rjbou]
+  * Add a test showing simulated pinning does not propagate version information [#6256 @rjbou]
 
 ### Engine
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -51,6 +51,7 @@ users)
   * [BUG] Stop double pin of packages located in ./opam/opam [#6343 @kit-ty-kate - fix #6342]
   * Don't ask confirmation when pinning an unknown package (absent from repositories) [#6309 @kit-ty-kate @rjbou - fix #3199]
   * [BUG] Do not ask to install pin-depends twice [#6375 @kit-ty-kate - fix #6374]
+  * [BUG] Ensure the right versions (the pinned one) of packages are used when simulating pinning [#6256 @rjbou @kit-ty-kate - fix #6248 #6379]
 
 ## List
 

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1060,10 +1060,11 @@ opam-version: "2.0"
 ### <pkg:deps-sim.2>
 opam-version: "2.0"
 ### opam install ./sim --deps-only
-The following actions will be performed:
-=== install 1 package
-  - install deps-sim 1 [required by sim]
+[ERROR] Package conflict!
+  * Incompatible packages:
+    - (invariant) -> simcomp
+    - deps-of-sim
+    You can temporarily relax the switch invariant with `--update-invariant'
 
-<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> installed deps-sim.1
-Done.
+No solution found, exiting
+# Return code 20 #

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1035,3 +1035,35 @@ The following actions will be performed:
 -> installed dep2.2
 -> installed dep1.dev
 Done.
+### : opam install . --deps-only not selecting the good version
+### <pkg:simcomp.1>
+opam-version: "2.0"
+flags: compiler
+### opam switch create simulate-pin simcomp
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["simcomp"]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed simcomp.1
+Done.
+### <pin:sim/sim.opam>
+opam-version: "2.0"
+version: "2.0"
+depends: "deps-sim" { = "2" }
+conflicts: "simcomp"
+### <pkg:sim.1>
+opam-version: "2.0"
+depends: "deps-sim" { = "1" }
+### <pkg:deps-sim.1>
+opam-version: "2.0"
+### <pkg:deps-sim.2>
+opam-version: "2.0"
+### opam install ./sim --deps-only
+The following actions will be performed:
+=== install 1 package
+  - install deps-sim 1 [required by sim]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed deps-sim.1
+Done.


### PR DESCRIPTION
Force the version constraint on requested package when a simulate pin is done.
See explanation in https://github.com/ocaml/opam/issues/6379#issue-2836236793


Fixes https://github.com/ocaml/opam/issues/6379
Fixes https://github.com/ocaml/opam/issues/6248

~This PR is queued on top of #6209~
~The current title is temporary while i'm trying to understand what is the cause of the bug~

~I'm really confused as to what is making the made-up test work just fine but the test with goblint fail.~
~I'd like to understand what is making opam get almost all the dependencies but miss `ppx_blob` in the first deps-only install.~
~Ideally once we understand what's happening we should be able to build a dedicated test and remove the one relying on opam-repository~

