### PR TITLE
Prevent 'opam switch create <version>' from looking for packages mentioning the sys-ocaml-version variable

### DIFF
--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -746,9 +746,15 @@ let guess_compiler_invariant ?repos rt strings =
   in
   let opams = OpamRepositoryState.build_index rt repos  in
   let packages = OpamPackage.keys opams in
+  let sys_ocaml = OpamVariable.of_string "sys-ocaml-version" in
   let compiler_packages =
     OpamPackage.Map.filter
-      (fun _ -> OpamFile.OPAM.has_flag Pkgflag_Compiler)
+      (fun _ opam ->
+         OpamFile.OPAM.has_flag Pkgflag_Compiler opam &&
+         not @@ List.exists (fun var ->
+             OpamVariable.Full.is_global var &&
+             OpamVariable.equal sys_ocaml (OpamVariable.Full.variable var))
+           (OpamFilter.variables (OpamFile.OPAM.available opam)))
       opams
     |> OpamPackage.keys
   in

--- a/tests/reftests/conflict-resto.test
+++ b/tests/reftests/conflict-resto.test
@@ -377,7 +377,7 @@ dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
 ### opam switch create default 4.12.0 --fake
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
-Switch invariant: ["ocaml-base-compiler" {= "4.12.0"} | "ocaml-system" {= "4.12.0"}]
+Switch invariant: ["ocaml-base-compiler" {= "4.12.0"}]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Faking installation of base-bigarray.base

--- a/tests/reftests/cudf-preprocess.test
+++ b/tests/reftests/cudf-preprocess.test
@@ -5,7 +5,7 @@ ad4dd344
 ### opam switch create 4.11.0
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
-Switch invariant: ["ocaml-base-compiler" {= "4.11.0"} | "ocaml-system" {= "4.11.0"}]
+Switch invariant: ["ocaml-base-compiler" {= "4.11.0"}]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Faking installation of base-bigarray.base

--- a/tests/reftests/install-pgocaml.test
+++ b/tests/reftests/install-pgocaml.test
@@ -3,7 +3,7 @@ f372039d
 ### opam switch create --fake 4.06.1
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
-Switch invariant: ["ocaml-base-compiler" {= "4.06.1"} | "ocaml-system" {= "4.06.1"}]
+Switch invariant: ["ocaml-base-compiler" {= "4.06.1"}]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Faking installation of base-bigarray.base

--- a/tests/reftests/list-coinstallable.test
+++ b/tests/reftests/list-coinstallable.test
@@ -6,7 +6,7 @@
 ### opam switch create 4.12.0 --fake
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
-Switch invariant: ["ocaml-base-compiler" {= "4.12.0"} | "ocaml-system" {= "4.12.0"}]
+Switch invariant: ["ocaml-base-compiler" {= "4.12.0"}]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Faking installation of base-bigarray.base


### PR DESCRIPTION
Proposal 2 for making `opam switch create <version>` avoid `ocaml-system` coherently with the new behaviour of `opam init` introduced in #6307
Mentioned in https://github.com/ocaml/opam/issues/6407#issuecomment-2762011057

Pros:
- Does not affect custom repositories like Proposal 1
- Simpler implementation compared to Proposal 1

Cons:
- There isn't really any way to prevent this behaviour for people who want the old one, except if were to add an ugly option just for this