### PR TITLE
A few performance improvements

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -116,6 +116,7 @@ users)
 
 ## Internal
   * Improve cache-loading performance when using OCaml >= 5.4 by using `Gc.ramp_up` [#6515 @dra27]
+  * Make OpamStd.String.compare_case allocation free [#6515 @dra27]
 
 ## Internal: Unix
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -163,3 +163,5 @@ users)
   * `OpamCmdliner` was added. It is accessible through a new `opam-core.cmdliner` sub-library [#6755 @kit-ty-kate]
   * `OpamUrl`: rename and expose `local_path` as `looks_like_local_path` [#5979 @kit-ty-kate]
   * `OpamCompat.Gc.ramp_up`: was added [#6515 @dra27]
+  * `OpamCompat.Int.min`: was added [#6515 @kit-ty-kate]
+  * `OpamStd.String.compare_case`: is now allocation free [#6515 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -166,3 +166,4 @@ users)
   * `OpamCompat.Gc.ramp_up`: was added [#6515 @dra27]
   * `OpamCompat.Int.min`: was added [#6515 @kit-ty-kate]
   * `OpamStd.String.compare_case`: is now allocation free [#6515 @dra27]
+  * `OpamVersionCompare.{compare,equal}`: are now allocation free [#6515 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -115,6 +115,7 @@ users)
 ## Shell
 
 ## Internal
+  * Improve cache-loading performance when using OCaml >= 5.4 by using `Gc.ramp_up` [#6515 @dra27]
 
 ## Internal: Unix
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -161,3 +161,4 @@ users)
 ## opam-core
   * `OpamCmdliner` was added. It is accessible through a new `opam-core.cmdliner` sub-library [#6755 @kit-ty-kate]
   * `OpamUrl`: rename and expose `local_path` as `looks_like_local_path` [#5979 @kit-ty-kate]
+  * `OpamCompat.Gc.ramp_up`: was added [#6515 @dra27]

--- a/src/core/opamCached.ml
+++ b/src/core/opamCached.ml
@@ -56,7 +56,8 @@ end = struct
     let chrono = OpamConsole.timer () in
     let f ic =
       try
-        let (cache: t) = Marshal.from_channel ic in
+        let (cache: t) =
+          OpamCompat.Gc.ramp_up (fun () -> Marshal.from_channel ic) in
         log "Loaded %a in %.3fs" (slog OpamFilename.to_string) file (chrono ());
         Some cache
       with End_of_file | Failure _ ->

--- a/src/core/opamCompat.ml
+++ b/src/core/opamCompat.ml
@@ -261,3 +261,12 @@ module Pair = struct
   let equal eq1 eq2 (x1, y1) (x2, y2) =
     eq1 x1 x2 && eq2 y1 y2
 end
+
+module Int = struct
+  [@@@warning "-32"]
+
+  (* NOTE: OCaml >= 4.13 *)
+  let min : int -> int -> int = Stdlib.min
+
+  include Stdlib.Int
+end

--- a/src/core/opamCompat.ml
+++ b/src/core/opamCompat.ml
@@ -8,6 +8,16 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Gc = struct
+  [@@@warning "-32"]
+
+  let ramp_up f = (f (), ())
+
+  include Gc
+
+  let ramp_up f = fst (ramp_up f)
+end
+
 module String = struct
   [@@@warning "-32"]
 

--- a/src/core/opamCompat.mli
+++ b/src/core/opamCompat.mli
@@ -88,3 +88,8 @@ module Pair : sig
     ('a -> 'a -> bool) -> ('b -> 'b -> bool) ->
     ('a * 'b) -> ('a * 'b) -> bool
 end
+
+module Int : sig
+  (** NOTE: OCaml >= 4.13 *)
+  val min : int -> int -> int
+end

--- a/src/core/opamCompat.mli
+++ b/src/core/opamCompat.mli
@@ -8,6 +8,12 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Gc : sig
+  (* NOTE: OCaml >= 5.4; we don't expose the suspended_collection_work as
+           it's not needed by opam and it complicates the backport *)
+  val ramp_up : (unit -> 'a) -> 'a
+end
+
 module String : sig
   (* NOTE: OCaml >= 4.13 *)
   val exists: (char -> bool) -> string -> bool

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -632,25 +632,25 @@ module OpamString = struct
         f acc next current last normal in
     f [] 0 "" 0 true
 
+  let rec compare_case_aux len s1 s2 i =
+    if i < (len : int) then
+      let c1 = String.unsafe_get s1 i and c2 = String.unsafe_get s2 i in
+      match Char.compare (Char.lowercase_ascii c1) (Char.lowercase_ascii c2)
+      with
+      | 0 ->
+        (match Char.compare c1 c2 with
+         | 0 -> compare_case_aux len s1 s2 (i+1)
+         | c -> c)
+      | c -> c
+    else
+      let l1 = String.length s1 and l2 = String.length s2 in
+      if l1 < (l2 : int) then -1
+      else if l1 > (l2 : int) then 1
+      else 0
+
   let compare_case s1 s2 =
-    let l1 = String.length s1 and l2 = String.length s2 in
-    let len = min l1 l2 in
-    let rec aux i =
-      if i < len then
-        let c1 = s1.[i] and c2 = s2.[i] in
-        match Char.compare (Char.lowercase_ascii c1) (Char.lowercase_ascii c2)
-        with
-        | 0 ->
-          (match Char.compare c1 c2 with
-           | 0 -> aux (i+1)
-           | c -> c)
-        | c -> c
-      else
-        if l1 < l2 then -1
-        else if l1 > l2 then 1
-        else 0
-    in
-    aux 0
+    let len = OpamCompat.Int.min (String.length s1) (String.length s2) in
+    compare_case_aux len s1 s2 0
 
   let is_prefix_of ~from ~full s =
     let length_s = String.length s in


### PR DESCRIPTION
Our version comparison function is very hot. While looking around it in the context of #4245, I picked up on a few easy wins. These are some basic results from hyperfine on my system for `opam show dune`, but they must be taken with an appropriate amount of salt:

```
OCaml 5.4.0
Base:    902.6 ms ±  32.7 ms
ramp_up: 553.4 ms ±  48.5 ms
closure: 539.6 ms ±  26.9 ms
files:   378.0 ms ±  14.5 ms

OCaml 5.3.0
Base:    913.2 ms ±  46.4 ms
ramp_up: 878.5 ms ±  36.5 ms
closure: 866.5 ms ±  34.7 ms
files:   756.4 ms ±  38.7 ms

OCaml 4.14.2
Base:    1.090 s ±  0.030 s
ramp_up: 1.114 s ±  0.053 s
closure: 1.108 s ±  0.059 s
files:   842.2 ms ±  26.9 ms
```

The interesting part is that on OCaml 5.4, `opam show` spends almost its entire time unmarshalling the repository state cache. However, these changes shouldn't be assessed in terms of performance _improvement_ because what's happening on all versions of OCaml is a reduction in GC pressure (i.e. if opam were doing a bit more work, the GC would almost certainly run again and the time reduction wouldn't be as stark). The three changes are:

- Use OCaml 5.4's `Gc.ramp_up` for the unmarshalling call in `OpamCached`. This is logically sensible, as the caches are never collected. The speedup comes from the fact that the major GC doesn't actually have to run any more in the `opam show` command, and the 5.3.0 and 4.14.2 results for that commit are well within the noise of the microbenchmark.
- `OpamStd.String.compare_case` added in #4328 contained a small mistake - the closure allocation for the `aux` function shows up in flame graphs. The derivation of sets of packages from the map of opams in OpamRepositoryState (which is also done in OpamSwitchState) is mostly dominated by `OpamVersionCompare`, but eliminating the closure in `compare_case` has a benefit (as it happens, I also got a small benefit from a Hacker's Delight-style optimisation noting that opam package names can't contain certain characters, but as the function is also used for system package names, I decided not to commit that one!). The diff looks noisy without space-change being ignored - all I've done is move the `aux` function out of `compare_case`.
- ~Finally, I noticed with `opam show dune` that the switch selections of the switches are read in proportion to the number of versions being displayed. That creates both unnecessary I/O and GC pressure.~ extracted in #6818

I think all three of these changes are worth putting in, but I'd countenance against hyping the performance improvement on `opam show` because it won't always show up that way!