### PR TITLE
GHA: add a job that test opam libs dependencies compilation

### DIFF
--- a/.github/scripts/main/preamble.sh
+++ b/.github/scripts/main/preamble.sh
@@ -42,7 +42,7 @@ else
   OPAM_REPO_CACHE=$OPAM_REPO_MAIN
 fi
 
-# used only for TEST jobs
+# used only for TEST and DOC jobs
 init-bootstrap () {
   if [ "$OPAM_TEST" = "1" ] || [ "$OPAM_DOC" = "1" ] || [ -n "$SOLVER" ]; then
     export OPAMROOT=$OPAMBSROOT

--- a/.github/scripts/main/preamble.sh
+++ b/.github/scripts/main/preamble.sh
@@ -19,6 +19,7 @@ PATH=$OPAM_LOCAL/bin:$OCAML_LOCAL/bin:$PATH; export PATH
 OPAM_COLD=${OPAM_COLD:-0}
 OPAM_TEST=${OPAM_TEST:-0}
 OPAM_DOC=${OPAM_DOC:-0}
+OPAM_DEPENDS=${OPAM_DEPENDS:-0}
 OPAM_UPGRADE=${OPAM_UPGRADE:-0}
 
 OPAM_REPO_MAIN=https://github.com/ocaml/opam-repository.git
@@ -44,13 +45,20 @@ fi
 
 # used only for TEST and DOC jobs
 init-bootstrap () {
-  if [ "$OPAM_TEST" = "1" ] || [ "$OPAM_DOC" = "1" ] || [ -n "$SOLVER" ]; then
+  if [ "$OPAM_TEST" = "1" ] || [ "$OPAM_DOC" = "1" ] || [ "$OPAM_DEPENDS" = "1" ] || [ -n "$SOLVER" ]; then
     export OPAMROOT=$OPAMBSROOT
     # The system compiler will be picked up
-    if [ "${OPAM_REPO%.git}" != "${OPAM_REPO_MAIN%.git}" ]; then
-      opam init --no-setup git+$OPAM_REPO_MAIN#$OPAM_REPO_SHA
+
+    if [ "$OPAM_DEPENDS" = "1" ]; then
+      REPO_SHA=$OPAM_TEST_REPO_SHA
     else
-      opam init --no-setup git+$OPAM_REPO_CACHE#$OPAM_REPO_SHA
+      REPO_SHA=$OPAM_REPO_SHA
+    fi
+
+    if [ "${OPAM_REPO%.git}" != "${OPAM_REPO_MAIN%.git}" ]; then
+      opam init --no-setup git+$OPAM_REPO_MAIN#$REPO_SHA
+    else
+      opam init --no-setup git+$OPAM_REPO_CACHE#$REPO_SHA
     fi
 
     cat >> $OPAMROOT/config <<EOF

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ env:
   OPAMBSROOT: ~/.cache/.opam.cached
   OPAM12CACHE: ~/.cache/opam1.2/cache
   OPAM_REPO: https://github.com/ocaml/opam-repository.git
-  OPAM_TEST_REPO_SHA: e9ce8525130a382fac004612302b2f2268f4188c
+  OPAM_TEST_REPO_SHA: 3dab8c734b15bf2b5c1d8b99bb134f51361a6bee
   OPAM_REPO_SHA: e9ce8525130a382fac004612302b2f2268f4188c
   SOLVER:
   CYGWIN_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
@@ -688,3 +688,69 @@ jobs:
         PR_REF_SHA: ${{ github.event.pull_request.head.sha }}
       if: steps.files.outputs.all != ''
       run: bash -exu .github/scripts/main/hygiene.sh
+
+  Depends-Linux:
+    runs-on: ubuntu-latest
+    needs: [ Analyse, Build-Linux ]
+    strategy:
+      matrix:
+        ocamlv: [ 4.14.2, 5.3.0 ]
+      fail-fast: false
+    env:
+      OPAM_DEPENDS: 1
+    steps:
+    - name: Checkout tree
+      uses: actions/checkout@v5
+    - name: Get changed files
+      id: files
+      if: github.event_name == 'pull_request'
+      uses: Ana06/get-changed-files@v2.3.0
+      with:
+        filter: src/**/*.mli
+    - name: src_ext/archives and opam-repository Cache
+      id: archives
+      if: steps.files.outputs.all != ''
+      uses: actions/cache@v4
+      with:
+        path: |
+          src_ext/archives
+          ~/opam-repository
+        key: ${{ needs.Analyse.outputs.archives }}
+        enableCrossOsArchive: true
+    - name: Install bubblewrap
+      if: steps.files.outputs.all != ''
+      run: sudo apt install bubblewrap
+    - name: Disable AppArmor
+      if: steps.files.outputs.all != ''
+      run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+    - name: OCaml ${{ matrix.ocamlv }} Cache
+      id: ocaml-cache
+      if: steps.files.outputs.all != ''
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ocaml-local/**
+        key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ needs.Analyse.outputs.ocaml-cache }}
+    - name: Create OCaml ${{ matrix.ocamlv }} cache
+      if: steps.files.outputs.all != '' && steps.ocaml-cache.outputs.cache-hit != 'true'
+      run: bash -exu .github/scripts/main/ocaml-cache.sh ${{ runner.os }} ${{ matrix.ocamlv }}
+    - name: opam bootstrap Cache
+      id: opam-bootstrap
+      if: steps.files.outputs.all != ''
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ env.OPAMBSROOT }}/**
+          ~/.cache/opam-local/bin/**
+        key: opamdepends-${{ runner.os }}-${{ env.OPAMBSVERSION }}-${{ matrix.ocamlv }}-${{ env.OPAM_REPO_SHA }}-${{ needs.Analyse.outputs.opam-bs-cache }}
+    - name: Create opam bootstrap cache
+      if: steps.files.outputs.all != '' && steps.opam-bootstrap.outputs.cache-hit != 'true'
+      run: bash -exu .github/scripts/main/opam-bs-cache.sh
+    - name: Compile
+      env:
+        BASE_REF_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_REF_SHA: ${{ github.event.pull_request.head.sha }}
+        GITHUB_PR_USER: ${{ github.event.pull_request.user.login }}
+        JOB_URL: ${{ steps.get-job-id.outputs.job_url }}
+        FAIL_IF_DEPENDENT: opam-publish opam-rt opam-build opam-test
+      if: steps.files.outputs.all != ''
+      run: bash -exu .github/scripts/main/main.sh x86_64-pc-linux-gnu

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -657,12 +657,24 @@ jobs:
     runs-on: ubuntu-22.04
     needs: Analyse
     steps:
-    - name: Install system's dune and ocaml packages
-      run: sudo apt install dune ocaml
     - name: Checkout tree
       uses: actions/checkout@v5
+    - name: Get changed files
+      id: files
+      if: github.event_name == 'pull_request'
+      uses: Ana06/get-changed-files@v2.3.0
+      with:
+        filter: |
+          configure.ac
+          shell/install.sh
+          src_ext/**
+          .github/workflows/**
+    - name: Install system's dune and ocaml packages
+      if: steps.files.outputs.all != ''
+      run: sudo apt install dune ocaml
     - name: src_ext/archives and opam-repository Cache
       id: archives
+      if: steps.files.outputs.all != ''
       uses: actions/cache@v4
       with:
         path: |
@@ -670,27 +682,9 @@ jobs:
           ~/opam-repository
         key: ${{ needs.Analyse.outputs.archives }}
         enableCrossOsArchive: true
-    - name: Get changed files
-      id: files
-      if: github.event_name == 'pull_request'
-      uses: Ana06/get-changed-files@v2.3.0
-    - name: Changed files list
-      run: |
-        for changed_file in ${{ steps.files.outputs.modified }}; do
-          echo "M  ${changed_file}."
-        done
-        for changed_file in ${{ steps.files.outputs.removed }}; do
-          echo "D  ${changed_file}."
-        done
-        for changed_file in ${{ steps.files.outputs.added }}; do
-          echo "A  ${changed_file}."
-        done
-        for changed_file in ${{ steps.files.outputs.renamed }}; do
-          echo "AD ${changed_file}."
-        done
     - name: Hygiene
       env:
         BASE_REF_SHA: ${{ github.event.pull_request.base.sha }}
         PR_REF_SHA: ${{ github.event.pull_request.head.sha }}
-      if: contains(steps.files.outputs.modified, 'configure.ac') || contains(steps.files.outputs.modified, 'shell/install.sh') || contains(steps.files.outputs.all, 'src_ext') || contains(steps.files.outputs.all, '.github/workflows')
+      if: steps.files.outputs.all != ''
       run: bash -exu .github/scripts/main/hygiene.sh

--- a/master_changes.md
+++ b/master_changes.md
@@ -126,6 +126,7 @@ users)
   * Fix the nixos depexts tests (git is now already installed in the nix docker image) [#6652 @kit-ty-kate]
   * Ensure every part of the scripts are run with `set -ue` [#6648 @kit-ty-kate]
   * Only run the `get-changed-files` action when in a PR [#6582 @kit-ty-kate]
+  * Add a CI job to test reverse dependencies of opam. Track and report dependency and build failures, hard-failing only on maintained packages. [#6394 @rjbou @arozovyk]
   * Enhance changed files job dependant handling [#6394 @rjbou]
 
 ## Doc

--- a/master_changes.md
+++ b/master_changes.md
@@ -136,8 +136,8 @@ users)
   * Fix URL to Software Heritage [#6650 @gahr]
   * Clarify conditions in subsection titles in the Packaging page [#6653 @jmid]
   * Upgrade the deprecated md5 `checksum` example to sha256 [#6653 @jmid]
-
-* Add mention of `opam admin compare-versions` in the Manual. [#6596 @mbarbin]
+  * Add mention of `opam admin compare-versions` in the Manual. [#6596 @mbarbin]
+  * Update release documentation to add a step updating test repository hash and version number in reverse dependecies test script [#6364 @arozovyk]
 
 ## Security fixes
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -126,6 +126,7 @@ users)
   * Fix the nixos depexts tests (git is now already installed in the nix docker image) [#6652 @kit-ty-kate]
   * Ensure every part of the scripts are run with `set -ue` [#6648 @kit-ty-kate]
   * Only run the `get-changed-files` action when in a PR [#6582 @kit-ty-kate]
+  * Enhance changed files job dependant handling [#6394 @rjbou]
 
 ## Doc
   * Update the installation documentation with the release of opam 2.4.1 [#6620 @kit-ty-kate]

--- a/release/readme.md
+++ b/release/readme.md
@@ -37,6 +37,7 @@
 
 * finalise the release (publish)
 * add hashes in `install.sh` and `install.ps1` (and check signatures)
+* update `OPAM_TEST_REPO_SHA` in `ci.ml` and update version in `main.sh` for dependencies job
 * bring the changes to the changelog (CHANGES) from the branch of the release to the `master` branch
 * Update doc/pages/Install.md
 * publish opam packages in opam-repository (use `opam publish --pre-release` if this is not a stable version)


### PR DESCRIPTION
In it based on the same mechanism than opam-rt, it permits to keep them synchronised with the current API
TODO
* [x] add a release step to check CI log for failing projects
* [x] add a mechanism to retrieve automatically opam lib rev deps
* [x] add a mechanism to eliminate pinned packages that rely on old versions of opam
* [x] condition job launch to changes of mli files

This PR also contains an enhancement of changed files step (and it use/conditionning). 