### PR TITLE
Fix opam file lookup when a pin is done with a local directory and a branch is specified 

### DIFF
--- a/src/state/opamPinned.ml
+++ b/src/state/opamPinned.ml
@@ -140,8 +140,11 @@ let check_locked ?locked default =
        locked, Some ext)
 
 let find_opam_file_in_source ?locked name dir =
+(* OpamConsole.error "find : %s in %s" (OpamPackage.Name.to_string name) (OpamFilename.Dir.to_string dir); *)
   let opt =
-    OpamStd.List.find_opt OpamFilename.exists
+    OpamStd.List.find_opt
+(*     (fun f -> OpamConsole.note "....%s -> %B" (OpamFilename.to_string f) (OpamFilename.exists f); OpamFilename.exists f) *)
+    OpamFilename.exists
       (possible_definition_filenames dir name)
   in
   opt

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1035,3 +1035,48 @@ The following actions will be performed:
 -> installed dep2.2
 -> installed dep1.dev
 Done.
+### :C:d: local directory pinned with non selected branch
+### mkdir local
+### git -C local init -q --initial-branch=master
+### git -C local config core.autocrlf false
+### git -C local commit -qm "init" --allow-empty
+### git -C local checkout -b fst master
+Switched to a new branch 'fst'
+### <pin:local/fst.opam>
+opam-version: "2.0"
+synopsis: "I'm the first package"
+### git -C local add fst.opam
+### git -C local commit -qm "fst"
+### git -C local checkout -b snd master
+Switched to a new branch 'snd'
+### <pin:local/snd.opam>
+opam-version: "2.0"
+synopsis: "I'm the second package"
+### git -C local add snd.opam
+### git -C local commit -qm "snd"
+### git -C local checkout fst
+Switched to branch 'fst'
+### opam switch create local-magic --empty
+### git -C local branch --show-current
+fst
+### opam pin fst ./local#fst -n
+[NOTE] Package fst does not exist in opam repositories registered in the current switch.
+[fst.dev] synchronised (git+file://${BASEDIR}/local#fst)
+fst is now pinned to git+file://${BASEDIR}/local#fst (version dev)
+### opam show fst --field synopsis
+I'm the first package
+### git -C local branch --show-current
+fst
+### opam pin snd ./local#snd -n
+[NOTE] Package snd does not exist in opam repositories registered in the current switch.
+[snd.dev] synchronised (git+file://${BASEDIR}/local#snd)
+[NOTE] No package definition found for snd.dev: please complete the template
+[WARNING] The opam file didn't pass validation:
+             error 22: Some fields are present but empty; remove or fill them: "homepage", "license", "bug_reports"
+             error 57: Synopsis must not be empty
+           warning 62: License doesn't adhere to the SPDX standard, see https://spdx.org/licenses/ : ""
+Proceed anyway ('no' will re-edit)? [Y/n] y
+You can edit this file again with "opam pin edit snd", export it with "opam show snd --raw"
+snd is now pinned to git+file://${BASEDIR}/local#snd (version dev)
+### opam show snd --field synopsis
+

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1070,13 +1070,6 @@ fst
 ### opam pin snd ./local#snd -n
 [NOTE] Package snd does not exist in opam repositories registered in the current switch.
 [snd.dev] synchronised (git+file://${BASEDIR}/local#snd)
-[NOTE] No package definition found for snd.dev: please complete the template
-[WARNING] The opam file didn't pass validation:
-             error 22: Some fields are present but empty; remove or fill them: "homepage", "license", "bug_reports"
-             error 57: Synopsis must not be empty
-           warning 62: License doesn't adhere to the SPDX standard, see https://spdx.org/licenses/ : ""
-Proceed anyway ('no' will re-edit)? [Y/n] y
-You can edit this file again with "opam pin edit snd", export it with "opam show snd --raw"
 snd is now pinned to git+file://${BASEDIR}/local#snd (version dev)
 ### opam show snd --field synopsis
-
+I'm the second package


### PR DESCRIPTION
fix #6408 
I'm not fully satisfied with that solution... But it may not be kept, superseded by #6419.

~This PR changes the behaviour of `opam pin add ./local-vcs` which would take the opam files from the VCS repository even if they had untracked changes. This behaviour exists since opam 2.1 (see https://github.com/ocaml/opam/pull/4300) but opam 2.0 didn't have the same behaviour.~
~The addition of a note about untracked changes can be added separately and is tracked by https://github.com/ocaml/opam/issues/6414~
