### PR TITLE
lint: add W74 to detect 'pin-depends' packages that are not present in 'depends' nor in 'depopts'

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -71,6 +71,7 @@ users)
   * [NEW] Add options `--require-checksums` and `--no-checksums` to harmonise with `opam install` [#5563 @rjbou]
 
 ## Lint
+  * [NEW] Add W74 to detect `pin-depends` packages that are neither present in the `depends` nor `depopts` field [#6317 @rjbou - fix #5795]
 
 ## Repository
   * Accurately tag `curl` download command when loaded from global config file [#6270 @rjbou]

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -1098,6 +1098,22 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
        "Field 'extra-files' contains path with '..'"
        ~detail:relative
        (relative <> []));
+    (let missing =
+       let pkgs =
+         List.fold_left
+           (fun set (pkg, _) ->
+              OpamPackage.Name.Set.add (OpamPackage.name pkg) set)
+           OpamPackage.Name.Set.empty t.pin_depends
+       in
+       OpamPackage.Name.Set.fold
+         (fun pkgname acc -> OpamPackage.Name.to_string pkgname :: acc)
+         (OpamPackage.Name.Set.diff pkgs all_depends) []
+     in
+     cond 74 `Warning
+       "Field 'pin-depends' contains packages that are neither in 'depends' \
+        nor in 'depopts'"
+       ~detail:missing
+       (missing <> []));
   ]
   in
   format_errors @

--- a/tests/reftests/lint.test
+++ b/tests/reftests/lint.test
@@ -1012,6 +1012,7 @@ maintainer: "maint@tain.er"
 license: "ISC"
 dev-repo: "git+file://./../to@li.nt"
 bug-reports: "https://nobug"
+depends: "pinned"
 url {
   src:"file://./my/url/path"
   checksum: "md5=00000000000000000000000000000000"
@@ -1265,6 +1266,126 @@ ${BASEDIR}/lint.opam: Errors.
              error 53: Mismatching 'extra-files:' field: "./relative/path", "/absolute/../relative/path", "/absolute/path", "extra-files..patch.patch"
              error 73: Field 'extra-files' contains path with '..': "/absolute/../relative/path"
 # Return code 1 #
+### : E74: Field 'pin-depends' contains packages that are neither in 'depends' nor in 'depopts'
+### <lint.opam>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+pin-depends: [
+  [ "foo.1" "file:///some/path" ]
+  [ "bar.1" "file:///some/path" ]
+]
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Warnings.
+           warning 74: Field 'pin-depends' contains packages that are neither in 'depends' nor in 'depopts': "foo", "bar"
+### <lint.opam>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+depends: [ "foo" ]
+pin-depends: [
+  [ "foo.1" "file:///some/path" ]
+  [ "bar.1" "file:///some/path" ]
+]
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Warnings.
+           warning 74: Field 'pin-depends' contains packages that are neither in 'depends' nor in 'depopts': "bar"
+### <lint.opam>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+depopts: [ "bar" ]
+pin-depends: [
+  [ "foo.1" "file:///some/path" ]
+  [ "bar.1" "file:///some/path" ]
+]
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Warnings.
+           warning 74: Field 'pin-depends' contains packages that are neither in 'depends' nor in 'depopts': "foo"
+### <lint.opam>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+depends: [ "foo" "oof" ]
+depopts: [ "bar" "rab" ]
+pin-depends: [
+  [ "foo.1" "file:///some/path" ]
+  [ "bar.1" "file:///some/path" ]
+]
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Passed.
+### <lint.opam>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+depends: [ "foo" ]
+pin-depends: [
+  [ "foo.1" "file:///some/path" ]
+]
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Passed.
+### <lint.opam>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+depopts: [ "bar" ]
+pin-depends: [
+  [ "bar.1" "file:///some/path" ]
+]
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Passed.
+### <lint.opam>
+opam-version: "2.0"
+synopsis: "A word"
+description: "Two words."
+authors: "the testing team"
+homepage: "egapemoh"
+maintainer: "maint@tain.er"
+license: "ISC"
+dev-repo: "hg+https://to@li.nt"
+bug-reports: "https://nobug"
+depends: [ "foo" { = "1" } ]
+pin-depends: [
+  [ "foo.2" "file:///some/path" ]
+]
+### opam lint ./lint.opam
+${BASEDIR}/lint.opam: Passed.
 ### :::::::::::::::::::::
 ### : Test parse errors :
 ### :::::::::::::::::::::


### PR DESCRIPTION
fix #5795
This lint doesn't detect when the versions mismatch.