### PR TITLE
Do depexts status check at opam update time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,7 @@ on:
       - 'shell/'
   push:
     branches:
-      - 'master'
-      - '2.**'
+      - '*'
 
 env:
   OPAMBSVERSION: 2.1.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,8 @@ on:
       - 'shell/'
   push:
     branches:
-      - '*'
+      - 'master'
+      - '2.**'
 
 env:
   OPAMBSVERSION: 2.1.0

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -1078,6 +1078,7 @@ let get_virtual_switch_state repo_root env =
     repos_definitions = singl repo_def;
     repo_opams = singl opams;
     repos_tmp;
+    sys_pkg_statues = singl (OpamSysPkg.status_empty);
   } in
   let gt =
     {gt with global_variables =

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -1078,7 +1078,7 @@ let get_virtual_switch_state repo_root env =
     repos_definitions = singl repo_def;
     repo_opams = singl opams;
     repos_tmp;
-    sys_pkg_statues = singl (OpamSysPkg.status_empty);
+    sys_pkg_statues = singl (OpamPackage.Map.empty); (* TODO: should it be computed here ? *)
   } in
   let gt =
     {gt with global_variables =

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -379,7 +379,7 @@ let parallel_apply t
       (* Turns out these depexts weren't needed after all. Remember that and
          make the bypass permanent. *)
       try
-        (OpamPackage.Map.find nv (Lazy.force !t_ref.sys_packages)).s_available
+        (OpamPackage.Map.find nv (!t_ref.sys_packages)).s_available
       with Not_found -> OpamSysPkg.Set.empty
     in
     let bypass = OpamSysPkg.Set.union missing_depexts !bypass_ref in
@@ -1152,7 +1152,7 @@ let get_depexts ?(force=false) ?(recover=false) t
       if recover then
         OpamSwitchState.depexts_status_of_packages t pkg_to_install
       else
-        let base = Lazy.force t.sys_packages in
+        let base = t.sys_packages in
         (* workaround: st.sys_packages is not always updated with added
            packages *)
         let more_pkgs =
@@ -1337,9 +1337,9 @@ let install_depexts ?(force_depext=false) ?(confirm=true) t
               sys_map
           | None -> sys_map)
         pkg_to_install
-        (Lazy.force t.sys_packages)
+        (t.sys_packages)
     in
-    { t with sys_packages = lazy sys_packages }
+    { t with sys_packages = sys_packages }
   in
   let confirm =
     confirm && not (OpamSysInteract.Cygwin.is_internal t.switch_global.config)

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -20,6 +20,7 @@ module Cache = struct
   type t = {
     cached_repofiles: (repository_name * OpamFile.Repo.t) list;
     cached_opams: (repository_name * OpamFile.OPAM.t OpamPackage.Map.t) list;
+    cached_sys_pkg_statues: (repository_name * sys_pkg_status) list;
   }
 
   module C = OpamCached.Make (struct
@@ -54,6 +55,8 @@ module Cache = struct
         cached_opams =
           OpamRepositoryName.Map.bindings
             (filter_out_nourl rt.repo_opams);
+        cached_sys_pkg_statues = OpamRepositoryName.Map.bindings
+        (filter_out_nourl rt.sys_pkg_statues);
       }
 
   let file rt =
@@ -72,7 +75,8 @@ module Cache = struct
     | Some cache ->
       Some
         (OpamRepositoryName.Map.of_list cache.cached_repofiles,
-         OpamRepositoryName.Map.of_list cache.cached_opams)
+         OpamRepositoryName.Map.of_list cache.cached_opams,
+         OpamRepositoryName.Map.of_list cache.cached_sys_pkg_statues)
     | None -> None
 
 end
@@ -122,6 +126,20 @@ let load_repo repo repo_root =
     (OpamRepositoryName.to_string repo.repo_name)
     (t ());
   repo_def, opams
+
+let get_repo_depexts opams gt =
+  let env = OpamPackageVar.resolve_global gt in
+  OpamPackage.Map.fold (fun _ opam acc ->
+      let depexts =
+        List.fold_left (fun depexts (names, filter) ->
+            if OpamFilter.eval_to_bool ~default:false env filter then
+              OpamSysPkg.Set.Op.(names ++ depexts)
+            else
+              depexts)
+          OpamSysPkg.Set.empty (OpamFile.OPAM.depexts opam) 
+      in
+      OpamSysPkg.Set.Op.(depexts ++ acc)) 
+    opams OpamSysPkg.Set.empty
 
 (* Cleaning directories follows the repo path pattern:
    TMPDIR/opam-tmp-dir/repo-dir, defined in [load]. *)
@@ -193,7 +211,7 @@ let load lock_kind gt =
         ) in
         Hashtbl.add repos_tmp name tmp
     ) repositories;
-  let make_rt repos_definitions opams =
+  let make_rt repos_definitions opams sys_pkg_statues =
     let rt = {
       repos_global = (gt :> unlocked global_state);
       repos_lock = lock;
@@ -201,28 +219,36 @@ let load lock_kind gt =
       repositories;
       repos_definitions;
       repo_opams = opams;
+      sys_pkg_statues
     } in
     OpamStd.Sys.at_exit (fun () -> cleanup rt);
     rt
   in
   match Cache.load gt.root with
-  | Some (repofiles, opams) ->
+  | Some (repofiles, opams, sys_pkg_statues) ->
     log "Cache found";
-    make_rt repofiles opams
+    make_rt repofiles opams sys_pkg_statues
   | None ->
     log "No cache found";
     OpamFilename.with_flock_upgrade `Lock_read lock @@ fun _ ->
-    let repofiles, opams =
-      OpamRepositoryName.Map.fold (fun name url (defs, opams) ->
+    let repofiles, opams, sys_pkg_statues =
+      OpamRepositoryName.Map.fold (fun name url (defs, opams, sys_pkg_statues) ->
           let repo = mk_repo name url in
           let repo_def, repo_opams =
             load_repo repo (get_root_raw gt.root repos_tmp name)
           in
+          let repo_depexts = get_repo_depexts repo_opams gt in
+          let repo_sys_pkg_status =
+            OpamSysInteract.packages_status gt.config repo_depexts
+          in
           OpamRepositoryName.Map.add name repo_def defs,
-          OpamRepositoryName.Map.add name repo_opams opams)
-        repos_map (OpamRepositoryName.Map.empty, OpamRepositoryName.Map.empty)
+          OpamRepositoryName.Map.add name repo_opams opams,
+          OpamRepositoryName.Map.add name repo_sys_pkg_status sys_pkg_statues
+        )
+        repos_map (OpamRepositoryName.Map.empty, OpamRepositoryName.Map.empty,
+                   OpamRepositoryName.Map.empty)
     in
-    let rt = make_rt repofiles opams in
+    let rt = make_rt repofiles opams sys_pkg_statues in
     Cache.save_new rt;
     rt
 

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -251,8 +251,7 @@ let load lock_kind gt =
           in
           OpamRepositoryName.Map.add name repo_def defs,
           OpamRepositoryName.Map.add name repo_opams opams,
-          OpamRepositoryName.Map.add name repo_sys_pkg_status sys_pkg_statues
-        )
+          OpamRepositoryName.Map.add name repo_sys_pkg_status sys_pkg_statues)
         repos_map (OpamRepositoryName.Map.empty, OpamRepositoryName.Map.empty,
                    OpamRepositoryName.Map.empty)
     in

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -20,7 +20,7 @@ module Cache = struct
   type t = {
     cached_repofiles: (repository_name * OpamFile.Repo.t) list;
     cached_opams: (repository_name * OpamFile.OPAM.t OpamPackage.Map.t) list;
-    cached_sys_pkg_statues: (repository_name * sys_pkg_status) list;
+    cached_sys_pkg_statues: (repository_name * sys_pkg_status OpamPackage.Map.t) list;
   }
 
   module C = OpamCached.Make (struct
@@ -129,7 +129,7 @@ let load_repo repo repo_root =
 
 let get_repo_depexts opams gt =
   let env = OpamPackageVar.resolve_global gt in
-  OpamPackage.Map.fold (fun _ opam acc ->
+  OpamPackage.Map.fold (fun package opam acc ->
       let depexts =
         List.fold_left (fun depexts (names, filter) ->
             if OpamFilter.eval_to_bool ~default:false env filter then
@@ -138,8 +138,8 @@ let get_repo_depexts opams gt =
               depexts)
           OpamSysPkg.Set.empty (OpamFile.OPAM.depexts opam) 
       in
-      OpamSysPkg.Set.Op.(depexts ++ acc)) 
-    opams OpamSysPkg.Set.empty
+      OpamPackage.Map.add package depexts acc ) 
+    opams OpamPackage.Map.empty
 
 (* Cleaning directories follows the repo path pattern:
    TMPDIR/opam-tmp-dir/repo-dir, defined in [load]. *)
@@ -239,7 +239,9 @@ let load lock_kind gt =
           in
           let repo_depexts = get_repo_depexts repo_opams gt in
           let repo_sys_pkg_status =
-            OpamSysInteract.packages_status gt.config repo_depexts
+            OpamPackage.Map.map (fun sys_packages -> 
+                OpamSysInteract.packages_status gt.config sys_packages)
+              repo_depexts
           in
           OpamRepositoryName.Map.add name repo_def defs,
           OpamRepositoryName.Map.add name repo_opams opams,

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -129,17 +129,19 @@ let load_repo repo repo_root =
 
 let get_repo_depexts opams gt =
   let env = OpamPackageVar.resolve_global gt in
-  OpamPackage.Map.fold (fun package opam acc ->
+  OpamPackage.Map.fold (fun package opam (s,m) ->
+      let open OpamSysPkg.Set.Op in 
       let depexts =
-        List.fold_left (fun depexts (names, filter) ->
+        List.fold_left (fun (depexts) (names, filter) ->
             if OpamFilter.eval_to_bool ~default:false env filter then
-              OpamSysPkg.Set.Op.(names ++ depexts)
+              (names ++ depexts)
             else
               depexts)
           OpamSysPkg.Set.empty (OpamFile.OPAM.depexts opam) 
       in
-      OpamPackage.Map.add package depexts acc ) 
-    opams OpamPackage.Map.empty
+      (depexts ++ s),
+      OpamPackage.Map.add package depexts m ) 
+    opams (OpamSysPkg.Set.empty, OpamPackage.Map.empty)
 
 (* Cleaning directories follows the repo path pattern:
    TMPDIR/opam-tmp-dir/repo-dir, defined in [load]. *)
@@ -237,11 +239,15 @@ let load lock_kind gt =
           let repo_def, repo_opams =
             load_repo repo (get_root_raw gt.root repos_tmp name)
           in
-          let repo_depexts = get_repo_depexts repo_opams gt in
+          let repo_depexts, pkg_to_depext = get_repo_depexts repo_opams gt in
+          let status = OpamSysInteract.packages_status gt.config repo_depexts in 
           let repo_sys_pkg_status =
-            OpamPackage.Map.map (fun sys_packages -> 
-                OpamSysInteract.packages_status gt.config sys_packages)
-              repo_depexts
+            OpamPackage.Map.map (fun set ->
+                OpamSysPkg.Set.Op.
+                  { OpamSysPkg.
+                    s_available = set %% status.s_available;
+                    s_not_found = set %% status.s_not_found })
+              pkg_to_depext
           in
           OpamRepositoryName.Map.add name repo_def defs,
           OpamRepositoryName.Map.add name repo_opams opams,

--- a/src/state/opamRepositoryState.mli
+++ b/src/state/opamRepositoryState.mli
@@ -22,7 +22,8 @@ module Cache: sig
   val load:
     dirname ->
     (OpamFile.Repo.t repository_name_map *
-     OpamFile.OPAM.t package_map repository_name_map)
+     OpamFile.OPAM.t package_map repository_name_map *
+     sys_pkg_status repository_name_map)
       option
   val remove: unit -> unit
 end

--- a/src/state/opamRepositoryState.mli
+++ b/src/state/opamRepositoryState.mli
@@ -23,7 +23,7 @@ module Cache: sig
     dirname ->
     (OpamFile.Repo.t repository_name_map *
      OpamFile.OPAM.t package_map repository_name_map *
-     sys_pkg_status repository_name_map)
+     sys_pkg_status package_map repository_name_map)
       option
   val remove: unit -> unit
 end

--- a/src/state/opamStateTypes.mli
+++ b/src/state/opamStateTypes.mli
@@ -90,6 +90,9 @@ type +'lock repos_state = {
   repo_opams: OpamFile.OPAM.t package_map repository_name_map;
   (** All opam files that can be found in the configured repositories *)
 
+  sys_pkg_statues: sys_pkg_status repository_name_map;
+  (** System package statuses of all depexts mentionned in opam files in a given repository *)
+
   repos_tmp: (OpamRepositoryName.t, OpamFilename.Dir.t Lazy.t) Hashtbl.t;
   (** Temporary directories containing the uncompressed contents of the
       repositories *)

--- a/src/state/opamStateTypes.mli
+++ b/src/state/opamStateTypes.mli
@@ -138,7 +138,7 @@ type +'lock switch_state = {
   packages: package_set;
   (** The set of all known packages *)
 
-  sys_packages: sys_pkg_status package_map Lazy.t;
+  sys_packages: sys_pkg_status package_map;
   (** Map of package and their system dependencies packages status. Only
       initialised for otherwise available packages *)
 

--- a/src/state/opamStateTypes.mli
+++ b/src/state/opamStateTypes.mli
@@ -90,7 +90,7 @@ type +'lock repos_state = {
   repo_opams: OpamFile.OPAM.t package_map repository_name_map;
   (** All opam files that can be found in the configured repositories *)
 
-  sys_pkg_statues: sys_pkg_status repository_name_map;
+  sys_pkg_statues: sys_pkg_status package_map repository_name_map;
   (** System package statuses of all depexts mentionned in opam files in a given repository *)
 
   repos_tmp: (OpamRepositoryName.t, OpamFilename.Dir.t Lazy.t) Hashtbl.t;

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -565,16 +565,16 @@ let load lock_kind gt rt switch =
     || OpamStateConfig.(!r.no_depexts) then
       OpamPackage.Map.empty
     else (
-(*       let available = (Lazy.force available_packages) in 
-      depexts_status_from_repo available gt.config switch_config rt  *)
-      depexts_status_of_packages_raw gt.config switch_config
+       let available = (Lazy.force available_packages) in 
+      depexts_status_from_repo available gt.config switch_config rt  
+    (*   depexts_status_of_packages_raw gt.config switch_config
           ~env:gt.global_variables
           (Lazy.force available_packages)
           ~depexts:(fun package ->
              let env =
                OpamPackageVar.resolve_switch_raw ~package gt switch switch_config
              in
-             depexts_raw ~env package opams) 
+             depexts_raw ~env package opams)  *)
     )
   in
   let available_packages =

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -178,8 +178,6 @@ module Installed_cache = OpamCached.Make(struct
     let name = "installed"
   end)
 
-
-
 let depexts_status_from_repo packages global_config switch_config rt =
   let open OpamSysPkg.Set.Op in
   let bypass =
@@ -187,11 +185,6 @@ let depexts_status_from_repo packages global_config switch_config rt =
     switch_config.OpamFile.Switch_config.depext_bypass
   in
   let repos = repos_list_raw rt switch_config in
-  let initial_map =
-    OpamPackage.Set.fold (fun pkg acc ->
-        OpamPackage.Map.add pkg OpamSysPkg.status_empty acc
-      ) packages OpamPackage.Map.empty
-  in
   let check_status status = 
     if OpamStateConfig.(!r.no_depexts) then
       (* Mark all as available. This is necessary to store the exceptions
@@ -204,27 +197,22 @@ let depexts_status_from_repo packages global_config switch_config rt =
     else
       status
   in 
-  List.fold_left (fun acc_map repo_name ->
+  List.fold_left (fun pkg_to_sys repo_name ->
       match OpamRepositoryName.Map.find_opt repo_name rt.sys_pkg_statues with
-      | None -> acc_map
-      | Some pkg_to_status ->
+      | None -> pkg_to_sys
+      | Some repo_pkg_to_status ->
         OpamPackage.Map.fold (fun pkg sys_status acc ->
             if OpamPackage.Set.mem pkg packages then
-              let current = OpamPackage.Map.find pkg acc in
-              let merged = OpamSysPkg.{
-                  s_available = (sys_status.s_available ++ current.s_available -- bypass);
-                  s_not_found = (sys_status.s_not_found ++ current.s_not_found -- bypass);
+              let sys_pkg_status = OpamSysPkg.{
+                  s_available = (sys_status.s_available -- bypass);
+                  s_not_found = (sys_status.s_not_found -- bypass);
                 } in
-              let status_checked = check_status merged in 
+              let status_checked = check_status sys_pkg_status in 
               OpamPackage.Map.add pkg status_checked acc
             else
               acc
-          ) pkg_to_status acc_map
-    ) initial_map repos
-
-  
-     
-
+          ) repo_pkg_to_status pkg_to_sys
+    ) OpamPackage.Map.empty repos
 
 let depexts_status_of_packages_raw
     ~depexts ?env global_config switch_config packages =
@@ -566,7 +554,7 @@ let load lock_kind gt rt switch =
       OpamPackage.Map.empty
     else (
        let available = (Lazy.force available_packages) in 
-      depexts_status_from_repo available gt.config switch_config rt  
+      depexts_status_from_repo available gt.config switch_config rt
     (*   depexts_status_of_packages_raw gt.config switch_config
           ~env:gt.global_variables
           (Lazy.force available_packages)

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -515,8 +515,8 @@ let load lock_kind gt rt switch =
   let sys_packages =
     if not (OpamFile.Config.depext gt.config)
     || OpamStateConfig.(!r.no_depexts) then
-      lazy OpamPackage.Map.empty
-    else lazy (
+       OpamPackage.Map.empty
+    else (
       depexts_status_of_packages_raw gt.config switch_config
         ~env:gt.global_variables
         (Lazy.force available_packages)
@@ -530,7 +530,7 @@ let load lock_kind gt rt switch =
   let available_packages =
     if not (OpamFile.Config.depext gt.config) then available_packages
     else lazy (
-      let sys_packages = Lazy.force sys_packages in
+      let sys_packages =  sys_packages in
       OpamPackage.Set.filter (fun nv ->
           depexts_unavailable_raw sys_packages nv = None)
         (Lazy.force available_packages)
@@ -542,7 +542,7 @@ let load lock_kind gt rt switch =
           OpamPackage.Set.mem pkg installed
           && not (OpamSysPkg.Set.is_empty spkg.OpamSysPkg.s_available
                   && OpamSysPkg.Set.is_empty spkg.OpamSysPkg.s_not_found))
-        (Lazy.force sys_packages)
+        sys_packages
     in
     if OpamSysInteract.stateless_install ~env:gt.global_variables ()
        || OpamPackage.Map.is_empty sys_packages then
@@ -656,7 +656,7 @@ let load_virtual ?repos_list ?(avail_default=true) gt rt =
     opams;
     conf_files = OpamPackage.Name.Map.empty;
     packages;
-    sys_packages = lazy OpamPackage.Map.empty;
+    sys_packages = OpamPackage.Map.empty;
     available_packages;
     reinstall = lazy OpamPackage.Set.empty;
     invalidated = lazy (OpamPackage.Set.empty);
@@ -781,7 +781,7 @@ let depexts_status_of_packages st set =
     ~env:st.switch_global.global_variables ~depexts:(depexts st)
 
 let depexts_unavailable st nv =
-  depexts_unavailable_raw (Lazy.force st.sys_packages) nv
+  depexts_unavailable_raw st.sys_packages nv
 
 let dev_packages st =
   OpamPackage.Set.filter (is_dev_package st)
@@ -1029,7 +1029,7 @@ let universe st
           if OpamSysPkg.Set.is_empty status.OpamSysPkg.s_available
           then acc
           else OpamPackage.Set.add nv acc)
-        (Lazy.force st.sys_packages)
+        st.sys_packages
         OpamPackage.Set.empty)
   in
   let avoid_versions =
@@ -1264,16 +1264,16 @@ let update_pin nv opam st =
   if not (OpamFile.Config.depext st.switch_global.config)
   || OpamSysPkg.Set.is_empty (depexts st nv)
   then st else
-  let sys_packages = lazy (
-    OpamPackage.Map.union (fun _ n -> n)
-      (Lazy.force st.sys_packages)
-      (depexts_status_of_packages st (OpamPackage.Set.singleton nv))
-  ) in
-  let available_packages = lazy (
-    OpamPackage.Set.filter (fun nv -> depexts_unavailable st nv = None)
-      (Lazy.force st.available_packages)
-  ) in
-  { st with sys_packages; available_packages }
+    let sys_packages = (
+      OpamPackage.Map.union (fun _ n -> n)
+        st.sys_packages
+        (depexts_status_of_packages st (OpamPackage.Set.singleton nv))
+    ) in
+    let available_packages = lazy (
+      OpamPackage.Set.filter (fun nv -> depexts_unavailable st nv = None)
+        (Lazy.force st.available_packages)
+    ) in
+    { st with sys_packages; available_packages }
 
 let do_backup lock st = match lock with
   | `Lock_write ->

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -178,6 +178,54 @@ module Installed_cache = OpamCached.Make(struct
     let name = "installed"
   end)
 
+
+
+let depexts_status_from_repo packages global_config switch_config rt =
+  let open OpamSysPkg.Set.Op in
+  let bypass =
+    OpamFile.Config.depext_bypass global_config ++
+    switch_config.OpamFile.Switch_config.depext_bypass
+  in
+  let repos = repos_list_raw rt switch_config in
+  let initial_map =
+    OpamPackage.Set.fold (fun pkg acc ->
+        OpamPackage.Map.add pkg OpamSysPkg.status_empty acc
+      ) packages OpamPackage.Map.empty
+  in
+  let check_status status = 
+    if OpamStateConfig.(!r.no_depexts) then
+      (* Mark all as available. This is necessary to store the exceptions
+         afterwards *)
+      OpamSysPkg.{ status_empty with
+                   s_available = status.s_available ++ status.s_not_found; }
+    else if OpamFile.Config.depext_cannot_install global_config then
+      { OpamSysPkg.status_empty with
+        s_not_found = status.s_available ++ status.s_not_found; }
+    else
+      status
+  in 
+  List.fold_left (fun acc_map repo_name ->
+      match OpamRepositoryName.Map.find_opt repo_name rt.sys_pkg_statues with
+      | None -> acc_map
+      | Some pkg_to_status ->
+        OpamPackage.Map.fold (fun pkg sys_status acc ->
+            if OpamPackage.Set.mem pkg packages then
+              let current = OpamPackage.Map.find pkg acc in
+              let merged = OpamSysPkg.{
+                  s_available = (sys_status.s_available ++ current.s_available -- bypass);
+                  s_not_found = (sys_status.s_not_found ++ current.s_not_found -- bypass);
+                } in
+              let status_checked = check_status merged in 
+              OpamPackage.Map.add pkg status_checked acc
+            else
+              acc
+          ) pkg_to_status acc_map
+    ) initial_map repos
+
+  
+     
+
+
 let depexts_status_of_packages_raw
     ~depexts ?env global_config switch_config packages =
   if OpamPackage.Set.is_empty packages then OpamPackage.Map.empty else
@@ -515,22 +563,24 @@ let load lock_kind gt rt switch =
   let sys_packages =
     if not (OpamFile.Config.depext gt.config)
     || OpamStateConfig.(!r.no_depexts) then
-       OpamPackage.Map.empty
+      OpamPackage.Map.empty
     else (
+(*       let available = (Lazy.force available_packages) in 
+      depexts_status_from_repo available gt.config switch_config rt  *)
       depexts_status_of_packages_raw gt.config switch_config
-        ~env:gt.global_variables
-        (Lazy.force available_packages)
-        ~depexts:(fun package ->
-            let env =
-              OpamPackageVar.resolve_switch_raw ~package gt switch switch_config
-            in
-            depexts_raw ~env package opams)
+          ~env:gt.global_variables
+          (Lazy.force available_packages)
+          ~depexts:(fun package ->
+             let env =
+               OpamPackageVar.resolve_switch_raw ~package gt switch switch_config
+             in
+             depexts_raw ~env package opams) 
     )
   in
   let available_packages =
     if not (OpamFile.Config.depext gt.config) then available_packages
     else lazy (
-      let sys_packages =  sys_packages in
+      let sys_packages = sys_packages in
       OpamPackage.Set.filter (fun nv ->
           depexts_unavailable_raw sys_packages nv = None)
         (Lazy.force available_packages)

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -1039,9 +1039,9 @@ let run_test ?(vars=[]) ~opam t =
               in
               match cache with
               | None -> print_string "No cache\n"
-              | Some (_, cache) when OpamRepositoryName.Map.is_empty cache ->
+              | Some (_, cache, _) when OpamRepositoryName.Map.is_empty cache ->
                 print_string "Empty cache\n"
-              | Some (_, cache) ->
+              | Some (_, cache, _) ->
                 let cache =
                   if OpamPackage.Name.Map.is_empty nvs then cache else
                     OpamRepositoryName.Map.map


### PR DESCRIPTION
This is a Draft for #6461 

- Added `sys_pkg_statues` to repository state and cache
- Removed `Lazy.t` from `switch_state.sys_packages` 
- Added a lookup into repository state to be used on switch state load 

This results in a significant speedup by avoiding calling `OpamSysInteract.packages_status` each time:  
```py
00:02.330  STATE                  depexts loaded in 1.865s
```

For instance `./opam install conf-clang-format.1` on my machine seems to go from 
```py
 5.06s user 0.38s system 83% cpu 6.495 total
 5.05s user 0.41s system 67% cpu 8.028 total
 5.05s user 0.39s system 87% cpu 6.203 total
```
to 
```py 
 4.08s user 0.15s system 84% cpu 4.987 total
 4.06s user 0.15s system 81% cpu 5.149 total
 4.09s user 0.15s system 89% cpu 4.736 total
```
In both cases (sys call and rt retrieval) the depext availability for the package `clang-format` is checked.


This breaks `depexts`and `pin` tests,  as the mechanism of this PR is not really compatible with the tests as they are (the use of `N0REP0`?)

Will be exploring it further. 