### PR TITLE
Docs: Fix broken link to non-existing community repo

### DIFF
--- a/doc/pages/Install.md
+++ b/doc/pages/Install.md
@@ -68,7 +68,7 @@ available release per distribution). Here is a list of supported distributions:
 
 [![badge](https://repology.org/badge/version-for-repo/arch/opam.svg)](https://repology.org/project/opam/versions)
 
-The [opam](https://www.archlinux.org/packages/community/x86_64/opam/)
+The [opam](https://www.archlinux.org/packages/extra/x86_64/opam/)
 package is available in the official distribution. To install it simply run:
 
 ```

--- a/master_changes.md
+++ b/master_changes.md
@@ -179,6 +179,7 @@ users)
   * Clarify documentation for `enable` pseudo-variable [#5659 @gridbugs]
   * Manual: add information when flags (`avoid-version`, `deprecated`) were introduced [#6320 @hannesm]
   * Add winget command for installing opam [#6338 @tobil4sk]
+  * Fix broken link to non-existing archlinux community repo [#6361 @juergenhoetzel]
 
 ## Security fixes
 


### PR DESCRIPTION
Arch Linux community repo was merged into extra repo:

https://archlinux.org/news/git-migration-announcement/


