### PR TITLE
Add the explicit flag to make a package unavailable unless explicitly requested

### DIFF
--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -202,7 +202,7 @@ let upgrade_t
                       List.exists (function
                           | Pkgflag_AvoidVersion | Pkgflag_Deprecated -> true
                           | Pkgflag_LightUninstall | Pkgflag_Verbose
-                          | Pkgflag_Plugin | Pkgflag_Compiler
+                          | Pkgflag_Plugin | Pkgflag_Compiler | Pkgflag_Explicit
                           | Pkgflag_Conf | Pkgflag_Unknown _ -> false)
                         (OpamFile.OPAM.flags opam)
                     in

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -748,7 +748,9 @@ let guess_compiler_invariant ?repos rt strings =
   let packages = OpamPackage.keys opams in
   let compiler_packages =
     OpamPackage.Map.filter
-      (fun _ -> OpamFile.OPAM.has_flag Pkgflag_Compiler)
+      (fun _ opam ->
+         OpamFile.OPAM.has_flag Pkgflag_Compiler opam &&
+         not (OpamFile.OPAM.has_flag Pkgflag_Explicit opam))
       opams
     |> OpamPackage.keys
   in

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3499,6 +3499,7 @@ module OPAM = struct
       flags      =
         (List.filter (function
              | Pkgflag_Plugin -> true
+             | Pkgflag_Explicit -> not modulo_state
              | Pkgflag_LightUninstall
              | Pkgflag_Verbose
              | Pkgflag_Compiler

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -122,6 +122,7 @@ type package_flag =
   | Pkgflag_Deprecated (** This version of the package will only be installed if
                            strictly required and will print a deprecation
                            warning *)
+  | Pkgflag_Explicit (** TODO *)
   | Pkgflag_Unknown of string (** Used for error reporting, otherwise ignored *)
 
 (** At some point we want to abstract so that the same functions can be used

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -233,6 +233,7 @@ let string_of_pkg_flag = function
   | Pkgflag_Conf -> "conf"
   | Pkgflag_AvoidVersion -> "avoid-version"
   | Pkgflag_Deprecated -> "deprecated"
+  | Pkgflag_Explicit -> "explicit"
   | Pkgflag_Unknown s -> s
 
 let pkg_flag_of_string = function
@@ -243,6 +244,7 @@ let pkg_flag_of_string = function
   | "conf" -> Pkgflag_Conf
   | "avoid-version" -> Pkgflag_AvoidVersion
   | "deprecated" -> Pkgflag_Deprecated
+  | "explicit" -> Pkgflag_Explicit
   | s -> Pkgflag_Unknown s
 
 let action_contents = function

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -1003,7 +1003,19 @@ let universe st
        would be much more involved, but some solvers might struggle without any
        cleanup at this point *)
     (* remove_conflicts st base *)
-    st.available_packages
+    let is_not_explicit pkg =
+      let name = OpamPackage.name pkg in
+      let opam = OpamPackage.Map.find pkg st.opams in
+      not (
+        OpamFile.OPAM.has_flag Pkgflag_Explicit opam &&
+        not (OpamPackage.Set.mem pkg st.pinned) &&
+        not (OpamPackage.Set.mem pkg st.installed) &&
+        not (OpamFormula.exists (fun (n, _) -> OpamPackage.Name.equal n name) st.switch_invariant)
+      )
+    in
+    lazy (
+      OpamPackage.Set.filter is_not_explicit (Lazy.force st.available_packages)
+    )
   in
   let u_reinstall =
     (* Ignore reinstalls outside of the dependency cone of


### PR DESCRIPTION
Alternative to https://github.com/ocaml/opam/pull/6465 and https://github.com/ocaml/opam/pull/6466 where `flags: [compiler explicit]` would be added to the `ocaml-system` package in opam-repository

Fixes https://github.com/ocaml/opam/issues/4526