### PR TITLE
sandbox: respect the `DUNE_CACHE_ROOT` environment variable if it exists

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -85,6 +85,7 @@ users)
 ## Format upgrade
 
 ## Sandbox
+  * Respect the `DUNE_CACHE_ROOT` environment variable if it exists [#6326 @smorimoto]
 
 ## VCS
 

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -95,7 +95,7 @@ add_ccache_mount() {
 }
 
 add_dune_cache_mount() {
-  local dune_cache=${XDG_CACHE_HOME:-$HOME/.cache}/dune
+  local dune_cache=${DUNE_CACHE_ROOT:-${XDG_CACHE_HOME:-$HOME/.cache}/dune}
   mount_linked_cache "$dune_cache"
 }
 

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -51,7 +51,7 @@ add_ccache_mount() {
 }
 
 add_dune_cache_mount() {
-  local dune_cache=${XDG_CACHE_HOME:-$HOME/.cache}/dune
+  local dune_cache=${DUNE_CACHE_ROOT:-${XDG_CACHE_HOME:-$HOME/.cache}/dune}
   mkdir -p "${dune_cache}"
   add_mounts rw "$dune_cache"
 }


### PR DESCRIPTION
Users can set `DUNE_CACHE_ROOT`, which has a higher priority than other environment variables.
Currently, there are some cases where the cache functionality does not work well when `DUNE_CACHE_ROOT` is set.

Ref: https://dune.readthedocs.io/en/stable/caching.html