### PR TITLE
GHA: Show Cygwin version info after loading it from the cache

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -342,6 +342,7 @@ let main_build_job ~analyse_job ~cygwin_job ?section runner start_version ~oc ~w
     ++ cache Archives
     ++ cache OCaml platform "${{ matrix.ocamlv }}" host
     ++ only_on Windows (unpack_cygwin "${{ matrix.build }}" "${{ matrix.host }}")
+    ++ only_on Windows (run "Cygwin info" ["uname -a"])
     ++ build_cache OCaml platform "${{ matrix.ocamlv }}" host
     ++ run "Build" ["bash -exu .github/scripts/main/main.sh " ^ host]
     ++ not_on Windows (run "Test (basic)" ["bash -exu .github/scripts/main/test.sh"])

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,6 +205,8 @@ jobs:
     - name: Unpack Cygwin
       shell: cmd
       run: .github\scripts\cygwin.cmd ${{ matrix.build }} D:\Cache\cygwin ${{ matrix.host }}
+    - name: Cygwin info
+      run: uname -a
     - name: Unpack OCaml ${{ matrix.ocamlv }}
       run: bash -exu .github/scripts/main/ocaml-cache.sh ${{ runner.os }} ${{ matrix.ocamlv }} ${{ matrix.host }}
     - name: Build

--- a/master_changes.md
+++ b/master_changes.md
@@ -188,6 +188,7 @@ users)
   * Add OCaml 5.3 to the build matrix [#6192 @kit-ty-kate]
   * Add OCaml 5.3/MSVC to the build matrix [#6192 @kit-ty-kate]
   * Add a test making sure `opam init` works in the absence of `OPAMROOT` [#5663 @kit-ty-kate]
+  * Show Cygwin version info after loading it from the cache [#6383 @kit-ty-kate]
 
 ## Doc
   * Update the command to install opam to point to the new simplified url on opam.ocaml.org [#6226 @kit-ty-kate]


### PR DESCRIPTION
This is useful in case of a known Cygwin bug so we know if we need to clear the cache or not.

Example of such issue can be found in the previous latest Cygwin version 3.5.5: https://cygwin.com/pipermail/cygwin/2025-January/257058.html
In this case i'm suspecting our cache does use Cygwin 3.5.5 at the moment as CI has been experiencing some timeout which clears out after rebuild but i have no way of knowing if this is the problem, thus adding that information sounds like a plus to me. EDIT: We are indeed using 3.5.5, i'm clearing the cache right away.