### PR TITLE
Run shellcheck on shell/install.sh and make it pass, add a CI job to check next changes

### DIFF
--- a/.github/scripts/main/hygiene.sh
+++ b/.github/scripts/main/hygiene.sh
@@ -124,4 +124,17 @@ please run dune exec --root=. -- ./ci.exe from .github/workflows and fixup the c
 fi
 (set +x ; echo -en "::endgroup::check workflow generation\r") 2>/dev/null
 
+###
+# Shellcheck
+###
+
+(set +x ; echo -en "::group::check shell scripts using shellcheck\r") 2>/dev/null
+if shellcheck shell/install.sh ; then
+  (set +x; echo "shell/install.sh: OK") 2>/dev/null
+else
+  (set +x; echo -e "shell/install.sh: \e[31mERROR\e[0m") 2>/dev/null
+  ERROR=1
+fi
+(set +x ; echo -en "::endgroup::check shell scripts using shellcheck\r") 2>/dev/null
+
 exit $ERROR

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -492,6 +492,7 @@ let hygiene_job (type a) ~analyse_job (platform : a platform) ~oc ~workflow f =
          "done";
        ]
     ++ run "Hygiene" ~cond:(Or[Predicate(true, Contains("steps.files.outputs.modified", "configure.ac"));
+                               Predicate(true, Contains("steps.files.outputs.modified", "shell/install.sh"));
                                Predicate(true, Contains("steps.files.outputs.all", "src_ext"));
                                Predicate(true, Contains("steps.files.outputs.all", ".github/workflows"))])
                      ~env:[("BASE_REF_SHA", "${{ github.event.pull_request.base.sha }}");

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -671,5 +671,5 @@ jobs:
       env:
         BASE_REF_SHA: ${{ github.event.pull_request.base.sha }}
         PR_REF_SHA: ${{ github.event.pull_request.head.sha }}
-      if: contains(steps.files.outputs.modified, 'configure.ac') || contains(steps.files.outputs.all, 'src_ext') || contains(steps.files.outputs.all, '.github/workflows')
+      if: contains(steps.files.outputs.modified, 'configure.ac') || contains(steps.files.outputs.modified, 'shell/install.sh') || contains(steps.files.outputs.all, 'src_ext') || contains(steps.files.outputs.all, '.github/workflows')
       run: bash -exu .github/scripts/main/hygiene.sh

--- a/master_changes.md
+++ b/master_changes.md
@@ -114,6 +114,7 @@ users)
 ## Client
 
 ## Shell
+  * Make `shell/install.sh` more robust, using shellcheck [#6313 @ElectreAAS @kit-ty-kate]
 
 ## Internal
   * Make `curl` the default download tool instead of `wget` on macOS [#6304 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -143,6 +143,7 @@ users)
   * Add a doc generation job under linux [#5349 @rjbou]
   * Update the github action scripts now that homebrew renamed the GNU patch binary to gpatch [#6296 @kit-ty-kate]
   * Add branch scheme `username/branch` for opam-rt specific branch to use [#6274 @rjbou]
+  * Check `shell/install.sh` using `shellcheck` [#6313 @kit-ty-kate]
 
 ## Doc
   * Update the command to install opam to point to the new simplified url on opam.ocaml.org [#6226 @kit-ty-kate]


### PR DESCRIPTION
This is a partial subset of https://github.com/ocaml/opam/pull/5778.
This PR is meant as a way to more easily kickstart the use of shellcheck to lint checkout shell scripts.

Details of reason behind the shell changes:
* [SC2006](https://www.shellcheck.net/wiki/SC2006): `$()` vs backticks
* [SC2268](https://www.shellcheck.net/wiki/SC2268): The x-prefix is actually unnecessary
* POSIX shell doesn't support `local`
* [SC2145](https://www.shellcheck.net/wiki/SC2145): `$@` in strings
* missing quotes
* [SC2162](https://www.shellcheck.net/wiki/SC2162): `read` without `-r` will interpret backslashes
* variables inside the format string for `printf` could contain `%` which could make the command fail

This PR also make sure the script keeps passing `shellcheck` by adding it to our CI.