### PR TITLE
Fix opam switch list-available when given several arguments

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -39,7 +39,7 @@ users)
 
 ## Switch
   * [BUG] Fix `opam switch remove <dir>` failure when it is a linked switch [#6276 @btjorge - fix #6275]
-  * Fix `opam switch list-available` when given several arguments [#6318 @kit-ty-kate]
+  * [BUG] Fix `opam switch list-available` when given several arguments [#6318 @kit-ty-kate]
 
 ## Config
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -39,6 +39,7 @@ users)
 
 ## Switch
   * [BUG] Fix `opam switch remove <dir>` failure when it is a linked switch [#6276 @btjorge - fix #6275]
+  * Fix `opam switch list-available` when given several arguments [#6318 @kit-ty-kate]
 
 ## Config
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2904,7 +2904,7 @@ let switch cli =
       in
       let all_compilers =
         OpamListCommand.filter ~base:compilers st
-          (OpamFormula.ands (List.map (fun f -> OpamFormula.Atom f) filters))
+          (OpamFormula.ors (List.map (fun f -> OpamFormula.Atom f) filters))
       in
       let compilers =
         if all then
@@ -3199,7 +3199,7 @@ let pin_doc = "Pin a given package to a specific version or source."
 let pin ?(unpin_only=false) cli =
   let doc = pin_doc in
   let commands = [
-    cli_original, "list", `list, [], 
+    cli_original, "list", `list, [],
     "Lists pinned packages. \
      If the source is a remote repository, \
      displays the hash representing its state.";

--- a/tests/reftests/switch-list-available.test
+++ b/tests/reftests/switch-list-available.test
@@ -149,3 +149,7 @@ comp_c 1
 # Name # Version # Synopsis
 comp_c 1
 comp_c 2
+### : show the behaviour of list-available with several arguments
+### opam switch list-available "comp-*" "comp_*"
+# Listing available compilers from repositories: default
+# No matches found

--- a/tests/reftests/switch-list-available.test
+++ b/tests/reftests/switch-list-available.test
@@ -152,4 +152,12 @@ comp_c 2
 ### : show the behaviour of list-available with several arguments
 ### opam switch list-available "comp-*" "comp_*"
 # Listing available compilers from repositories: default
-# No matches found
+# Name # Version # Synopsis
+comp-a 1
+comp-b 1
+comp_c 1
+comp-a 2
+comp-a 3
+comp-a 4
+comp-b 4
+[NOTE] Some compilers have been hidden (e.g. pre-releases). If you want to display them, run: 'opam switch list-available --all'


### PR DESCRIPTION
Required for #6186 

Giving several arguments would never have given any results before. Furthermore it now matches the behaviour of `opam list`