### PR TITLE
Display the version number of packages flagged with avoid-version/deprecated gray

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -213,6 +213,7 @@ users)
   * `OpamFile.Repos_config.t`: change the type to not allow repositories without an URL [#6249 @kit-ty-kate]
 
 ## opam-core
+  * `OpamConsole`: Replace `black` text style (unused and not very readable) by `gray` [#6358 @kit-ty-kate]
   * `OpamStd.List.split`: Improve performance [#6210 @kit-ty-kate]
   * `OpamStd.Sys.{get_terminal_columns,uname,getconf,guess_shell_compat}`: Harden the process calls to account for failures [#6230 @kit-ty-kate - fix #6215]
   * `OpamStd.Sys.getconf`: was removed, replaced by `get_long_bit` [#6217 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -190,6 +190,7 @@ users)
   * Manual: add information when flags (`avoid-version`, `deprecated`) were introduced [#6320 @hannesm]
   * Add winget command for installing opam [#6338 @tobil4sk]
   * Fix broken link to non-existing archlinux community repo [#6361 @juergenhoetzel]
+  * Document the meaning of colored version numbers in the manpage of `opam show` [#6358 @kit-ty-kate]
 
 ## Security fixes
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -51,6 +51,7 @@ users)
 ## List
 
 ## Show
+  * Display the version number of packages flagged with avoid-version/deprecated gray [#6358 @kit-ty-kate - fix #6354]
 
 ## Var/Option
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -921,7 +921,18 @@ let show cli =
         available packages as well as a short description for each.";
     `P "Paths to package definition files or to directories containing package \
         definitions can also be specified, in which case the corresponding \
-        metadata will be shown."
+        metadata will be shown.";
+    `P "Note: on terminal supporting it, version numbers can be colored the \
+        following ways:";
+    `Noblank;
+    `I ("-", "Magenta and bold: versions installed the current switch");
+    `Noblank;
+    `I ("-", "Bold: versions installed in other switches");
+    `Noblank;
+    `I ("-", "Red and crossed: versions not available on the current platform");
+    `Noblank;
+    `I ("-", "Gray: versions tagged with the $(i,avoid-version) or \
+              $(i,deprecated) flag");
   ] in
   let fields =
     mk_opt ~cli cli_original ["f";"field"] "FIELDS"

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -506,6 +506,7 @@ let field_of_string ~raw =
     | Some f -> Field f
     | None -> OpamConsole.error_and_exit `Bad_arguments "No printer for %S" s
 
+(* NOTE: upon changes, please update the man page section in opamCommands.ml *)
 let version_color st nv =
   let installed = (* (in any switch) *)
     OpamGlobalState.installed_versions st.switch_global nv.name

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -520,7 +520,14 @@ let version_color st nv =
   in
   if OpamPackage.Set.mem nv st.installed then [`bold;`magenta] else
     (if OpamPackage.Map.mem nv installed then [`bold] else []) @
-    (if is_available nv then [] else [`crossed;`red])
+    (if is_available nv then
+       match OpamSwitchState.opam_opt st nv with
+       | Some opam when
+           OpamFile.OPAM.has_flag Pkgflag_AvoidVersion opam ||
+           OpamFile.OPAM.has_flag Pkgflag_Deprecated opam ->
+         [`gray]
+       | None | Some _ -> []
+     else [`crossed;`red])
 
 let mini_field_printer ?(prettify=false) ?(normalise=false) =
   let module OpamPrinter = OpamPrinter.FullPos in

--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -193,7 +193,7 @@ type text_style =
   [ `bold
   | `underline
   | `crossed
-  | `black
+  | `gray
   | `red
   | `green
   | `yellow
@@ -206,7 +206,7 @@ let style_code (c: text_style) = match c with
   | `bold      -> "01"
   | `underline -> "04"
   | `crossed   -> "09"
-  | `black     -> "30"
+  | `gray      -> "90"
   | `red       -> "31"
   | `green     -> "32"
   | `yellow    -> "33"

--- a/src/core/opamConsole.mli
+++ b/src/core/opamConsole.mli
@@ -26,7 +26,7 @@ val disp_status_line: unit -> bool
 (** Settable attributes for ANSI terminal output. Nesting is generally not
     handled. *)
 type text_style =
-  [ `black
+  [ `gray
   | `blue
   | `bold
   | `crossed


### PR DESCRIPTION
Example of the new output with `opam show ocaml-base-compiler`:
![scrn-2025-01-07-20-00-13](https://github.com/user-attachments/assets/62856418-38d0-46c8-8cd1-83fe26e7420d)

Fixes #6354, probably the less intrusive solution if the color scheme works for you. Compared to removing them completely as suggested in the ticket, it brings an issue of clarity of meaning between what yellow or red means, although this concern seems pretty minimal to me compared to the other UX concerns brought by a potential addition of `--all`.