### PR TITLE
Cygwin: Fallback to the existing setup-x86_64.exe if its upgrade failed to be fetched

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -63,6 +63,7 @@ users)
 ## Opamfile
 
 ## External dependencies
+  * Cygwin: Fallback to the existing `setup-x86_64.exe` if its upgrade failed to be fetched [#6482 @kit-ty-kate - fix #6495, partial fix #6474]
 
 ## Format upgrade
 

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -262,7 +262,7 @@ module Cygwin = struct
     let kind = `SHA512 in
     let dst_exists = OpamFilename.exists dst in
     let current_checksum =
-      if OpamFilename.exists dst then
+      if dst_exists then
         Some (OpamHash.compute ~kind (OpamFilename.to_string dst))
       else
         None
@@ -270,7 +270,7 @@ module Cygwin = struct
     let open OpamProcess.Job.Op in
     log "Downloading Cygwin setup checksums";
     if OpamConsole.disp_status_line () then
-      if OpamFilename.exists dst then
+      if dst_exists then
         OpamConsole.status_line "Checking if Cygwin setup is up-to-date"
       else
         OpamConsole.status_line "Downloading Cygwin setup from cygwin.com";
@@ -304,7 +304,7 @@ module Cygwin = struct
       with Not_found -> None
     in
     if OpamStd.Option.equal OpamHash.equal current_checksum checksum &&
-       OpamFilename.exists dst &&
+       dst_exists &&
        OpamStd.Option.equal OpamHash.equal current_checksum
          (Some (OpamHash.compute ~kind (OpamFilename.to_string dst))) then begin
       log "Up-to-date";


### PR DESCRIPTION
Partially f.i.x.e.s https://github.com/ocaml/opam/issues/6474
Fix #6495