### PR TITLE
Complete format upgrade mechanism at repo & switch level

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -70,6 +70,7 @@ users)
 ## External dependencies
 
 ## Format upgrade
+  * Complete upgrade mechanism to permit on the fly upgrade and write upgrade from repo and switch level [#6416 @rjbou]
 
 ## Sandbox
 

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -1150,12 +1150,26 @@ let from_2_2_beta_to_2_2 ~on_the_fly:_ _ conf = conf, gtc_none
 (* To add an upgrade layer
    * If it is a light upgrade, returns as second element if the repo or switch
      need an light upgrade with `gtc_*` values.
-   * If it is an hard upgrade, performs repo & switch upgrade in upgrade
-     function.
+   * [Should not happen] If it is an hard upgrade, performs repo & switch
+     upgrade in upgrade function.
 *)
 
 let latest_version = OpamFile.Config.root_version
 
+(* Development notes:
+   opam differentiates two kinds of format upgrade - "Hard" upgrades, which
+   must be written straight to disk, and "Light" upgrades, which can be
+   performed in-memory, and don't have to be written immediately.
+   This distinction was added in opam 2.1, as it allows users of a _newer_
+   version of opam-state to _read_ an opam root which is still being maintained
+   by an _older_ version of opam (for example, it allows a program compiled with
+   opam-state 2.1.0 to load the global configuration of an opam 2.0 user's root
+   without forcing the upgrade of that root to 2.1).
+
+   Essentially, a "Hard" upgrade is used where the change is difficult (or even
+   impossible) to perform in-memory. We try our hardest to keep all format
+   upgrades "Light" - i.e. the aim is that this version below should never
+   change. *)
 let latest_hard_upgrade = (* to *) v2_0_beta5
 
 (* intermediate roots that need a hard upgrade when upgrading from them *)

--- a/src/state/opamFormatUpgrade.mli
+++ b/src/state/opamFormatUpgrade.mli
@@ -38,17 +38,22 @@ val as_necessary:
   OpamFile.Config.t ->
   OpamFile.Config.t * gt_changes
 
-(* [as_necessary_repo_switch_light_upgrade lock kind gt] write upgraded global
-   config file with the root bump if an on-the-fly upgrade of global state
-   was performed there is remaining upgrade on repository or switch layers, and
-   there is a write lock required. It only writes global config file, repo &
-   switch config are written when needed during opam operations.  [lock] is the
-   current global lock, [kind] is [`Repo | `Switch], from where the function is
-   called (repo or switch state load), [gt] the on-the-fly upgraded global
-   state.
- *)
-val as_necessary_repo_switch_light_upgrade:
-  'a lock -> [`Repo | `Switch] -> 'b global_state -> unit
+(* [as_necessary_repo lock gt] does the upgrades at repo level. [lock] is the
+   required lock for repo state and gt the on-the-fly upgraded global lock. If
+   [lock] is none or read, it will perform an on-the-fly upgrade of repos-config
+   and return it. if [lock] is a write lock, it locks opam root and perform and
+   apply all needed upgrades (write global, repo & state config if needed).
+   At global state loading, [as_necessary] is called, so this function will do
+   the upgrades only if there is a known on-the-fly upgrade done by
+   [as_necessary]. Otherwise, it is an no-op and returns None. *)
+val as_necessary_repo:
+  'a lock -> 'b global_state -> OpamFile.Repos_config.t option
+
+(* As [as_necessay_repo] but acts on a given [switch]. In case of write [lock]
+   and upgrade that need to be done, it applies modification to all switches
+   (as well as global and repo config). *)
+val as_necessary_switch:
+  'a lock -> switch -> 'b global_state -> OpamFile.Switch_config.t option
 
 (* Try to launch a hard upgrade from 2;1 alpha's & beta's root
    to 2.1~rc one. Raises [Upgrade_done] (catched by main

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -155,10 +155,13 @@ let get_repo_root rt repo =
   get_root_raw rt.repos_global.root rt.repos_tmp repo.repo_name
 
 let load lock_kind gt =
-  OpamFormatUpgrade.as_necessary_repo_switch_light_upgrade lock_kind `Repo gt;
   log "LOAD-REPOSITORY-STATE %@ %a" (slog OpamFilename.Dir.to_string) gt.root;
   let lock = OpamFilename.flock lock_kind (OpamPath.repos_lock gt.root) in
-  let repos_map = OpamStateConfig.Repos.safe_read ~lock_kind gt in
+  let repos_map =
+    match OpamFormatUpgrade.as_necessary_repo lock_kind gt with
+    | Some repos_map -> repos_map
+    | None -> OpamStateConfig.Repos.safe_read ~lock_kind gt
+  in
   if OpamStateConfig.is_newer_than_self ~lock_kind gt then
     log "root version (%s) is greater than running binary's (%s); \
          load with best-effort (read-only)"

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -3213,7 +3213,7 @@ i-am-package      2           One-line description
 i-am-sys-compiler 2           One-line description
 ### rm -rf _opam
 ### :V:8:a: From 2.2 root, global
-### ocaml generate.ml $OPAMROOTVERSION
+### ocaml generate.ml 2.2
 ### # ro global state
 ### opam option jobs
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
@@ -3287,7 +3287,7 @@ installed: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 opam-version: "2.0"
 roots: ["i-am-another-package.2" "i-am-compiler.2" "i-am-package.2"]
 ### :V:8:b: From 2.2 root, local
-### ocaml generate.ml $OPAMROOTVERSION local
+### ocaml generate.ml 2.2 local
 ### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
@@ -3348,7 +3348,7 @@ installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:8:c: From 2.2 root, local unknown from config
-### ocaml generate.ml $OPAMROOTVERSION local
+### ocaml generate.ml 2.2 local
 ### opam list | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
@@ -3408,7 +3408,7 @@ installed: ["i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:8:d: Upgraded root and local 2.2 switch not recorded
-### ocaml generate.ml $OPAMROOTVERSION orphaned 2.2
+### ocaml generate.ml 2.2 orphaned 2.2
 ### # ro global state, ro repo state, ro switch state
 ### opam list
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM


### PR DESCRIPTION
Current mechanism permit to load on-the-fly if no write lock is required global config files. These files are written if at global, repo or switch level a write is requested.

We want to change repo state format, so we need to update that mechanism to act also on repo & switch config files.

In this PR, we still have the old system : hard upgrade that block, light upgrades that don't block (confirmation message), and on-the-fly upgrade on global config. Plus, is added a mechanism to retrieve repo & switch config on-the-fly if lock read or none is requested, and if write lock is required a global upgrade with writes is launched (global lock required).

I've put it in its own commit the comment about no more upgrading hard upgrade version for visibility (and in changes)