### PR TITLE
Fix a memory leak by removing OPAMSTATS

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -13,6 +13,7 @@ users)
 ## Version
 
 ## Global CLI
+  * Remove handling of the `OPAMSTATS` environment variable [#6485 @hannesm]
 
 ## Plugins
 
@@ -94,6 +95,7 @@ users)
 ## Shell
 
 ## Internal
+  * Fix a memory leak happening when running large numbers of commands or opening large number of opam files [#6485 @hannesm - fix #6484]
 
 ## Internal: Unix
 
@@ -116,6 +118,8 @@ users)
 
 # API updates
 ## opam-client
+  * `OpamClientConfig`: remove `STATS` variant and related `print_stats` field in config record [#6485 @hannesm]
+  * `OpamArg.environment_variable`: make `STATS` as removed from cli 2.3 [#6485 @rjbou]
 
 ## opam-repository
 
@@ -124,5 +128,7 @@ users)
 ## opam-solver
 
 ## opam-format
+  * `OpamFile`: remove `Stats` module [#6485 @hannesm]
 
 ## opam-core
+  * `OpamSystem`: remove `print_stats` function [#6485 @hannesm]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -312,7 +312,7 @@ let environment_variables =
       "see option `--show'.";
       "SKIPUPDATE", cli_original, (fun v -> SKIPUPDATE (env_bool v)),
       "see option `--skip-updates'.";
-      "STATS", cli_original, (fun v -> STATS (env_bool v)),
+      "STATS", cli_between cli2_0 cli2_4, (fun _v -> OpamStd.Config.E.REMOVED),
       "display stats at the end of command.";
       "VERBOSEON", cli_from cli2_2, (fun v -> VERBOSEON (env_string_list v)),
       "see option --verbose-on";
@@ -575,7 +575,6 @@ let apply_global_options cli o =
     (* - client options - *)
     ?working_dir:(flag o.working_dir)
     ?ignore_pin_depends:(flag o.ignore_pin_depends)
-    (* ?print_stats:bool *)
     (* ?sync_archives:bool *)
     (* ?pin_kind_auto:bool *)
     (* ?autoremove:bool *)

--- a/src/client/opamCliMain.ml
+++ b/src/client/opamCliMain.ml
@@ -490,10 +490,6 @@ let main () =
   end;
   OpamStd.Sys.at_exit (fun () ->
       flush_all_noerror ();
-      if OpamClientConfig.(!r.print_stats) then (
-        OpamFile.Stats.print ();
-        OpamSystem.print_stats ();
-      );
       json_out ()
     );
   run ()

--- a/src/client/opamClientConfig.ml
+++ b/src/client/opamClientConfig.ml
@@ -29,7 +29,6 @@ module E = struct
     | ROOTISOK of bool option
     | SHOW of bool option
     | SKIPUPDATE of bool option
-    | STATS of bool option
     | WORKINGDIR of bool option
     | VERBOSEON of string list option
 
@@ -52,14 +51,12 @@ module E = struct
   let rootisok = value (function ROOTISOK b -> b | _ -> None)
   let show = value (function SHOW b -> b | _ -> None)
   let skipupdate = value (function SKIPUPDATE b -> b | _ -> None)
-  let stats = value (function STATS b -> b | _ -> None)
   let workingdir = value (function WORKINGDIR b -> b | _ -> None)
   let verboseon = value (function VERBOSEON s -> s | _ -> None)
 
 end
 
 type t = {
-  print_stats: bool;
   pin_kind_auto: bool;
   autoremove: bool;
   editor: string;
@@ -82,7 +79,6 @@ type t = {
 }
 
 let default = {
-  print_stats = false;
   pin_kind_auto = true;
   autoremove = false;
   editor = "nano";
@@ -105,7 +101,6 @@ let default = {
 }
 
 type 'a options_fun =
-  ?print_stats:bool ->
   ?pin_kind_auto:bool ->
   ?autoremove:bool ->
   ?editor:string ->
@@ -128,7 +123,6 @@ type 'a options_fun =
   'a
 
 let setk k t
-    ?print_stats
     ?pin_kind_auto
     ?autoremove
     ?editor
@@ -151,7 +145,6 @@ let setk k t
   =
   let (+) x opt = match opt with Some x -> x | None -> x in
   k {
-    print_stats = t.print_stats + print_stats;
     pin_kind_auto = t.pin_kind_auto + pin_kind_auto;
     autoremove = t.autoremove + autoremove;
     editor = t.editor + editor;
@@ -186,7 +179,6 @@ let initk k =
     E.editor () ++ OpamStd.Env.(getopt "VISUAL" ++ getopt "EDITOR")
   in
   setk (setk (fun c -> r := c; k)) !r
-    ?print_stats:(E.stats ())
     ?pin_kind_auto:(E.pinkindauto ())
     ?autoremove:(E.autoremove ())
     ?editor

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -31,7 +31,6 @@ module E: sig
     | ROOTISOK of bool option
     | SHOW of bool option
     | SKIPUPDATE of bool option
-    | STATS of bool option
     | WORKINGDIR of bool option
     | VERBOSEON of string list option
     val cli: unit -> string option
@@ -41,7 +40,6 @@ module E: sig
 end
 
 type t = private {
-  print_stats: bool;
   pin_kind_auto: bool;
   autoremove: bool;
   editor: string;
@@ -64,7 +62,6 @@ type t = private {
 }
 
 type 'a options_fun =
-  ?print_stats:bool ->
   ?pin_kind_auto:bool ->
   ?autoremove:bool ->
   ?editor:string ->
@@ -104,7 +101,6 @@ val opam_init:
   ?skip_version_checks:bool ->
   ?all_parens:bool ->
   ?log_dir:OpamTypes.dirname ->
-  ?print_stats:bool ->
   ?pin_kind_auto:bool ->
   ?autoremove:bool ->
   ?editor:string ->

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -519,14 +519,6 @@ let get_cygpath_path_transform =
   else
     Lazy.from_val (fun ~pathlist:_ x -> x)
 
-let runs = ref []
-let print_stats () =
-  match !runs with
-  | [] -> ()
-  | l  ->
-    OpamConsole.msg "%d external processes called:\n%s"
-      (List.length l) (OpamStd.Format.itemize ~bullet:"  " (String.concat " ") l)
-
 let log_file ?dir name = temp_file ?dir (OpamStd.Option.default "log" name)
 
 let make_command
@@ -554,7 +546,6 @@ let run_process
     ?verbose ?env ~name ?metadata ?stdout ?allow_stdin command =
   let env = match env with None -> OpamProcess.default_env () | Some e -> e in
   let chrono = OpamConsole.timer () in
-  runs := command :: !runs;
   match command with
   | []          -> invalid_arg "run_process"
   | cmd :: args ->

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -358,9 +358,6 @@ val translate_patch: dir:string -> string -> string -> unit
     terminates (default: [true]). *)
 val temp_file: ?auto_clean:bool -> ?dir:string -> string -> string
 
-(** Print stats *)
-val print_stats: unit -> unit
-
 (** Registers an exception printer that adds some OPAM version info, and details
     on process and Unix errors *)
 val register_printer: unit -> unit

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -1129,13 +1129,6 @@ end
 (** {2 urls.txt file *} *)
 module File_attributes: IO_FILE with type t = file_attribute_set
 
-module Stats: sig
-
-  (** Display statistics about file access. *)
-  val print: unit -> unit
-
-end
-
 (** Helper module for manipulation of the raw syntax ([opamfile]) format.
     (the specific file handling modules are derived from this one) *)
 module Syntax : sig


### PR DESCRIPTION
especially in long-running applications that use opam as a library reading and/or writing lots of opam files, this lead to a huge amount of memory usage for no obvious gain.

Partially addresses #6484