### PR TITLE
Update some of the platforms the prebuilt binaries are built on to Alpine 2.21 and OpenBSD 7.7

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -9,7 +9,7 @@ FLEXDLLV = 0.43
 OCAML_URL = https://github.com/ocaml/ocaml/archive/refs/tags/$(OCAMLV).tar.gz
 FLEXDLL_URL = https://github.com/ocaml/flexdll/archive/refs/tags/$(FLEXDLLV).tar.gz
 
-ALPINE_VERSION = 3.20
+ALPINE_VERSION = 3.21
 
 HOST_OS = $(shell uname -s | tr A-Z a-z | sed -e 's/_.*//' -e 's/darwin/macos/' -e 's/cygwin/windows/')
 HOST = $(shell uname -m | sed 's/amd64/x86_64/')-$(HOST_OS)

--- a/release/release.sh
+++ b/release/release.sh
@@ -91,6 +91,6 @@ make JOBS="${JOBS}" TAG="$TAG" riscv64-linux
 [ -f "${OUTDIR}/opam-$TAG-arm64-macos" ] || make TAG="$TAG" JOBS="${JOBS}" macos-local MACOS_ARCH=arm64 REMOTE_DIR=opam-release-$TAG GIT_URL="$CWD/.."
 [ -d ./qemu-base-images ] || git clone https://gitlab.com/kit-ty-kate/qemu-base-images.git
 [ -f "${OUTDIR}/opam-$TAG-x86_64-netbsd" ] || qemu_build 9996 NetBSD-10.0-amd64 "pkgin -y install gmake curl bzip2" gmake x86_64
-[ -f "${OUTDIR}/opam-$TAG-x86_64-openbsd" ] || qemu_build 9999 OpenBSD-7.6-amd64 "pkg_add gmake curl bzip2" gmake x86_64
+[ -f "${OUTDIR}/opam-$TAG-x86_64-openbsd" ] || qemu_build 9999 OpenBSD-7.7-amd64 "pkg_add gmake curl bzip2" gmake x86_64
 [ -f "${OUTDIR}/opam-$TAG-x86_64-freebsd" ] || qemu_build 9998 FreeBSD-14.1-RELEASE-amd64 "env IGNORE_OSVERSION=yes pkg install -y gmake curl bzip2" gmake x86_64
 [ -f "${OUTDIR}/opam-$TAG-x86_64-windows" ] || windows_build 9997 Windows-10-x86_64

--- a/release/release.sh
+++ b/release/release.sh
@@ -89,7 +89,7 @@ make JOBS="${JOBS}" TAG="$TAG" s390x-linux
 make JOBS="${JOBS}" TAG="$TAG" riscv64-linux
 [ -f "${OUTDIR}/opam-$TAG-x86_64-macos" ] || make TAG="$TAG" JOBS="${JOBS}" macos-local MACOS_ARCH=x86_64 REMOTE_DIR=opam-release-$TAG GIT_URL="$CWD/.."
 [ -f "${OUTDIR}/opam-$TAG-arm64-macos" ] || make TAG="$TAG" JOBS="${JOBS}" macos-local MACOS_ARCH=arm64 REMOTE_DIR=opam-release-$TAG GIT_URL="$CWD/.."
-[ -d ./qemu-base-images ] || git clone https://gitlab.com/kit-ty-kate/qemu-base-images.git
+[ -d ./qemu-base-images ] || git clone https://github.com/kit-ty-kate/qemu-base-images.git
 [ -f "${OUTDIR}/opam-$TAG-x86_64-netbsd" ] || qemu_build 9996 NetBSD-10.0-amd64 "pkgin -y install gmake curl bzip2" gmake x86_64
 [ -f "${OUTDIR}/opam-$TAG-x86_64-openbsd" ] || qemu_build 9999 OpenBSD-7.7-amd64 "pkg_add gmake curl bzip2" gmake x86_64
 [ -f "${OUTDIR}/opam-$TAG-x86_64-freebsd" ] || qemu_build 9998 FreeBSD-14.1-RELEASE-amd64 "env IGNORE_OSVERSION=yes pkg install -y gmake curl bzip2" gmake x86_64


### PR DESCRIPTION
Was **not** used for the 2.4.0~alpha2 release.
Requires an update in https://github.com/kit-ty-kate/alpine
Requires an update in https://github.com/kit-ty-kate/qemu-base-images