### PR TITLE
the opam lock command now exits with a non-zero exit code when dependencies are not yet installed in the current switch issue:#5520 reopened pr#6341

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -4409,7 +4409,9 @@ let lock cli =
     let pkg_done =
       OpamPackage.Set.fold (fun nv msgs ->
           let opam = OpamSwitchState.opam st nv in
-          let locked = OpamLockCommand.lock_opam ~only_direct st opam in
+          let locked = try OpamLockCommand.lock_opam ~only_direct st opam 
+          with e -> exit 1
+          in
           let locked_fname =
             OpamFilename.add_extension
               (OpamFilename.of_string (OpamPackage.name_to_string nv))


### PR DESCRIPTION
this might fix https://github.com/ocaml/opam/issues/5520

i mistakenly deleted the branch that was on https://github.com/ocaml/opam/pull/6341 thus i am re opening this pull request.

sorry for my silly mistake  
