### PR TITLE
Improve the messages when a package is not up-to-date on opam upgrade

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -33,6 +33,7 @@ users)
 ## UI
   * [BUG] Fix the detection of the current terminal size [#6244 @kit-ty-kate - fix #6243]
   * [BUG] Ensure the output of opam commands using a column style UI stay consistent accross environment by setting the number of columns to 80 if stdout is not a tty and if the `COLUMNS` env variable is not set [#6244 @kit-ty-kate]
+  * Improve the messages when a package is not up-to-date on opam upgrade [#6272 @kit-ty-kate - fix #6270]
 
 ## Switch
 

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -279,26 +279,29 @@ let upgrade_t
              ) latest OpamPackage.Map.empty
          in
 
-         if (OpamConsole.verbose ()) && not (OpamPackage.Set.is_empty unav) then
-           (OpamConsole.formatted_msg
-              "%s.\n\
-               The following newer versions couldn't be installed:\n"
-              hdmsg;
-            OpamConsole.msg "%s"
-              (OpamStd.Format.itemize (fun p ->
-                   Printf.sprintf "%s.%s: %s"
-                     (OpamConsole.colorise `bold
-                        (OpamPackage.name_to_string p))
-                     (OpamPackage.version_to_string p)
-                     (OpamSwitchState.unavailable_reason t
-                        ~default:"unavailable for unknown reasons (this may \
-                                  be a bug in opam)"
-                        (OpamPackage.name p,
-                         Atom (`Eq, OpamPackage.version p))))
-                  (OpamPackage.Set.elements unav)))
+         if not (OpamPackage.Set.is_empty unav) then
+           if OpamConsole.verbose () then
+             (OpamConsole.formatted_msg
+                "%s.\n\
+                 The following newer versions couldn't be installed:\n"
+                hdmsg;
+              OpamConsole.msg "%s"
+                (OpamStd.Format.itemize (fun p ->
+                     Printf.sprintf "%s.%s: %s"
+                       (OpamConsole.colorise `bold
+                          (OpamPackage.name_to_string p))
+                       (OpamPackage.version_to_string p)
+                       (OpamSwitchState.unavailable_reason t
+                          ~default:"unavailable for unknown reasons (this may \
+                                    be a bug in opam)"
+                          (OpamPackage.name p,
+                           Atom (`Eq, OpamPackage.version p))))
+                    (OpamPackage.Set.elements unav)))
+           else
+             OpamConsole.formatted_msg
+               "%s (run with --verbose to show unavailable upgrades).\n" hdmsg
          else
-           OpamConsole.formatted_msg
-             "%s (run with --verbose to show unavailable upgrades).\n" hdmsg;
+           OpamConsole.formatted_msg "%s\n" hdmsg;
          if not (OpamPackage.Set.is_empty unopt) then
            (let bullet =
               OpamConsole.(colorise `red
@@ -330,9 +333,11 @@ let upgrade_t
                  ) (OpamPackage.Set.elements unopt))
            );
          OpamConsole.formatted_msg
-           "However, you may \"opam upgrade\" these packages explicitly, \
+           "However, you may \"opam upgrade\" these packages explicitly \
+            at these versions (e.g. \"opam upgrade %s\"), \
             which will ask permission to downgrade or uninstall the \
-            conflicting packages.\n";
+            conflicting packages.\n"
+           (OpamPackage.to_string (OpamPackage.Set.choose notuptodate));
 
         )
     );

--- a/tests/reftests/avoid-version.test
+++ b/tests/reftests/avoid-version.test
@@ -20,11 +20,11 @@ The following actions will be faked:
 Faking installation of a.1
 Done.
 ### opam upgrade a
-Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
+Everything as up-to-date as possible
 
 The following packages are not being upgraded because the new versions conflict with other installed packages:
   - a.2
-However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade a.2"), which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.
 ### <pkg:a.1.1>
 opam-version: "2.0"
@@ -77,11 +77,11 @@ The following actions will be faked:
 Faking installation of b.1
 Done.
 ### opam upgrade
-Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
+Everything as up-to-date as possible
 
 The following packages are not being upgraded because the new versions conflict with other installed packages:
   - b.2
-However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade b.2"), which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.
 ### opam upgrade b
 The following actions will be faked:
@@ -112,12 +112,12 @@ flags: avoid-version
 opam-version: "2.0"
 flags: avoid-version
 ### opam upgrade
-Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
+Everything as up-to-date as possible
 
 The following packages are not being upgraded because the new versions conflict with other installed packages:
   - a.4
   - b.3
-However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade a.4"), which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.
 ### opam upgrade b.3
 The following actions will be faked:

--- a/tests/reftests/deprecated.test
+++ b/tests/reftests/deprecated.test
@@ -20,11 +20,11 @@ The following actions will be faked:
 Faking installation of a.1
 Done.
 ### opam upgrade a
-Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
+Everything as up-to-date as possible
 
 The following packages are not being upgraded because the new versions conflict with other installed packages:
   - a.2
-However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade a.2"), which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.
 ### <pkg:a.1.1>
 opam-version: "2.0"
@@ -80,11 +80,11 @@ The following actions will be faked:
 Faking installation of b.1
 Done.
 ### opam upgrade
-Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
+Everything as up-to-date as possible
 
 The following packages are not being upgraded because the new versions conflict with other installed packages:
   - b.2
-However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade b.2"), which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.
 ### opam upgrade b
 The following actions will be faked:
@@ -118,12 +118,12 @@ flags: deprecated
 opam-version: "2.0"
 flags: deprecated
 ### opam upgrade
-Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
+Everything as up-to-date as possible
 
 The following packages are not being upgraded because the new versions conflict with other installed packages:
   - a.4
   - b.3
-However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade a.4"), which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.
 ### opam upgrade b.3
 The following actions will be faked:

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -129,7 +129,7 @@ Done.
 ["ocaml" {>= "4.05.0"}]
 ### opam upgrade
 Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
-However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade ocaml.4.10.0"), which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.
 ### opam upgrade ocaml
 The following actions will be performed:

--- a/tests/reftests/install-formula.test
+++ b/tests/reftests/install-formula.test
@@ -132,7 +132,7 @@ You may run "opam upgrade --fixup" to let opam fix the current state.
 ### opam upgrade --formula '"mirage-solo5" | "mirage-no-solo5"'
 [WARNING] Flag --formula is experimental, there is no guarantee that it will be kept; avoid using it in scripts.
 Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
-However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade ocaml.4.10.0"), which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.
 ### opam upgrade mirage-solo5 --formula '"mirage-no-solo5"' --best-effort
 [WARNING] Flag --formula is experimental, there is no guarantee that it will be kept; avoid using it in scripts.

--- a/tests/reftests/switch-invariant.test
+++ b/tests/reftests/switch-invariant.test
@@ -60,8 +60,8 @@ Switch invariant: ["baz" {= "1"}]
 -> installed baz.1
 Done.
 ### opam upgrade -v
-Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
-However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
+Everything as up-to-date as possible
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade bar.2"), which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.
 ### <pkg:baz.1>
 opam-version: "2.0"

--- a/tests/reftests/upgrade-two-point-o.test
+++ b/tests/reftests/upgrade-two-point-o.test
@@ -28,12 +28,12 @@ STATE                           Inferred invariant: from base packages { i-am-co
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
-However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade i-am-compiler.2"), which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.
 ### opam pin remove i-am-compiler
 Ok, i-am-compiler is no longer pinned locally (version 1)
 Nothing to do.
 ### opam upgrade --show-action
-Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
-However, you may "opam upgrade" these packages explicitly, which will ask permission to downgrade or uninstall the conflicting packages.
+Everything as up-to-date as possible
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade i-am-compiler.2"), which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/6270 and also the confusing message about `--verbose` when it is unnecessary.