### PR TITLE
Nushell support

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -76,6 +76,7 @@ users)
 ## Clean
 
 ## Env
+  * [NEW] Add support for nushell in the opam env command
 
 ## Opamfile
 

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1135,6 +1135,7 @@ let shell_opt ?section cli validity =
     None,"csh",SH_csh;
     None,"zsh",SH_zsh;
     None,"fish",SH_fish;
+    None,"nu",SH_nu;
     Some cli2_2,"pwsh",SH_pwsh Powershell_pwsh;
     Some cli2_2,"cmd",SH_cmd;
     Some cli2_2,"powershell",SH_pwsh Powershell

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1129,7 +1129,7 @@ let rec cygwin_menu ~bypass_checks ~interactive header =
             options, internal_option, Some warning
           | None ->
             match OpamStd.Sys.guess_shell_compat () with
-            | SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish ->
+            | SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_nu ->
               let default, warning =
                 if kind = `Msys2 && OpamSystem.resolve_command pacman = None then
                   internal_option, Printf.sprintf

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1419,7 +1419,7 @@ let config cli =
          `Ok (OpamConfigCommand.env gt sw
                 ~set_opamroot ~set_opamswitch
                 ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
-                ~pwsh ~cmd:(shell=SH_cmd)
+                ~pwsh ~cmd:(shell=SH_cmd) ~nu:(shell=SH_nu)
                 ~inplace_path))
     | Some `revert_env, [] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -1429,7 +1429,7 @@ let config cli =
          `Ok (OpamConfigCommand.ensure_env gt sw;
               OpamConfigCommand.print_eval_env
                 ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
-                ~pwsh ~cmd:(shell=SH_cmd)
+                ~pwsh ~cmd:(shell=SH_cmd) ~nu:(shell=SH_nu)
                 (OpamEnv.add [] [])))
     | Some `list, [] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -1734,12 +1734,12 @@ let env cli =
          OpamConfigCommand.env gt sw
            ~set_opamroot ~set_opamswitch
            ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
-           ~pwsh ~cmd:(shell=SH_cmd)
+           ~pwsh ~cmd:(shell=SH_cmd) ~nu:(shell=SH_nu)
            ~inplace_path);
     | true ->
       OpamConfigCommand.print_eval_env
         ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
-        ~pwsh ~cmd:(shell=SH_cmd)
+        ~pwsh ~cmd:(shell=SH_cmd) ~nu:(shell=SH_nu)
         (OpamEnv.add [] [])
   in
   let open Common_config_flags in

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -23,7 +23,7 @@ open OpamStateTypes
 val env:
   'a global_state -> switch ->
   ?set_opamroot:bool -> ?set_opamswitch:bool ->
-  csh:bool -> sexp:bool -> fish:bool -> pwsh:bool -> cmd:bool ->
+  csh:bool -> sexp:bool -> fish:bool -> pwsh:bool -> cmd:bool -> nu:bool ->
   inplace_path:bool -> unit
 
 (** Ensures that the environment file exists in the given switch, regenerating
@@ -32,7 +32,7 @@ val ensure_env: 'a global_state -> switch -> unit
 
 (** Like [env] but allows one to specify the precise env to print rather than
     compute it from a switch state *)
-val print_eval_env: csh:bool -> sexp:bool -> fish:bool -> pwsh:bool -> cmd:bool -> env -> unit
+val print_eval_env: csh:bool -> sexp:bool -> fish:bool -> pwsh:bool -> cmd:bool -> nu:bool -> env -> unit
 
 (** Display the content of all available packages variables *)
 val list: 'a switch_state -> name list -> unit

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1039,7 +1039,7 @@ module OpamSys = struct
     fun () -> Lazy.force os
 
   type powershell_host = Powershell_pwsh | Powershell
-  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish
+  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_nu
     | SH_pwsh of powershell_host | SH_cmd
 
   let all_shells =
@@ -1047,6 +1047,7 @@ module OpamSys = struct
      SH_zsh;
      SH_csh;
      SH_fish;
+     SH_nu;
      SH_pwsh Powershell_pwsh;
      SH_pwsh Powershell;
      SH_cmd]
@@ -1061,6 +1062,7 @@ module OpamSys = struct
     | "zsh"  -> Some SH_zsh
     | "bash" -> Some SH_bash
     | "fish" -> Some SH_fish
+    | "nu"   -> Some SH_nu
     | "pwsh" -> Some (SH_pwsh Powershell_pwsh)
     | "dash"
     | "sh"   -> Some SH_sh
@@ -1159,6 +1161,8 @@ module OpamSys = struct
     match shell with
     | SH_fish ->
       Some (List.fold_left Filename.concat (home ".config") ["fish"; "config.fish"])
+    | SH_nu ->
+      Some (List.fold_left Filename.concat (home ".config") ["nushell"; "env.nu"])
     | SH_zsh  ->
       let zsh_home f = 
         try Filename.concat (Env.get "ZDOTDIR") f

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -531,7 +531,7 @@ module Sys : sig
 
   (** The different families of shells we know about *)
   type powershell_host = Powershell_pwsh | Powershell
-  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish
+  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_nu
     | SH_pwsh of powershell_host | SH_cmd
 
   (** List of all supported shells *)

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -321,7 +321,7 @@ type pin_kind = [ `version | OpamUrl.backend ]
 (** Shell compatibility modes *)
 type powershell_host = OpamStd.Sys.powershell_host = Powershell_pwsh | Powershell
 type shell = OpamStd.Sys.shell =
-  | SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh of powershell_host
+  | SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_nu | SH_pwsh of powershell_host
   | SH_cmd
 
 (** {2 Generic command-line definitions with filters} *)

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -42,6 +42,7 @@ let all_std_paths =
 
 let string_of_shell = function
   | SH_fish -> "fish"
+  | SH_nu   -> "nu"
   | SH_csh  -> "csh"
   | SH_zsh  -> "zsh"
   | SH_sh   -> "sh"


### PR DESCRIPTION
This change make the command `opam env` work within [nushell](https://github.com/nushell/nushell) by typing
```
load-env (opam env | from json)
```

It does not add full nushell support, only for the `env` command, but it’s the first step. I don’t know that much about the code of opam and could not figure out where to make the other changes neccessary / when they are called, so this is open to improvments.

**NOTE**: nushell still has some breaking changes sometimes, so I don’t know how this will hold up to the future, but I am certain that it will be easier to change an existing implementation.