### PR TITLE
Avoid issues when using wget2 where the requested url might return an html page instead of the expected content

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -118,6 +118,7 @@ users)
   * Make `curl` the default download tool instead of `wget` on macOS [#6304 @kit-ty-kate]
   * download tool: Use fetch on DragonFlyBSD and ftp on NetBSD [#6305 @kit-ty-kate]
   * Prefer curl over any other download tools on every systems, if available [#6305 @kit-ty-kate]
+  * Avoid issues when using wget2 where the requested url might return an html page instead of the expected content [#6303 @kit-ty-kate]
 
 ## Internal: Windows
 

--- a/src/repository/opamDownload.ml
+++ b/src/repository/opamDownload.ml
@@ -44,6 +44,13 @@ let curl_args =
       main_args
 
 let wget_args = [
+  (* wget2 by default has
+     Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+     which makes some servers return an html page instead of the expected
+     content. This is the case for the Software Heritage REST API.
+     Using "Accept: */*" makes it on par with curl
+  *)
+  CString "--header=Accept: */*", None;
   CString "-t", None; CIdent "retry", None;
   CString "-O", None; CIdent "out", None;
   CString "-U", None; user_agent, None;

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -33,7 +33,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
-+ wget "-t" "3" "-O" "${OPAMTMP}/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
++ wget "--header=Accept: */*" "-t" "3" "-O" "${OPAMTMP}/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
 Processing  1/1: [foo.1: extract]
 + tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
 Done.
@@ -147,7 +147,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [foo.1: http]
-+ wget "-t" "3" "-O" "${OPAMTMP}/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
++ wget "--header=Accept: */*" "-t" "3" "-O" "${OPAMTMP}/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
 Processing  1/1: [foo.1: extract]
 + tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"
 Done.
@@ -260,7 +260,7 @@ The following actions will be performed:
 SYSTEM                          rmdir ${BASEDIR}/OPAM/download/.opam-switch/sources/baz.1
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [baz.1: http]
-+ wget "-t" "3" "-O" "${OPAMTMP}/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
++ wget "--header=Accept: */*" "-t" "3" "-O" "${OPAMTMP}/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
 SYSTEM                          mv ${OPAMTMP}/v1.0.0.tar.gz.part -> ${OPAMTMP}/v1.0.0.tar.gz
 SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5-dir/
 SYSTEM                          copy ${OPAMTMP}/v1.0.0.tar.gz -> ${BASEDIR}/OPAM/download-cache/md5-dir/


### PR DESCRIPTION
When using wget2 (default wget on Fedora 40 and 41), the testsuite fails with:
```diff
diff --git a/tests/reftests/swhid.unix.test b/tests/reftests/swhid.unix.test
--- a/tests/reftests/swhid.unix.test
+++ b/tests/reftests/swhid.unix.test
@@ -109,9 +109,18 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Source https://fake.exe/url.tar.gz is not available. Do you want to try to retrieve it from Software Heritage cache (https://www.softwareheritage.org)? It may take few minutes. [y/N] y
--> retrieved snappy-swhid-dir.2  (SWH fallback)
--> installed snappy-swhid-dir.2
-Done.
+[ERROR] Failed to get sources of snappy-swhid-dir.2: SWH fallback: Unknown swhid
+
+OpamSolution.Fetch_fail("SWH fallback: Unknown swhid")
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - fetch snappy-swhid-dir 2
++- 
+- No changes have been performed
+'${OPAM} install snappy-swhid-dir -v' failed.
+# Return code 40 #
```
It turns out the issue was that by default wget2 prefers to get html files so the Software Heritage server will serve an html file instead of the expected `application/json`. This fix fixes this issue as well when downloading archives from some servers that also have the same behaviour of returning a different output depending on the value of `Accept:`.

See https://github.com/rockdaboot/wget2/issues/337