### PR TITLE
Don't ask confirmation when pinning a new package

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -47,6 +47,7 @@ users)
 ## Pin
   * [NEW] Make it so pin list display the current revision of a pinned repository in a new column [#6274 @desumn - fix #5533]
   * [BUG] Stop double pin of packages located in ./opam/opam [#6343 @kit-ty-kate - fix #6342]
+  * Don't ask confirmation when pinning an unknown package (absent from repositories) [#6309 @kit-ty-kate @rjbou - fix #3199]
 
 ## List
 

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -491,12 +491,10 @@ and source_pin
       version, None
   in
 
-  if not (OpamPackage.has_name st.packages name) &&
-     not (OpamConsole.confirm
-            "Package %s does not exist, create as a %s package?"
-            (OpamPackage.Name.to_string name)
-            (OpamConsole.colorise `bold "NEW"))
-  then raise Aborted;
+  if not (OpamPackage.has_name st.packages name) then
+    OpamConsole.note "Package %s does not exist in opam repositories \
+                      registered in the current switch."
+      (OpamPackage.Name.to_string name);
 
   (match OpamStd.Option.map OpamFile.URL.url cur_urlf, target_url with
    | Some u, Some target when OpamUrl.(

--- a/tests/reftests/assume-built.test
+++ b/tests/reftests/assume-built.test
@@ -14,7 +14,7 @@ versionned
 new!
 ### opam switch create assume-built --empty
 ### opam pin ./ongoing -n
-Package ongoing does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package ongoing does not exist in opam repositories registered in the current switch.
 ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
 ### : assume built
 ### opam install ongoing -v | sed-cmd test | sed-cmd sh | sed-cmd touch
@@ -199,7 +199,7 @@ install: [
 ]
 ### git -C ongoing clean -fdqx
 ### opam pin ./ongoing -n
-Package ongoing does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package ongoing does not exist in opam repositories registered in the current switch.
 ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version 1.0)
 ### touch ongoing/out
 ### opam install qux
@@ -253,7 +253,7 @@ install: [
 ]
 ### git -C ongoing clean -fdqx
 ### opam pin ./ongoing -n
-Package ongoing does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package ongoing does not exist in opam repositories registered in the current switch.
 ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
 ### touch ongoing/out
 ### opam install ongoing --assume-built --with-test

--- a/tests/reftests/autopin.test
+++ b/tests/reftests/autopin.test
@@ -260,7 +260,7 @@ Done.
 This will pin the following packages: foo-core, foo-format-bis, foo-format. Continue? [Y/n] y
 [NOTE] Package foo-core is already pinned to file://${BASEDIR}/foo (version 2.0).
 foo-core is now pinned to file://${BASEDIR}/foo (version 2.0)
-Package foo-format-bis does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package foo-format-bis does not exist in opam repositories registered in the current switch.
 foo-format-bis is now pinned to file://${BASEDIR}/foo (version 2.0)
 [NOTE] Package foo-format is already pinned to file://${BASEDIR}/foo (version 2.0).
 foo-format is now pinned to file://${BASEDIR}/foo (version 2.0)

--- a/tests/reftests/config.test
+++ b/tests/reftests/config.test
@@ -101,7 +101,7 @@ opam-version: "2.0"
 ### opam repository add second ./REPO2 --this-switch
 [second] Initialised
 ### opam pin pinned-package -y
-Package pinned-package does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package pinned-package does not exist in opam repositories registered in the current switch.
 pinned-package is now pinned to file://${BASEDIR}/pinned-package (version dev)
 
 The following actions will be performed:

--- a/tests/reftests/conflict-resto.test
+++ b/tests/reftests/conflict-resto.test
@@ -390,10 +390,10 @@ Faking installation of ocaml-options-vanilla.1
 Done.
 ### OPAMVAR_os=linux opam pin resto/ --with-version=0.6.1 --show --yes | unordered
 This will pin the following packages: ezresto-directory, ezresto, resto-acl, resto-client, resto-cohttp-client, resto-cohttp-self-serving-client, resto-cohttp-server, resto-cohttp, resto-directory, resto-json, resto-lwt, resto-self-serving-client, resto-server, resto. Continue? [Y/n] y
-Package resto-client does not exist, create as a NEW package? [Y/n] y
-Package resto-lwt does not exist, create as a NEW package? [Y/n] y
-Package resto-self-serving-client does not exist, create as a NEW package? [Y/n] y
-Package resto-server does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package resto-client does not exist in opam repositories registered in the current switch.
+[NOTE] Package resto-lwt does not exist in opam repositories registered in the current switch.
+[NOTE] Package resto-self-serving-client does not exist in opam repositories registered in the current switch.
+[NOTE] Package resto-server does not exist in opam repositories registered in the current switch.
 ezresto-directory is now pinned to file://${BASEDIR}/resto (version 0.6.1)
 ezresto is now pinned to file://${BASEDIR}/resto (version 0.6.1)
 resto-acl is now pinned to file://${BASEDIR}/resto (version 0.6.1)

--- a/tests/reftests/fetch-package.test
+++ b/tests/reftests/fetch-package.test
@@ -91,7 +91,7 @@ root.ml
 ### :: pinning
 ### opam switch create downloads-pin --empty
 ### opam pin foo-arch-pin arch.tgz -y
-Package foo-arch-pin does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package foo-arch-pin does not exist in opam repositories registered in the current switch.
 [foo-arch-pin.dev] synchronised (file://${BASEDIR}/arch.tgz)
 foo-arch-pin is now pinned to file://${BASEDIR}/arch.tgz (version dev)
 
@@ -108,7 +108,7 @@ files
 opam
 root.ml
 ### opam pin foo-git-pin ./a-dev -y
-Package foo-git-pin does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package foo-git-pin does not exist in opam repositories registered in the current switch.
 [foo-git-pin.dev] synchronised (git+file://${BASEDIR}/a-dev#master)
 foo-git-pin is now pinned to git+file://${BASEDIR}/a-dev#master (version dev)
 

--- a/tests/reftests/inplace.test
+++ b/tests/reftests/inplace.test
@@ -14,7 +14,7 @@ versionned
 new!
 ### opam switch create inplace --empty
 ### opam pin ./ongoing -n
-Package ongoing does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package ongoing does not exist in opam repositories registered in the current switch.
 ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
 ### opam install ongoing -v | sed-cmd test | sed-cmd cat | sed-cmd touch
 

--- a/tests/reftests/json.unix.test
+++ b/tests/reftests/json.unix.test
@@ -550,7 +550,7 @@ The former state can be restored with:
 ### <pin:nip/nip.opam>
 opam-version:"2.0"
 ### opam pin ./nip --json=out.json
-Package nip does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip does not exist in opam repositories registered in the current switch.
 nip is now pinned to file://${BASEDIR}/nip (version dev)
 
 The following actions will be performed:
@@ -665,7 +665,7 @@ Done.
   ]
 }
 ### opam install ./nip --json=out.json
-Package nip does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip does not exist in opam repositories registered in the current switch.
 nip is now pinned to file://${BASEDIR}/nip (version dev)
 The following actions will be performed:
 === install 1 package

--- a/tests/reftests/list-large-dependencies.test
+++ b/tests/reftests/list-large-dependencies.test
@@ -307,7 +307,7 @@ phylogenetics.0.0.0
 available: !?force-unav
 flags: compiler
 ### opam switch create ${BASEDIR}/test-not-in-repo --yes
-Package test-not-in-repo does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package test-not-in-repo does not exist in opam repositories registered in the current switch.
 test-not-in-repo is now pinned to file://${BASEDIR}/test-not-in-repo (version dev)
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>

--- a/tests/reftests/lock.test
+++ b/tests/reftests/lock.test
@@ -21,7 +21,7 @@ it's here
 ### : simple lock file :
 ### opam switch create locking --empty
 ### opam pin -n ./tolock --with-version 1
-Package tolock does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package tolock does not exist in opam repositories registered in the current switch.
 tolock is now pinned to file://${BASEDIR}/tolock (version 1)
 ### opam lock tolock
 [ERROR] Skipping tolock.1, dependencies are not satisfied in this switch, not installed packages are:
@@ -141,7 +141,7 @@ opam-version: "2.0"
 synopsis: "A word"
 version: "1"
 ### opam pin -n ./tolock --locked
-Package tolock does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package tolock does not exist in opam repositories registered in the current switch.
 tolock is now pinned to file://${BASEDIR}/tolock (version 1)
 ### opam show --normalise tolock --field depends:,depopts:,conflicts:
 depends:   ["bar" {= "1"} "baz" {= "1"} "foo" {= "1"}]
@@ -177,7 +177,7 @@ The following actions would be performed:
   - install foo    1          [required by tolock]
   - install tolock 1 (pinned)
 ### opam install ./tolock/tolock.opam --locked
-Package tolock does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package tolock does not exist in opam repositories registered in the current switch.
 tolock is now pinned to file://${BASEDIR}/tolock (version 1)
 The following actions will be performed:
 === install 4 packages
@@ -206,7 +206,7 @@ Done.
 opam-version: "2.0"
 depends: "foo"
 ### opam pin -n old1
-Package oldlock does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package oldlock does not exist in opam repositories registered in the current switch.
 oldlock is now pinned to file://${BASEDIR}/old1 (version dev)
 ### opam lock oldlock
 Generated lock files for:
@@ -266,7 +266,7 @@ Done.
 opam-version: "2.0"
 depends: "foo"
 ### opam pin -n old2
-Package granpa does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package granpa does not exist in opam repositories registered in the current switch.
 granpa is now pinned to file://${BASEDIR}/old2 (version opam)
 ### opam lock granpa
 Generated lock files for:
@@ -326,7 +326,7 @@ Done.
 opam-version: "2.0"
 depends: "foo"
 ### opam pin -n old3
-Package ancestor does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package ancestor does not exist in opam repositories registered in the current switch.
 ancestor is now pinned to file://${BASEDIR}/old3 (version opam)
 ### opam lock ancestor
 Generated lock files for:
@@ -387,7 +387,7 @@ opam-version: "2.0"
 name: "silver"
 depends: "foo"
 ### opam pin -n old
-Package silver does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package silver does not exist in opam repositories registered in the current switch.
 silver is now pinned to file://${BASEDIR}/old (version dev)
 ### opam lock silver
 Generated lock files for:
@@ -532,7 +532,7 @@ tolock-scan  locked-version  file://${BASEDIR}/tolock-scan  -
 ### git -C tolock commit -qm "init"
 ### opam switch create locking3 --empty
 ### opam pin -n ./tolock --locked
-Package tolock does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package tolock does not exist in opam repositories registered in the current switch.
 tolock is now pinned to git+file://${BASEDIR}/tolock#master (version 1)
 ### opam show --normalise tolock --field depends:,depopts:,conflicts:
 depends:   ["bar" {= "1"} "baz" {= "1"} "foo" {= "1"}]
@@ -554,7 +554,7 @@ The following actions would be performed:
   - install foo    1          [required by tolock]
   - install tolock 1 (pinned)
 ### opam pin ./tolock -n
-Package tolock does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package tolock does not exist in opam repositories registered in the current switch.
 tolock is now pinned to git+file://${BASEDIR}/tolock#master (version dev)
 ### opam install ./tolock --show
 The following actions would be performed:
@@ -592,7 +592,7 @@ Done.
 ### git -C tolock commit -qm "opam file"
 ### opam switch create locking4 --empty
 ### opam pin -n ./tolock --locked
-Package tolock does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package tolock does not exist in opam repositories registered in the current switch.
 tolock is now pinned to git+file://${BASEDIR}/tolock#master (version 1)
 ### opam show --normalise tolock --field depends:,depopts:,conflicts:
 depends:   ["bar" {= "1"} "baz" {= "1"} "foo" {= "1"}]
@@ -614,7 +614,7 @@ The following actions would be performed:
   - install foo    1          [required by tolock]
   - install tolock 1 (pinned)
 ### opam pin ./tolock -n
-Package tolock does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package tolock does not exist in opam repositories registered in the current switch.
 tolock is now pinned to git+file://${BASEDIR}/tolock#master (version dev)
 ### opam install ./tolock --show
 The following actions would be performed:
@@ -652,7 +652,7 @@ Done.
 ### git -C tolock commit -qm "lock"
 ### opam switch create locking5 --empty
 ### opam pin -n ./tolock --locked
-Package tolock does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package tolock does not exist in opam repositories registered in the current switch.
 tolock is now pinned to git+file://${BASEDIR}/tolock#master (version 1)
 ### opam show --normalise tolock --field depends:,depopts:,conflicts:
 depends:   ["bar" {= "1"} "baz" {= "1"} "foo" {= "1"}]
@@ -674,7 +674,7 @@ The following actions would be performed:
   - install foo    1          [required by tolock]
   - install tolock 1 (pinned)
 ### opam pin ./tolock -n
-Package tolock does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package tolock does not exist in opam repositories registered in the current switch.
 tolock is now pinned to git+file://${BASEDIR}/tolock#master (version dev)
 ### opam install ./tolock --show
 The following actions would be performed:
@@ -716,7 +716,7 @@ The following actions will be performed:
 -> removed   tolock.1
 Done.
 ### opam install ./tolock --locked
-Package tolock does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package tolock does not exist in opam repositories registered in the current switch.
 tolock is now pinned to git+file://${BASEDIR}/tolock#master (version 1)
 The following actions will be performed:
 === install 1 package
@@ -754,7 +754,7 @@ version: "1"
 ### <pin:tolock/tolock.opam.locked>
 version: "l1"
 ### opam pin ./tolock --locked
-Package tolock does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package tolock does not exist in opam repositories registered in the current switch.
 tolock is now pinned to file://${BASEDIR}/tolock (version l1)
 
 The following actions will be performed:
@@ -1104,22 +1104,22 @@ pin-depends: [
 ### OPAMYES=1
 ### OPAMLOCKED=locked
 ### opam pin add -n goblint.dev ./goblint
-Package goblint does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package goblint does not exist in opam repositories registered in the current switch.
 [goblint.dev] synchronised (file://${BASEDIR}/goblint)
 The following additional pinnings are required by goblint.dev:
   - apron.v0.9.13 at git+https://github.com/antoinemine/apron.git#c852ebcc89e5cf4a5a3318e7c13c73e1756abb11
   - goblint-cil.1.8.2 at git+https://github.com/goblint/cil.git#a3c91aa6e8f946fec9a9a13361b051a73b12a65c
   - ppx_deriving.5.2.1 at git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6
 Pin and install them? [Y/n] y
-Package apron does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package apron does not exist in opam repositories registered in the current switch.
 [apron.v0.9.13] synchronised (no changes)
 [WARNING] Failed checks on apron package definition from source at git+https://github.com/antoinemine/apron.git#c852ebcc89e5cf4a5a3318e7c13c73e1756abb11:
            warning 62: License doesn't adhere to the SPDX standard, see https://spdx.org/licenses/ : "LGPL-2.1 with linking exception"
 apron is now pinned to git+https://github.com/antoinemine/apron.git#c852ebcc89e5cf4a5a3318e7c13c73e1756abb11 (version v0.9.13)
-Package goblint-cil does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package goblint-cil does not exist in opam repositories registered in the current switch.
 [goblint-cil.1.8.2] synchronised (no changes)
 goblint-cil is now pinned to git+https://github.com/goblint/cil.git#a3c91aa6e8f946fec9a9a13361b051a73b12a65c (version 1.8.2)
-Package ppx_deriving does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package ppx_deriving does not exist in opam repositories registered in the current switch.
 [ppx_deriving.5.2.1] synchronised (no changes)
 ppx_deriving is now pinned to git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6 (version 5.2.1)
 goblint is now pinned to file://${BASEDIR}/goblint (version dev)

--- a/tests/reftests/pin-legacy.test
+++ b/tests/reftests/pin-legacy.test
@@ -50,7 +50,7 @@ foo is now pinned locally (version 1)
 ### <pin:nip/nip.opam>
 opam-version: "2.0"
 ### opam install ./nip
-Package nip does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip does not exist in opam repositories registered in the current switch.
 nip is now pinned to file://${BASEDIR}/nip (version dev)
 The following actions will be performed:
 === install 1 package
@@ -96,11 +96,11 @@ echo "pin-depends: [ \"qux.dev\" \"file://$basedir/qux\" ]" >> bar/bar.opam
 opam-version: "2.0"
 depexts: [ "another-inexistant" ]
 ### opam pin ./bar | '.*(/|\\|")echo(\.exe)?"? "' -> 'echo "'
-Package bar does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package bar does not exist in opam repositories registered in the current switch.
 The following additional pinnings are required by bar.dev:
   - qux.dev at file://${BASEDIR}/qux
 Pin and install them? [Y/n] y
-Package qux does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package qux does not exist in opam repositories registered in the current switch.
 [qux.dev] synchronised (no changes)
 qux is now pinned to file://${BASEDIR}/qux (version dev)
 bar is now pinned to file://${BASEDIR}/bar (version dev)
@@ -146,11 +146,11 @@ The following actions will be performed:
 -> removed   qux.dev
 Done.
 ### opam install ./bar | '.*(/|\\|")echo(\.exe)?"? "' -> 'echo "'
-Package bar does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package bar does not exist in opam repositories registered in the current switch.
 The following additional pinnings are required by bar.dev:
   - qux.dev at file://${BASEDIR}/qux
 Pin and install them? [Y/n] y
-Package qux does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package qux does not exist in opam repositories registered in the current switch.
 [qux.dev] synchronised (no changes)
 qux is now pinned to file://${BASEDIR}/qux (version dev)
 bar is now pinned to file://${BASEDIR}/bar (version dev)
@@ -265,7 +265,7 @@ Continue anyway? [Y/n] y
 ### git -C pin-empty add -A
 ### git -C pin-empty commit -qm 'opam'
 ### opam pin --no-action ./pin-empty
-Package pin-empty does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package pin-empty does not exist in opam repositories registered in the current switch.
 pin-empty is now pinned to git+file://${BASEDIR}/pin-empty#master (version dev)
 ### opam unpin pin-empty
 Ok, pin-empty is no longer pinned to git+file://${BASEDIR}/pin-empty#master (version dev)

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -89,7 +89,7 @@ Now run 'opam upgrade' to apply any package updates.
 ### opam switch create targets --empty
 ### : pin with url
 ### opam pin add nip-git git+file://$BASEDIR/nip-git
-Package nip-git does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-git does not exist in opam repositories registered in the current switch.
 [nip-git.dev] synchronised (git+file://${BASEDIR}/nip-git#master)
 nip-git is now pinned to git+file://${BASEDIR}/nip-git#master (version ved)
 
@@ -101,7 +101,7 @@ The following actions will be performed:
 -> installed nip-git.ved
 Done.
 ### opam pin add git+file://$BASEDIR/nip-git2
-Package nip-git2 does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-git2 does not exist in opam repositories registered in the current switch.
 nip-git2 is now pinned to git+file://${BASEDIR}/nip-git2#master (version ved)
 
 The following actions will be performed:
@@ -113,7 +113,7 @@ The following actions will be performed:
 Done.
 ### : pin add with a path
 ### opam pin add nip-path ./nip-path
-Package nip-path does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-path does not exist in opam repositories registered in the current switch.
 [nip-path.dev] synchronised (file://${BASEDIR}/nip-path)
 nip-path is now pinned to file://${BASEDIR}/nip-path (version ved)
 
@@ -125,7 +125,7 @@ The following actions will be performed:
 -> installed nip-path.ved
 Done.
 ### opam pin add ./nip-path2
-Package nip-path2 does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-path2 does not exist in opam repositories registered in the current switch.
 nip-path2 is now pinned to file://${BASEDIR}/nip-path2 (version ved)
 
 The following actions will be performed:
@@ -136,7 +136,7 @@ The following actions will be performed:
 -> installed nip-path2.ved
 Done.
 ### opam pin add $BASEDIR/nip-path3
-Package nip-path3 does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-path3 does not exist in opam repositories registered in the current switch.
 nip-path3 is now pinned to file://${BASEDIR}/nip-path3 (version ved)
 
 The following actions will be performed:
@@ -207,7 +207,7 @@ OPAM/targets/lib/no-url/no-url.ved.t
 ### opam switch create kinds --empty
 ### : path
 ### opam pin add ./nip-git --kind path
-Package nip-git does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-git does not exist in opam repositories registered in the current switch.
 nip-git is now pinned to file://${BASEDIR}/nip-git (version ved)
 
 The following actions will be performed:
@@ -218,7 +218,7 @@ The following actions will be performed:
 -> installed nip-git.ved
 Done.
 ### opam pin add ./nip-path --kind path
-Package nip-path does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-path does not exist in opam repositories registered in the current switch.
 nip-path is now pinned to file://${BASEDIR}/nip-path (version ved)
 
 The following actions will be performed:
@@ -230,7 +230,7 @@ The following actions will be performed:
 Done.
 ### : vcs
 ### opam pin add ./nip-git2 --kind git
-Package nip-git2 does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-git2 does not exist in opam repositories registered in the current switch.
 nip-git2 is now pinned to git+file://${BASEDIR}/nip-git2#master (version ved)
 
 The following actions will be performed:
@@ -246,7 +246,7 @@ Done.
 # Return code 99 #
 ### : auto
 ### opam pin add ./nip-git3 --kind auto
-Package nip-git3 does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-git3 does not exist in opam repositories registered in the current switch.
 nip-git3 is now pinned to git+file://${BASEDIR}/nip-git3#master (version ved)
 
 The following actions will be performed:
@@ -257,7 +257,7 @@ The following actions will be performed:
 -> installed nip-git3.ved
 Done.
 ### opam pin add ./nip-path3 --kind auto
-Package nip-path3 does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-path3 does not exist in opam repositories registered in the current switch.
 nip-path3 is now pinned to file://${BASEDIR}/nip-path3 (version ved)
 
 The following actions will be performed:
@@ -361,7 +361,7 @@ nip-path3
 ### : auto
 ### OPAMPINKINDAUTO=1
 ### opam pin add ./nip-git
-Package nip-git does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-git does not exist in opam repositories registered in the current switch.
 nip-git is now pinned to git+file://${BASEDIR}/nip-git#master (version ved)
 
 The following actions will be performed:
@@ -372,7 +372,7 @@ The following actions will be performed:
 -> installed nip-git.ved
 Done.
 ### opam pin add ./nip-path
-Package nip-path does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-path does not exist in opam repositories registered in the current switch.
 nip-path is now pinned to file://${BASEDIR}/nip-path (version ved)
 
 The following actions will be performed:
@@ -385,7 +385,7 @@ Done.
 ### : disable auto
 ### OPAMPINKINDAUTO=0
 ### opam pin add ./nip-git2
-Package nip-git2 does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-git2 does not exist in opam repositories registered in the current switch.
 nip-git2 is now pinned to file://${BASEDIR}/nip-git2 (version ved)
 
 The following actions will be performed:
@@ -396,7 +396,7 @@ The following actions will be performed:
 -> installed nip-git2.ved
 Done.
 ### opam pin add ./nip-path2
-Package nip-path2 does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-path2 does not exist in opam repositories registered in the current switch.
 nip-path2 is now pinned to file://${BASEDIR}/nip-path2 (version ved)
 
 The following actions will be performed:
@@ -423,10 +423,10 @@ OPAM/env-kinds/lib/nip-path2/nip-path2.ved.t
 ### :::::::::::::::::::::::
 ### opam switch create actions --empty
 ### opam pin add ./nip-git4 --no-action
-Package nip-git4 does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-git4 does not exist in opam repositories registered in the current switch.
 nip-git4 is now pinned to git+file://${BASEDIR}/nip-git4#master (version ved)
 ### opam pin add ./nip-path
-Package nip-path does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-path does not exist in opam repositories registered in the current switch.
 nip-path is now pinned to file://${BASEDIR}/nip-path (version ved)
 
 The following actions will be performed:
@@ -437,7 +437,7 @@ The following actions will be performed:
 -> installed nip-path.ved
 Done.
 ### opam pin add ./nip-path2
-Package nip-path2 does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-path2 does not exist in opam repositories registered in the current switch.
 nip-path2 is now pinned to file://${BASEDIR}/nip-path2 (version ved)
 
 The following actions will be performed:
@@ -488,7 +488,7 @@ OPAM/actions/lib/nip-path/nip-path.ved.t
 ### opam switch create edits --empty
 ### OPAMEDITOR='sed -i.bak "s/%{version}%/not-here/g" '
 ### opam pin add ./nip-path
-Package nip-path does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-path does not exist in opam repositories registered in the current switch.
 nip-path is now pinned to file://${BASEDIR}/nip-path (version ved)
 
 The following actions will be performed:
@@ -519,7 +519,7 @@ The following actions will be performed:
 [NOTE] Pinning command successful, but your installed packages may be out of sync.
 # Return code 31 #
 ### opam pin add ./nip-path2 --edit
-Package nip-path2 does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-path2 does not exist in opam repositories registered in the current switch.
 You can edit this file again with "opam pin edit nip-path2", export it with "opam show nip-path2 --raw"
 nip-path2 is now pinned to file://${BASEDIR}/nip-path2 (version ved)
 
@@ -541,7 +541,7 @@ The following actions will be performed:
 [NOTE] Pinning command successful, but your installed packages may be out of sync.
 # Return code 31 #
 ### opam pin add ./nip-git --edit
-Package nip-git does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-git does not exist in opam repositories registered in the current switch.
 You can edit this file again with "opam pin edit nip-git", export it with "opam show nip-git --raw"
 nip-git is now pinned to git+file://${BASEDIR}/nip-git#master (version ved)
 
@@ -613,8 +613,8 @@ nip-git3.ved^file://${BASEDIR}/lot_of_pkgs
 nip-git2.ved^file://${BASEDIR}/lot_of_pkgs
 ### opam pin add nip-git2.ved^file://${BASEDIR}/lot_of_pkgs nip-git3.ved^file://${BASEDIR}/lot_of_pkgs | unordered
 This will pin the following packages: nip-git2, nip-git3. Continue? [Y/n] y
-Package nip-git2 does not exist, create as a NEW package? [Y/n] y
-Package nip-git3 does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-git2 does not exist in opam repositories registered in the current switch.
+[NOTE] Package nip-git3 does not exist in opam repositories registered in the current switch.
 [nip-git2.ved] synchronised (no changes)
 nip-git2 is now pinned to file://${BASEDIR}/lot_of_pkgs (version ved)
 [nip-git3.ved] synchronised (no changes)
@@ -632,8 +632,8 @@ Done.
 ### # shell on Cygwin ads a trialing `\r` in the middle of the string
 ### sh -c 'opam pin add $(opam pin scan ./lot_of_pkgs --normalise | grep path | sed "s/\\r//g") ' | unordered
 This will pin the following packages: nip-path3, nip-path2. Continue? [Y/n] y
-Package nip-path3 does not exist, create as a NEW package? [Y/n] y
-Package nip-path2 does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-path3 does not exist in opam repositories registered in the current switch.
+[NOTE] Package nip-path2 does not exist in opam repositories registered in the current switch.
 [nip-path3.ved] synchronised (no changes)
 nip-path3 is now pinned to file://${BASEDIR}/lot_of_pkgs (version ved)
 [nip-path2.ved] synchronised (no changes)
@@ -665,7 +665,7 @@ OPAM/scans/lib/nip-path3/nip-path3.ved.t
 ### : pin url with version
 ### cp nip-path/nip-path.ved.t nip-path/nip-path.42.t
 ### opam pin add file://$BASEDIR/nip-path --with-version 42
-Package nip-path does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-path does not exist in opam repositories registered in the current switch.
 nip-path is now pinned to file://${BASEDIR}/nip-path (version 42)
 
 The following actions will be performed:
@@ -705,7 +705,7 @@ opam-version: "2.0"
 ### <nip-empty2/nip-empty2.opam>
 opam-version: "2.0"
 ### opam pin add nip-empty ./nip-empty
-Package nip-empty does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-empty does not exist in opam repositories registered in the current switch.
 [nip-empty.dev] synchronised (file://${BASEDIR}/nip-empty)
 [WARNING] Failed checks on nip-empty package definition from source at file://${BASEDIR}/nip-empty:
              error 23: Missing field 'maintainer'
@@ -725,7 +725,7 @@ The following actions will be performed:
 -> installed nip-empty.dev
 Done.
 ### opam pin add ./nip-empty2
-Package nip-empty2 does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-empty2 does not exist in opam repositories registered in the current switch.
 nip-empty2 is now pinned to file://${BASEDIR}/nip-empty2 (version dev)
 
 The following actions will be performed:
@@ -742,7 +742,7 @@ Done.
 ### opam switch create updates --empty
 ### sh add-pin.sh nip-mixed.dev2
 ### opam pin ./nip-mixed
-Package nip-mixed does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-mixed does not exist in opam repositories registered in the current switch.
 nip-mixed is now pinned to file://${BASEDIR}/nip-mixed (version dev2)
 
 The following actions will be performed:
@@ -804,7 +804,7 @@ Done.
 ### git -C ./nip-of rm nip-of.opam --cached -q
 ### git -C ./nip-of commit -qm "remove opam file"
 ### opam pin ./nip-of
-Package nip-of does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-of does not exist in opam repositories registered in the current switch.
 nip-of is now pinned to git+file://${BASEDIR}/nip-of#master (version dev1)
 
 The following actions will be performed:
@@ -856,7 +856,7 @@ dev3
 ### git -C ./nip-fo rm nip-fo.opam --cached -q
 ### git -C ./nip-fo commit -qm "remove opam file"
 ### opam install ./nip-fo
-Package nip-fo does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip-fo does not exist in opam repositories registered in the current switch.
 nip-fo is now pinned to git+file://${BASEDIR}/nip-fo#master (version dev1)
 The following actions will be performed:
 === install 1 package
@@ -929,7 +929,7 @@ i shouldn't be retrieved
 opam-version: "2.0"
 build: "false"
 ### opam pin vcs-local ./vcs-local --no-action
-Package vcs-local does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package vcs-local does not exist in opam repositories registered in the current switch.
 [vcs-local.dev] synchronised (git+file://${BASEDIR}/vcs-local#master)
 vcs-local is now pinned to git+file://${BASEDIR}/vcs-local#master (version dev)
 ### test -f OPAM/vcs-local/.opam-switch/sources/vcs-local/untracked
@@ -942,5 +942,5 @@ url.src: "git+file://${BASEDIR}/vcs-local#master"
 opam-version: "2.0"
 name: "double"
 ### opam pin -n double
-Package double does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package double does not exist in opam repositories registered in the current switch.
 double is now pinned to file://${BASEDIR}/double (version dev)

--- a/tests/reftests/rec-pin.test
+++ b/tests/reftests/rec-pin.test
@@ -62,17 +62,17 @@ lib: ["root-b_g.t"]
 ### opam switch create devnull --empty
 ### opam pin -n --recursive pinnes
 This will pin the following packages: root_g, root-a_p, root-a-i_g, root-a-i-j_g, root-a-k_p, root-b_g. Continue? [Y/n] y
-Package root_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root_g does not exist in opam repositories registered in the current switch.
 root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version dev)
-Package root-a_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version dev)
-Package root-a-i_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
 root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version dev)
-Package root-a-i-j_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
 root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version dev)
-Package root-a-k_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version dev)
-Package root-b_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
 root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version dev)
 ### opam list -s
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
@@ -93,12 +93,12 @@ Ok, root_g is no longer pinned to git+file://${BASEDIR}/pinnes#master (version d
 ### opam pin
 ### opam pin  --recursive pinnes | unordered
 This will pin the following packages: root_g, root-a_p, root-a-i_g, root-a-i-j_g, root-a-k_p, root-b_g. Continue? [Y/n] y
-Package root_g does not exist, create as a NEW package? [Y/n] y
-Package root-a_p does not exist, create as a NEW package? [Y/n] y
-Package root-a-i_g does not exist, create as a NEW package? [Y/n] y
-Package root-a-i-j_g does not exist, create as a NEW package? [Y/n] y
-Package root-a-k_p does not exist, create as a NEW package? [Y/n] y
-Package root-b_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root_g does not exist in opam repositories registered in the current switch.
+[NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
+[NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
+[NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
+[NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
+[NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
 root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version dev)
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version dev)
 root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version dev)
@@ -168,7 +168,7 @@ Done.
 # Packages matching: any & installed
 # No matches found
 ### opam install ./pinnes | unordered
-Package root_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root_g does not exist in opam repositories registered in the current switch.
 root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version dev)
 The following actions will be performed:
 === install 1 package
@@ -183,7 +183,7 @@ root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
 root_g.dev    git  git+file://${BASEDIR}/pinnes#master  (at HASH)
 ### opam install ./pinnes --subpath a | unordered
-Package root-a_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version dev)
 -> retrieved root-a_p.dev  (directory /a in file://${BASEDIR}/pinnes)
 The following actions will be performed:
@@ -200,7 +200,7 @@ root_g
 root-a_p.dev    rsync  directory /a in file://${BASEDIR}/pinnes
 root_g.dev      git    git+file://${BASEDIR}/pinnes#master       (at HASH)
 ### opam install ./pinnes --subpath b | unordered
-Package root-b_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
 root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version dev)
 -> retrieved root-b_g.dev  (directory /b in git+file://${BASEDIR}/pinnes#master)
 The following actions will be performed:
@@ -219,7 +219,7 @@ root-a_p.dev    rsync  directory /a in file://${BASEDIR}/pinnes
 root-b_g.dev    git    directory /b in git+file://${BASEDIR}/pinnes#master  (at HASH)
 root_g.dev      git    git+file://${BASEDIR}/pinnes#master                  (at HASH)
 ### opam install ./pinnes --subpath a/i | unordered
-Package root-a-i_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
 root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version dev)
 -> retrieved root-a-i_g.dev  (directory /a/i in git+file://${BASEDIR}/pinnes#master)
 The following actions will be performed:
@@ -240,7 +240,7 @@ root-a_p.dev      rsync  directory /a in file://${BASEDIR}/pinnes
 root-b_g.dev      git    directory /b in git+file://${BASEDIR}/pinnes#master    (at HASH)
 root_g.dev        git    git+file://${BASEDIR}/pinnes#master                    (at HASH)
 ### opam install ./pinnes --subpath a/i/j | unordered
-Package root-a-i-j_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
 root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version dev)
 -> retrieved root-a-i-j_g.dev  (directory /a/i/j in git+file://${BASEDIR}/pinnes#master)
 The following actions will be performed:
@@ -263,7 +263,7 @@ root-a_p.dev        rsync  directory /a in file://${BASEDIR}/pinnes
 root-b_g.dev        git    directory /b in git+file://${BASEDIR}/pinnes#master      (at HASH)
 root_g.dev          git    git+file://${BASEDIR}/pinnes#master                      (at HASH)
 ### opam install ./pinnes --subpath a/k | unordered
-Package root-a-k_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version dev)
 -> retrieved root-a-k_p.dev  (directory /a/k in file://${BASEDIR}/pinnes)
 The following actions will be performed:
@@ -452,13 +452,13 @@ Done.
 ### opam pin
 ### opam pin ./pinnes --subpath a --recursive -n
 This will pin the following packages: root-a_p, root-a-i_g, root-a-i-j_g, root-a-k_p. Continue? [Y/n] y
-Package root-a_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version 2)
-Package root-a-i_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
 root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version 2)
-Package root-a-i-j_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
 root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version 2)
-Package root-a-k_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version 2)
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
 root-a-i-j_g.2  (uninstalled)  git    directory /a/i/j in git+file://${BASEDIR}/pinnes#master  (at HASH)
@@ -529,22 +529,22 @@ root-a_p.2^file://${BASEDIR}/pinnes^a
 root_g.2^git+file://${BASEDIR}/pinnes#master
 ### opam pin -n --with-version 3 root-b_g.2^git+file://${BASEDIR}/pinnes#master^b root-a-i-j_g.2^git+file://${BASEDIR}/pinnes#master^a/i/j root-a-i_g.2^git+file://${BASEDIR}/pinnes#master^a/i root-a_p.2^file://${BASEDIR}/pinnes^a root_g^git+file://${BASEDIR}/pinnes#master root-a-k_p.2^file://${BASEDIR}/pinnes^a/k
 This will pin the following packages: root-b_g, root-a-i-j_g, root-a-i_g, root-a_p, root_g, root-a-k_p. Continue? [Y/n] y
-Package root-b_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
 [root-b_g.3] synchronised (no changes)
 root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version 3)
-Package root-a-i-j_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
 [root-a-i-j_g.3] synchronised (no changes)
 root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version 3)
-Package root-a-i_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
 [root-a-i_g.3] synchronised (no changes)
 root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version 3)
-Package root-a_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 [root-a_p.3] synchronised (no changes)
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version 3)
-Package root_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root_g does not exist in opam repositories registered in the current switch.
 [root_g.3] synchronised (no changes)
 root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version 3)
-Package root-a-k_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 [root-a-k_p.3] synchronised (no changes)
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version 3)
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
@@ -611,17 +611,17 @@ version: "l1"
 ### opam switch create devnull --empty
 ### opam pin -n --recursive pinnes
 This will pin the following packages: root_g, root-a_p, root-a-i_g, root-a-i-j_g, root-a-k_p, root-b_g. Continue? [Y/n] y
-Package root_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root_g does not exist in opam repositories registered in the current switch.
 root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version l1)
-Package root-a_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version l1)
-Package root-a-i_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
 root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version l1)
-Package root-a-i-j_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
 root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version l1)
-Package root-a-k_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version l1)
-Package root-b_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
 root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version l1)
 ### opam list -s
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
@@ -642,12 +642,12 @@ Ok, root_g is no longer pinned to git+file://${BASEDIR}/pinnes#master (version l
 ### opam pin
 ### opam pin  --recursive pinnes | unordered
 This will pin the following packages: root_g, root-a_p, root-a-i_g, root-a-i-j_g, root-a-k_p, root-b_g. Continue? [Y/n] y
-Package root_g does not exist, create as a NEW package? [Y/n] y
-Package root-a_p does not exist, create as a NEW package? [Y/n] y
-Package root-a-i_g does not exist, create as a NEW package? [Y/n] y
-Package root-a-i-j_g does not exist, create as a NEW package? [Y/n] y
-Package root-a-k_p does not exist, create as a NEW package? [Y/n] y
-Package root-b_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root_g does not exist in opam repositories registered in the current switch.
+[NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
+[NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
+[NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
+[NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
+[NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
 root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version l1)
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version l1)
 root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version l1)
@@ -704,7 +704,7 @@ Done.
 ### opam list -s
 ### opam pin
 ### opam install ./pinnes | unordered
-Package root_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root_g does not exist in opam repositories registered in the current switch.
 root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version l1)
 The following actions will be performed:
 === install 1 package
@@ -719,7 +719,7 @@ root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
 root_g.l1    git  git+file://${BASEDIR}/pinnes#master  (at HASH)
 ### opam install ./pinnes --subpath a | unordered
-Package root-a_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version l1)
 -> retrieved root-a_p.l1  (directory /a in file://${BASEDIR}/pinnes)
 The following actions will be performed:
@@ -736,7 +736,7 @@ root_g
 root-a_p.l1    rsync  directory /a in file://${BASEDIR}/pinnes
 root_g.l1      git    git+file://${BASEDIR}/pinnes#master       (at HASH)
 ### opam install ./pinnes --subpath b | unordered
-Package root-b_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
 root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version l1)
 -> retrieved root-b_g.l1  (directory /b in git+file://${BASEDIR}/pinnes#master)
 The following actions will be performed:
@@ -755,7 +755,7 @@ root-a_p.l1    rsync  directory /a in file://${BASEDIR}/pinnes
 root-b_g.l1    git    directory /b in git+file://${BASEDIR}/pinnes#master  (at HASH)
 root_g.l1      git    git+file://${BASEDIR}/pinnes#master                  (at HASH)
 ### opam install ./pinnes --subpath a/i | unordered
-Package root-a-i_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
 root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version l1)
 -> retrieved root-a-i_g.l1  (directory /a/i in git+file://${BASEDIR}/pinnes#master)
 The following actions will be performed:
@@ -776,7 +776,7 @@ root-a_p.l1      rsync  directory /a in file://${BASEDIR}/pinnes
 root-b_g.l1      git    directory /b in git+file://${BASEDIR}/pinnes#master    (at HASH)
 root_g.l1        git    git+file://${BASEDIR}/pinnes#master                    (at HASH)
 ### opam install ./pinnes --subpath a/i/j | unordered
-Package root-a-i-j_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
 root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version l1)
 -> retrieved root-a-i-j_g.l1  (directory /a/i/j in git+file://${BASEDIR}/pinnes#master)
 The following actions will be performed:
@@ -799,7 +799,7 @@ root-a_p.l1        rsync  directory /a in file://${BASEDIR}/pinnes
 root-b_g.l1        git    directory /b in git+file://${BASEDIR}/pinnes#master      (at HASH)
 root_g.l1          git    git+file://${BASEDIR}/pinnes#master                      (at HASH)
 ### opam install ./pinnes --subpath a/k | unordered
-Package root-a-k_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version l1)
 -> retrieved root-a-k_p.l1  (directory /a/k in file://${BASEDIR}/pinnes)
 The following actions will be performed:
@@ -965,13 +965,13 @@ The following actions will be performed:
 Done.
 ### opam pin ./pinnes --subpath a --recursive -n
 This will pin the following packages: root-a_p, root-a-i_g, root-a-i-j_g, root-a-k_p. Continue? [Y/n] y
-Package root-a_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version l2)
-Package root-a-i_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
 root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version l2)
-Package root-a-i-j_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
 root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version l2)
-Package root-a-k_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version l2)
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
 root-a-i-j_g.l2  (uninstalled)  git    directory /a/i/j in git+file://${BASEDIR}/pinnes#master  (at HASH)
@@ -1045,21 +1045,21 @@ root-a_p.l2^file://${BASEDIR}/pinnes^a
 root_g.l2^git+file://${BASEDIR}/pinnes#master
 ### opam pin --with-version 3 root-b_g^git+file://${BASEDIR}/pinnes#master^b root-a-i-j_g^git+file://${BASEDIR}/pinnes#master^a/i/j root-a-i_g^git+file://${BASEDIR}/pinnes#master^a/i root-a_p^file://${BASEDIR}/pinnes^a root_g^git+file://${BASEDIR}/pinnes#master root-a-k_p^file://${BASEDIR}/pinnes^a/k -n
 This will pin the following packages: root-b_g, root-a-i-j_g, root-a-i_g, root-a_p, root_g, root-a-k_p. Continue? [Y/n] y
-Package root-b_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
 [root-b_g.3] synchronised (no changes)
 root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version 3)
-Package root-a-i-j_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
 [root-a-i-j_g.3] synchronised (no changes)
 root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version 3)
-Package root-a-i_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
 [root-a-i_g.3] synchronised (no changes)
 root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version 3)
-Package root-a_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 [root-a_p.3] synchronised (no changes)
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version 3)
-Package root_g does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root_g does not exist in opam repositories registered in the current switch.
 [root_g.3] synchronised (no changes)
 root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version 3)
-Package root-a-k_p does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 [root-a-k_p.3] synchronised (no changes)
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version 3)

--- a/tests/reftests/switch-import.test
+++ b/tests/reftests/switch-import.test
@@ -26,7 +26,7 @@ snd branch
 ### git -C nip checkout fst-head
 Switched to branch 'fst-head'
 ### opam pin git+file://${BASEDIR}/nip#fst-head
-Package nip does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package nip does not exist in opam repositories registered in the current switch.
 nip is now pinned to git+file://${BASEDIR}/nip#fst-head (version dev)
 
 The following actions will be performed:

--- a/tests/reftests/tree.test
+++ b/tests/reftests/tree.test
@@ -610,9 +610,9 @@ depends: ["b" "installed-local-core"]
 opam-version: "2.0"
 depends: "a"
 ### opam install ./dir
-Package installed-local does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package installed-local does not exist in opam repositories registered in the current switch.
 installed-local is now pinned to file://${BASEDIR}/dir (version dev)
-Package installed-local-core does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package installed-local-core does not exist in opam repositories registered in the current switch.
 installed-local-core is now pinned to file://${BASEDIR}/dir (version dev)
 The following actions will be performed:
 === install 2 packages

--- a/tests/reftests/update-upgrade.test
+++ b/tests/reftests/update-upgrade.test
@@ -146,7 +146,7 @@ opam-version: "2.0"
 ### <pin:quux/quux.opam>
 opam-version: "2.0"
 ### opam install ./quux
-Package quux does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package quux does not exist in opam repositories registered in the current switch.
 quux is now pinned to file://${BASEDIR}/quux (version dev)
 The following actions will be performed:
 === install 1 package
@@ -313,7 +313,7 @@ quux   ${BASEDIR}/OPAM/upgrading/lib/quux ${BASEDIR}/OPAM/upgrading/lib/quux/fic
 opam-version: "2.0"
 depends:"quux"
 ### opam install ./quux-rdep
-Package quux-rdep does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package quux-rdep does not exist in opam repositories registered in the current switch.
 quux-rdep is now pinned to file://${BASEDIR}/quux-rdep (version dev)
 The following actions will be performed:
 === install 1 package
@@ -432,7 +432,7 @@ versionned
 ### git -C ./ongoing add -A
 ### git -C ./ongoing commit -qm "init"
 ### opam pin ./ongoing
-Package ongoing does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package ongoing does not exist in opam repositories registered in the current switch.
 ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
 
 The following actions will be performed:

--- a/tests/reftests/upgrade.test
+++ b/tests/reftests/upgrade.test
@@ -128,7 +128,7 @@ Done.
 ### <pin:quux/quux.opam>
 opam-version: "2.0"
 ### opam install ./quux
-Package quux does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package quux does not exist in opam repositories registered in the current switch.
 quux is now pinned to file://${BASEDIR}/quux (version dev)
 The following actions will be performed:
 === install 1 package
@@ -305,7 +305,7 @@ version: "dev6"
 opam-version: "2.0"
 ### opam pin ./quux --no-action
 This will pin the following packages: quuux, quux. Continue? [Y/n] y
-Package quuux does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package quuux does not exist in opam repositories registered in the current switch.
 quuux is now pinned to file://${BASEDIR}/quux (version dev)
 [NOTE] Package quux is already pinned to file://${BASEDIR}/quux (version dev5).
 quux is now pinned to file://${BASEDIR}/quux (version dev6)

--- a/tests/reftests/working-dir.test
+++ b/tests/reftests/working-dir.test
@@ -11,7 +11,7 @@ versionned
 ### git -C ./ongoing commit -qm "init"
 ### opam switch create working-dir --empty
 ### opam pin ./ongoing
-Package ongoing does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package ongoing does not exist in opam repositories registered in the current switch.
 ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
 
 The following actions will be performed:
@@ -242,7 +242,7 @@ opam-version:"2.0"
 opam-version: "2.0"
 depends: ["qux"]
 ### opam install ./ongoing --working-dir
-Package ongoing does not exist, create as a NEW package? [Y/n] y
+[NOTE] Package ongoing does not exist in opam repositories registered in the current switch.
 ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
 [ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)
 The following actions will be performed:


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/3199

While reading https://github.com/ocaml/opam/issues/3199 i asked myself why this question was asked and i couldn't find any reason. It was added in https://github.com/ocaml/opam/pull/1335 with no reasoning behind it either.

In my opinion the question is redundant as the user is already asking to pin the package(s).