### PR TITLE
depext: relax OpenBSD lookup for installed packages

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -83,6 +83,7 @@ users)
 ## External dependencies
   * Add apt-rpm/ALTLinux family support for depext [#6207 @RiderALT]
   * Lookup at `gpatch` before `patch` on macOS now that both homebrew and macports expose `gpatch` as `gpatch` since Homebrew/homebrew-core#174687 [#6255 @kit-ty-kate]
+  * Relax lookup on OpenBSD to consider all installed packages [#6362 @semarie]
 
 ## Format upgrade
 

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -974,7 +974,7 @@ let packages_status ?(env=OpamVariable.Map.empty) config packages =
     compute_sets sys_installed
   | Openbsd ->
     let sys_installed =
-      run_query_command "pkg_info" ["-mqP"]
+      run_query_command "pkg_info" ["-qP"]
       |> package_set_of_pkgpath
     in
     compute_sets sys_installed


### PR DESCRIPTION
uses the whole list of installed packages for depext, and not only the packages  manually installed.
