### PR TITLE
Remove the handling of the subpath field in url files and make the printers of the x-* fields a reflexion of their actual value

### DIFF
--- a/tests/reftests/lock.test
+++ b/tests/reftests/lock.test
@@ -770,9 +770,7 @@ version: "l2"
 
 <><> Synchronising development packages <><><><><><><><><><><><><><><><><><><><>
 [tolock.l1] synchronised (file://${BASEDIR}/tolock)
-[tolock] Conflicting update of the metadata from file://${BASEDIR}/tolock.
-Override files in ${BASEDIR}/OPAM/locking/.opam-switch/overlay/tolock (there will be a backup)? [Y/n] y
-User metadata backed up in ${BASEDIR}/OPAM/backup/tolock.bak
+[tolock] Installing new package description from upstream file://${BASEDIR}/tolock
 Now run 'opam upgrade' to apply any package updates.
 ### opam show tolock --field=version,build --normalise
 version l2
@@ -801,9 +799,7 @@ build: [ "echo" "locked" ]
 
 <><> Synchronising development packages <><><><><><><><><><><><><><><><><><><><>
 [tolock.l2] synchronised (file://${BASEDIR}/tolock)
-[tolock] Conflicting update of the metadata from file://${BASEDIR}/tolock.
-Override files in ${BASEDIR}/OPAM/locking/.opam-switch/overlay/tolock (there will be a backup)? [Y/n] y
-User metadata backed up in ${BASEDIR}/OPAM/backup/tolock.bak
+[tolock] Installing new package description from upstream file://${BASEDIR}/tolock
 Now run 'opam upgrade' to apply any package updates.
 ### opam show tolock --field=version,build --normalise
 version l3
@@ -827,9 +823,7 @@ version: "l4"
 
 <><> Synchronising development packages <><><><><><><><><><><><><><><><><><><><>
 [tolock.l3] synchronised (file://${BASEDIR}/tolock)
-[tolock] Conflicting update of the metadata from file://${BASEDIR}/tolock.
-Override files in ${BASEDIR}/OPAM/locking/.opam-switch/overlay/tolock (there will be a backup)? [Y/n] y
-User metadata backed up in ${BASEDIR}/OPAM/backup/tolock.bak
+[tolock] Installing new package description from upstream file://${BASEDIR}/tolock
 Now run 'opam upgrade' to apply any package updates.
 ### opam show tolock --field=version,build --normalise
 version l4
@@ -857,9 +851,7 @@ echo "]" >> tolock.install
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 [tolock.l4] synchronised (file://${BASEDIR}/tolock)
-[tolock] Conflicting update of the metadata from file://${BASEDIR}/tolock.
-Override files in ${BASEDIR}/OPAM/locking/.opam-switch/overlay/tolock (there will be a backup)? [Y/n] y
-User metadata backed up in ${BASEDIR}/OPAM/backup/tolock.bak
+[tolock] Installing new package description from upstream file://${BASEDIR}/tolock
 
 The following actions will be performed:
 === upgrade 1 package
@@ -1231,7 +1223,6 @@ pin-depends: [
   "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6"
 ]
 ]
-available: opam-version >= "2.1"
 url {
 }
 x-locked: "locked"

--- a/tests/reftests/rec-pin.test
+++ b/tests/reftests/rec-pin.test
@@ -467,7 +467,6 @@ root-a-k_p.2    (uninstalled)  rsync  directory /a/k in file://${BASEDIR}/pinnes
 root-a_p.2      (uninstalled)  rsync  directory /a in file://${BASEDIR}/pinnes
 ### opam-cat $OPAMROOT/devnull/.opam-switch/overlay/root-a_p/opam
 authors: "the testing team"
-available: opam-version >= "2.1"
 bug-reports: "https://nobug"
 description: "Two words."
 dev-repo: "hg+https://pkg@op.am"
@@ -484,7 +483,6 @@ src: "file://${BASEDIR}/pinnes"
 }
 ### opam-cat OPAM/devnull/.opam-switch/overlay/root-a-i_g/opam
 authors: "the testing team"
-available: opam-version >= "2.1"
 bug-reports: "https://nobug"
 description: "Two words."
 dev-repo: "hg+https://pkg@op.am"
@@ -980,7 +978,6 @@ root-a-k_p.l2    (uninstalled)  rsync  directory /a/k in file://${BASEDIR}/pinne
 root-a_p.l2      (uninstalled)  rsync  directory /a in file://${BASEDIR}/pinnes
 ### opam-cat $OPAMROOT/devnull/.opam-switch/overlay/root-a_p/opam
 authors: "the testing team"
-available: opam-version >= "2.1"
 bug-reports: "https://nobug"
 description: "Two words."
 dev-repo: "hg+https://pkg@op.am"
@@ -998,7 +995,6 @@ src: "file://${BASEDIR}/pinnes"
 }
 ### opam-cat OPAM/devnull/.opam-switch/overlay/root-a-i_g/opam
 authors: "the testing team"
-available: opam-version >= "2.1"
 bug-reports: "https://nobug"
 description: "Two words."
 dev-repo: "hg+https://pkg@op.am"


### PR DESCRIPTION
Extracted from https://github.com/ocaml/opam/pull/6438
Queued on https://github.com/ocaml/opam/pull/6438

Nothing really critical with this. This is just a cleanup proposal as i think having combinators modify the printer of a value is confusing and the `subpath` field should not have been exposed in url files.