### PR TITLE
Allow detection of installed packages through their virtual names on ALT Linux, RHEL-based and SUSE-based distributions

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -96,6 +96,7 @@ users)
   * Restore the distribution detection on Gentoo [#6886 @kit-ty-kate - fix #6887]
   * Add support for single-quoted values of the /etc/os-release file [#6886 @kit-ty-kate - fix #6887]
   * Fix a string injection from the depexts field to nix-build, when `os-family=nixos` [#6894 @RyanGibb]
+  * Allow detection of installed packages through their virtual names on ALT Linux, RHEL-based and SUSE-based distributions [#6431 @kit-ty-kate - fix #6426]
 
 ## Format upgrade
   * Fix switch and repo format upgrade on Windows. A block occurred because the global lock fd was reopened instead of using the one already opened.  [#6839 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -97,6 +97,7 @@ users)
   * Add support for single-quoted values of the /etc/os-release file [#6886 @kit-ty-kate - fix #6887]
   * Fix a string injection from the depexts field to nix-build, when `os-family=nixos` [#6894 @RyanGibb]
   * Allow detection of installed packages through their virtual names on ALT Linux, RHEL-based and SUSE-based distributions [#6431 @kit-ty-kate - fix #6426]
+  * Speedup the installed package detection by 2% on ALT Linux, RHEL and SUSE based distributions [#6431 @kit-ty-kate]
 
 ## Format upgrade
   * Fix switch and repo format upgrade on Windows. A block occurred because the global lock fd was reopened instead of using the one already opened.  [#6839 @rjbou]

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -785,8 +785,9 @@ let installed_packages_t ?(env=OpamVariable.Map.empty) config packages =
          slower to parse due to the extra number of package name but
          allows to detect virtual packages such as python3. *)
       run_query_command "rpm" ["-qa"; "--qf"; "%{NAME}\\n[%{PROVIDES}\\n]"]
-      |> List.map OpamSysPkg.of_string
-      |> OpamSysPkg.Set.of_list
+      |> List.fold_left (fun acc name ->
+          OpamSysPkg.Set.add (OpamSysPkg.of_string name) acc)
+        OpamSysPkg.Set.empty
     in
     get_relevant sys_installed
   | Cygwin ->

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -779,7 +779,12 @@ let installed_packages_t ?(env=OpamVariable.Map.empty) config packages =
        >python3-pip-wheel
     *)
     let sys_installed =
-      run_query_command "rpm" ["-qa"; "--qf"; "%{NAME}\\n"]
+      (* NOTE: In practice %{PROVIDES} seems to always contains %{NAME}
+         but this behaviour isn't documented, so just to be sure, it is
+         safer to add %{NAME} anyway. Using %{PROVIDES}% is a little bit
+         slower to parse due to the extra number of package name but
+         allows to detect virtual packages such as python3. *)
+      run_query_command "rpm" ["-qa"; "--qf"; "%{NAME}\\n[%{PROVIDES}\\n]"]
       |> List.map OpamSysPkg.of_string
       |> OpamSysPkg.Set.of_list
     in


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/6426
Queued on 
* https://github.com/ocaml/opam/pull/6464
* #6489

Per discussion in the ticket, getting the list of available packages on SUSE-based distributions is too costly.
Instead, the solution is one similar to https://github.com/ocaml/opam/pull/4791 which was chosen for RHEL-based distributions: simply disable the detection of available packages.

However, while with the original issue the user will be able to install `conf-python-3` on openSUSE Tumbleweed, opam will continue to detect that the package isn't installed and continuously bug the user about the missing `python3` package which is in fact already installed.

To fix that we use the `%{PROVIDES}` tag (documented in http://ftp.rpm.org/max-rpm/ch-queryformat-tags.html):
- Pros: adds support for virtual packages on RHEL-based distributions as well
- Cons: increases the time it takes to get the availability information by 18% (locally on Fedora: before takes 1.5s, now takes 1.77 seconds)

Related to https://github.com/ocaml/opam/issues/4759