### PR TITLE
Fix sandboxing support in NixOS

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -86,6 +86,7 @@ users)
 
 ## Sandbox
   * Respect the `DUNE_CACHE_ROOT` environment variable if it exists [#6326 @smorimoto]
+  * Fix sandboxing support in NixOS [#6333 @kit-ty-kate]
 
 ## VCS
 

--- a/src/state/shellscripts/bwrap.sh
+++ b/src/state/shellscripts/bwrap.sh
@@ -68,6 +68,10 @@ for dir in /*; do
     *) add_sys_mounts "$dir";;
     esac
 done
+# NOTE: This is required for NixOS (see https://github.com/NixOS/nixpkgs/pull/363770)
+if [ -d /run/current-system/sw ]; then
+  add_sys_mounts /run/current-system/sw
+fi
 
 mount_linked_cache() {
   local l_cache=$1


### PR DESCRIPTION
Upstreams changes from https://github.com/NixOS/nixpkgs/pull/363770

The issue is that in the bubblewrap sandbox `/run` is mounted as tmpfs so its content is emptied inside the sandbox and Nix makes use of `/run/current-system/sw` to store the whole system (everything symlinks to it if i understand correctly).

cc @RyanGibb just in case you can tell me if i've done/said something awful