### PR TITLE
Remove ocaml-system from the list of default compilers used during opam init

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -20,6 +20,7 @@ users)
 
 ## Init
   * [BUG] Fix the detection of `ZDOTDIR` when using `zsh` [#6299 @acasta-yhliu - fix #6281]
+  * Remove `ocaml-system` from the list of default compilers [#6307 @kit-ty-kate - fix #3509]
 
 ## Config report
 
@@ -178,6 +179,7 @@ users)
   * Add a test showing the behaviour of `opam upgrade` with packages flagged with `avoid-version`/`deprecated` [#6273 @kit-ty-kate]
   * Add a test showing the behaviour when a pin depend is unpinned [#6380 @rjbou]
   * Add a test to ensure `opam upgrade <pkg>` will not upgrade unrelated things [#6373 @kit-ty-kate]
+  * Add a test in init to show ocaml system compiler selection behaviour [#6307 @kit-ty-kate @rjbou]
 
 ### Engine
 

--- a/src/client/opamInitDefaults.ml
+++ b/src/client/opamInitDefaults.ml
@@ -19,12 +19,8 @@ let repository_url = {
 }
 
 let default_compiler =
-  OpamFormula.ors [
-    OpamFormula.Atom (OpamPackage.Name.of_string "ocaml-system",
-                      OpamFormula.Empty);
-    OpamFormula.Atom (OpamPackage.Name.of_string "ocaml-base-compiler",
-                      OpamFormula.Empty);
-  ]
+  OpamFormula.Atom (OpamPackage.Name.of_string "ocaml-base-compiler",
+                    OpamFormula.Empty)
 
 let default_invariant =
   OpamFormula.Atom

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -67,6 +67,8 @@ depends: [ "ocaml" {= "4.10.0" & post} ]
 flags: compiler
 conflict-class: "ocaml-core-compiler"
 ### :---:
+### :I: Default compiler selection
+### :I:1: No system compiler
 ### rm -rf ${OPAMROOT}
 ### <opamrc>
 eval-variables: [ sys-ocaml-version ["false"] "no system compiler" ]
@@ -87,6 +89,7 @@ Switch invariant: ["ocaml" {>= "4.05.0"}]
 Done.
 ### opam switch invariant
 ["ocaml" {>= "4.05.0"}]
+### :I:2: system compiler not compliant with default invariant
 ### rm -rf ${OPAMROOT}
 ### <opamrc>
 eval-variables: [ sys-ocaml-version ["echo" "4.02.3"] "old system compiler" ]
@@ -107,6 +110,7 @@ Switch invariant: ["ocaml" {>= "4.05.0"}]
 Done.
 ### opam switch invariant
 ["ocaml" {>= "4.05.0"}]
+### :I:3: System compiler = 4.07.0, should be selected default
 ### rm -rf ${OPAMROOT}
 ### <opamrc>
 eval-variables: [ sys-ocaml-version ["echo" "4.07.0"] "new system compiler" ]
@@ -146,8 +150,8 @@ The following actions will be performed:
 -> installed ocaml-base-compiler.4.10.0
 -> installed ocaml.4.10.0
 Done.
-### : Init with config file :
-### :: default setup ::
+### :II: Init with config file :
+### :II:a: default setup ::
 ### rm -rf $OPAMROOT
 ### opam init --bypass-checks --bare --no-setup default REPO/ | grep -v Cygwin
 No configuration file found, using built-in defaults.
@@ -168,7 +172,7 @@ swh-fallback: false
 wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
 wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
 wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
-### :: full configured opamrc ::
+### :II:b: full configured opamrc ::
 ### rm -rf $OPAMROOT
 ### <opamrc>
 opam-version: "2.0"

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -110,7 +110,7 @@ Switch invariant: ["ocaml" {>= "4.05.0"}]
 Done.
 ### opam switch invariant
 ["ocaml" {>= "4.05.0"}]
-### :I:3: System compiler = 4.07.0, should be selected default
+### :I:3: Base compiler should be selected default
 ### rm -rf ${OPAMROOT}
 ### <opamrc>
 eval-variables: [ sys-ocaml-version ["echo" "4.07.0"] "new system compiler" ]
@@ -120,36 +120,38 @@ Configuring from ${BASEDIR}/opamrc and then from built-in defaults.
 <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
 [default] Initialised
 
-<><> Creating initial switch 'default' (invariant ["ocaml" {>= "4.05.0"}] - initially with ocaml-system)
+<><> Creating initial switch 'default' (invariant ["ocaml" {>= "4.05.0"}] - initially with ocaml-base-compiler)
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
 Switch invariant: ["ocaml" {>= "4.05.0"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed ocaml-base-compiler.4.10.0
+-> installed ocaml.4.10.0
+Done.
+### opam switch invariant
+["ocaml" {>= "4.05.0"}]
+### :I:4: ocaml-system explicit selection
+### rm -rf $OPAMROOT
+### <opamrc>
+eval-variables: [ sys-ocaml-version ["echo" "4.07.0"] "new system compiler" ]
+### opam init --no-setup --bypass-checks default REPO/ --config opamrc -c ocaml-system | grep -v Cygwin
+Configuring from ${BASEDIR}/opamrc and then from built-in defaults.
+
+<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+[default] Initialised
+
+<><> Creating initial switch 'ocaml-system' (invariant ["ocaml-system"]) ><><><>
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-system"]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed ocaml-system.4.07.0
 -> installed ocaml.4.07.0
 Done.
 ### opam switch invariant
-["ocaml" {>= "4.05.0"}]
-### opam upgrade
-Everything as up-to-date as possible (run with --verbose to show unavailable upgrades).
-However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade ocaml.4.10.0"), which will ask permission to downgrade or uninstall the conflicting packages.
-Nothing to do.
-### opam upgrade ocaml
-The following actions will be performed:
-=== remove 1 package
-  - remove  ocaml-system        4.07.0           [conflicts with ocaml-base-compiler]
-=== upgrade 1 package
-  - upgrade ocaml               4.07.0 to 4.10.0
-=== install 1 package
-  - install ocaml-base-compiler 4.10.0           [required by ocaml]
-
-<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> removed   ocaml.4.07.0
--> removed   ocaml-system.4.07.0
--> installed ocaml-base-compiler.4.10.0
--> installed ocaml.4.10.0
-Done.
+["ocaml-system"]
 ### :II: Init with config file :
 ### :II:a: default setup ::
 ### rm -rf $OPAMROOT
@@ -159,7 +161,7 @@ No configuration file found, using built-in defaults.
 <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
 [default] Initialised
 ### opam-cat $OPAMROOT/config | 'opam-root-version: "${OPAMROOTVERSION}"' -> 'opam-root-version: current' | grep -v sys-pkg-manager-cmd | grep -v global-variables | grep -v eval-variables:
-default-compiler: ["ocaml-system" "ocaml-base-compiler"]
+default-compiler: ["ocaml-base-compiler"]
 default-invariant: ["ocaml" {>= "4.05.0"}]
 depext: true
 depext-cannot-install: false


### PR DESCRIPTION
Fixes #3509

I don't think having `ocaml-system` in the list of default compiler is a good choice.
Most platforms actually won't work if you installed the `ocaml` package alone. They usually all require some sort of extra `ocaml-compiler-libs` to be complete and not end up in very confusing error messages for new users.

System compilers are also not tested in the CI for opam-repository as of today (see https://github.com/ocurrent/opam-repo-ci/issues/327) and end up breaking packages from time to time.

Experienced developers can always use `opam init -c ocaml-system` if they really want a system compiler and `ocaml-system` can always be installed explicitly later if needed, but as a default for everyone it seems to brittle to me.