### PR TITLE
Internal `repos-config` new syntax

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -72,6 +72,7 @@ users)
 ## External dependencies
 
 ## Format upgrade
+  * Fix switch and repo format upgrade on Windows. A block occurred because the global lock fd was reopened instead of using the one already opened.  [#6839 @rjbou]
 
 ## Sandbox
   * Allow the macOS sandbox to write in the `/var/folders/` and `/var/db/mds/` directories as it is required by some of macOS core tools [#4797 @kit-ty-kate - fix #4389 #6460]

--- a/master_changes.md
+++ b/master_changes.md
@@ -164,6 +164,7 @@ users)
   * `OpamRepositoryState.load_opams_from_diff` track added packages to avoid removing version-equivalent packages [#6774 @arozovyk fix #6754]
   * `OpamGlobalState.all_installed_versions`: was added [#6818 @dra27]
   * `OpamGlobalState.installed_versions`: was removed [#6818 @dra27]
+  * `OpamStateTypes.global_state`: add field `lock` that contains the global lock (not config one) [#6839 @rjbou]
 
 ## opam-solver
 

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -1087,6 +1087,7 @@ let get_virtual_switch_state repo_root env =
   in
   let gt = {
     global_lock = OpamSystem.lock_none;
+    lock = OpamSystem.lock_none;
     root = OpamStateConfig.(!r.root_dir);
     config = OpamStd.Option.Op.(OpamStateConfig.(
         load ~lock_kind:`Lock_read !r.root_dir) +!

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1849,9 +1849,15 @@ let init
           OpamStd.Sys.exit_because `Aborted);
       try
         (* Create the content of ~/.opam/config *)
-        let repos = match repo with
-          | Some r -> [r.repo_name, (r.repo_url, r.repo_trust)]
-          | None -> OpamFile.InitConfig.repositories init_config
+        let repos =
+          match repo with
+          | Some r ->
+            [r.repo_name,
+             OpamFile.Repo_config.create ?trust:r.repo_trust r.repo_url]
+          | None ->
+            List.map (fun (n,(u,t)) ->
+                n, OpamFile.Repo_config.create ?trust:t u)
+              (OpamFile.InitConfig.repositories init_config)
         in
         let config =
           update_with_init_config
@@ -1862,7 +1868,7 @@ let init
         let config, mechanism, system_packages, msys2_check_root =
           if Sys.win32 then
             determine_windows_configuration ?cygwin_setup ?git_location
-                                            ~bypass_checks ~interactive config
+              ~bypass_checks ~interactive config
           else
             config, None, [], None
         in
@@ -1899,7 +1905,9 @@ let init
           else config
         in
         OpamFile.Config.write config_f config;
-        let repos_config = OpamRepositoryName.Map.of_list repos in
+        let repos_config =
+          OpamFile.Repos_config.create (OpamRepositoryName.Map.of_list repos)
+        in
         OpamFile.Repos_config.write (OpamPath.repos_config root)
           repos_config;
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2565,6 +2565,7 @@ let repository cli =
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
       let repos =
         OpamStateConfig.Repos.safe_read ~lock_kind:`Lock_read gt
+        |> OpamFile.Repos_config.repos
       in
       let not_found =
         List.filter (fun r -> not (OpamRepositoryName.Map.mem r repos)) names
@@ -4330,6 +4331,7 @@ let clean cli =
        @@ fun _lock ->
        let repos_config =
          OpamStateConfig.Repos.safe_read ~lock_kind:`Lock_write gt
+         |> OpamFile.Repos_config.repos
        in
        let all_repos =
          OpamRepositoryName.Map.keys repos_config |>
@@ -4368,7 +4370,8 @@ let clean cli =
        OpamConsole.msg "Updating %s\n"
          (OpamFile.to_string (OpamPath.repos_config root));
        if not dry_run then
-         OpamFile.Repos_config.write (OpamPath.repos_config root) repos_config);
+         OpamFile.Repos_config.write (OpamPath.repos_config root)
+           (OpamFile.Repos_config.create repos_config));
     if repo_cache then
       (OpamConsole.msg "Clearing repository cache\n";
        if not dry_run then OpamRepositoryState.Cache.remove ());

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -1395,7 +1395,7 @@ module ConfigSyntax = struct
   let internal = "config"
   let format_version = OpamVersion.of_string "2.1"
   let file_format_version = OpamVersion.of_string "2.0"
-  let root_version = OpamVersion.of_string "2.2"
+  let root_version = OpamVersion.of_string "2.6~alpha1"
 
   let default_old_root_version = OpamVersion.of_string "2.1~~previous"
 
@@ -1966,7 +1966,9 @@ module InitConfig = struct
   include SyntaxFile(InitConfigSyntax)
 end
 
-module Repos_configSyntax = struct
+(** Repositories configuration *)
+
+module Repos_config_LegacySyntax = struct
 
   let internal = "repos-config"
   let format_version = OpamVersion.of_string "2.0"
@@ -2000,6 +2002,145 @@ module Repos_configSyntax = struct
   let pp = pp_cond ()
 
 end
+
+module Repos_config_Legacy = struct
+  include Repos_config_LegacySyntax
+  include SyntaxFile(Repos_config_LegacySyntax)
+  module BestEffort = MakeBestEffort(Repos_config_LegacySyntax)
+end
+
+(* A repository configuration section "repo" in <repos/reposèconfig> file *)
+
+module Repo_configSyntax = struct
+  let internal = "repo-config"
+  let format_version = OpamVersion.of_string "2.6"
+
+  type t = {
+    url: url;
+    trust: trust_anchors option;
+    errors: (string * Pp.bad_format) list;
+  }
+
+  let empty = {
+    url = OpamUrl.empty;
+    trust  = None;
+    errors = [];
+  }
+
+  let create ?trust url = { url; trust; errors = [] }
+
+  let url t = t.url
+  let trust t = t.trust
+
+  let fields = [
+    "url", Pp.ppacc
+      (fun url t -> { t with url })
+      (fun { url; _ } -> url)
+      Pp.V.url;
+    "fingerprint", Pp.ppacc_opt
+      (fun fingerprints t ->
+         match t.trust with
+         | Some x -> { t with trust = Some { x with fingerprints }}
+         | None -> { t with trust = Some { fingerprints; quorum = 1}})
+      (fun t ->
+         match t.trust with
+         | Some {fingerprints; _} -> Some fingerprints
+         | None -> None)
+      (Pp.V.map_list ~depth:1 Pp.V.string);
+    "quorum",
+    Pp.ppacc_opt
+      (fun quorum t ->
+         match t.trust with
+         | Some x -> { t with trust = Some { x with quorum }}
+         | None -> { t with trust = Some { quorum; fingerprints = []}})
+      (fun t ->
+         match t.trust with
+         | Some {quorum; _} -> Some quorum
+         | None -> None)
+      Pp.V.int;
+  ]
+
+  let pp_contents : (opamfile_item list, t) OpamPp.t =
+    let name = internal in
+    Pp.I.fields ~name ~empty fields
+    -| Pp.I.on_errors ~name (fun t e -> {t with errors = e::t.errors})
+    -| Pp.pp ~name
+      (fun ~pos t ->
+         if t.url = OpamUrl.empty then
+           OpamPp.bad_format ~pos "missing URL in repo field"
+         else t)
+      (fun x -> x)
+
+  let pp = Pp.I.map_file pp_contents
+
+end
+
+module Repo_config = struct
+  include Repo_configSyntax
+  include SyntaxFile(Repo_configSyntax)
+end
+
+(* Repositories configuration <repos/repos-config> *)
+
+module Repos_configSyntax = struct
+
+  let internal = "repos-config"
+  let format_version = OpamVersion.of_string "2.6"
+  let file_format_version = OpamVersion.of_string "2.0"
+
+  type repo = Repo_config.t
+  type t = {
+    opam_version: opam_version;
+    repos : repo OpamRepositoryName.Map.t;
+  }
+
+  let empty = {
+    opam_version = file_format_version;
+    repos = OpamRepositoryName.Map.empty;
+  }
+
+  let create ?opam_version repos = {
+    opam_version = OpamStd.Option.default file_format_version opam_version;
+    repos;
+  }
+
+  let opam_version t = t.opam_version
+  let repos t = t.repos
+  let with_opam_version opam_version t = { t with opam_version }
+  let with_repos repos t = { t with repos }
+
+  let fields = [
+    "opam-version", Pp.ppacc with_opam_version opam_version
+      (Pp.V.string -| Pp.of_module "opam-version" (module OpamVersion));
+  ]
+
+  let sections = [
+    "repo", Pp.ppacc with_repos repos
+      ((Pp.map_list
+          (Pp.map_pair
+             (Pp.pp
+                (fun ~pos -> function
+                   | Some o -> OpamRepositoryName.of_string o
+                   | None -> Pp.bad_format ~pos "missing repo name")
+                (fun b -> Some (OpamRepositoryName.to_string b)))
+             Repo_config.pp_contents))
+       -| Pp.of_pair "RepositoryNameMap"
+         OpamRepositoryName.Map.(of_list, bindings))
+  ]
+
+  let pp_cond ?f ?condition () =
+    let name = internal in
+    let format_version = file_format_version in
+    Pp.I.map_file @@
+    Pp.I.check_opam_version ?f ~format_version ()
+    -| Pp.I.opam_version ~format_version ()
+    -| Pp.I.fields ~name ~empty ~sections fields
+    -| Pp.I.show_errors ~name ?condition ()
+
+  let pp = pp_cond ()
+
+end
+
 module Repos_config = struct
   include Repos_configSyntax
   include SyntaxFile(Repos_configSyntax)

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -1067,8 +1067,39 @@ module Repo_config_legacy : sig
   include IO_FILE with type t := t
 end
 
-module Repos_config: sig
+module Repos_config_Legacy: sig
   type t = (url * trust_anchors option) OpamRepositoryName.Map.t
+  include IO_FILE with type t := t
+  module BestEffort: BestEffortRead with type t := t
+end
+
+module Repo_config: sig
+  type t = {
+    url: url;
+    trust: trust_anchors option;
+    errors: (string * OpamPp.bad_format) list;
+  }
+
+  val create: ?trust:trust_anchors -> url -> t
+
+  val url: t -> url
+  val trust: t -> trust_anchors option
+
+  include IO_FILE with type t := t
+end
+
+module Repos_config: sig
+  type repo = Repo_config.t
+  type t = {
+    opam_version: opam_version;
+    repos : repo OpamTypes.repository_name_map;
+  }
+
+  val create:
+    ?opam_version:opam_version -> repo OpamTypes.repository_name_map -> t
+
+  val repos: t -> repo OpamTypes.repository_name_map
+
   include IO_FILE with type t := t
   module BestEffort: BestEffortRead with type t := t
 end

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -1155,6 +1155,11 @@ let from_2_2_beta_to_2_2 ~on_the_fly:_ _ conf = conf, gtc_none
 (* To add an upgrade layer
    * If it is a light upgrade, returns as second element if the repo or switch
      need an light upgrade with `gtc_*` values.
+       * If it is a repo or switch upgrade:
+         * define 'on the fly' function
+         * add it in the main function with a write action if not 'on the fly'
+         * add it in [as_necessary_swich] or [as_necessary_repo] functions
+           upgrades list.
    * [Should not happen] If it is an hard upgrade, performs repo & switch
      upgrade in upgrade function.
 *)

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -139,12 +139,14 @@ let load lock_kind =
           acc)
       global_variables eval_variables
   in
-  { global_lock = config_lock;
+  {
+    lock = global_lock;
+    global_lock = config_lock;
     root;
     config;
     global_variables;
     global_state_to_upgrade;
-    }
+  }
 
 let switches gt =
   OpamFile.Config.installed_switches gt.config

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -245,19 +245,20 @@ let load lock_kind gt =
   log "LOAD-REPOSITORY-STATE %@ %a" (slog OpamFilename.Dir.to_string) gt.root;
   let lock = OpamFilename.flock lock_kind (OpamPath.repos_lock gt.root) in
   let repos_map =
-    match OpamFormatUpgrade.as_necessary_repo lock_kind gt with
+    (match OpamFormatUpgrade.as_necessary_repo lock_kind gt with
     | Some repos_map -> repos_map
-    | None -> OpamStateConfig.Repos.safe_read ~lock_kind gt
+    | None -> OpamStateConfig.Repos.safe_read ~lock_kind gt)
+    |> OpamFile.Repos_config.repos
   in
   if OpamStateConfig.is_newer_than_self ~lock_kind gt then
     log "root version (%s) is greater than running binary's (%s); \
          load with best-effort (read-only)"
       (OpamVersion.to_string (OpamFile.Config.opam_root_version gt.config))
       (OpamVersion.to_string (OpamFile.Config.root_version));
-  let mk_repo name (url, ta) = {
+  let mk_repo name repo = {
     repo_name = name;
-    repo_url = url;
-    repo_trust = ta;
+    repo_url = OpamFile.Repo_config.url repo;
+    repo_trust = OpamFile.Repo_config.trust repo;
   } in
   let repositories = OpamRepositoryName.Map.mapi mk_repo repos_map in
   let repos_tmp_root = lazy (OpamFilename.mk_tmp_dir ()) in
@@ -369,9 +370,11 @@ let with_ lock gt f =
 
 let write_config rt =
   OpamFile.Repos_config.write (OpamPath.repos_config rt.repos_global.root)
+  @@ OpamFile.Repos_config.create
     (OpamRepositoryName.Map.filter_map (fun _ r ->
          if r.repo_url = OpamUrl.empty then None
-         else Some (r.repo_url, r.repo_trust))
+         else
+           Some (OpamFile.Repo_config.create ?trust:r.repo_trust r.repo_url))
         rt.repositories)
 
 let check_last_update () =

--- a/src/state/opamStateTypes.mli
+++ b/src/state/opamStateTypes.mli
@@ -51,6 +51,10 @@ type gt_changes = { gtc_repo: bool; gtc_switch: bool }
 (** Global state corresponding to an opam root and its configuration *)
 type +'lock global_state = {
   global_lock: OpamSystem.lock;
+  (** Global config lock file *)
+
+  lock: OpamSystem.lock;
+  (** Global lock file *)
 
   root: OpamPath.t;
   (** The global opam root path (caution: this is stored here but some code may

--- a/tests/reftests/init-ocaml-eval-variables.unix.test
+++ b/tests/reftests/init-ocaml-eval-variables.unix.test
@@ -7,6 +7,10 @@ let opamroot = Sys.getenv "OPAMROOT"
 let opam_version = Printf.sprintf "opam-version: %S"
 let opam_version_2_0 = opam_version "2.0"
 let opam_version_2_1 = opam_version "2.1"
+let basedir = String.escaped (Sys.getenv "BASEDIR")
+let repos_config = Printf.sprintf {|opam-version: "2.0"
+repositories: "default" {"file://%s/REPO"}
+|} basedir
 let repo = {|repositories: "default"|}
 let depext = {|
 depext: true
@@ -33,6 +37,10 @@ let _ =
   let content = get_files Sys.argv.(1) in
   let fd = open_out name in
   List.iter (fun l -> output_string fd (l^"\n")) content;
+  close_out fd;
+  let rcname = Filename.concat (Filename.concat opamroot "repo") "repos-config" in
+  let fd = open_out rcname in
+  output_string fd repos_config;
   close_out fd
 ### rm -rf "$OPAMROOT"
 ### ::::::::::::::::::::::::::

--- a/tests/reftests/init-ocaml-eval-variables.win32.test
+++ b/tests/reftests/init-ocaml-eval-variables.win32.test
@@ -7,6 +7,10 @@ let opamroot = Sys.getenv "OPAMROOT"
 let opam_version = Printf.sprintf "opam-version: %S"
 let opam_version_2_0 = opam_version "2.0"
 let opam_version_2_1 = opam_version "2.1"
+let basedir = String.escaped (Sys.getenv "BASEDIR")
+let repos_config = Printf.sprintf {|opam-version: "2.0"
+repositories: "default" {"file://%s/REPO"}
+|} basedir
 let repo = {|repositories: "default"|}
 let depext = {|
 depext: true
@@ -33,6 +37,10 @@ let _ =
   let content = get_files Sys.argv.(1) in
   let fd = open_out name in
   List.iter (fun l -> output_string fd (l^"\n")) content;
+  close_out fd;
+  let rcname = Filename.concat (Filename.concat opamroot "repo") "repos-config" in
+  let fd = open_out rcname in
+  output_string fd repos_config;
   close_out fd
 ### rm -rf "$OPAMROOT"
 ### ::::::::::::::::::::::::::

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -248,7 +248,9 @@ wrap-install-commands: ["%{hooks}%/a-script.sh" "wrap-install"]
 wrap-remove-commands: ["%{hooks}%/a-script.sh" "wrap-remove"]
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "norepo" {"file://${BASEDIR}/REPO"}
+repo "norepo" {
+url: "file://${BASEDIR}/REPO"
+}
 ### sh $OPAMROOT/opam-init/hooks/a-script.sh test
 script test launched STOP i repeat STOP script test launched
 ### :II:c: partially configured opamrc ::
@@ -302,7 +304,9 @@ wrap-install-commands: ["%{hooks}%/a-script.sh" "wrap-install"]
 wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "norepo" {"file://${BASEDIR}/REPO"}
+repo "norepo" {
+url: "file://${BASEDIR}/REPO"
+}
 ### :II:d: Parse error on config file
 ### <wrong-config>
 this is not the content of a config file

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -12,7 +12,8 @@ installed-switches: "foo"
 switch: "foo"
 |}
 let neant = "neant: 0"
-let repo = {|repositories: [ "default" {"file:///${BASEDIR/dontexist"} ]|}
+let basedir = String.escaped (Sys.getenv "BASEDIR")
+let repo = Printf.sprintf {|repo "default" {url:"file://%s/dontexist"}|} basedir
 let switch_config = {|synopsis: "foo"|}
 let _ =
   let configs =
@@ -29,7 +30,7 @@ let _ =
        ])
   in
   let files = [
-    "repos-config", [ repo ];
+    "repos-config", [ opam_version "2.0"; repo ];
     "switch-config", [ opam_version "2.0"; switch_config ];
   ] @ configs
   in
@@ -80,7 +81,7 @@ GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 [WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
-            - At ${BASEDIR}/OPAM/repo/repos-config:2:0-2:8::
+            - At ${BASEDIR}/OPAM/repo/repos-config:3:0-3:8::
               Invalid field neant
 
 RSTATE                          Cache found
@@ -91,7 +92,7 @@ GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] No switch is currently set, perhaps you meant '--set-default'?
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 [WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
-            - At ${BASEDIR}/OPAM/repo/repos-config:2:0-2:8::
+            - At ${BASEDIR}/OPAM/repo/repos-config:3:0-3:8::
               Invalid field neant
 
 RSTATE                          Cache found
@@ -261,7 +262,7 @@ GSTATE                          root version (4.8) is greater than running binar
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 GSTATE                          root version (4.8) is greater than running binary's current; load with best-effort (read-only)
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
-FORMAT                          File errors in ${BASEDIR}/OPAM/repo/repos-config, ignored fields: At ${BASEDIR}/OPAM/repo/repos-config:2:0-2:8::
+FORMAT                          File errors in ${BASEDIR}/OPAM/repo/repos-config, ignored fields: At ${BASEDIR}/OPAM/repo/repos-config:3:0-3:8::
 Invalid field neant
 RSTATE                          root version (4.8) is greater than running binary's current; load with best-effort (read-only)
 RSTATE                          Cache found
@@ -568,13 +569,15 @@ let invariant_sw_sys_comp = {|invariant: ["i-am-sys-compiler"]|}
 let root_version =  Printf.sprintf "opam-root-version: %S"
 let synopsis = Printf.sprintf "synopsis: %S"
 let opam_root = Printf.sprintf "opam-root: %S" opamroot
-let repos_config = Printf.sprintf {|
-opam-version: "2.0"
-repositories: "default" {"file://%s/default"}
-|} (Sys.getenv "BASEDIR" |> String.map (function '\\' -> '/' | c -> c))
+let repos_config v = {|opam-version: "2.0"
+|} ^
+  Printf.sprintf
+  (if v < 2.6 then {|repositories: ["default" {"file://%s/default"}]|}
+   else {|repo "default" {url:"file://%s/default"}|})
+  (Sys.getenv "BASEDIR" |> String.map (function '\\' -> '/' | c -> c))
 let opam_20 =
   [ "config", [ opam_version_2_0; repo; installed_switches; eval; default_compiler ];
-    "repo/repos-config", [ repos_config ];
+    "repo/repos-config", [ repos_config 2.0 ];
     "default/.opam-switch/switch-config", [ opam_version_2_0; synopsis "default switch" ];
     "default/.opam-switch/switch-state", [ opam_version_2_0; sw_state_default ];
     "sw-comp/.opam-switch/switch-config", [ opam_version_2_0; synopsis "switch with compiler" ];
@@ -587,7 +590,7 @@ let opam_20 =
   ]
 let opam_21alpha =
   [ "config", [ opam_version_2_0; repo; installed_switches; eval; default_compiler ];
-    "repo/repos-config", [ repos_config ];
+    "repo/repos-config", [ repos_config 2.1 ];
     "default/.opam-switch/switch-config", [ opam_version_2_1; synopsis "default switch"; invariant_default ];
     "default/.opam-switch/switch-state", [ opam_version_2_0; sw_state_default ];
     "sw-comp/.opam-switch/switch-config", [ opam_version_2_1; synopsis "switch with compiler"; invariant_sw_comp ];
@@ -600,7 +603,7 @@ let opam_21alpha =
   ]
 let opam_21alpha2 =
   [ "config", [ opam_version_2_1; repo; installed_switches; eval; default_compiler; depext; ];
-    "repo/repos-config", [ repos_config ];
+    "repo/repos-config", [ repos_config 2.1 ];
     "default/.opam-switch/switch-config", [ opam_version_2_1; synopsis "default switch"; invariant_default ];
     "default/.opam-switch/switch-state", [ opam_version_2_0; sw_state_default ];
     "sw-comp/.opam-switch/switch-config", [ opam_version_2_1; synopsis "switch with compiler"; invariant_sw_comp ];
@@ -614,7 +617,7 @@ let opam_21alpha2 =
 let opam_21rc =
   let root_version =  {|opam-root-version: "2.1~rc"|} in
   [ "config", [ opam_version_2_0; root_version; repo; installed_switches; eval; default_compiler; default_invariant; depext ];
-    "repo/repos-config", [ repos_config ];
+    "repo/repos-config", [ repos_config 2.1 ];
     "default/.opam-switch/switch-config", [ opam_version_2_0; synopsis "default switch"; invariant_default ];
     "default/.opam-switch/switch-state", [ opam_version_2_0; sw_state_default ];
     "sw-comp/.opam-switch/switch-config", [ opam_version_2_0; synopsis "switch with compiler"; invariant_sw_comp ];
@@ -627,7 +630,7 @@ let opam_21rc =
   ]
 let opam_current v =
   [ "config", [ opam_version_2_0; root_version v; repo; installed_switches; eval; default_compiler; default_invariant; depext ];
-    "repo/repos-config", [ repos_config ];
+    "repo/repos-config", [ repos_config (float_of_string (String.sub v 0 3)) ];
     "default/.opam-switch/switch-config", [ opam_version_2_0; synopsis "default switch"; invariant_default ];
     "default/.opam-switch/switch-state", [ opam_version_2_0; sw_state_default ];
     "sw-comp/.opam-switch/switch-config", [ opam_version_2_0; synopsis "switch with compiler"; invariant_sw_comp ];
@@ -758,7 +761,9 @@ swh-fallback: false
 switch: "sw-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-config
 invariant: ["i-am-compiler" {>= "2"}]
 opam-version: "2.0"
@@ -837,7 +842,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -917,7 +924,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -984,7 +993,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -1129,7 +1140,9 @@ wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "
 wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-config
 invariant: ["i-am-compiler"]
 opam-version: "2.0"
@@ -1202,7 +1215,9 @@ wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "
 wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -1278,7 +1293,9 @@ wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "
 wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -1344,7 +1361,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -1497,7 +1516,9 @@ wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "
 wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-config
 invariant: ["i-am-compiler"]
 opam-version: "2.0"
@@ -1572,7 +1593,9 @@ wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "
 wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -1650,7 +1673,9 @@ wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "
 wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -1716,7 +1741,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -1858,7 +1885,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-config
 invariant: ["i-am-compiler"]
 opam-version: "2.0"
@@ -1930,7 +1959,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -2004,7 +2035,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -2065,7 +2098,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -2175,6 +2210,11 @@ GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.1 to current
 FMT_UPG                         Format upgrade done
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1 to version current which can't be reverted.
+You may want to back it up before going further.
+Continue? [Y/n] y
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. You can restore the fixed value using:
+           opam option jobs=1 --global
 RSTATE                          Cache found
 [root-config] Initialised
 [NOTE] Repository root-config has been added to the selections of switch sw-sys-comp only.
@@ -2183,15 +2223,6 @@ RSTATE                          Cache found
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-[WARNING] Removing global switch 'this-internal-error' as it no longer exists
-FMT_UPG                         Light config upgrade, from 2.1 to current
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.1 to version current which can't be reverted.
-You may want to back it up before going further.
-
-Continue? [Y/n] y
-[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. You can restore the fixed value using:
-           opam option jobs=1 --global
-Format upgrade done.
 Set to '4' the field jobs in global configuration
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables | grep -v eval-variables:
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
@@ -2200,7 +2231,7 @@ depext: true
 depext-cannot-install: false
 depext-run-installs: true
 download-jobs: 1
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
 jobs: 4
 opam-root-version: current
 opam-version: "2.0"
@@ -2209,7 +2240,12 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: ["default" {"file://${BASEDIR}/default"} "root-config" {"file://${BASEDIR}/root-config"}]
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
+repo "root-config" {
+url: "file://${BASEDIR}/root-config"
+}
 ### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-config
 invariant: ["i-am-compiler"]
 opam-version: "2.0"
@@ -2280,7 +2316,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -2353,7 +2391,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -2426,7 +2466,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -2536,6 +2578,11 @@ GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~alpha to current
 FMT_UPG                         Format upgrade done
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~alpha to version current which can't be reverted.
+You may want to back it up before going further.
+Continue? [Y/n] y
+[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. You can restore the fixed value using:
+           opam option jobs=1 --global
 RSTATE                          Cache found
 [root-config] Initialised
 [NOTE] Repository root-config has been added to the selections of switch sw-sys-comp only.
@@ -2544,15 +2591,6 @@ RSTATE                          Cache found
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-[WARNING] Removing global switch 'this-internal-error' as it no longer exists
-FMT_UPG                         Light config upgrade, from 2.2~alpha to current
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~alpha to version current which can't be reverted.
-You may want to back it up before going further.
-
-Continue? [Y/n] y
-[NOTE] The 'jobs' option was reset, its value was 1 and its new value will vary according to the current number of cores on your machine. You can restore the fixed value using:
-           opam option jobs=1 --global
-Format upgrade done.
 Set to '4' the field jobs in global configuration
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
@@ -2562,7 +2600,7 @@ depext-cannot-install: false
 depext-run-installs: true
 download-jobs: 1
 eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
 jobs: 4
 opam-root-version: current
 opam-version: "2.0"
@@ -2571,7 +2609,12 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: ["default" {"file://${BASEDIR}/default"} "root-config" {"file://${BASEDIR}/root-config"}]
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
+repo "root-config" {
+url: "file://${BASEDIR}/root-config"
+}
 ### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-config
 invariant: ["i-am-compiler"]
 opam-version: "2.0"
@@ -2644,7 +2687,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -2717,7 +2762,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -2791,7 +2838,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -2902,6 +2951,9 @@ GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~beta to current
 FMT_UPG                         Format upgrade done
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version current which can't be reverted.
+You may want to back it up before going further.
+Continue? [Y/n] y
 RSTATE                          Cache found
 [root-config] Initialised
 [NOTE] Repository root-config has been added to the selections of switch sw-sys-comp only.
@@ -2910,13 +2962,6 @@ RSTATE                          Cache found
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
-[WARNING] Removing global switch 'this-internal-error' as it no longer exists
-FMT_UPG                         Light config upgrade, from 2.2~beta to current
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version current which can't be reverted.
-You may want to back it up before going further.
-
-Continue? [Y/n] y
-Format upgrade done.
 Set to '4' the field jobs in global configuration
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
@@ -2926,7 +2971,7 @@ depext-cannot-install: false
 depext-run-installs: true
 download-jobs: 1
 eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
 jobs: 4
 opam-root-version: current
 opam-version: "2.0"
@@ -2935,7 +2980,12 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: ["default" {"file://${BASEDIR}/default"} "root-config" {"file://${BASEDIR}/root-config"}]
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
+repo "root-config" {
+url: "file://${BASEDIR}/root-config"
+}
 ### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-config
 invariant: ["i-am-compiler"]
 opam-version: "2.0"
@@ -3006,7 +3056,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -3077,7 +3129,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -3149,7 +3203,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -3215,6 +3271,369 @@ i-am-sys-compiler 2           One-line description
 ### :V:8:a: From 2.2 root, global
 ### ocaml generate.ml 2.2
 ### # ro global state
+### opam option jobs | '${OPAMROOTVERSION}($|,)' -> current
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.2 to current
+FMT_UPG                         Format upgrade done
+### # ro global state, ro repo state, ro switch state
+### opam list | '${OPAMROOTVERSION}($|,)' -> current
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.2 to current
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          No cache found
+RSTATE                          loaded opam files from repo default in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name               # Installed # Synopsis
+i-am-another-package 2           One-line description
+i-am-package         2           One-line description
+i-am-sys-compiler    1           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-another-package --switch sw-comp | '${OPAMROOTVERSION}($|,)' -> current
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.2 to current
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+=== install 1 package
+  - install i-am-another-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-another-package.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2 }
+Done.
+### # ro global state, rw repo state
+### opam repo add root-config ./root-config | '${OPAMROOTVERSION}($|,)' -> current
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.2 to current
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2 to version current which can't be reverted.
+You may want to back it up before going further.
+Continue? [Y/n] y
+RSTATE                          Cache found
+[root-config] Initialised
+[NOTE] Repository root-config has been added to the selections of switch sw-sys-comp only.
+       Run `opam repository add root-config --all-switches|--set-default' to use it in all existing switches, or in newly created switches, respectively.
+
+### # rw global state
+### opam option jobs=4
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+Set to '4' the field jobs in global configuration
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+depext: true
+depext-cannot-install: false
+depext-run-installs: true
+download-jobs: 1
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default" "this-internal-error"]
+jobs: 4
+opam-root-version: current
+opam-version: "2.0"
+repositories: "default"
+swh-fallback: false
+switch: "sw-sys-comp"
+### opam-cat $OPAMROOT/repo/repos-config
+opam-version: "2.0"
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
+repo "root-config" {
+url: "file://${BASEDIR}/root-config"
+}
+### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-config
+invariant: ["i-am-compiler"]
+opam-version: "2.0"
+synopsis: "switch with compiler"
+### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-state
+compiler: ["i-am-compiler.2"]
+installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+opam-version: "2.0"
+roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
+### :V:8:b: From 2.2 root, local
+### ocaml generate.ml 2.2 local
+### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.2 to current
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          No cache found
+RSTATE                          loaded opam files from repo default in 0.000s
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-sys-compiler 2           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-package | '${OPAMROOTVERSION}($|,)' -> current
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.2 to current
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+=== install 1 package
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+Done.
+### # rw global state
+### opam option jobs=4 | '${OPAMROOTVERSION}($|,)' -> current
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Light config upgrade, from 2.2 to current
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2 to version current which can't be reverted.
+You may want to back it up before going further.
+
+Continue? [Y/n] y
+Format upgrade done.
+Set to '4' the field jobs in global configuration
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+depext: true
+depext-cannot-install: false
+depext-run-installs: true
+download-jobs: 1
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "${BASEDIR}" "default"]
+jobs: 4
+opam-root-version: current
+opam-version: "2.0"
+repositories: "default"
+swh-fallback: false
+switch: "sw-sys-comp"
+### opam-cat $OPAMROOT/repo/repos-config
+opam-version: "2.0"
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
+### opam-cat _opam/.opam-switch/switch-config
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
+opam-version: "2.0"
+synopsis: "local switch"
+### opam-cat _opam/.opam-switch/switch-state
+compiler: ["i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+### :V:8:c: From 2.2 root, local unknown from config
+### ocaml generate.ml 2.2 local
+### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.2 to current
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          No cache found
+RSTATE                          loaded opam files from repo default in 0.000s
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-sys-compiler 2           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-package | "${OPAMROOTVERSION}($|,)" -> "current"
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.2 to current
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+=== install 1 package
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+Done.
+### # rw global state
+### opam option jobs=4 | '${OPAMROOTVERSION}($|,)' -> current
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Light config upgrade, from 2.2 to current
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2 to version current which can't be reverted.
+You may want to back it up before going further.
+
+Continue? [Y/n] y
+Format upgrade done.
+Set to '4' the field jobs in global configuration
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+depext: true
+depext-cannot-install: false
+depext-run-installs: true
+download-jobs: 1
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "${BASEDIR}" "default"]
+jobs: 4
+opam-root-version: current
+opam-version: "2.0"
+repositories: "default"
+swh-fallback: false
+switch: "sw-sys-comp"
+### opam-cat $OPAMROOT/repo/repos-config
+opam-version: "2.0"
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
+### opam-cat _opam/.opam-switch/switch-config
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
+opam-version: "2.0"
+synopsis: "local switch"
+### opam-cat _opam/.opam-switch/switch-state
+compiler: ["i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+### :V:8:d: Upgraded root and local 2.2 switch not recorded
+### ocaml generate.ml 2.2 orphaned 2.2
+### # ro global state, ro repo state, ro switch state
+### opam list | '${OPAMROOTVERSION}($|,)' -> current
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.2 to current
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          No cache found
+RSTATE                          loaded opam files from repo default in 0.000s
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-sys-compiler 2           One-line description
+### # ro global state, ro repo state, rw switch state
+### opam install i-am-package | '${OPAMROOTVERSION}($|,)' -> current
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FMT_UPG                         On-the-fly config upgrade, from 2.2 to current
+FMT_UPG                         Format upgrade done
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+STATE                           Detected changed packages (marked for reinstall): {}
+The following actions will be performed:
+=== install 1 package
+  - install i-am-package 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-package.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+Done.
+### # rw global state
+### opam option jobs=4 | '${OPAMROOTVERSION}($|,)' -> current
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Light config upgrade, from 2.2 to current
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2 to version current which can't be reverted.
+You may want to back it up before going further.
+
+Continue? [Y/n] y
+Format upgrade done.
+Set to '4' the field jobs in global configuration
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+depext: true
+depext-cannot-install: false
+depext-run-installs: true
+download-jobs: 1
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+jobs: 4
+opam-root-version: current
+opam-version: "2.0"
+repositories: "default"
+swh-fallback: false
+switch: "sw-sys-comp"
+### opam-cat $OPAMROOT/repo/repos-config
+opam-version: "2.0"
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
+### opam-cat _opam/.opam-switch/switch-config
+invariant: ["i-am-sys-compiler" | "i-am-compiler"]
+opam-root: "${BASEDIR}/OPAM"
+opam-version: "2.0"
+synopsis: "local switch"
+### opam-cat _opam/.opam-switch/switch-state
+compiler: ["i-am-sys-compiler.2"]
+installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+opam-version: "2.0"
+roots: ["i-am-package.2" "i-am-sys-compiler.2"]
+### :V:8:e: reinit from 2.2
+### ocaml generate.ml 2.2
+### opam init --reinit --bypass-checks --no-setup | grep -v Cygwin | '${OPAMROOTVERSION}($|,)' -> current
+No configuration file found, using built-in defaults.
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+[WARNING] Removing global switch 'this-internal-error' as it no longer exists
+FMT_UPG                         Light config upgrade, from 2.2 to current
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2 to version current which can't be reverted.
+You may want to back it up before going further.
+
+Continue? [Y/n] y
+Format upgrade done.
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          No cache found
+RSTATE                          loaded opam files from repo default in 0.000s
+
+<><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[default] no changes from file://${BASEDIR}/default
+### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
+default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
+default-invariant: ["i-am-sys-compiler"]
+depext: true
+depext-cannot-install: false
+depext-run-installs: true
+download-jobs: 3
+eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
+installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+opam-root-version: current
+opam-version: "2.0"
+repositories: "default"
+swh-fallback: false
+switch: "sw-sys-comp"
+wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"] {os = "linux" | os = "macos"}
+wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"] {os = "linux" | os = "macos"}
+wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "macos"}
+### opam switch --short
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+${BASEDIR}
+default
+sw-comp
+sw-sys-comp
+### opam list
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+# Packages matching: installed
+# Name            # Installed # Synopsis
+i-am-package      2           One-line description
+i-am-sys-compiler 2           One-line description
+### rm -rf _opam
+### :V:9:a: From 2.6~alpha1 root, global
+### ocaml generate.ml 2.6~alpha1
+### # ro global state
 ### opam option jobs
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 ### # ro global state, ro repo state, ro switch state
@@ -3276,7 +3695,12 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: ["default" {"file://${BASEDIR}/default"} "root-config" {"file://${BASEDIR}/root-config"}]
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
+repo "root-config" {
+url: "file://${BASEDIR}/root-config"
+}
 ### opam-cat $OPAMROOT/sw-comp/.opam-switch/switch-config
 invariant: ["i-am-compiler"]
 opam-version: "2.0"
@@ -3286,8 +3710,8 @@ compiler: ["i-am-compiler.2"]
 installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 opam-version: "2.0"
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
-### :V:8:b: From 2.2 root, local
-### ocaml generate.ml 2.2 local
+### :V:9:b: From 2.6~alpha1 root, local
+### ocaml generate.ml 2.6~alpha1 local
 ### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
@@ -3336,7 +3760,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -3347,8 +3773,8 @@ compiler: ["i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
-### :V:8:c: From 2.2 root, local unknown from config
-### ocaml generate.ml 2.2 local
+### :V:9:c: From 2.6~alpha1 root, local unknown from config
+### ocaml generate.ml 2.6~alpha1 local
 ### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
@@ -3396,7 +3822,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -3407,8 +3835,8 @@ compiler: ["i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
-### :V:8:d: Upgraded root and local 2.2 switch not recorded
-### ocaml generate.ml 2.2 orphaned 2.2
+### :V:9:d: Upgraded root and local 2.6~alpha1 switch not recorded
+### ocaml generate.ml 2.6~alpha1 orphaned 2.6~alpha1
 ### # ro global state, ro repo state, ro switch state
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
@@ -3457,7 +3885,9 @@ swh-fallback: false
 switch: "sw-sys-comp"
 ### opam-cat $OPAMROOT/repo/repos-config
 opam-version: "2.0"
-repositories: "default" {"file://${BASEDIR}/default"}
+repo "default" {
+url: "file://${BASEDIR}/default"
+}
 ### opam-cat _opam/.opam-switch/switch-config
 invariant: ["i-am-sys-compiler" | "i-am-compiler"]
 opam-root: "${BASEDIR}/OPAM"
@@ -3468,9 +3898,9 @@ compiler: ["i-am-sys-compiler.2"]
 installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
-### :V:8:e: reinit from 2.2
-### ocaml generate.ml 2.2
-### opam init --reinit --bypass-checks --no-setup | grep -v Cygwin
+### :V:9:e: reinit from 2.6~alpha1
+### ocaml generate.ml 2.6~alpha1
+### opam init --reinit --bypass-checks --no-setup | grep -v Cygwin | "${OPAMROOTVERSION}" -> "current"
 No configuration file found, using built-in defaults.
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
@@ -3513,3 +3943,4 @@ STATE                           Switch state loaded in 0.000s
 # Name            # Installed # Synopsis
 i-am-package      2           One-line description
 i-am-sys-compiler 2           One-line description
+### rm -rf _opam

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -687,12 +687,12 @@ No configuration file found, using built-in defaults.
 ### :V:1:a: From 2.0 root, global
 ### ocaml generate.ml 2.0
 ### # ro global state
-### opam option jobs | "${OPAMROOTVERSION}$" -> "current"
+### opam option jobs | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.0 to current
 FMT_UPG                         Format upgrade done
 ### # ro global state, ro repo state, ro switch state
-### opam list | "${OPAMROOTVERSION}$" -> "current"
+### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.0 to current
 FMT_UPG                         Format upgrade done
@@ -708,7 +708,7 @@ i-am-another-package 2           One-line description
 i-am-package         2           One-line description
 i-am-sys-compiler    1           One-line description
 ### # ro global state, ro repo state, rw switch state
-### opam install i-am-another-package --switch sw-comp | "${OPAMROOTVERSION}$" -> "current"
+### opam install i-am-another-package --switch sw-comp | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.0 to current
 FMT_UPG                         Format upgrade done
@@ -856,7 +856,7 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:1:c: From 2.0 root, local unknown from config
 ### ocaml generate.ml 2.0 orphaned
 ### # ro global state, ro repo state, ro switch state
-### opam list | "${OPAMROOTVERSION}$" -> " current"
+### opam list | "${OPAMROOTVERSION}($|,)" -> " current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.0 to  current
 FMT_UPG                         Format upgrade done
@@ -870,7 +870,7 @@ STATE                           Switch state loaded in 0.000s
 # Name            # Installed # Synopsis
 i-am-sys-compiler 2           One-line description
 ### # ro global state, ro repo state, rw switch state
-### opam install i-am-package | "${OPAMROOTVERSION}$" -> "current"
+### opam install i-am-package | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.0 to current
 FMT_UPG                         Format upgrade done
@@ -2132,12 +2132,12 @@ wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"] {os = "linux" | os = "ma
 ### :V:5:a: From 2.1 root, global
 ### ocaml generate.ml 2.1
 ### # ro global state
-### opam option jobs | "${OPAMROOTVERSION}$" -> "current"
+### opam option jobs | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.1 to current
 FMT_UPG                         Format upgrade done
 ### # ro global state, ro repo state, ro switch state
-### opam list | "${OPAMROOTVERSION}$" -> "current"
+### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.1 to current
 FMT_UPG                         Format upgrade done
@@ -2152,7 +2152,7 @@ i-am-another-package 2           One-line description
 i-am-package         2           One-line description
 i-am-sys-compiler    1           One-line description
 ### # ro global state, ro repo state, rw switch state
-### opam install i-am-another-package --switch sw-comp | "${OPAMROOTVERSION}$" -> "current"
+### opam install i-am-another-package --switch sw-comp | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.1 to current
 FMT_UPG                         Format upgrade done
@@ -2170,7 +2170,7 @@ The following actions will be performed:
 STATE                           dependencies (0.000) result={ i-am-compiler.2 }
 Done.
 ### # ro global state, rw repo state
-### opam repo add root-config ./root-config | "${OPAMROOTVERSION}$" -> "current"
+### opam repo add root-config ./root-config | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.1 to current
 FMT_UPG                         Format upgrade done
@@ -2233,7 +2233,7 @@ STATE                           Switch state loaded in 0.000s
 # Packages matching: installed
 # Name            # Installed # Synopsis
 i-am-sys-compiler 2           One-line description
-### opam install i-am-package | "${OPAMROOTVERSION}$" -> "current"
+### opam install i-am-package | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.1 to current
 FMT_UPG                         Format upgrade done
@@ -2367,7 +2367,7 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:5:d: Upgraded root and local 2.1 switch not recorded
 ### ocaml generate.ml 2.1 orphaned 2.1
 ### # ro global state, ro repo state, ro switch state
-### opam list | "${OPAMROOTVERSION}$" -> "current"
+### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.1 to current
 FMT_UPG                         Format upgrade done
@@ -2380,7 +2380,7 @@ STATE                           Switch state loaded in 0.000s
 # Name            # Installed # Synopsis
 i-am-sys-compiler 2           One-line description
 ### # ro global state, ro repo state, rw switch state
-### opam install i-am-package | "${OPAMROOTVERSION}$" -> "current"
+### opam install i-am-package | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.1 to current
 FMT_UPG                         Format upgrade done
@@ -2493,12 +2493,12 @@ i-am-sys-compiler 2           One-line description
 ### :V:6:a: From 2.2~alpha root, global
 ### ocaml generate.ml 2.2~alpha
 ### # ro global state
-### opam option jobs | "${OPAMROOTVERSION}$" -> "current"
+### opam option jobs | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~alpha to current
 FMT_UPG                         Format upgrade done
 ### # ro global state, ro repo state, ro switch state
-### opam list | "${OPAMROOTVERSION}$" -> "current"
+### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~alpha to current
 FMT_UPG                         Format upgrade done
@@ -2513,7 +2513,7 @@ i-am-another-package 2           One-line description
 i-am-package         2           One-line description
 i-am-sys-compiler    1           One-line description
 ### # ro global state, ro repo state, rw switch state
-### opam install i-am-another-package --switch sw-comp | "${OPAMROOTVERSION}$" -> "current"
+### opam install i-am-another-package --switch sw-comp | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~alpha to current
 FMT_UPG                         Format upgrade done
@@ -2531,7 +2531,7 @@ The following actions will be performed:
 STATE                           dependencies (0.000) result={ i-am-compiler.2 }
 Done.
 ### # ro global state, rw repo state
-### opam repo add root-config ./root-config | "${OPAMROOTVERSION}$" -> "current"
+### opam repo add root-config ./root-config | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~alpha to current
 FMT_UPG                         Format upgrade done
@@ -2596,7 +2596,7 @@ STATE                           Switch state loaded in 0.000s
 # Name            # Installed # Synopsis
 i-am-sys-compiler 2           One-line description
 ### # ro global state, ro repo state, rw switch state
-### opam install i-am-package | "${OPAMROOTVERSION}$" -> "current"
+### opam install i-am-package | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~alpha to current
 FMT_UPG                         Format upgrade done
@@ -2731,7 +2731,7 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:6:d: Upgraded root and local 2.2~alpha switch not recorded
 ### ocaml generate.ml 2.2~alpha orphaned 2.2~alpha
 ### # ro global state, ro repo state, ro switch state
-### opam list | "${OPAMROOTVERSION}$" -> "current"
+### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~alpha to current
 FMT_UPG                         Format upgrade done
@@ -2744,7 +2744,7 @@ STATE                           Switch state loaded in 0.000s
 # Name            # Installed # Synopsis
 i-am-sys-compiler 2           One-line description
 ### # ro global state, ro repo state, rw switch state
-### opam install i-am-package | "${OPAMROOTVERSION}$" -> "current"
+### opam install i-am-package | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~alpha to current
 FMT_UPG                         Format upgrade done
@@ -2859,12 +2859,12 @@ i-am-sys-compiler 2           One-line description
 ### :V:7:a: From 2.2~beta root, global
 ### ocaml generate.ml 2.2~beta
 ### # ro global state
-### opam option jobs | "${OPAMROOTVERSION}$" -> "current"
+### opam option jobs | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~beta to current
 FMT_UPG                         Format upgrade done
 ### # ro global state, ro repo state, ro switch state
-### opam list | "${OPAMROOTVERSION}$" -> "current"
+### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~beta to current
 FMT_UPG                         Format upgrade done
@@ -2879,7 +2879,7 @@ i-am-another-package 2           One-line description
 i-am-package         2           One-line description
 i-am-sys-compiler    1           One-line description
 ### # ro global state, ro repo state, rw switch state
-### opam install i-am-another-package --switch sw-comp | "${OPAMROOTVERSION}$" -> "current"
+### opam install i-am-another-package --switch sw-comp | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~beta to current
 FMT_UPG                         Format upgrade done
@@ -2897,7 +2897,7 @@ The following actions will be performed:
 STATE                           dependencies (0.000) result={ i-am-compiler.2 }
 Done.
 ### # ro global state, rw repo state
-### opam repo add root-config ./root-config | "${OPAMROOTVERSION}$" -> "current"
+### opam repo add root-config ./root-config | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~beta to current
 FMT_UPG                         Format upgrade done
@@ -2908,11 +2908,11 @@ RSTATE                          Cache found
        Run `opam repository add root-config --all-switches|--set-default' to use it in all existing switches, or in newly created switches, respectively.
 
 ### # rw global state
-### opam option jobs=4 | "${OPAMROOTVERSION}$" -> "current"
+### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Light config upgrade, from 2.2~beta to current
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version 2.2, which can't be reverted.
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version current which can't be reverted.
 You may want to back it up before going further.
 
 Continue? [Y/n] y
@@ -2960,7 +2960,7 @@ STATE                           Switch state loaded in 0.000s
 # Name            # Installed # Synopsis
 i-am-sys-compiler 2           One-line description
 ### # ro global state, ro repo state, rw switch state
-### opam install i-am-package | "${OPAMROOTVERSION}$" -> "current"
+### opam install i-am-package | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~beta to current
 FMT_UPG                         Format upgrade done
@@ -2979,11 +2979,11 @@ The following actions will be performed:
 STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
-### opam option jobs=4 | "${OPAMROOTVERSION}$" -> "current"
+### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Light config upgrade, from 2.2~beta to current
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version 2.2, which can't be reverted.
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version current which can't be reverted.
 You may want to back it up before going further.
 
 Continue? [Y/n] y
@@ -3050,11 +3050,11 @@ The following actions will be performed:
 STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
-### opam option jobs=4 | "${OPAMROOTVERSION}$" -> "current"
+### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Light config upgrade, from 2.2~beta to current
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version 2.2, which can't be reverted.
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version current which can't be reverted.
 You may want to back it up before going further.
 
 Continue? [Y/n] y
@@ -3091,7 +3091,7 @@ roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:7:d: Upgraded root and local 2.2~beta switch not recorded
 ### ocaml generate.ml 2.2~beta orphaned 2.2~beta
 ### # ro global state, ro repo state, ro switch state
-### opam list | "${OPAMROOTVERSION}$" -> "current"
+### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~beta to current
 FMT_UPG                         Format upgrade done
@@ -3104,7 +3104,7 @@ STATE                           Switch state loaded in 0.000s
 # Name            # Installed # Synopsis
 i-am-sys-compiler 2           One-line description
 ### # ro global state, ro repo state, rw switch state
-### opam install i-am-package | "${OPAMROOTVERSION}$" -> "current"
+### opam install i-am-package | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FMT_UPG                         On-the-fly config upgrade, from 2.2~beta to current
 FMT_UPG                         Format upgrade done
@@ -3122,11 +3122,11 @@ The following actions will be performed:
 STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
-### opam option jobs=4 | "${OPAMROOTVERSION}$" -> "current"
+### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Light config upgrade, from 2.2~beta to current
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version 2.2, which can't be reverted.
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version current which can't be reverted.
 You may want to back it up before going further.
 
 Continue? [Y/n] y
@@ -3162,12 +3162,12 @@ opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:7:e: reinit from 2.2~beta
 ### ocaml generate.ml 2.2~beta
-### opam init --reinit --bypass-checks --no-setup | grep -v Cygwin
+### opam init --reinit --bypass-checks --no-setup | grep -v Cygwin | '${OPAMROOTVERSION}($|,)' -> current
 No configuration file found, using built-in defaults.
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
-FMT_UPG                         Light config upgrade, from 2.2~beta to 2.2
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version 2.2, which can't be reverted.
+FMT_UPG                         Light config upgrade, from 2.2~beta to current
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version current which can't be reverted.
 You may want to back it up before going further.
 
 Continue? [Y/n] y

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -811,37 +811,157 @@ nourl        file://${BASEDIR}/nourl nourl
 # Packages matching: any
 # Name # Installed # Synopsis
 no     --
+### # ---
 ### <OPAM/repo/repos-config>
 opam-version: "2.0"
-repositories: [ "nourl" ]
+repo "nourl" { }
 ### opam repo --all
 [WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
-            - At ${BASEDIR}/OPAM/repo/repos-config:2:16-2:23::
-              expected url
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing URL in repo field
 
 # Repository # Url # Switches(rank)
 ### <nourl/packages/yes/yes.1/opam>
 opam-version: "2.0"
 ### opam update nourl
 [WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
-            - At ${BASEDIR}/OPAM/repo/repos-config:2:16-2:23::
-              expected url
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing URL in repo field
 
 [ERROR] Unknown repositories or installed packages: nourl
 # Return code 40 #
 ### opam list -A
 [WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
-            - At ${BASEDIR}/OPAM/repo/repos-config:2:16-2:23::
-              expected url
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing URL in repo field
 
 # Packages matching: any
 # No matches found
 ### sh -c "rm OPAM/repo/state-*.cache"
 ### opam list -A
 [WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
-            - At ${BASEDIR}/OPAM/repo/repos-config:2:16-2:23::
-              expected url
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing URL in repo field
 
+# Packages matching: any
+# No matches found
+### # ---
+### <OPAM/repo/repos-config>
+opam-version: "2.0"
+repo "nourl" { another-field: "this is not an url" }
+### opam repo --all
+[WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing URL in repo field
+
+# Repository # Url # Switches(rank)
+### <nourl/packages/yes/yes.1/opam>
+opam-version: "2.0"
+### opam update nourl
+[WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing URL in repo field
+
+[ERROR] Unknown repositories or installed packages: nourl
+# Return code 40 #
+### opam list -A
+[WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing URL in repo field
+
+# Packages matching: any
+# No matches found
+### sh -c "rm OPAM/repo/state-*.cache"
+### opam list -A
+[WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing URL in repo field
+
+# Packages matching: any
+# No matches found
+### # ---
+### <OPAM/repo/repos-config>
+opam-version: "2.0"
+repo { url: "https://thi.s/is/a/lin.g" }
+### opam repo --all
+[WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing repo name
+
+# Repository # Url # Switches(rank)
+### <nourl/packages/yes/yes.1/opam>
+opam-version: "2.0"
+### opam update nourl
+[WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing repo name
+
+[ERROR] Unknown repositories or installed packages: nourl
+# Return code 40 #
+### opam list -A
+[WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing repo name
+
+# Packages matching: any
+# No matches found
+### sh -c "rm OPAM/repo/state-*.cache"
+### opam list -A
+[WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing repo name
+
+# Packages matching: any
+# No matches found
+### # ---
+### <OPAM/repo/repos-config>
+opam-version: "2.0"
+repo { }
+### opam repo --all
+[WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing URL in repo field
+
+# Repository # Url # Switches(rank)
+### <nourl/packages/yes/yes.1/opam>
+opam-version: "2.0"
+### opam update nourl
+[WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing URL in repo field
+
+[ERROR] Unknown repositories or installed packages: nourl
+# Return code 40 #
+### opam list -A
+[WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing URL in repo field
+
+# Packages matching: any
+# No matches found
+### sh -c "rm OPAM/repo/state-*.cache"
+### opam list -A
+[WARNING] Errors in ${BASEDIR}/OPAM/repo/repos-config, some fields have been ignored:
+            - In ${BASEDIR}/OPAM/repo/repos-config:
+              missing URL in repo field
+
+# Packages matching: any
+# No matches found
+### # ---
+### <OPAM/repo/repos-config>
+opam-version: "2.0"
+### opam repo --all
+# Repository # Url # Switches(rank)
+### <nourl/packages/yes/yes.1/opam>
+opam-version: "2.0"
+### opam update nourl
+[ERROR] Unknown repositories or installed packages: nourl
+# Return code 40 #
+### opam list -A
+# Packages matching: any
+# No matches found
+### sh -c "rm OPAM/repo/state-*.cache"
+### opam list -A
 # Packages matching: any
 # No matches found
 ### mv repos-config.bak OPAM/repo/repos-config

--- a/tests/reftests/upgrade-two-point-o.test
+++ b/tests/reftests/upgrade-two-point-o.test
@@ -21,6 +21,13 @@ pinned: ["i-am-compiler.1"]
 ### <OPAM/pinned-comp/.opam-switch/switch-config>
 opam-version: "2.0"
 synopsis: "switch with pinned compiler"
+### <repos.sh>
+basedir=$(printf '%s' "$BASEDIR" | sed 's/\\/\\\\/g')
+cat > OPAM/repo/repos-config <<EOF
+opam-version: "2.0"
+repositories: [ "default" {"file://${basedir}/REPO"} ]
+EOF
+### sh repos.sh
 ### OPAMDEBUGSECTIONS=STATE opam upgrade --show-action --debug-level=-1
 STATE                           LOAD-SWITCH-STATE @ pinned-comp
 STATE                           Definition missing for installed package i-am-compiler.1, copying from repo


### PR DESCRIPTION
It is quite difficult and misleading to repository related information in the `repos-config` file (like in #4933 and #6283).
The current format contain a list with a some optional elements, which complicated the parsing
> `repositories: [ <string> { <URL> } { {<string>}+ } { <int> } ... ]`: lists the configured repository idents, their URLs and trust anchors. The format is similar to [repositories:](https://opam.ocaml.org/doc/Manual.html#opamrcfield-repositories) from opamrc, except that the <URL> itself is optional.

The PR implements a new syntax for this file: each repository is a section with it's own defined labeled fields:
```
repo <string> {
  url: <URL>
  fingerprints:  <string>
  quorum: <int>
}
```
Adding then a new field is quite easy.

This change implies an hard upgrade (no best effort loading if read only) to update the opam root.

fix #6327

TODO:
* [ ] update doc
* [ ] update changes
* [x] update opam root test
* [x] move to light upgrade
* [x] add a comment on hard upgrade that it should not be changed, ideally (done in #6417)
* [x] queued on #6417 
* [x] queued on #6839