### PR TITLE
Upgrade to cmdliner 2.0.0

### DIFF
--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -1378,12 +1378,12 @@ let help =
     | None       -> `Help (`Pager, None)
     | Some topic ->
       let topics = "topics" :: cmds in
-      let conv, _ = Cmdliner.Arg.enum (List.rev_map (fun s -> (s, s)) topics) in
-      match conv topic with
-      | `Error e -> `Error (false, e)
-      | `Ok t when t = "topics" ->
+      let conv = Cmdliner.Arg.enum (List.rev_map (fun s -> (s, s)) topics) in
+      match Arg.Conv.parser conv topic with
+      | Error e -> `Error (false, e)
+      | Ok t when t = "topics" ->
           List.iter (OpamConsole.msg "%s\n") cmds; `Ok ()
-      | `Ok t -> `Help (man_format, Some t) in
+      | Ok t -> `Help (man_format, Some t) in
 
   Term.(ret (const help $Arg.man_format $Term.choice_names $topic)),
   Cmd.info "help" ~doc ~man

--- a/src/client/opamArgTools.ml
+++ b/src/client/opamArgTools.ml
@@ -708,12 +708,15 @@ type 'a default = [> `default of string] as 'a
 
 let mk_subcommands_with_default ~cli commands =
   let enum_with_default_valrem sl =
-    let parse, print = Arg.enum sl in
-    let parse s =
-      match parse s with
-      | `Ok x -> `Ok (x)
-      | _ -> `Ok (Valid (`default s)) in
-    parse, print
+    let conv = Arg.enum sl in
+    let parser s =
+      match Arg.Conv.parser conv s with
+      | Ok x -> Ok x
+      | Error _ -> Ok (Valid (`default s))
+    in
+    let pp = Arg.Conv.pp conv in
+    let docv = Arg.Conv.docv conv in
+    Arg.Conv.make ~parser ~pp ~docv ()
   in
   mk_subcommands_aux ~cli enum_with_default_valrem commands
 

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -456,7 +456,11 @@ let run () =
   let to_new_cmdliner_api (term, info) = Cmd.v info term in
   let default, default_info = default in
   let commands = List.map to_new_cmdliner_api commands in
-  match Cmd.eval_value ~catch:false ~argv (Cmd.group ~default default_info commands) with
+  let env = function
+    | "CMDLINER_LEGACY_PREFIXES" -> Some "true"
+    | key -> Sys.getenv_opt key
+  in
+  match Cmd.eval_value ~env ~catch:false ~argv (Cmd.group ~default default_info commands) with
   | Error _ -> exit (OpamStd.Sys.get_exit_code `Bad_arguments)
   | Ok _    -> exit (OpamStd.Sys.get_exit_code `Success)
 

--- a/src/tools/opam_installer.ml
+++ b/src/tools/opam_installer.ml
@@ -381,17 +381,15 @@ let command =
 let info =
   let doc = "Handles (un)installation of package files following instructions from \
              opam *.install files." in
-  (Term.info [@ocaml.warning "-3"]) "opam-installer" ~version:OpamVersion.(to_string current) ~doc
+  Cmd.info "opam-installer" ~version:OpamVersion.(to_string current) ~doc
 
 let () =
   OpamSystem.init ();
   OpamCoreConfig.init ();
   try
-    match
-      (Term.eval [@ocaml.warning "-3"]) ~catch:false (command,info)
-    with
-    | `Error _ -> exit 2
-    | _ -> exit 0
+    match Cmd.eval_value ~catch:false (Cmd.v info command) with
+    | Error _ -> exit 2
+    | Ok _ -> exit 0
   with
   | Invalid_argument s ->
     OpamConsole.error "%s" s; exit 2


### PR DESCRIPTION
Fixes #6425 

Issues to address:
- [ ] I'm personally unconvinced about the `CMDLINER_LEGACY_PREFIXES=true` escape hatch. I would much rather have a global reference (e.g. https://github.com/kit-ty-kate/cmdliner/commit/94ecc8a6f1cb3b5b07fa34bd0999e72349325f7c) or whatever to make sure the behaviour doesn't change between two versions while we weren't looking
- [ ] The escape hatch in combination with `?env` doesn't work with `Arg.enum`. Using the example patch above, this issue would be fixed.

If we decide to fork cmdliner with the following patch above master https://github.com/kit-ty-kate/cmdliner/commit/1565763d2af8515f3bc6212ec359fe4769891242, those issues wouldn't be there anymore at the cost of extra maintenance.

cc @dbuenzli 