### PR TITLE
[2.3] Release script: Add NetBSD/x86_64 to the build matrix

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -69,6 +69,7 @@ CLINKING_macos = \
 
 CLINKING_openbsd = $(CLINKING_macos)
 CLINKING_freebsd = $(CLINKING_macos)
+CLINKING_netbsd = $(CLINKING_macos)
 
 CLINKING_windows = \
 -lunix -lmccs_stubs -lmccs_glpk_stubs -lsha_stubs -lopam_core_stubs \
@@ -83,6 +84,10 @@ CPATH=/usr/local/include: \
 LIBRARY_PATH=/usr/local/lib: \
 
 EXPORTS_freebsd = \
+CPATH=/usr/local/include: \
+LIBRARY_PATH=/usr/local/lib: \
+
+EXPORTS_netbsd = \
 CPATH=/usr/local/include: \
 LIBRARY_PATH=/usr/local/lib: \
 

--- a/release/release.sh
+++ b/release/release.sh
@@ -76,7 +76,7 @@ qemu_build() {
   fi
   ${SSH} -p "${port}" root@localhost "${install}"
   make TAG="$TAG" JOBS="${JOBS}" qemu QEMU_PORT="${port}" REMOTE_MAKE="${make}" REMOTE_DIR="opam-release-$TAG"
-  ${SSH} -p "${port}" root@localhost "shutdown -p now"
+  ${SSH} -p "${port}" root@localhost "/sbin/shutdown -p now"
 }
 
 make JOBS="${JOBS}" TAG="$TAG" "${OUTDIR}/opam-full-$TAG.tar.gz"
@@ -90,6 +90,7 @@ make JOBS="${JOBS}" TAG="$TAG" riscv64-linux
 [ -f "${OUTDIR}/opam-$TAG-x86_64-macos" ] || make TAG="$TAG" JOBS="${JOBS}" macos-local MACOS_ARCH=x86_64 REMOTE_DIR=opam-release-$TAG GIT_URL="$CWD/.."
 [ -f "${OUTDIR}/opam-$TAG-arm64-macos" ] || make TAG="$TAG" JOBS="${JOBS}" macos-local MACOS_ARCH=arm64 REMOTE_DIR=opam-release-$TAG GIT_URL="$CWD/.."
 [ -d ./qemu-base-images ] || git clone https://gitlab.com/kit-ty-kate/qemu-base-images.git
+[ -f "${OUTDIR}/opam-$TAG-x86_64-netbsd" ] || qemu_build 9996 NetBSD-10.0-amd64 "pkgin -y install gmake curl bzip2" gmake x86_64
 [ -f "${OUTDIR}/opam-$TAG-x86_64-openbsd" ] || qemu_build 9999 OpenBSD-7.6-amd64 "pkg_add gmake curl bzip2" gmake x86_64
 [ -f "${OUTDIR}/opam-$TAG-x86_64-freebsd" ] || qemu_build 9998 FreeBSD-14.1-RELEASE-amd64 "env IGNORE_OSVERSION=yes pkg install -y gmake curl bzip2" gmake x86_64
 [ -f "${OUTDIR}/opam-$TAG-x86_64-windows" ] || windows_build 9997 Windows-10-x86_64


### PR DESCRIPTION
Successfully built during the 2.3.0~beta2 release

Forward-ported to master in https://github.com/ocaml/opam/pull/6259