### PR TITLE
Fix UI glitches and do not pre-write the answer to questions with the default anwser

### DIFF
--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -824,12 +824,13 @@ let confirm ?(require_unsafe_yes=false) ?(default=true) fmt =
       then
         (formatted_msg "%sn\n" prompt; false)
       else
-        short_user_input ~prompt ~default:(if default then 'y' else 'n')
+        short_user_input ~prompt ~default:' '
         (function
-        | "y" | "yes" -> Some true
-        | "n" | "no" -> Some false
-        | "\027" -> Some false (* echap *)
-        | _  -> None))
+          | " " -> Some default
+          | "y" | "yes" -> Some true
+          | "n" | "no" -> Some false
+          | "\027" -> Some false (* echap *)
+          | _  -> None))
     fmt
 
 let read fmt =


### PR DESCRIPTION
~~Queued on top of https://github.com/ocaml/opam/pull/6289~~
This implements what was described in https://github.com/ocaml/opam/pull/6289#pullrequestreview-2428097616 with the addition of a UI bugfix:
```
$ opam pin edit ppxlib
Package ppxlib is not pinned. Edit as a new pinning to version 0.33.1~5.3preview? [y/n] y
Press enter to start "vim" (this can be customised by setting EDITOR or OPAMEDITOR)...[WARNING] The opam file didn't pass validation:
  warning 59: url doesn't contain a checksum
Proceed anyway ('no' will re-edit)? [y/n] 
```
In this example you can see the `Press enter ...` line is missing the end of line character. This happens because `OpamConsole.pause` (used to write this line) uses `short_user_input` with `~default:""`, but this function wasn't made to have its default be anything but a string of length 1 in interactive mode. This is marked evident as the prompt subfunction will move the cursor left then remove one character, which happens to be the issue here.