### PR TITLE
Only download Cygwin's setup.exe when the command is actually going to be displayed or used

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -179,6 +179,7 @@ users)
   * Use a C stub to call the `uname` function from the C standard library instead of calling the `uname` POSIX command [#6217 @kit-ty-kate]
 
 ## Internal: Windows
+  * Only download Cygwin's `setup.exe` when the command is actually going to be displayed or used [#6467 @kit-ty-kate]
 
 ## Test
   * Add a library test for the new OCaml implementation of patch and diff [#5892 @rjbou]
@@ -210,6 +211,7 @@ users)
   * Add show test to highlight precedence of opam file selection and check that if an opam file is given it is always this one that is taken [#6209 @rjbou]
   * Add a reftest showing the effect of env updates containing empty strings on `variables.sh` [#6198 @kit-ty-kate]
   * Add tests showing behaviour of `opam pin` when confronted with a missing opam description [#6319 @kit-ty-kate]
+  * Make the reftests more reliable by not downloading Cygwin's setup.exe on Windows [#6467 @kit-ty-kate]
 
 ### Engine
 
@@ -274,6 +276,7 @@ users)
 ## opam-state
   * `OpamStateConfig`: Make the `?lock_kind` parameters non-optional to avoid breaking the library users after they upgrade their opam root [#5488 @kit-ty-kate]
   * `OpamSwitchState.load_selections`: Make the `?lock_kind` parameter non-optional to avoid breaking the library users after they upgrade their opam root [#5488 @kit-ty-kate]
+  * `OpamSysInteract.Cygwin.check_setup`: unexpose the function [#6467 @kit-ty-kate]
 
 ## opam-solver
 

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1217,10 +1217,6 @@ let install_sys_packages ~map_sysmap ~confirm env config sys_packages t =
     | `Ignore -> bypass t
     | `Quit -> give_up_msg (); OpamStd.Sys.exit_because `Aborted
   and print_command sys_packages =
-    (* Ensure that setup-x86_64.exe exists, so that an invalid command is not
-       displayed to the user. *)
-    if OpamSysPoll.os_distribution env = Some "cygwin" then
-      OpamSysInteract.Cygwin.check_setup ~update:false;
     let commands =
       OpamSysInteract.install_packages_commands ~env config sys_packages
       |> List.map (fun ((`AsAdmin c | `AsUser c), a) -> c::a)
@@ -1251,8 +1247,6 @@ let install_sys_packages ~map_sysmap ~confirm env config sys_packages t =
     | `Quit -> give_up ()
   and auto_install t sys_packages =
     try
-      if OpamSysPoll.os_distribution env = Some "cygwin" then
-        OpamSysInteract.Cygwin.check_setup ~update:true;
       OpamSysInteract.install ~env config sys_packages; (* handles dry_run *)
       map_sysmap (fun _ -> OpamSysPkg.Set.empty) t
     with Failure msg ->

--- a/src/state/opamSysInteract.mli
+++ b/src/state/opamSysInteract.mli
@@ -74,12 +74,6 @@ module Cygwin : sig
   (* Returns true if Cygwin install is internal *)
   val is_internal: OpamFile.Config.t -> bool
 
-  (* [check_setup ~update] downloads and stores a Cygwin setup executable to
-     <opamroot>/.cygwin/setup-x86_64.exe. If [~update = false], this only
-     happens if the setup executable does not already exist, otherwise it is.
-     updated. *)
-  val check_setup: update:bool -> unit
-
   (* Return Cygwin binary path *)
   val cygbin_opt: OpamFile.Config.t -> OpamFilename.Dir.t option
 


### PR DESCRIPTION
opam only look at `os-distribution` to know if it should download Cygwin's `setup.exe` or not:
https://github.com/ocaml/opam/blob/1458aa74921cd71b8a0f0182de308bd06e7146a6/src/client/opamSolution.ml#L1222
https://github.com/ocaml/opam/blob/1458aa74921cd71b8a0f0182de308bd06e7146a6/src/client/opamSolution.ml#L1254

The tests have been failing quite frequently over the past two days due to some network issues with `cygwin.com`. Setting `os-distribution` to not be `cygwin` should alleviate this.