### PR TITLE
Fix the detection of ZDOTDIR when using zsh

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -19,6 +19,7 @@ users)
 ## Plugins
 
 ## Init
+  * [BUG] Fix the detection of `ZDOTDIR` when using `zsh` [#6299 @acasta-yhliu - fix #6281]
 
 ## Config report
 

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1162,7 +1162,11 @@ module OpamSys = struct
     match shell with
     | SH_fish ->
       Some (List.fold_left Filename.concat (home ".config") ["fish"; "config.fish"])
-    | SH_zsh  -> Some (home ".zshrc")
+    | SH_zsh  ->
+      let zsh_home f = 
+        try Filename.concat (Env.get "ZDOTDIR") f
+        with Not_found -> home f in 
+      Some (zsh_home ".zshrc")
     | SH_bash ->
       let shell =
         (try


### PR DESCRIPTION
As mentioned in #6281, `ZDOTDIR` is not checked when modifying env by `opam init`. Detection is added to `src/core/openStd.ml`

Fixes #6281 