### PR TITLE
Avoid polymorphic comparison functions in OpamListCommand

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -154,6 +154,7 @@ users)
   * Avoid issues when using wget2 where the requested url might return an html page instead of the expected content [#6303 @kit-ty-kate]
   * Ensure each repositories stored in repos-config is associated with an URL [#6249 @kit-ty-kate]
   * Run `Gc.compact` in OpamParallel, when the main process is waiting for the children processes for the first time [#5396 @kkeundotnet]
+  * Avoid polymorphic comparison functions in `OpamListCommand` [#6381 @kit-ty-kate]
 
 ## Internal: Unix
   * Use a C stub to call the `uname` function from the C standard library instead of calling the `uname` POSIX command [#6217 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -240,6 +240,7 @@ users)
   * `OpamConsole`: Replace `black` text style (unused and not very readable) by `gray` [#6358 @kit-ty-kate]
   * `OpamConsole.pause`: Ensure the function always prints a newline character at the end [#6376 @kit-ty-kate]
   * `OpamStd.List.split`: Improve performance [#6210 @kit-ty-kate]
+  * `OpamStd.Option.equal_some`: was added, which tests equality of an option with a value [#6381 @kit-ty-kate]
   * `OpamStd.Sys.{get_terminal_columns,uname,getconf,guess_shell_compat}`: Harden the process calls to account for failures [#6230 @kit-ty-kate - fix #6215]
   * `OpamStd.Sys.getconf`: was removed, replaced by `get_long_bit` [#6217 @kit-ty-kate]
   * `OpamStd.Sys.get_long_bit`: was added, which returns the output of the `getconf LONG_BIT` command [#6217 @kit-ty-kate]

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -521,6 +521,10 @@ module Option = struct
     | None, None -> true
     | _ , _  -> false
 
+  let equal_some f v1 = function
+    | None -> false
+    | Some v2 -> f v1 v2
+
   let to_string ?(none="") f = function
     | Some x -> f x
     | None -> none

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -163,6 +163,8 @@ module Option: sig
 
   val equal: ('a -> 'a -> bool) -> 'a option -> 'a option -> bool
 
+  val equal_some : ('a -> 'a -> bool) -> 'a -> 'a option -> bool
+
   val to_string: ?none:string -> ('a -> string) -> 'a option -> string
 
   val to_list: 'a option -> 'a list


### PR DESCRIPTION
Queued on https://github.com/ocaml/opam/pull/5488
Reasoning to avoid polymorphic comparison functions in https://github.com/ocaml/ocaml/pull/9928