### PR TITLE
Fix 'opam install --deps-only .' not doing anything if the package is already installed but not pinned

### DIFF
--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -57,7 +57,7 @@ val reinit:
 val install:
   rw switch_state ->
   ?formula:formula ->
-  ?autoupdate:atom list -> ?add_to_roots:bool -> ?deps_only:bool ->
+  ?autoupdate:atom list -> ?add_to_roots:bool -> ?deps_only:_ switch_state option ->
   ?ignore_conflicts:bool -> ?assume_built:bool -> ?download_only:bool ->
   ?depext_only:bool -> atom list ->
   rw switch_state
@@ -68,7 +68,7 @@ val install_t:
   rw switch_state ->
   ?ask:bool -> ?ignore_conflicts:bool -> ?depext_only:bool -> ?download_only:bool ->
   atom list -> ?formula:formula ->
-  bool option -> deps_only:bool -> assume_built:bool ->
+  bool option -> deps_only:_ switch_state option -> assume_built:bool ->
   rw switch_state
 
 (** Check that the given list of packages [atoms] have their dependencies

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1877,10 +1877,16 @@ let install cli =
       else atoms_or_locals
     in
     if formula = OpamFormula.Empty && atoms_or_locals = [] then `Ok () else
-    let st, atoms =
-      OpamAuxCommands.autopin
-        st ~recurse ?subpath ~quiet:check ~simulate:(deps_only||check||depext_only)
-        ?locked:OpamStateConfig.(!r.locked) atoms_or_locals
+    let st, deps_only, atoms =
+      let deps_st, atoms =
+        OpamAuxCommands.autopin
+          st ~recurse ?subpath ~quiet:check ~simulate:(deps_only||check||depext_only)
+          ?locked:OpamStateConfig.(!r.locked) atoms_or_locals
+      in
+      if deps_only then
+        (st, Some deps_st, atoms)
+      else
+        (deps_st, None, atoms)
     in
     if formula = OpamFormula.Empty && atoms = [] then
       (OpamConsole.msg "Nothing to do\n";
@@ -3150,7 +3156,7 @@ let switch cli =
            then OpamSwitchAction.update_switch_state st
            else
                OpamClient.install_t st ~ask:true [] None ~formula:invariant
-               ~deps_only:false ~assume_built:false
+               ~deps_only:None ~assume_built:false
          in
          OpamSwitchState.drop st;
          `Ok ())

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3469,6 +3469,9 @@ module OPAM = struct
         URL.with_checksum [cksum] URL.empty
         (* ignore actual url and extra checksums *)
     in
+    let filter_empty_cmd field =
+      List.filter (fun (cmd, _) -> cmd <> []) field
+    in
     {
       opam_version = empty.opam_version;
 
@@ -3494,10 +3497,10 @@ module OPAM = struct
             t.flags);
       env        = t.env;
 
-      build      = t.build;
-      run_test   = t.deprecated_build_test @ t.run_test;
-      install    = t.install;
-      remove     = t.remove;
+      build      = filter_empty_cmd t.build;
+      run_test   = filter_empty_cmd (t.deprecated_build_test @ t.run_test);
+      install    = filter_empty_cmd t.install;
+      remove     = filter_empty_cmd t.remove;
 
       substs     = t.substs;
       patches    = t.patches;

--- a/tests/reftests/depexts.test
+++ b/tests/reftests/depexts.test
@@ -364,6 +364,7 @@ Done.
 Set to '"depext-avail"' the field depext-bypass in switch bypass
 ### opam install bar
 [NOTE] Package bar is already installed (current version is 1).
+Nothing to do.
 ### opam remove bar
 The following actions will be performed:
 === remove 1 package

--- a/tests/reftests/extrasource.test
+++ b/tests/reftests/extrasource.test
@@ -1314,6 +1314,7 @@ The following actions will be performed:
 Done.
 ### opam install escape-absolute --require-checksums
 [NOTE] Package escape-absolute is already installed (current version is 1).
+Nothing to do.
 ### opam source escape-absolute
 Successfully extracted to ${BASEDIR}/escape-absolute.1
 ### test -f escape-absolute.1/etc/passwd

--- a/tests/reftests/opamrt-reinstall.test
+++ b/tests/reftests/opamrt-reinstall.test
@@ -70,6 +70,7 @@ d
 ### : 3/ Install d
 ### opam install d
 [NOTE] Package d is already installed (current version is 1).
+Nothing to do.
 ### opam list -sV
 a.1
 b.1

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1427,3 +1427,74 @@ Pin and install them? [Y/n] y
 [pkg.dev] synchronised (no changes)
 [ERROR] No valid package definition found for pkg
 # Return code 5 #
+:C:h: #6501
+:C:h:1: same version
+### opam switch create patch --empty
+### <pkg:patch.1>
+opam-version: "2.0"
+depends: [
+  "dep-patch"
+  "dep-test-patch" { with-test}
+]
+### <pkg:dep-patch.1>
+opam-version: "2.0"
+### <pkg:dep-test-patch.1>
+opam-version: "2.0"
+### <pin:patch/patch.opam>
+opam-version: "2.0"
+version: "1"
+depends: [
+  "dep-patch"
+  "dep-test-patch" { with-test}
+]
+### opam install patch
+The following actions will be performed:
+=== install 2 packages
+  - install dep-patch 1 [required by patch]
+  - install patch     1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-patch.1
+-> installed patch.1
+Done.
+### opam install ./patch --with-test --deps
+### opam install dep-test-patch
+The following actions will be performed:
+=== install 1 package
+  - install dep-test-patch 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-test-patch.1
+Done.
+### :C:h:2: change version
+### opam switch create patch2 --empty
+### opam install patch
+The following actions will be performed:
+=== install 2 packages
+  - install dep-patch 1 [required by patch]
+  - install patch     1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-patch.1
+-> installed patch.1
+Done.
+### <pin:patch/patch.opam>
+opam-version: "2.0"
+version: "2"
+depends: [
+  "dep-patch"
+  "dep-test-patch" { with-test}
+]
+### opam install ./patch --with-test --deps
+The following actions will be performed:
+=== remove 1 package
+  - remove  patch          1 [no longer available]
+=== install 1 package
+  - install dep-test-patch 1 [required by patch]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   patch.1
+-> installed dep-test-patch.1
+Done.
+### opam install dep-test-patch
+[NOTE] Package dep-test-patch is already installed (current version is 1).

--- a/tests/reftests/switch-list.test
+++ b/tests/reftests/switch-list.test
@@ -157,6 +157,7 @@ opam-version: "2.0"
 invariant: ["b" { >= "1" } |"c" { >= "1" }]
 ### opam install e
 [NOTE] Package e is already installed (current version is 1).
+Nothing to do.
 ### opam switch
 #   switch   compiler  description
 ->  display  d.1       b >= 1 | c >= 1


### PR DESCRIPTION
Fixes #6501 

This is a WIP fix for #6501. It currently fixes the main issue (dependencies are not installed when the base package is already installed but not pinned), but does not fix the secondary issue where the base package ends up being removed if the local version has a different version because it internally thinks the package is being pinned.

I'm not sure how to fix that secondary issue yet. @rjbou any idea?