### PR TITLE
[2.3 backport] Fix opam admin check in the presence of the with-dev-setup variable

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -79,6 +79,7 @@ users)
 ## Install script
 
 ## Admin
+  * [BUG] Fix `opam admin check` in the presence of the `with-dev-setup` variable [#6331 @kit-ty-kate - fix #6329]
 
 ## Opam installer
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -104,6 +104,7 @@ users)
 ## Reftests
 ### Tests
   * Extend the tests on opam admin to include packages using builtin global variables [#6331 @kit-ty-kate]
+  * Extend the tests on opam admin check by including all the arguments [#6331 @kit-ty-kate @rjbou]
 
 ### Engine
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -102,6 +102,7 @@ users)
 
 ## Reftests
 ### Tests
+  * Extend the tests on opam admin to include packages using builtin global variables [#6331 @kit-ty-kate]
 
 ### Engine
 

--- a/src/client/opamAdminCheck.ml
+++ b/src/client/opamAdminCheck.ml
@@ -11,7 +11,7 @@
 open OpamTypes
 open OpamPackage.Set.Op
 
-let env ~with_test ~with_doc ~dev nv v =
+let env ~with_test ~with_doc ~with_dev_setup ~dev nv v =
   match OpamVariable.Full.scope v,
         OpamVariable.(to_string (Full.variable v))
   with
@@ -27,10 +27,12 @@ let env ~with_test ~with_doc ~dev nv v =
     Some (B dev)
   | OpamVariable.Full.Global, "with-doc" ->
     Some (B with_doc)
+  | OpamVariable.Full.Global, "with-dev-setup" ->
+    Some (B with_dev_setup)
   | _ -> None
 
-let get_universe ~with_test ~with_doc ~dev opams =
-  let env = env ~with_test ~with_doc ~dev in
+let get_universe ~with_test ~with_doc ~with_dev_setup ~dev opams =
+  let env = env ~with_test ~with_doc ~with_dev_setup ~dev in
   let packages = OpamPackage.keys opams in
   {
     u_packages = packages;
@@ -419,7 +421,7 @@ let check ~quiet ~installability ~cycles ~obsolete ~ignore_test repo_root =
   in
   let univ =
     get_universe
-      ~with_test:(not ignore_test) ~with_doc:(not ignore_test) ~dev:false
+      ~with_test:(not ignore_test) ~with_doc:(not ignore_test) ~with_dev_setup:false ~dev:false
       opams
   in
 

--- a/tests/reftests/admin.test
+++ b/tests/reftests/admin.test
@@ -273,6 +273,14 @@ depends: "lorem" { < "1" }
 ### <packages/non/non.1/opam>
 opam-version: "2.0"
 depends: "lorem"
+### <packages/vars/vars.1/opam>
+opam-version: "2.0"
+depends: [
+  "lorem" {with-test}
+  "ipsum" {with-doc}
+  "dolor" {with-dev-setup}
+  "sit" {dev}
+]
 ### <add-content.sh>
 for op in `ls packages/*/*/opam`; do
   grep -q synopsis $op || echo 'synopsis: "A word"' >> $op
@@ -309,17 +317,15 @@ ocaml-variants      --          A word
 risus               --
 sed                 --          A word
 sit                 --          A word
+vars                --          A word
 ### :::::::::::::
 ### :III: check :
 ### :::::::::::::
 ### opam admin check
 Checking installability of every package. This may take a few minutes...
-[ERROR] These packages are not installable (2):
-        ocaml-system.1.2 risus.1
-Summary: out of 20 packages (17 distinct names)
-- 2 uninstallable roots
-
-# Return code 1 #
+Fatal error:
+Invalid_argument("filter_deps")
+# Return code 99 #
 ### : index :
 ### opam admin index
 Generating urls.txt...
@@ -331,6 +337,9 @@ packages/
 packages/base-comp/
 packages/base-comp/base-comp.base/
 packages/base-comp/base-comp.base/opam
+packages/vars/
+packages/vars/vars.1/
+packages/vars/vars.1/opam
 packages/risus/
 packages/risus/risus.1/
 packages/risus/risus.1/opam
@@ -434,6 +443,7 @@ opam-version: "2.0"
 depends: "lorem"
 ### opam admin add-constraint lorem<1.2
 [WARNING] In package adipiscing.1, updated constraint lorem {< "1.2" & > "2"} cannot be satisfied, not updating (use `--force' to update anyway)
+[WARNING] In package vars.1, updated constraint lorem {< "1.2" & with-test & > "1.2"} cannot be satisfied, not updating (use `--force' to update anyway)
 ### opam show --just-file ./packages/non/non.1/opam --field depends
 "lorem" {< "1.2"}
 ### opam show --just-file ./packages/sed/sed.1/opam --field depends
@@ -460,6 +470,7 @@ depends: "lorem"
 ### opam admin add-constraint lorem=1.2
 [WARNING] In package adipiscing.1, updated constraint lorem {= "1.2" & > "2"} cannot be satisfied, not updating (use `--force' to update anyway)
 [WARNING] In package sed.1, updated constraint lorem {= "1.2" & < "1"} cannot be satisfied, not updating (use `--force' to update anyway)
+[WARNING] In package vars.1, updated constraint lorem {= "1.2" & < "1.2" & with-test & > "1.2"} cannot be satisfied, not updating (use `--force' to update anyway)
 ### opam show --just-file ./packages/non/non.1/opam --field depends
 "lorem" {= "1.2"}
 ### opam show --just-file ./packages/sed/sed.1/opam --field depends

--- a/tests/reftests/admin.test
+++ b/tests/reftests/admin.test
@@ -321,14 +321,94 @@ vars                --          A word
 ### :::::::::::::
 ### :III: check :
 ### :::::::::::::
+### <packages/suspendisse/suspendisse.1/opam>
+opam-version: "2.0"
+depends: [
+  "lorem" { = "1.0" & with-test } # for obsolete -i test
+  "not-found" { with-test } # for installability -i test
+]
+### <packages/lectus/lectus.1/opam>
+opam-version: "2.0"
+depends: [
+  "tortor" # for cycle test
+  "dignissim" {with-doc} # for cycle -i test
+]
+### <packages/tortor/tortor.1/opam>
+opam-version: "2.0"
+depends: "lectus"
+### <packages/dignissim/dignissim.1/opam>
+opam-version: "2.0"
+depends: "lectus"
+### # by default, the check does installability & cycle check
 ### opam admin check
+Checking installability of every package. This may take a few minutes...
+[ERROR] These packages are not installable (3):
+        ocaml-system.1.2 risus.1 suspendisse.1
+[ERROR] Dependency cycles detected:
+  * lectus = 1 -> dignissim = 1
+  * lectus = 1 -> tortor = 1
+Summary: out of 25 packages (22 distinct names)
+- 3 uninstallable roots
+- 3 packages part of dependency cycles
+
+# Return code 1 #
+### opam admin check -i
 Checking installability of every package. This may take a few minutes...
 [ERROR] These packages are not installable (2):
         ocaml-system.1.2 risus.1
-Summary: out of 21 packages (18 distinct names)
+[ERROR] Dependency cycles detected:
+  * lectus = 1 -> tortor = 1
+Summary: out of 25 packages (22 distinct names)
+- 2 uninstallable roots
+- 2 packages part of dependency cycles
+
+# Return code 1 #
+### opam admin check --installability
+Checking installability of every package. This may take a few minutes...
+[ERROR] These packages are not installable (3):
+        ocaml-system.1.2 risus.1 suspendisse.1
+Summary: out of 25 packages (22 distinct names)
+- 3 uninstallable roots
+
+# Return code 1 #
+### opam admin check --installability -i
+Checking installability of every package. This may take a few minutes...
+[ERROR] These packages are not installable (2):
+        ocaml-system.1.2 risus.1
+Summary: out of 25 packages (22 distinct names)
 - 2 uninstallable roots
 
 # Return code 1 #
+### opam admin check --obsolete
+[ERROR] Obsolete packages detected:
+  - lorem 2.0
+Summary: out of 25 packages (22 distinct names)
+- 1 obsolete packages
+
+# Return code 1 #
+### opam admin check --obsolete -i
+[ERROR] Obsolete packages detected:
+  - lorem 1.0, 2.0
+Summary: out of 25 packages (22 distinct names)
+- 2 obsolete packages
+
+# Return code 1 #
+### opam admin check --cycles
+[ERROR] Dependency cycles detected:
+  * lectus = 1 -> dignissim = 1
+  * lectus = 1 -> tortor = 1
+Summary: out of 25 packages (22 distinct names)
+- 3 packages part of dependency cycles
+
+# Return code 1 #
+### opam admin check --cycles -i
+[ERROR] Dependency cycles detected:
+  * lectus = 1 -> tortor = 1
+Summary: out of 25 packages (22 distinct names)
+- 2 packages part of dependency cycles
+
+# Return code 1 #
+### rm -r packages/suspendisse packages/lectus packages/tortor packages/dignissim
 ### : index :
 ### opam admin index
 Generating urls.txt...

--- a/tests/reftests/admin.test
+++ b/tests/reftests/admin.test
@@ -323,9 +323,12 @@ vars                --          A word
 ### :::::::::::::
 ### opam admin check
 Checking installability of every package. This may take a few minutes...
-Fatal error:
-Invalid_argument("filter_deps")
-# Return code 99 #
+[ERROR] These packages are not installable (2):
+        ocaml-system.1.2 risus.1
+Summary: out of 21 packages (18 distinct names)
+- 2 uninstallable roots
+
+# Return code 1 #
 ### : index :
 ### opam admin index
 Generating urls.txt...


### PR DESCRIPTION
Backport of https://github.com/ocaml/opam/pull/6331 to the 2.3 branch
Queued on #6337 