### PR TITLE
Change 'opam switch create <version>' to look for packages listed in default-compiler instead of any compiler packages

### DIFF
--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -879,6 +879,8 @@ let global_allowed_fields, global_allowed_sections =
              c),
         Config.with_git_location_opt
           (InitConfig.git_location in_config ++ Config.git_location Config.empty);
+        "default-compiler", Atomic,
+        Config.with_default_compiler (Config.default_compiler Config.empty);
       ] @ List.map (fun f ->
           f, Atomic, Config.with_criteria
             (Config.criteria Config.empty))

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -1147,6 +1147,17 @@ let v2_2 = OpamVersion.of_string "2.2"
 
 let from_2_2_beta_to_2_2 ~on_the_fly:_ _ conf = conf, gtc_none
 
+let v2_4_alpha = OpamVersion.of_string "2.4~alpha"
+
+let from_2_2_to_2_4_alpha ~on_the_fly:_ _ conf =
+  (* default-compiler was never used outside of 'opam init' before
+     opam 2.4.0~alpha1 so it is safe to set unconditionnally *)
+  let default_compiler =
+    OpamFormula.Atom (OpamPackage.Name.of_string "ocaml-base-compiler",
+                      OpamFormula.Empty)
+  in
+  OpamFile.Config.with_default_compiler default_compiler conf, gtc_none
+
 (* To add an upgrade layer
    * If it is a light upgrade, returns as second element if the repo or switch
      need an light upgrade with `gtc_*` values.
@@ -1244,6 +1255,7 @@ let as_necessary ?reinit requested_lock global_lock root config =
       v2_2_alpha,  from_2_1_to_2_2_alpha;
       v2_2_beta,   from_2_2_alpha_to_2_2_beta;
       v2_2,        from_2_2_beta_to_2_2;
+      v2_4_alpha,  from_2_2_to_2_4_alpha;
     ]
     |> List.filter (fun (v,_) ->
         OpamVersion.compare root_version v < 0)

--- a/tests/reftests/conflict-resto.test
+++ b/tests/reftests/conflict-resto.test
@@ -377,7 +377,7 @@ dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
 ### opam switch create default 4.12.0 --fake
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
-Switch invariant: ["ocaml-base-compiler" {= "4.12.0"} | "ocaml-system" {= "4.12.0"}]
+Switch invariant: ["ocaml-base-compiler" {= "4.12.0"}]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Faking installation of base-bigarray.base

--- a/tests/reftests/cudf-preprocess.test
+++ b/tests/reftests/cudf-preprocess.test
@@ -5,7 +5,7 @@ ad4dd344
 ### opam switch create 4.11.0
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
-Switch invariant: ["ocaml-base-compiler" {= "4.11.0"} | "ocaml-system" {= "4.11.0"}]
+Switch invariant: ["ocaml-base-compiler" {= "4.11.0"}]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Faking installation of base-bigarray.base

--- a/tests/reftests/install-pgocaml.test
+++ b/tests/reftests/install-pgocaml.test
@@ -3,7 +3,7 @@ f372039d
 ### opam switch create --fake 4.06.1
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
-Switch invariant: ["ocaml-base-compiler" {= "4.06.1"} | "ocaml-system" {= "4.06.1"}]
+Switch invariant: ["ocaml-base-compiler" {= "4.06.1"}]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Faking installation of base-bigarray.base

--- a/tests/reftests/legacy-git.test
+++ b/tests/reftests/legacy-git.test
@@ -733,6 +733,8 @@ Updated ${BASEDIR}/OPAM/repo/test/packages/P3.1~weird-version.test/opam
 Updated ${BASEDIR}/OPAM/repo/test/packages/P4.1/opam
 Updated ${BASEDIR}/OPAM/repo/test/packages/P5.1/opam
 Now run 'opam upgrade' to apply any package updates.
+### opam option --global default-compiler="ocaml"
+Set to '"ocaml"' the field default-compiler in global configuration
 ### opam switch create system "--formula=[\"ocaml\" {= \"system\"}]"
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>

--- a/tests/reftests/legacy-local.test
+++ b/tests/reftests/legacy-local.test
@@ -672,6 +672,8 @@ Updated ${BASEDIR}/OPAM/repo/test/packages/P3.1~weird-version.test/opam
 Updated ${BASEDIR}/OPAM/repo/test/packages/P4.1/opam
 Updated ${BASEDIR}/OPAM/repo/test/packages/P5.1/opam
 Now run 'opam upgrade' to apply any package updates.
+### opam option --global default-compiler="ocaml"
+Set to '"ocaml"' the field default-compiler in global configuration
 ### opam switch create system "--formula=[\"ocaml\" {= \"system\"}]"
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>

--- a/tests/reftests/list-coinstallable.test
+++ b/tests/reftests/list-coinstallable.test
@@ -6,7 +6,7 @@
 ### opam switch create 4.12.0 --fake
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
-Switch invariant: ["ocaml-base-compiler" {= "4.12.0"} | "ocaml-system" {= "4.12.0"}]
+Switch invariant: ["ocaml-base-compiler" {= "4.12.0"}]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Faking installation of base-bigarray.base


### PR DESCRIPTION
Proposal 1 for making `opam switch create <version>` avoid `ocaml-system` coherently with the new behaviour of `opam init` introduced in #6307
Mentioned in https://github.com/ocaml/opam/issues/6407#issuecomment-2762011057
Proposal 2: https://github.com/ocaml/opam/pull/6466

Pros:
- The set of default compiler packages is now arbitrary configurable via `opam option`

Cons:
- if someone relied on the previous behaviour using arbitrary package names, it is now hard to do
- this makes opam a bit more opam-repository specific by default, without changing the new `default-compiler` option