### PR TITLE
Speedup opam update when nothing changed

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -95,6 +95,7 @@ users)
 ## Shell
 
 ## Internal
+  * Ensure each repositories stored in repos-config is associated with an URL [#6249 @kit-ty-kate]
 
 ## Internal: Windows
 
@@ -125,5 +126,6 @@ users)
 ## opam-solver
 
 ## opam-format
+  * `OpamFile.Repos_config.t`: change the type to not allow repositories without an URL [#6249 @kit-ty-kate]
 
 ## opam-core

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -882,6 +882,8 @@ let get_virtual_switch_state repo_root env =
     repo_name = OpamRepositoryName.of_string "local";
     repo_url = OpamUrl.empty;
     repo_trust = None;
+    repo_etag = None;
+    repo_last_modified = None;
   } in
   let repo_file = OpamRepositoryPath.repo repo_root in
   let repo_def = OpamFile.Repo.safe_read repo_file in

--- a/src/client/opamAdminRepoUpgrade.ml
+++ b/src/client/opamAdminRepoUpgrade.ml
@@ -196,7 +196,7 @@ let do_upgrade repo_root =
                 let base = OpamFilename.Base.of_string "package.patch" in
                 OpamFilename.create dir base
               in
-              OpamDownload.download_as ~overwrite:false url f @@| fun () ->
+              OpamDownload.download_as ~etag:None ~last_modified:None ~overwrite:false url f @@| fun _was_downloaded ->
               let hash = OpamHash.compute (OpamFilename.to_string f) in
               Hashtbl.add url_md5 url hash;
               Some hash)),

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1885,10 +1885,7 @@ let init
           else config
         in
         OpamFile.Config.write config_f config;
-        let repos_config =
-          OpamRepositoryName.Map.of_list repos |>
-          OpamRepositoryName.Map.map OpamStd.Option.some
-        in
+        let repos_config = OpamRepositoryName.Map.of_list repos in
         OpamFile.Repos_config.write (OpamPath.repos_config root)
           repos_config;
 

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1836,7 +1836,7 @@ let init
       try
         (* Create the content of ~/.opam/config *)
         let repos = match repo with
-          | Some r -> [r.repo_name, (r.repo_url, r.repo_trust)]
+          | Some r -> [r.repo_name, (r.repo_url, r.repo_trust, r.repo_etag, r.repo_last_modified)]
           | None -> OpamFile.InitConfig.repositories init_config
         in
         let config =

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -135,7 +135,7 @@ let get_init_config ~no_sandboxing ~no_default_config_file ~add_config_file =
         | Some f -> OpamFile.make f
         | None ->
           let f = OpamFilename.of_string (OpamSystem.temp_file "conf") in
-          OpamProcess.Job.run (OpamDownload.download_as ~overwrite:false url f);
+          let _was_downloaded = OpamProcess.Job.run (OpamDownload.download_as ~etag:None ~last_modified:None ~overwrite:false url f) in
           let hash = OpamHash.compute ~kind:`SHA256 (OpamFilename.to_string f) in
           if OpamConsole.confirm
               "Using configuration file from %s. \

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -478,7 +478,7 @@ let init cli =
     let repo =
       OpamStd.Option.map (fun url ->
           let repo_url = OpamUrl.parse ?backend:repo_kind ~from_file:false url in
-          { repo_name; repo_url; repo_trust = None })
+          { repo_name; repo_url; repo_trust = None; repo_etag = None; repo_last_modified = None })
         repo_url
     in
     let gt, rt, default_compiler =

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -168,7 +168,7 @@ let (@|) g f = OpamStd.Op.(g @* f) ()
 let init_config ?(sandboxing=true) () =
   I.empty |>
   I.with_repositories
-    [OpamRepositoryName.of_string "default", (repository_url, None)] |>
+    [OpamRepositoryName.of_string "default", (repository_url, None, None, None)] |>
   I.with_default_compiler default_compiler |>
   I.with_default_invariant default_invariant |>
   I.with_eval_variables eval_variables |>

--- a/src/client/opamRepositoryCommand.ml
+++ b/src/client/opamRepositoryCommand.ml
@@ -80,7 +80,8 @@ let add rt name url trust_anchors =
       (OpamUrl.to_string url)
   | None ->
     let repo = { repo_name = name; repo_url = url;
-                 repo_trust = trust_anchors; }
+                 repo_trust = trust_anchors;
+                 repo_etag = None; repo_last_modified = None; }
     in
     if OpamFilename.exists_dir (OpamRepositoryPath.root root name) ||
        OpamFilename.exists (OpamRepositoryPath.tar root name)

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1798,7 +1798,7 @@ module InitConfigSyntax = struct
     Pp.V.map_options_3
       (Pp.V.string -|
        Pp.of_module "repository" (module OpamRepositoryName))
-      (Pp.opt @@ Pp.singleton -| Pp.V.url)
+      (Pp.singleton -| Pp.V.url)
       (Pp.map_list Pp.V.string)
       (Pp.opt @@
        Pp.singleton -| Pp.V.int -|
@@ -1821,10 +1821,8 @@ module InitConfigSyntax = struct
         with_repositories repositories
         (Pp.V.map_list ~depth:1 @@
          pp_repository_def -|
-         Pp.pp (fun ~pos -> function
-             | (name, Some url, ta) -> (name, (url, ta))
-             | (_, None, _) -> Pp.bad_format ~pos "Missing repository URL")
-           (fun (name, (url, ta)) -> (name, Some url, ta)));
+         Pp.pp (fun ~pos:_ (name, url, ta) -> (name, (url, ta)))
+           (fun (name, (url, ta)) -> (name, url, ta)));
       "default-compiler", Pp.ppacc
         with_default_compiler default_compiler
         (Pp.V.package_formula `Disj Pp.V.(constraints Pp.V.version));
@@ -1965,7 +1963,7 @@ module Repos_configSyntax = struct
   let format_version = OpamVersion.of_string "2.0"
   let file_format_version = OpamVersion.of_string "2.0"
 
-  type t = ((url * trust_anchors option) option) OpamRepositoryName.Map.t
+  type t = (url * trust_anchors option) OpamRepositoryName.Map.t
 
   let empty = OpamRepositoryName.Map.empty
 
@@ -1975,12 +1973,8 @@ module Repos_configSyntax = struct
       ((Pp.V.map_list ~depth:1 @@
         InitConfigSyntax.pp_repository_def -|
         Pp.pp
-          (fun ~pos:_ -> function
-             | (name, Some url, ta) -> name, Some (url, ta)
-             | (name, None, _) -> name, None)
-          (fun (name, def) -> match def with
-             | Some (url, ta) -> name, Some url, ta
-             | None -> name, None, None)) -|
+          (fun ~pos:_ (name, url, ta) -> (name, (url, ta)))
+          (fun (name, (url, ta)) -> (name, url, ta))) -|
        Pp.of_pair "repository-url-list"
          OpamRepositoryName.Map.(of_list, bindings));
   ]

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -254,7 +254,7 @@ module InitConfig: sig
   include IO_FILE
 
   val opam_version: t -> opam_version
-  val repositories: t -> (repository_name * (url * trust_anchors option)) list
+  val repositories: t -> (repository_name * (url * trust_anchors option * string option * string option)) list
   val default_compiler: t -> formula
   val default_invariant: t -> formula
   val jobs: t -> int option
@@ -274,7 +274,7 @@ module InitConfig: sig
 
   val with_opam_version: opam_version -> t -> t
   val with_repositories:
-    (repository_name * (url * trust_anchors option)) list -> t -> t
+    (repository_name * (url * trust_anchors option * string option * string option)) list -> t -> t
   val with_default_compiler: formula -> t -> t
   val with_default_invariant: formula -> t -> t
   val with_jobs: int option -> t -> t
@@ -1028,7 +1028,7 @@ module Repo_config_legacy : sig
 end
 
 module Repos_config: sig
-  type t = (url * trust_anchors option) OpamRepositoryName.Map.t
+  type t = (url * trust_anchors option * string option * string option) OpamRepositoryName.Map.t
   include IO_FILE with type t := t
   module BestEffort: BestEffortRead with type t := t
 end

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -1028,7 +1028,7 @@ module Repo_config_legacy : sig
 end
 
 module Repos_config: sig
-  type t = (url * trust_anchors option) option OpamRepositoryName.Map.t
+  type t = (url * trust_anchors option) OpamRepositoryName.Map.t
   include IO_FILE with type t := t
   module BestEffort: BestEffortRead with type t := t
 end

--- a/src/format/opamFormat.ml
+++ b/src/format/opamFormat.ml
@@ -244,6 +244,20 @@ module V = struct
       pp4 -|
     pp (fun ~pos:_ (((a,b),c),d) -> a,b,c,d) (fun (a,b,c,d) -> ((a,b),c),d)
 
+  let map_options_5 pp1 pp2 pp3 pp4 pp5 pp6 =
+    option_depth 5 -|
+    option_strict -| map_option_contents
+      (option_strict -| map_option_contents
+         (option_strict -| map_option_contents
+            (option_strict -| map_option_contents
+               (option_strict -| map_option_contents
+                  pp1 pp2)
+               pp3)
+            pp4)
+         pp5)
+      pp6 -|
+    pp (fun ~pos:_ (((((a,b),c),d),e),f) -> a,b,c,d,e,f) (fun (a,b,c,d,e,f) -> ((((a,b),c),d),e),f)
+
   let map_pair pp1 pp2 =
     pp ~name:(Printf.sprintf "[%s %s]" pp1.ppname pp2.ppname)
       (fun ~pos:_ v -> match v.pelem with

--- a/src/format/opamFormat.mli
+++ b/src/format/opamFormat.mli
@@ -101,6 +101,13 @@ module V : sig
     (value list, 'b) t -> (value list, 'c) t -> (value list, 'd) t ->
     (value, 'a * 'b * 'c * 'd) t
 
+  (** Maps over five options (e.g. [v {op1} {op2} {op3} {op4} {op5}]) *)
+  val map_options_5 :
+    (value, 'a) t ->
+    (value list, 'b) t -> (value list, 'c) t -> (value list, 'd) t ->
+    (value list, 'e) t -> (value list, 'f) t ->
+    (value, 'a * 'b * 'c * 'd * 'e * 'f) t
+
   (** A pair is simply a list with two elements in the [value] type *)
   val map_pair :
     (value, 'a) t ->

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -176,9 +176,11 @@ type trust_anchors = {
 
 (** Repositories *)
 type repository = {
-  repo_name    : repository_name;
-  repo_url     : url;
-  repo_trust   : trust_anchors option;
+  repo_name          : repository_name;
+  repo_url           : url;
+  repo_trust         : trust_anchors option;
+  repo_etag          : string option;
+  repo_last_modified : string option;
 }
 
 (** {2 Variable-based filters} *)

--- a/src/repository/opamDownload.mli
+++ b/src/repository/opamDownload.mli
@@ -31,7 +31,7 @@ val download_as:
   etag:string option -> last_modified:string option ->
   ?checksum:OpamHash.t ->
   OpamUrl.t -> OpamFilename.t ->
-  bool OpamProcess.job
+  [`Was_downloaded of (string option * string option) | `Not_downloaded] OpamProcess.job
 
 
 (** Software Heritage fallback *)

--- a/src/repository/opamDownload.mli
+++ b/src/repository/opamDownload.mli
@@ -28,9 +28,10 @@ val download:
 (** As [download], but with a specified output filename. *)
 val download_as:
   ?quiet:bool -> ?validate:bool -> overwrite:bool -> ?compress:bool ->
+  etag:string option -> last_modified:string option ->
   ?checksum:OpamHash.t ->
   OpamUrl.t -> OpamFilename.t ->
-  unit OpamProcess.job
+  bool OpamProcess.job
 
 
 (** Software Heritage fallback *)

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -55,10 +55,10 @@ module B = struct
     @@ fun () ->
     OpamRepositoryBackend.job_text repo_name "sync"
       (sync_state ~etag ~last_modified repo_name quarantine url) @@+ function
-    | `Was_downloaded ->
+    | `Was_downloaded was_downloaded ->
       (if not (OpamFilename.exists_dir repo_root) ||
           OpamFilename.dir_is_empty repo_root then
-         Done (OpamRepositoryBackend.Update_full quarantine)
+         Done (OpamRepositoryBackend.Update_full (quarantine, was_downloaded))
        else
          OpamProcess.Job.finally finalise @@ fun () ->
          OpamRepositoryBackend.job_text repo_name "diff"
@@ -68,7 +68,7 @@ module B = struct
               (OpamFilename.basename_dir quarantine))
          @@| function
          | None -> OpamRepositoryBackend.Update_empty
-         | Some patch -> OpamRepositoryBackend.Update_patch patch)
+         | Some patch -> OpamRepositoryBackend.Update_patch (patch, was_downloaded))
     | `Not_downloaded ->
       Done OpamRepositoryBackend.Update_empty
 

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -67,7 +67,7 @@ module B = struct
               (OpamFilename.basename_dir repo_root)
               (OpamFilename.basename_dir quarantine))
          @@| function
-         | None -> OpamRepositoryBackend.Update_empty
+         | None -> OpamRepositoryBackend.Update_metadata was_downloaded
          | Some patch -> OpamRepositoryBackend.Update_patch (patch, was_downloaded))
     | `Not_downloaded ->
       Done OpamRepositoryBackend.Update_empty

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -144,7 +144,7 @@ module B = struct
   let pull_dir_quiet local_dirname url =
     rsync_dirs url local_dirname
 
-  let fetch_repo_update repo_name ?cache_dir:_ repo_root url =
+  let fetch_repo_update ~etag:_ ~last_modified:_ repo_name ?cache_dir:_ repo_root url =
     log "pull-repo-update";
     let quarantine =
       OpamFilename.Dir.(of_string (to_string repo_root ^ ".new"))

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -176,7 +176,7 @@ module B = struct
     | Result _ ->
       if not (OpamFilename.exists_dir repo_root) ||
          OpamFilename.dir_is_empty repo_root then
-        Done (OpamRepositoryBackend.Update_full quarantine)
+        Done (OpamRepositoryBackend.Update_full (quarantine, (None, None)))
       else
         OpamProcess.Job.finally finalise @@ fun () ->
         OpamRepositoryBackend.job_text repo_name "diff" @@
@@ -186,7 +186,7 @@ module B = struct
           (OpamFilename.basename_dir quarantine)
         @@| function
         | None -> OpamRepositoryBackend.Update_empty
-        | Some p -> OpamRepositoryBackend.Update_patch p
+        | Some p -> OpamRepositoryBackend.Update_patch (p, (None, None))
 
   let repo_update_complete _ _ = Done ()
 

--- a/src/repository/opamRepository.mli
+++ b/src/repository/opamRepository.mli
@@ -25,7 +25,7 @@ val packages_with_prefixes: dirname -> string option package_map
 (** Update {i $opam/repo/$repo}. Raises [Failure] in case the update couldn't be
     achieved. Returns [`No_changes] if the update did not bring any changes, and
     [`Changes] otherwise. *)
-val update: repository -> dirname -> [`Changes | `No_changes] OpamProcess.job
+val update: repository -> dirname -> [`Changes of string option * string option | `No_changes] OpamProcess.job
 
 (** [pull_shared_tree ?cache_dir ?cache_url labels_dirnames checksums urls]
     Fetch an URL and put the resulting tree into the supplied directories

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -14,8 +14,8 @@ let log = OpamConsole.log "REPO_BACKEND"
 let slog = OpamConsole.slog
 
 type update =
-  | Update_full of dirname
-  | Update_patch of filename
+  | Update_full of dirname * (string option * string option)
+  | Update_patch of filename * (string option * string option)
   | Update_empty
   | Update_err of exn
 

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -26,6 +26,7 @@ module type S = sig
     ?cache_dir:dirname -> ?subpath:subpath -> dirname -> OpamHash.t option -> url ->
     filename option download OpamProcess.job
   val fetch_repo_update:
+    etag:string option -> last_modified:string option ->
     repository_name -> ?cache_dir:dirname -> dirname -> url ->
     update OpamProcess.job
   val repo_update_complete: dirname -> url -> unit OpamProcess.job

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -17,6 +17,7 @@ type update =
   | Update_full of dirname * (string option * string option)
   | Update_patch of filename * (string option * string option)
   | Update_empty
+  | Update_metadata of (string option * string option)
   | Update_err of exn
 
 module type S = sig

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -23,6 +23,8 @@ type update =
       local repository with 'patch -p1' would get it to the upstream state *)
   | Update_empty
   (** The repository is already up to date *)
+  | Update_metadata of (string option * string option)
+  (** The etag and last_modified have to be updated *)
   | Update_err of exn
   (** Failed to obtain the update *)
 

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -60,6 +60,7 @@ module type S = sig
       verifications. The file or directory returned is always temporary and
       should be cleaned up by the caller. *)
   val fetch_repo_update:
+    etag:string option -> last_modified:string option ->
     repository_name -> ?cache_dir:dirname -> dirname -> url ->
     update OpamProcess.job
 

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -15,10 +15,10 @@ open OpamTypes
 
 (** Type returned by repository updates. *)
 type update =
-  | Update_full of dirname
+  | Update_full of dirname * (string option * string option)
   (** No previous known state, the full contents have been put in the given
       temporary directory *)
-  | Update_patch of filename
+  | Update_patch of filename * (string option * string option)
   (** The given patch file corresponds to the update, i.e. applying it to the
       local repository with 'patch -p1' would get it to the upstream state *)
   | Update_empty

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -41,7 +41,7 @@ module Make (VCS: VCS) = struct
 
   let name = VCS.name
 
-  let fetch_repo_update repo_name ?cache_dir repo_root repo_url =
+  let fetch_repo_update ~etag:_ ~last_modified:_ repo_name ?cache_dir repo_root repo_url =
     let full_fetch = false in
     if VCS.exists repo_root then
       OpamProcess.Job.catch (fun e -> Done (OpamRepositoryBackend.Update_err e))

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -53,7 +53,7 @@ module Make (VCS: VCS) = struct
         (VCS.diff repo_root repo_url)
       @@| function
       | None -> OpamRepositoryBackend.Update_empty
-      | Some patch -> OpamRepositoryBackend.Update_patch patch
+      | Some patch -> OpamRepositoryBackend.Update_patch (patch, (None, None))
     else
       OpamProcess.Job.catch (fun e ->
           OpamFilename.rmdir repo_root;
@@ -70,7 +70,7 @@ module Make (VCS: VCS) = struct
       OpamProcess.Job.catch (fun e -> OpamFilename.rmdir tmpdir; raise e)
       @@ fun () ->
       VCS.reset_tree tmpdir repo_url @@| fun () ->
-      OpamRepositoryBackend.Update_full tmpdir
+      OpamRepositoryBackend.Update_full (tmpdir, (None, None))
 
   let repo_update_complete dirname url =
     VCS.patch_applied dirname url @@+ fun () ->

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -770,7 +770,7 @@ let from_1_3_dev7_to_2_0_alpha ~on_the_fly:_ root conf =
   in
   OpamFile.Repos_config.write (OpamPath.repos_config root)
     (OpamRepositoryName.Map.of_list
-       (List.map (fun (_, r, u) -> r, (u,None)) prio_repositories));
+       (List.map (fun (_, r, u) -> r, (u,None,None,None)) prio_repositories));
   let prio_repositories =
     List.stable_sort (fun (prio1, _, _) (prio2, _, _) -> prio2 - prio1)
       prio_repositories

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -770,7 +770,7 @@ let from_1_3_dev7_to_2_0_alpha ~on_the_fly:_ root conf =
   in
   OpamFile.Repos_config.write (OpamPath.repos_config root)
     (OpamRepositoryName.Map.of_list
-       (List.map (fun (_, r, u) -> r, Some (u,None)) prio_repositories));
+       (List.map (fun (_, r, u) -> r, (u,None)) prio_repositories));
   let prio_repositories =
     List.stable_sort (fun (prio1, _, _) (prio2, _, _) -> prio2 - prio1)
       prio_repositories

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -164,10 +164,12 @@ let load lock_kind gt =
          load with best-effort (read-only)"
       (OpamVersion.to_string (OpamFile.Config.opam_root_version gt.config))
       (OpamVersion.to_string (OpamFile.Config.root_version));
-  let mk_repo name (url, ta) = {
+  let mk_repo name (url, ta, etag, last_modified) = {
     repo_name = name;
     repo_url = url;
     repo_trust = ta;
+    repo_etag = etag;
+    repo_last_modified = last_modified;
   } in
   let repositories = OpamRepositoryName.Map.mapi mk_repo repos_map in
   let repos_tmp_root = lazy (OpamFilename.mk_tmp_dir ()) in
@@ -280,7 +282,7 @@ let write_config rt =
   OpamFile.Repos_config.write (OpamPath.repos_config rt.repos_global.root)
     (OpamRepositoryName.Map.filter_map (fun _ r ->
          if r.repo_url = OpamUrl.empty then None
-         else Some (r.repo_url, r.repo_trust))
+         else Some (r.repo_url, r.repo_trust, r.repo_etag, r.repo_last_modified))
         rt.repositories)
 
 let check_last_update () =

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -299,8 +299,8 @@ module Cygwin = struct
       log "Downloading setup-x86_64.exe";
       if OpamConsole.disp_status_line () then
         OpamConsole.status_line "Downloading Cygwin setup from cygwin.com";
-      OpamDownload.download_as ~overwrite ?checksum url_setupexe dst @@+
-        fun () ->
+      OpamDownload.download_as ~etag:None ~last_modified:None ~overwrite ?checksum url_setupexe dst @@+
+        fun _was_downloaded ->
           OpamConsole.clear_status ();
           Done ()
     end

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -67,7 +67,7 @@ let repository rt repo =
     in
     OpamProcess.Job.with_text text @@
     OpamRepository.update r repo_root @@+ fun has_changes ->
-    let has_changes = if redirect then `Changes else has_changes in
+    let has_changes = if redirect then `Changes (None, None) else has_changes in
     if n <> max_loop && r = repo then
       (OpamConsole.warning "%s: Cyclic redirections, stopping."
          (OpamRepositoryName.to_string repo.repo_name);
@@ -99,7 +99,7 @@ let repository rt repo =
   | `No_changes ->
     log "Repository did not change: nothing to do.";
     Done None
-  | `Changes ->
+  | `Changes was_downloaded ->
     log "Repository has new changes";
     let repo_file = OpamFile.Repo.safe_read repo_file_path in
     let repo_file = OpamFile.Repo.with_root_url repo.repo_url repo_file in
@@ -145,6 +145,7 @@ let repository rt repo =
       else if OpamFilename.exists tarred_repo then
         (OpamFilename.move_dir ~src:repo_root ~dst:local_dir;
          OpamFilename.remove tarred_repo);
+      let repo = {repo with repo_etag = fst was_downloaded; repo_last_modified = snd was_downloaded} in
       Done (Some (
           (* Return an update function to make parallel execution possible *)
           fun rt ->


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/5553
Queued on https://github.com/ocaml/opam/issues/6327

The code in its current form is very crude and in no way ready to be merged.
This PR achieves a 8x speedup compared to 2.3.0~rc1 on subsequent empty updates after initialization of the new values, going from 3.5s to an almost instantaneous 0.4s.

TODO:
- [ ] make etag and last_modified their own record to avoid having to carry both around
- [ ] write the repos-config file when there is no diff but etag&last_modified differ
- [ ] bump the opam_version of repos-config to 2.4 (new syntax is not ignored by previous versions of opam)
- [ ] add some dedicated tests
- [ ] make sure the cache is invalidated