### PR TITLE
opam admin check: Set with-test and with-doc to false by default

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -118,6 +118,8 @@ users)
 ## Admin
   * ◈ Add `opam admin compare-versions` to compare package versions for sanity checks [#6197 @mbarbin]
   * [BUG] Fix `opam admin check` in the presence of the `with-dev-setup` variable [#6331 @kit-ty-kate - fix #6329]
+  * ✘ The `-i`/`--ignore-test-doc` argument has been removed from `opam admin check` [#6335 @kit-ty-kate]
+  * ✘ `opam admin check` now sets `with-test` and `with-doc` to `false` instead of `true` [#6335 @kit-ty-kate]
 
 ## Opam installer
 

--- a/src/client/opamAdminCheck.ml
+++ b/src/client/opamAdminCheck.ml
@@ -11,7 +11,7 @@
 open OpamTypes
 open OpamPackage.Set.Op
 
-let env ~with_test ~with_doc ~with_dev_setup ~dev nv v =
+let env nv v =
   match OpamVariable.Full.scope v,
         OpamVariable.(to_string (Full.variable v))
   with
@@ -22,17 +22,16 @@ let env ~with_test ~with_doc ~with_dev_setup ~dev nv v =
   | OpamVariable.Full.Global, "opam-version" ->
     Some (S OpamVersion.(to_string current))
   | OpamVariable.Full.Global, "with-test" ->
-    Some (B with_test)
+    Some (B false)
   | OpamVariable.Full.Global, "dev" ->
-    Some (B dev)
+    Some (B false)
   | OpamVariable.Full.Global, "with-doc" ->
-    Some (B with_doc)
+    Some (B false)
   | OpamVariable.Full.Global, "with-dev-setup" ->
-    Some (B with_dev_setup)
+    Some (B false)
   | _ -> None
 
-let get_universe ~with_test ~with_doc ~with_dev_setup ~dev opams =
-  let env = env ~with_test ~with_doc ~with_dev_setup ~dev in
+let get_universe opams =
   let packages = OpamPackage.keys opams in
   {
     u_packages = packages;
@@ -405,7 +404,7 @@ let get_obsolete univ opams =
       if is_obsolete then acc ++ pkgs else acc)
     aggregates PkgSet.empty
 
-let check ~quiet ~installability ~cycles ~obsolete ~ignore_test repo_root =
+let check ~quiet ~installability ~cycles ~obsolete repo_root =
   let pkg_prefixes = OpamRepository.packages_with_prefixes repo_root in
   let opams =
     OpamPackage.Map.fold (fun nv prefix acc ->
@@ -419,11 +418,7 @@ let check ~quiet ~installability ~cycles ~obsolete ~ignore_test repo_root =
       pkg_prefixes
       OpamPackage.Map.empty
   in
-  let univ =
-    get_universe
-      ~with_test:(not ignore_test) ~with_doc:(not ignore_test) ~with_dev_setup:false ~dev:false
-      opams
-  in
+  let univ = get_universe opams in
 
   (* Installability check *)
   let unav_roots, uninstallable =

--- a/src/client/opamAdminCheck.mli
+++ b/src/client/opamAdminCheck.mli
@@ -25,7 +25,6 @@ val cycle_check: universe -> package_set * formula list list
     sets are empty. *)
 val check:
   quiet:bool -> installability:bool -> cycles:bool -> obsolete:bool ->
-  ignore_test:bool ->
   dirname -> package_set * package_set * package_set * package_set * package_set
 
 (** Returns a subset of "obsolete" packages, i.e. packages for which a strictly

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -761,11 +761,6 @@ let check_command cli =
         are supposed to be available. By default, all checks are run."
   ]
   in
-  let ignore_test_arg =
-    OpamArg.mk_flag ~cli OpamArg.cli_original ["ignore-test-doc";"i"]
-      "By default, $(b,{with-test}) and $(b,{with-doc}) dependencies are \
-       included. This ignores them, and makes the test more tolerant."
-  in
   let print_short_arg =
     OpamArg.mk_flag ~cli OpamArg.cli_original ["s";"short"]
       "Only output a list of uninstallable packages"
@@ -782,7 +777,7 @@ let check_command cli =
     OpamArg.mk_flag ~cli OpamArg.cli_original ["obsolete"]
       "Analyse for obsolete packages"
   in
-  let cmd global_options ignore_test print_short
+  let cmd global_options print_short
       installability cycles obsolete () =
     OpamArg.apply_global_options cli global_options;
     let repo_root = checked_repo_root () in
@@ -793,7 +788,7 @@ let check_command cli =
     in
     let pkgs, unav_roots, uninstallable, cycle_packages, obsolete =
       OpamAdminCheck.check
-        ~quiet:print_short ~installability ~cycles ~obsolete ~ignore_test
+        ~quiet:print_short ~installability ~cycles ~obsolete
         repo_root
     in
     let all_ok =
@@ -827,7 +822,7 @@ let check_command cli =
     OpamStd.Sys.exit_because (if all_ok then `Success else `False)
   in
   OpamArg.mk_command  ~cli OpamArg.cli_original command ~doc ~man
-  Term.(const cmd $ global_options cli $ ignore_test_arg $ print_short_arg
+  Term.(const cmd $ global_options cli $ print_short_arg
         $ installability_arg $ cycles_arg $ obsolete_arg)
 
 let compare_versions_command_doc = "Compare two package versions"

--- a/tests/reftests/admin.test
+++ b/tests/reftests/admin.test
@@ -342,18 +342,6 @@ depends: "lectus"
 ### # by default, the check does installability & cycle check
 ### opam admin check
 Checking installability of every package. This may take a few minutes...
-[ERROR] These packages are not installable (3):
-        ocaml-system.1.2 risus.1 suspendisse.1
-[ERROR] Dependency cycles detected:
-  * lectus = 1 -> dignissim = 1
-  * lectus = 1 -> tortor = 1
-Summary: out of 25 packages (22 distinct names)
-- 3 uninstallable roots
-- 3 packages part of dependency cycles
-
-# Return code 1 #
-### opam admin check -i
-Checking installability of every package. This may take a few minutes...
 [ERROR] These packages are not installable (2):
         ocaml-system.1.2 risus.1
 [ERROR] Dependency cycles detected:
@@ -365,14 +353,6 @@ Summary: out of 25 packages (22 distinct names)
 # Return code 1 #
 ### opam admin check --installability
 Checking installability of every package. This may take a few minutes...
-[ERROR] These packages are not installable (3):
-        ocaml-system.1.2 risus.1 suspendisse.1
-Summary: out of 25 packages (22 distinct names)
-- 3 uninstallable roots
-
-# Return code 1 #
-### opam admin check --installability -i
-Checking installability of every package. This may take a few minutes...
 [ERROR] These packages are not installable (2):
         ocaml-system.1.2 risus.1
 Summary: out of 25 packages (22 distinct names)
@@ -381,27 +361,12 @@ Summary: out of 25 packages (22 distinct names)
 # Return code 1 #
 ### opam admin check --obsolete
 [ERROR] Obsolete packages detected:
-  - lorem 2.0
-Summary: out of 25 packages (22 distinct names)
-- 1 obsolete packages
-
-# Return code 1 #
-### opam admin check --obsolete -i
-[ERROR] Obsolete packages detected:
   - lorem 1.0, 2.0
 Summary: out of 25 packages (22 distinct names)
 - 2 obsolete packages
 
 # Return code 1 #
 ### opam admin check --cycles
-[ERROR] Dependency cycles detected:
-  * lectus = 1 -> dignissim = 1
-  * lectus = 1 -> tortor = 1
-Summary: out of 25 packages (22 distinct names)
-- 3 packages part of dependency cycles
-
-# Return code 1 #
-### opam admin check --cycles -i
 [ERROR] Dependency cycles detected:
   * lectus = 1 -> tortor = 1
 Summary: out of 25 packages (22 distinct names)


### PR DESCRIPTION
Queued on top of #6331 

Currently `opam admin check` sets `with-test` and `with-doc` to true by default, which in my opinion makes little sense, especially in light of https://github.com/ocaml/opam/issues/4541 as it does not take into account user behaviour at all but some hypothetical "what if someone had OPAMWITHTEST=1 and OPAMWITHDOC=1 always set in their environment".

This draft PR flips the default for those two variables to use what the actual default everywhere else is (`with-test=false` and `with-doc=false`). It also gets rid of `-i` which has no purpose anymore.

Instead this PR introduces three more arguments: `--with-test`, `--with-doc` and `--with-dev-setup`. However in light of https://github.com/ocaml/opam/issues/4541 i'm not sure this is a good idea and i don't this anyone uses `opam admin check` without `-i` currently, which makes the introduction of those replacements seem useless. What do you think?

Related to https://github.com/ocaml/opam/issues/5805