### PR TITLE
Display Windows `NTSTATUS` exit codes in hex

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -38,6 +38,7 @@ users)
   * Improve the messages when a package is not up-to-date on opam upgrade [#6272 @kit-ty-kate - fix #6270]
   * Use a non-underline uppercase character to denotate the default when asking a question [#6289 @hannesm @kit-ty-kate - fix #6288]
   * Do not pre-write the answer to questions with the default anwser [#6376 @kit-ty-kate]
+  * Display Windows NTSTATUS exit codes in hex [#6401 @dra27 @MisterDA]
 
 ## Switch
   * [BUG] Fix `opam switch remove <dir>` failure when it is a linked switch [#6276 @btjorge - fix #6275]

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -842,10 +842,12 @@ let string_of_result ?(color=`yellow) r =
   Buffer.contents b
 
 let result_summary r =
-  Printf.sprintf "%S exited with code %d%s"
+  Printf.sprintf "%S exited with code %s%s"
     (try OpamStd.List.assoc String.equal "command" r.r_info
      with Not_found -> "command")
-    r.r_code
+    (if Sys.win32 && r.r_code < 0 then
+       Printf.sprintf "0x%08lx" (Int32.of_int r.r_code)
+     else string_of_int r.r_code)
     (if r.r_code = 0 then "" else
      match r.r_stderr, r.r_stdout with
      | [e], _ | [], [e] -> Printf.sprintf " \"%s\"" e


### PR DESCRIPTION
On Windows, "negative" exit codes are probably `NTSTATUS` values. For example, if a program accesses an invalid memory location, Unix sends a `SIGSEGV` signal which, if unhandled, will terminate the process (setting some kind of non-zero exit code - for example, Linux sets the exit code to 128 + signal number to give a fairly memorable 139). In the equivalent scenario, Windows throws an `EXCEPTION_ACCESS_VIOLATION` which, if handled by the default exception handler, will terminate the process with exit code `STATUS_ACCESS_VIOLATION`. These codes are large negative numbers, which are not terribly memorable in decimal, so for negative exit codes we instead display them in hexadecimal as `0xc0000005` is slightly more memorable than `-1073741819`.

These exit codes can also occur if an executable is missing a DLL, which can be the case of a broken or missing Cygwin/MinGW-w64 package.
