### PR TITLE
Don't suggest setting the `nodosfilewarning` option of `CYGWIN`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ fully unattended, choose a mirror URL from https://cygwin.com/mirrors.lst and ad
 the `--site` switch to the command line
 (e.g., `--site=https://www.mirrorservice.org/sites/sourceware.org/pub/cygwin/`).
 
-It is recommended that you set the `CYGWIN` environment variable to
-`nodosfilewarning winsymlinks:native`.
+It is recommended that you set the [`CYGWIN`](https://cygwin.com/cygwin-ug-net/using-cygwinenv.html)
+environment variable to `winsymlinks:native`.
 
 Cygwin is started either from a shortcut or by running:
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -252,6 +252,7 @@ users)
   * Document the meaning of colored version numbers in the manpage of `opam show` [#6358 @kit-ty-kate]
   * Add an explanation of how plugins work to the manual [#5627 @kit-ty-kate]
   * Improve the installation documentation [#6372 @kit-ty-kate]
+  * Don't suggest setting the nodosfilewarning option of CYGWIN [#6470 @MisterDA]
 
 ## Security fixes
 


### PR DESCRIPTION
It's obsolete, a no-op, and its semantics are not even specified.

> `(no)dosfilewarning` - This option had been disabled for quite some
>                        time and nobody missed it.
