### PR TITLE
GHA: Avoid the broken diffutils 3.11 release

### DIFF
--- a/.github/scripts/cygwin.cmd
+++ b/.github/scripts/cygwin.cmd
@@ -90,9 +90,10 @@ if "%1" equ "x86_64-pc-cygwin" (
   set CYGWIN_PACKAGES=
 )
 
+:: TODO: Remove the explicit version set for diffutils when https://debbugs.gnu.org/cgi/bugreport.cgi?bug=76452 is fixed
 :: libicu-devel is needed until an alternative to the uconv call in MungeSymlinks
 :: is found
-set CYGWIN_PACKAGES=make,patch,curl,diffutils,tar,unzip,git,gcc-g++,libicu-devel%CYGWIN_PACKAGES%
+set CYGWIN_PACKAGES=make,patch,curl,diffutils=3.10-1,tar,unzip,git,gcc-g++,libicu-devel%CYGWIN_PACKAGES%
 :: xxd is needed for reftests
 set CYGWIN_PACKAGES=xxd,%CYGWIN_PACKAGES%
 


### PR DESCRIPTION
diffutils 3.11 is broken and should not be used. This causes problems in our `patcher` test:
```
diff --git a/_build/default/tests/lib/patcher.expected b/_build/default/tests/lib/patcher.output
index 8164fa1..bc5074d 100644
--- a/_build/default/tests/lib/patcher.expected
+++ b/_build/default/tests/lib/patcher.output
@@ -2,11 +2,9 @@ PATCH                           No CRLF adaptation necessary for b/always-crlf
 PATCH                           No CRLF adaptation necessary for b/always-lf
 PATCH                           CRLF adaptation skipped for b/no-eol-at-all
 PATCH                           No CRLF adaptation necessary for b/no-eol-at-eof
-PATCH                           CRLF adaptation skipped for b/null-file
 PATCH                           No CRLF adaptation necessary for b/test1
 PATCH                           No CRLF adaptation necessary for b/test2
 PATCH                           No CRLF adaptation necessary for b/test3
-PATCH                           No CRLF adaptation necessary for b/will-null-file
 PATCH                           No patch translation needed for input.patch -> output.patch
 Before patch state of c:
   ./always-crlf: CRLF
@@ -22,33 +20,28 @@ patching file always-crlf
 patching file always-lf
 patching file no-eol-at-all
 patching file no-eol-at-eof
-patching file null-file
 patching file test1
 patching file test2
 patching file test3
-patching file will-null-file
 After patch state of c:
   ./always-crlf: CRLF
   ./always-lf: LF
   ./no-eol-at-all: mixed (no eol-at-eof)
   ./no-eol-at-eof: LF (no eol-at-eof)
-  ./null-file: LF
+  ./null-file: mixed (no eol-at-eof)
   ./test1: LF
   ./test2: LF
-  ./will-null-file: mixed (no eol-at-eof)
+  ./will-null-file: LF
 PATCH                           No CRLF adaptation necessary for b/always-crlf
 PATCH                           No CRLF adaptation necessary for b/always-lf
 PATCH                           CRLF adaptation skipped for b/no-eol-at-all
 PATCH                           Adding \r to patch chunks for b/no-eol-at-eof
-PATCH                           CRLF adaptation skipped for b/null-file
 PATCH                           No CRLF adaptation necessary for b/test1
 PATCH                           Adding \r to patch chunks for b/test2
 PATCH                           No CRLF adaptation necessary for b/test3
-PATCH                           Adding \r to patch chunks for b/will-null-file
 PATCH                           Transforming patch input.patch to output.patch
 PATCH                           Transform 32-36 +\r
-PATCH                           Transform 62-67 +\r
-PATCH                           Transform 82-87 +\r
+PATCH                           Transform 53-58 +\r
 Before patch state of c:
   ./always-crlf: CRLF
   ./always-lf: LF
@@ -63,17 +56,15 @@ patching file always-crlf
 patching file always-lf
 patching file no-eol-at-all
 patching file no-eol-at-eof
-patching file null-file
 patching file test1
 patching file test2
 patching file test3
-patching file will-null-file
 After patch state of c:
   ./always-crlf: CRLF
   ./always-lf: LF
   ./no-eol-at-all: mixed (no eol-at-eof)
   ./no-eol-at-eof: CRLF (no eol-at-eof)
-  ./null-file: LF
+  ./null-file: mixed (no eol-at-eof)
   ./test1: LF
   ./test2: CRLF
-  ./will-null-file: mixed (no eol-at-eof)
+  ./will-null-file: CRLF
```
Upstream ticket at https://debbugs.gnu.org/cgi/bugreport.cgi?bug=76452