### PR TITLE
Manual: add information when flags (avoid-version, deprecated) were introduced

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -1154,11 +1154,12 @@ files.
       [solver criteria](#configfield-solver-criteria). This can be useful for
       beta releases, or to discourage installation of releases with known bugs.
       Note that this behaviour is disabled when a flagged version of the package
-      is already installed.
+      is already installed. This was introduced in opam 2.1.
     - <a id="opamflag-deprecated">`deprecated`</a>: this flag is equivalent to
       [`avoid-version`](#opamflag-avoid-version) except for the addition of a
       deprecation message after the package is installed as well as marked as
-      deprecated in the solution shown to the user upon installation.
+      deprecated in the solution shown to the user upon installation. This was
+      introduced in opam 2.2.
 
 - <a id="opamfield-features">
   `features: [ <ident> { <pkgname> { <filtered-package-formula> } ... } { <string> } ... ]`

--- a/master_changes.md
+++ b/master_changes.md
@@ -154,6 +154,7 @@ users)
   * Manual: Document the stamp field from repo files [#6306 @kit-ty-kate]
   * Fix typo in pin edit man page doc [#6315 @shym]
   * Clarify documentation for `enable` pseudo-variable [#5659 @gridbugs]
+  * Manual: add information when flags (`avoid-version`, `deprecated`) were introduced [#6320 @hannesm]
 
 ## Security fixes
 


### PR DESCRIPTION
As discussed with @kit-ty-kate. It would for sure make sense to add version information on more fields in the documentation. But for me that is pretty tedious since I'd have to manually look every field up. I'll do when I dig around more fields. But maybe someone else has the stamina to go through the entire manual.