### PR TITLE
console: bound queue to 10 items

### DIFF
--- a/src/core/opamConsole.ml
+++ b/src/core/opamConsole.ml
@@ -541,6 +541,11 @@ let () =
 
 let pending = Queue.create ()
 
+let add_to_queue data =
+  Queue.push data pending;
+  if Queue.length pending > 10 then
+    ignore (Queue.pop pending)
+
 let clear_pending debug_level =
   let f (level, timestamp, msg) =
     if level <= abs debug_level then
@@ -565,7 +570,7 @@ let log section ?(level=1) fmt =
   if not OpamCoreConfig.(!r.set) then
     let b = Buffer.create 128 in
     let timestamp = timestamp () ^ "  " in
-    let k _ = Queue.push (level, timestamp, Buffer.contents b) pending in
+    let k _ = add_to_queue (level, timestamp, Buffer.contents b) in
     Format.kfprintf k (Format.formatter_of_buffer b) ("%a  " ^^ fmt ^^ "\n%!")
       (acolor_w 30 `yellow) section
   else if level <= abs debug_level then


### PR DESCRIPTION
If you've an application like me
(https://github.com/hannesm/maintenance-intent-filter), where nothing ever calls OpamCoreConfig.set/update, you get a pretty large queue. The application consumes a lot of memory. Instead, let's bound the queue size to be 10 (of course, we can discuss the threshold - maybe some other number is better for your use cases)?

This partially addresses #6484

Please update `master_changes.md` file with your changes.
