### PR TITLE
Fix GHA when opam-rt uses a diverging API

### DIFF
--- a/.github/scripts/main/main.sh
+++ b/.github/scripts/main/main.sh
@@ -130,16 +130,18 @@ if [ "$OPAM_TEST" = "1" ]; then
   if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && git ls-remote --exit-code origin "$GITHUB_PR_USER/$BRANCH" ; then
     BRANCH=$GITHUB_PR_USER/$BRANCH
   fi
-  if git ls-remote --exit-code origin $BRANCH ; then
-    if git branch | grep -q $BRANCH; then
-      git checkout $BRANCH
-      git reset --hard origin/$BRANCH
-    else
-      git checkout -b $BRANCH origin/$BRANCH
-    fi
+  if git ls-remote --exit-code origin "$BRANCH"; then
+    OPAM_RT_BRANCH=$BRANCH
+  elif [ "$GITHUB_EVENT_NAME" = pull_request ] && git ls-remote --exit-code origin "$GITHUB_BASE_REF"; then
+    OPAM_RT_BRANCH=$GITHUB_BASE_REF
   else
-    git checkout master
-    git reset --hard origin/master
+    OPAM_RT_BRANCH=master
+  fi
+  if git branch | grep -q "$OPAM_RT_BRANCH"; then
+    git checkout "$OPAM_RT_BRANCH"
+    git reset --hard "origin/$OPAM_RT_BRANCH"
+  else
+    git checkout -b "$OPAM_RT_BRANCH" "origin/$OPAM_RT_BRANCH"
   fi
 
   test -d _opam || opam switch create . --no-install --formula '"ocaml-system"'


### PR DESCRIPTION
Backported to 2.3 in #6337 

Currently our Github Action script uses either opam-rt's master branch or a branch with the same name as the source branch. Obviously when a change to opam-rt is required between master and a backport branch such as 2.3, master becomes only available for opam master and the backport PRs will start failing.

This PR fixes this by simply looking up if the name of the target branch is available in the opam-rt repository and use that instead.