### PR TITLE
GHA: Restore the OCaml cache for the Windows jobs

### DIFF
--- a/.github/scripts/main/ocaml-cache.sh
+++ b/.github/scripts/main/ocaml-cache.sh
@@ -10,11 +10,6 @@ HOST="${3:-}"
 
 if [ "$PLATFORM" = Windows ]; then
   EXE='.exe'
-  if [ -e $OCAML_LOCAL.tar ]; then
-    mkdir -p "$OCAML_LOCAL"
-    tar -C "$OCAML_LOCAL" -pxf "$OCAML_LOCAL.tar"
-    exit 0
-  fi
 else
   EXE=''
 fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,7 +199,7 @@ jobs:
       id: ocaml-cache
       uses: actions/cache@v4
       with:
-        path: D:\Cache\ocaml-local.tar
+        path: D:\Cache\ocaml-local
         key: ${{ runner.os }}-${{ matrix.host }}-ocaml-${{ matrix.ocamlv }}-${{ needs.Analyse.outputs.ocaml-cache }}
         enableCrossOsArchive: true
     - name: Unpack Cygwin
@@ -207,7 +207,8 @@ jobs:
       run: .github\scripts\cygwin.cmd ${{ matrix.build }} D:\Cache\cygwin ${{ matrix.host }}
     - name: Cygwin info
       run: uname -a
-    - name: Unpack OCaml ${{ matrix.ocamlv }}
+    - name: Create OCaml ${{ matrix.ocamlv }} cache
+      if: steps.ocaml-cache.outputs.cache-hit != 'true'
       run: bash -exu .github/scripts/main/ocaml-cache.sh ${{ runner.os }} ${{ matrix.ocamlv }} ${{ matrix.host }}
     - name: Build
       run: bash -exu .github/scripts/main/main.sh ${{ matrix.host }}

--- a/master_changes.md
+++ b/master_changes.md
@@ -236,6 +236,7 @@ users)
   * Some cleaning in depext generate action and instruction for local testing [#6471 @rjbou]
   * Cache the repository and a minimal one in docker image for depext jobs [#6471 @rjbou]
   * Use the good opam binary in depext jobs [#6471 @RyanGibb]
+  * Restore the OCaml cache for the Windows jobs [#6469 @kit-ty-kate]
 
 ## Doc
   * Update the command to install opam to point to the new simplified url on opam.ocaml.org [#6226 @kit-ty-kate]


### PR DESCRIPTION
This cache was broken during the switch from `ocaml-opam/cache` to `actions/cache@v4` in https://github.com/ocaml/opam/pull/6081

This reduces the time the CI takes by at minimum 8 minutes overall.
Tested successfully on my local fork in https://github.com/kit-ty-kate/opam/pull/12. Both cache creation and restoration work fine.