### PR TITLE
Do not include compiler packages flagged with avoid-version/deprecated in the invariant when calling 'opam switch create [name] <version>'

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -32,6 +32,7 @@ users)
 ## UI
 
 ## Switch
+  * Do not include compiler packages flagged with `avoid-version`/`deprecated` in the invariant when calling `opam switch create [name] <version>` [#6494 @kit-ty-kate]
 
 ## Config
 

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -748,7 +748,10 @@ let guess_compiler_invariant ?repos rt strings =
   let packages = OpamPackage.keys opams in
   let compiler_packages =
     OpamPackage.Map.filter
-      (fun _ -> OpamFile.OPAM.has_flag Pkgflag_Compiler)
+      (fun _ opam ->
+         OpamFile.OPAM.has_flag Pkgflag_Compiler opam &&
+         not (OpamFile.OPAM.has_flag Pkgflag_AvoidVersion opam) &&
+         not (OpamFile.OPAM.has_flag Pkgflag_Deprecated opam))
       opams
     |> OpamPackage.keys
   in

--- a/tests/reftests/switch-creation.test
+++ b/tests/reftests/switch-creation.test
@@ -75,7 +75,7 @@ depends: "ocaml-system" {= version} | "ocaml-base-compiler" {= version}
 ### opam switch create 5.3.0
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
-Switch invariant: ["ocaml-base-compiler" {= "5.3.0"} | "ocaml-system" {= "5.3.0"}]
+Switch invariant: ["ocaml-base-compiler" {= "5.3.0"}]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed ocaml-base-compiler.5.3.0
@@ -83,7 +83,7 @@ Done.
 ### opam switch create --solver=builtin-mccs+glpk 5.3-mccs 5.3.0
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
-Switch invariant: ["ocaml-base-compiler" {= "5.3.0"} | "ocaml-system" {= "5.3.0"}]
+Switch invariant: ["ocaml-base-compiler" {= "5.3.0"}]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed ocaml-base-compiler.5.3.0
@@ -91,7 +91,7 @@ Done.
 ### opam switch create --solver=builtin-0install 5.3-0install 5.3.0
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
-Switch invariant: ["ocaml-base-compiler" {= "5.3.0"} | "ocaml-system" {= "5.3.0"}]
+Switch invariant: ["ocaml-base-compiler" {= "5.3.0"}]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed ocaml-base-compiler.5.3.0
@@ -151,7 +151,7 @@ flags: [compiler deprecated]
 ### opam switch create deprecated 4.14.0
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
-Switch invariant: ["ocaml-base-compiler" {= "4.14.0"} | "ocaml-system" {= "4.14.0"}]
+Switch invariant: ["ocaml-base-compiler" {= "4.14.0"}]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed ocaml-base-compiler.4.14.0


### PR DESCRIPTION
Yet another alternative to #6465 #6466 and #6493 