### PR TITLE
Save disk space by only caching dev packages into the internal 'sources' directory

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -31,6 +31,7 @@ users)
 
 ## Actions
   * Reorder the list of actions by increased priority [#6864 @kit-ty-kate - fix #6863]
+  * The internal `sources` directory now only serves to cache dev packages instead of every packages, saving disk space. For other packages it is now removed during the build phase. [#6440 @kit-ty-kate - fix #4056 #5448]
 
 ## Install
   * Remove the build directory as soon as possible when installing a package [#6906 @kit-ty-kate - fix #5884]
@@ -332,6 +333,7 @@ users)
   * `OpamSysInteract`: add `available_packages` and `installed_packages` to be computed separately, redefine `packages_status` accordingly. These funct-ions are now no-op if the given system packages set is empty.  [#6489 @arozovyk]
   * `OpamGlobalState`: add `is_root_read_only` to check if we are in sandboxed environment [#6489 @rjbou]
   * `OpamSwitchState`: add `update_sys_packages` to update depexts status of a set of packages. [#6489 @arozovyk]
+  * `OpamSwitchState`: add `is_source_dir_temporary` [#6440 @kit-ty-kate]
   * `OpamSysInteract`: add `available_packages` and `installed_packages` to be computed separately, redefine `packages_status` accordingly [#6489 @arozovyk]
   * `OpamStateTypes`: add available system package status field `repos_syspkgs_available` (and its type `repo_syspkgs_available`) in `repos_state` for all the depexts declared in repo's packages. The new field is also added to the cache. [#6489 @arozovyk @rjbou]
   * `OpamRepositoryState.load`: load repo's available system packages [#6489 @arozovyk]

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -661,8 +661,12 @@ let parallel_apply t
       in
       let source_dir = source_dir nv in
       (if OpamFilename.exists_dir source_dir
-       then (if not is_inplace then
-               OpamFilename.copy_dir ~src:source_dir ~dst:build_dir)
+       then
+         (if not is_inplace then
+            (if OpamSwitchState.is_source_dir_temporary t nv then
+               OpamFilename.move_dir ~src:source_dir ~dst:build_dir
+             else
+               OpamFilename.copy_dir ~src:source_dir ~dst:build_dir))
        else OpamFilename.mkdir build_dir;
        OpamAction.prepare_package_source t nv build_dir @@+ function
        | Some exn -> store_time (); Done (`Exception exn)
@@ -702,7 +706,11 @@ let parallel_apply t
          OpamFilename.rmdir d;
          let source_dir = source_dir nv in
          if OpamFilename.exists_dir source_dir
-         then OpamFilename.copy_dir ~src:source_dir ~dst:d
+         then
+           (if OpamSwitchState.is_source_dir_temporary t nv then
+              OpamFilename.move_dir ~src:source_dir ~dst:d
+            else
+              OpamFilename.copy_dir ~src:source_dir ~dst:d)
          else OpamFilename.mkdir d;
          OpamAction.prepare_package_source t nv d
        else Done None) @@+ fun _ ->

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -808,6 +808,9 @@ let source_dir st nv =
   then OpamPath.Switch.pinned_package st.switch_global.root st.switch nv.name
   else OpamPath.Switch.sources st.switch_global.root st.switch nv
 
+let is_source_dir_temporary st nv =
+  not (OpamPackage.Set.mem nv st.pinned || is_dev_package st nv)
+
 let overlay_opam_file st name =
   if is_pinned st name then
     let file =

--- a/src/state/opamSwitchState.mli
+++ b/src/state/opamSwitchState.mli
@@ -152,8 +152,14 @@ val dev_packages: 'a switch_state -> package_set
 
 (** Returns the local source mirror for the given package
     ({!OpamPath.Switch.sources} or {!OpamPath.Switch.pinned_package}, depending
-    on wether it's pinned). *)
+    on whether it's pinned. If it's not pinned, be mindful that the directory
+    is temporary (see {!is_source_dir_temporary}). *)
 val source_dir: 'a switch_state -> package -> dirname
+
+(** Returns [true] if the {!source_dir} of the package is meant to be a
+    temporary directory: packages that are not pinned or "dev package"
+    as defined in {!is_dev_package}. *)
+val is_source_dir_temporary: 'a switch_state -> package -> bool
 
 (** Returns the opam file overlay stored internally for pinned packages *)
 val overlay_opam_file:

--- a/tests/reftests/action-disk.test
+++ b/tests/reftests/action-disk.test
@@ -234,9 +234,7 @@ SYSTEM                          rmdir ${OPAMTMP}
 SYSTEM                          rm ${OPAMTMP}/x-source
 -> retrieved main-repo.1  (file://${BASEDIR}/archive.tgz)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1
-SYSTEM                          copydir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1 -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1
-SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1
-SYSTEM                          copy ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1/content -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/content
+SYSTEM                          mv ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1 -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1
 SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/x-source.main-repo.1
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/x-file.main-repo.1
@@ -290,8 +288,7 @@ The following actions will be performed:
   - recompile main-repo 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1
-SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1/content
+SYSTEM                          mv ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1 -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/4: [main-repo.1: extract]
@@ -315,17 +312,12 @@ SYSTEM                          write ${BASEDIR}/OPAM/install-from-repo/.opam-sw
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1/x-source.main-repo.1
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/x-file.main-repo.1
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/build-file
-SYSTEM                          copydir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1 -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1
-SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1
-SYSTEM                          copy ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1/content -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/content
 Processing  2/4: [main-repo: touch build-file]
 + touch "build-file" (CWD=${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1)
 -> compiled  main-repo.1
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1
-SYSTEM                          copydir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1 -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1
-SYSTEM                          copy ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1/content -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1/content
 Processing  3/4: [main-repo: touch removal-file]
 + touch "removal-file" (CWD=${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1)
 FILE(.install)                  Cannot find ${BASEDIR}/OPAM/install-from-repo/.opam-switch/install/main-repo.install
@@ -356,7 +348,6 @@ CACHE(installed)                Writing the installed cache to ${BASEDIR}/OPAM/i
 CACHE(installed)                ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache written in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache (write => none)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1
-SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1/content
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1/x-file.main-repo.1
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1/removal-file
 Done.
@@ -396,8 +387,9 @@ SYSTEM                          copydir ${OPAMTMP} -> ${OPAMTMP}
 SYSTEM                          copy ${OPAMTMP}/content -> ${OPAMTMP}/content
 SYSTEM                          rmdir ${OPAMTMP}
 SYSTEM                          rm ${OPAMTMP}/content
+SYSTEM                          mv ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2 -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2
+SYSTEM                          mv ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1 -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1
-SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1/content
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1
 SYSTEM                          copydir ${OPAMTMP} -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1
 SYSTEM                          copy ${OPAMTMP}/content -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1/content
@@ -408,9 +400,6 @@ SYSTEM                          rmdir ${OPAMTMP}
 SYSTEM                          rm ${OPAMTMP}/content
 -> retrieved main-repo.1, main-repo.2  (cached)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2
-SYSTEM                          copydir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2 -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2
-SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2
-SYSTEM                          copy ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2/content -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2/content
 SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2/x-source.main-repo.2
 SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1/x-source.main-repo.1
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files/x-file.main-repo.2
@@ -424,9 +413,6 @@ Processing  2/4: [main-repo: touch build-file]
 + touch "build-file" (CWD=${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2)
 -> compiled  main-repo.2
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1
-SYSTEM                          copydir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1 -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1
-SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1
-SYSTEM                          copy ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1/content -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1/content
 Processing  3/4: [main-repo: touch removal-file]
 + touch "removal-file" (CWD=${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1)
 FILE(.install)                  Cannot find ${BASEDIR}/OPAM/install-from-repo/.opam-switch/install/main-repo.install
@@ -466,8 +452,6 @@ SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switc
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/main-repo.1
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/main-repo.1/files/x-file.main-repo.1
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/main-repo.1/opam
-SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1
-SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1/content
 Done.
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/lock (write => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/lock (none => none)
@@ -498,8 +482,8 @@ The following actions will be performed:
   - remove main-repo 2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+SYSTEM                          mv ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2 -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2
-SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2/content
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/2: [main-repo.2: extract]
@@ -510,9 +494,6 @@ SYSTEM                          rmdir ${OPAMTMP}
 SYSTEM                          rm ${OPAMTMP}/content
 -> retrieved main-repo.2  (cached)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2
-SYSTEM                          copydir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2 -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2
-SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2
-SYSTEM                          copy ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2/content -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2/content
 SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2/x-source.main-repo.2
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files/x-file.main-repo.2
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2/x-file.main-repo.2
@@ -542,8 +523,6 @@ SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switc
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/main-repo.2
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/main-repo.2/opam
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/main-repo.2/files/x-file.main-repo.2
-SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2
-SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2/content
 Done.
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/lock (write => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/lock (none => none)
@@ -1167,6 +1146,8 @@ SYSTEM                          copydir ${BASEDIR}/OPAM/install-from-path-pin-al
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/remove/main-ppin.dev
 SYSTEM                          copy ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin.dev/content -> ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/remove/main-ppin.dev/content
 SYSTEM                          copy ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin.dev/main-ppin.opam -> ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/remove/main-ppin.dev/main-ppin.opam
+SYSTEM                          rm ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin.dev/content
+SYSTEM                          rm ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin.dev/main-ppin.opam
 Processing  2/2: [main-ppin: touch removal-file]
 + touch "removal-file" (CWD=${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/remove/main-ppin.dev)
 FILE(.install)                  Cannot find ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/install/main-ppin.install
@@ -1192,8 +1173,6 @@ SYSTEM                          rm ${BASEDIR}/OPAM/install-from-path-pin-all/.op
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/main-ppin.dev
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/main-ppin.dev/opam
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin.dev
-SYSTEM                          rm ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin.dev/content
-SYSTEM                          rm ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin.dev/main-ppin.opam
 Done.
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (write => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => none)
@@ -1885,6 +1864,8 @@ SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/remove/main-gpin.dev/.git
 SYSTEM                          copy ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev/content -> ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/remove/main-gpin.dev/content
 SYSTEM                          copy ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev/main-gpin.opam -> ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/remove/main-gpin.dev/main-gpin.opam
+SYSTEM                          rm ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev/content
+SYSTEM                          rm ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev/main-gpin.opam
 Processing  2/2: [main-gpin: touch removal-file]
 + touch "removal-file" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/remove/main-gpin.dev)
 FILE(.install)                  Cannot find ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/install/main-gpin.install
@@ -1910,8 +1891,6 @@ SYSTEM                          rm ${BASEDIR}/OPAM/install-from-git-pin-all/.opa
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/main-gpin.dev
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/main-gpin.dev/opam
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev
-SYSTEM                          rm ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev/content
-SYSTEM                          rm ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev/main-gpin.opam
 Done.
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (write => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => none)
@@ -2331,9 +2310,7 @@ SYSTEM                          rmdir ${OPAMTMP}
 SYSTEM                          rm ${OPAMTMP}/content
 -> retrieved main-repo.2  (cached)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2
-SYSTEM                          copydir ${BASEDIR}/OPAM/package-switch/.opam-switch/sources/main-repo.2 -> ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2
-SYSTEM                          mkdir ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2
-SYSTEM                          copy ${BASEDIR}/OPAM/package-switch/.opam-switch/sources/main-repo.2/content -> ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2/content
+SYSTEM                          mv ${BASEDIR}/OPAM/package-switch/.opam-switch/sources/main-repo.2 -> ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2
 SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2/x-source.main-repo.2
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files/x-file.main-repo.2
 SYSTEM                          write ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2/x-file.main-repo.2
@@ -2578,7 +2555,6 @@ SYSTEM                          rm ${BASEDIR}/OPAM/package-switch/.opam-switch/p
 SYSTEM                          rm ${BASEDIR}/OPAM/package-switch/.opam-switch/packages/main-repo.2/files/x-file.main-repo.2
 SYSTEM                          rm ${BASEDIR}/OPAM/package-switch/.opam-switch/packages/cache
 SYSTEM                          rm ${BASEDIR}/OPAM/package-switch/.opam-switch/switch-config
-SYSTEM                          rm ${BASEDIR}/OPAM/package-switch/.opam-switch/sources/main-repo.2/content
 SYSTEM                          rm ${BASEDIR}/OPAM/package-switch/.opam-switch/switch-state
 SYSTEM                          rm ${BASEDIR}/OPAM/package-switch/.opam-switch/environment
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (write => none)

--- a/tests/reftests/sources-directory-cleaning.test
+++ b/tests/reftests/sources-directory-cleaning.test
@@ -49,7 +49,6 @@ The following actions will be performed:
 -> installed waste.1
 Done.
 ### ls OPAM/sources-dir/.opam-switch/sources/
-waste.1
 ### : at removal
 ### opam remove waste
 The following actions will be performed:
@@ -71,7 +70,6 @@ The following actions will be performed:
 -> installed waste.1
 Done.
 ### ls OPAM/sources-dir/.opam-switch/sources
-waste.1
 ### opam reinstall waste
 The following actions will be performed:
 === recompile 1 package
@@ -83,7 +81,6 @@ The following actions will be performed:
 -> installed waste.1
 Done.
 ### ls OPAM/sources-dir/.opam-switch/sources
-waste.1
 ### : at atomic reinstall
 ### opam remove waste
 The following actions will be performed:
@@ -119,7 +116,6 @@ The following actions will be performed:
 -> installed waste.1
 Done.
 ### ls OPAM/sources-dir/.opam-switch/sources
-waste.1
 ### opam remove waste
 The following actions will be performed:
 === remove 1 package
@@ -156,7 +152,6 @@ The following actions will be performed:
 -> installed waste.1
 Done.
 ### ls OPAM/sources-dir/.opam-switch/sources
-waste.1
 ### opam remove waste
 The following actions will be performed:
 === remove 1 package


### PR DESCRIPTION
Fixes #5448 
Fixes #4056
~Queued on #6912~

The `.opam-switch/sources` directory currently stores the source of every installed packages in the following format:
* `<pkgname>`: are for pinned packages
* `<pkgname>.<version>`: are for the rest

In https://github.com/ocaml/opam/pull/2825 (opam 2.0.0~beta) the change from `packages.dev` to `sources` was introduced to support (as i understand it) non-pinned dev packages (e.g. `ocaml-variants.5.4.0+trunk`). This is a good change but this also had for side-effect to store the source of every packages regardless of whether it's a dev package or not, which i think isn't a good change given that it duplicates data that's already in the archive cache that could instead be extracted very easily (the cost of extraction vs. copy is negligible).
As a side note, extracting the sources from their tarball would be way faster on Windows that extraction + copy for the same reason detailed in #5741 

~As it currently stands this PR is a WIP. It compiles but still has many unsolved issues (in particular it breaks caching for non-pinned dev packages) and the reftests fail, but i'm opening it anyway to show the rough area of the code that needs to change and in case anyone wants to take over this work while i'm doing something else.~

Post-WIP edit: Further improvements can be made by extracting the tarball directly into the build directory and would also f.i.x https://github.com/ocaml/opam/issues/6693, but i think it is simpler to do that separately in a future PR.