### PR TITLE
CI: fiw macos jobs regarding gpatch

### DIFF
--- a/.github/scripts/main/preamble.sh
+++ b/.github/scripts/main/preamble.sh
@@ -12,6 +12,7 @@ OCAML_LOCAL=$CACHE/ocaml-local
 OPAM_LOCAL=$CACHE/opam-local
 if [ "$RUNNER_OS" = 'macOS' ]; then
   PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"
+  PATH="/opt/homebrew/opt/gpatch/libexec/gnubin:$PATH"
 fi
 PATH=$OPAM_LOCAL/bin:$OCAML_LOCAL/bin:$PATH; export PATH
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -126,6 +126,7 @@ users)
 
 ## Github Actions
   * Add a doc generation job under linux [#5349 @rjbou]
+  * Update the github action scripts now that homebrew renamed the GNU patch binary to gpatch [#6296 @kit-ty-kate]
 
 ## Doc
   * Update the command to install opam to point to the new simplified url on opam.ocaml.org [#6226 @kit-ty-kate]


### PR DESCRIPTION
Update the github action scripts now that homebrew renamed the GNU patch binary to gpatch (see Homebrew/homebrew-core#174687)

Ported from #6292
