### PR TITLE
Make sure download.test does not fail due to a checksum collision in the download cache

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -164,6 +164,7 @@ users)
   * Extend the tests on opam admin to include packages using builtin global variables [#6331 @kit-ty-kate]
   * Extend the tests on opam admin check by including all the arguments [#6331 @kit-ty-kate @rjbou]
   * Add double pinning test in case of opam/opam opam file [#6343 @rjbou]
+  * Make sure `download.test` does not fail due to a checksum collision in the download cache [#6378 @kit-ty-kate]
 
 ### Engine
 

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -178,6 +178,8 @@ echo "}" >> "$file"
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 Now run 'opam upgrade' to apply any package updates.
+### opam clean -c
+Clearing cache of downloaded files
 ### opam install foo --download-only -vv --debug-level=-1 | grep -v "^+-" | sed-cmd rsync | sed-cmd tar | grep -v "state-.*.export" | "md5[/\\].*" -> "md5-dir/"
 The following actions will be performed:
 === install 1 package
@@ -251,6 +253,8 @@ url {
   src: "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
   checksum: "md5=c9c157af4229fbb45d3f59f0d6d75dbe"
 }
+### opam clean -c
+Clearing cache of downloaded files
 ### opam install baz --download-only -vv --debug-level=-1 | grep -v "^+-" | sed-cmd wget | sed-cmd tar | "${OPAMVERSION}" -> "current" | grep -v "state-.*.export" | "md5[/\\].*" -> "md5-dir/" | grep -v "OPAM[/\\]log"
 The following actions will be performed:
 === install 1 package


### PR DESCRIPTION
Example of random failure: https://github.com/ocaml/opam/actions/runs/13137623611/job/36656730451?pr=6273
```
 diff --git a/_build/default/tests/reftests/download.test b/_build/default/tests/reftests/download.out
File "tests/reftests/download.test", line 1, characters 0-0:
"C:\Program Files\Git\cmd\git.exe" --no-pager diff --no-index --color=always -u --ignore-cr-at-eol _build/default/tests/reftests/download.test _build/default/tests/reftests/download.out
Command exited with code 1.
index c01c510..e2a08c0 100644
--- a/_build/default/tests/reftests/download.test
+++ b/_build/default/tests/reftests/download.out
@@ -262,7 +262,6 @@ SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [baz.1: http]
 + wget "--header=Accept: */*" "-t" "3" "-O" "${OPAMTMP}/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
 SYSTEM                          mv ${OPAMTMP}/v1.0.0.tar.gz.part -> ${OPAMTMP}/v1.0.0.tar.gz
-SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5-dir/
 SYSTEM                          copy ${OPAMTMP}/v1.0.0.tar.gz -> ${BASEDIR}/OPAM/download-cache/md5-dir/
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [baz.1: extract]
 ```
 This happens because some archives are being created above in the tests and their checksums will vary with the time of day so in some cases a collision will happen with the fix get_line archive