### PR TITLE
Upgrade to opam-file-format 2.2.0~alpha1

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -82,6 +82,8 @@ users)
 ## VCS
 
 ## Build
+  * Upgrade to opam-file-format 2.2.0~alpha1 [#6321 @kit-ty-kate]
+  * Add menhir to the list of vendored packages [#6321 @kit-ty-kate]
 
 ## Infrastructure
 

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -22,7 +22,7 @@ ifndef FETCH
   endif
 endif
 
-SRC_EXTS = cppo base64 extlib re cmdliner ocamlgraph cudf dose3 opam-file-format seq stdlib-shims spdx_licenses opam-0install-cudf 0install-solver uutf jsonm sha swhid_core
+SRC_EXTS = cppo base64 extlib re cmdliner ocamlgraph cudf dose3 opam-file-format seq stdlib-shims spdx_licenses opam-0install-cudf 0install-solver uutf jsonm sha swhid_core menhir
 
 ifeq ($(MCCS_ENABLED),true)
 SRC_EXTS := $(SRC_EXTS) mccs

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -31,8 +31,8 @@ MD5_opam-0install-cudf = 75419722aa839f518a25cae1b3c6efd4
 URL_0install-solver = https://github.com/0install/0install/releases/download/v2.18/0install-2.18.tbz
 MD5_0install-solver = 030edc9b1d3676c06d51397ffb5a737d
 
-URL_opam-file-format = https://github.com/ocaml/opam-file-format/archive/refs/tags/2.1.6.tar.gz
-MD5_opam-file-format = 706ce5fc3e77db746a4c8b11d79cefef
+URL_opam-file-format = https://github.com/ocaml/opam-file-format/releases/download/2.2.0-alpha1/opam-file-format-2.2.0-alpha1.tar.gz
+MD5_opam-file-format = e7454160b5f3982016ddaac2dfd5bf52
 
 include Makefile.dune
 
@@ -56,3 +56,6 @@ MD5_sha = 08bc953d9a26380bc220b05d680791fb
 
 URL_swhid_core = https://github.com/OCamlPro/swhid_core/archive/refs/tags/0.1.tar.gz
 MD5_swhid_core = 77d88d4b1d96261c866f140c64d89af8
+
+URL_menhir = https://gitlab.inria.fr/fpottier/menhir/-/archive/20240715/archive.tar.gz
+MD5_menhir = d39a8943fe1be28199e5ec1f4133504c


### PR DESCRIPTION
now depends on menhir instead of ocamlyacc.

Requires https://github.com/ocaml/opam-file-format/pull/60