### PR TITLE
fix a typo in the man page

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -129,6 +129,7 @@ users)
   * mli documentation: fix code blocks, references [#6150 @rjbou]
   * mli documentation: fix code blocks, references, add `@raise` tags [#6150 @rjbou]
   * Unhide `OpamProcess` functions [#6150 @rjbou]
+  * Fix a typo in the default man page [#6267 @fccm2]
 
 ## Security fixes
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -4442,7 +4442,7 @@ let default cli =
     `P "It has support for different remote repositories such as HTTP, rsync, \
         git, darcs and mercurial. Everything is installed within a local opam \
         directory, that can include multiple installation prefixes with \
-        different sets of intalled packages.";
+        different sets of installed packages.";
     `P "Use either $(b,opam <command> --help) or $(b,opam help <command>) \
         for more information on a specific command.";
     `S Manpage.s_commands;


### PR DESCRIPTION
Hi, Just fix a typo in the man page: `s/intalled/installed/`