### PR TITLE
`opam install . --deps-only` comply with the real constraints of packages

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -36,6 +36,7 @@ users)
 ## Config
 
 ## Pin
+  * [BUG] When using `--deps-only`, no longer take into account the simulated pin information. This is hit when a package `pkg` is already installed and `opam install ./pkg --deps` is called, if there is a conflict between installed `pkg` dependencies and local `pkg` declaration, the conflict is not seen and the already installed `pkg` is kept. [#6530 @rjbou - fix #6529]
 
 ## List
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -110,6 +110,7 @@ users)
 
 ## Reftests
 ### Tests
+  * Add some related pin tests: fetching, reinstall trigger & simulated pin (deps-only) [#6530 @rjbou]
 
 ### Engine
 

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -390,6 +390,15 @@ let simulate_local_pinnings ?quiet ?(for_view=false) st to_pin =
       ++ local_packages
     else st.pinned
   in
+  let overwrote_opams =
+    if for_view then OpamPackage.Map.empty else
+      OpamPackage.Map.filter_map (fun nv opam ->
+          if OpamPackage.Set.mem nv local_packages then
+             Some (OpamPackage.Set.mem nv st.pinned, opam)
+           else
+             None)
+        st.opams
+  in
   let st = {
     st with
     opams =
@@ -429,6 +438,7 @@ let simulate_local_pinnings ?quiet ?(for_view=false) st to_pin =
         installed_pinned (Lazy.force st.reinstall)
     );
     pinned;
+    overwrote_opams;
   } in
   st, local_packages
 

--- a/src/state/opamStateTypes.mli
+++ b/src/state/opamStateTypes.mli
@@ -166,6 +166,10 @@ type +'lock switch_state = {
       of removed system dependencies. Only packages which are unavailable end up
       in this set, they are otherwise put in {!field:reinstall}. *)
 
+  overwrote_opams: (bool * OpamFile.OPAM.t) package_map;
+  (** In case of simulated pins, keep the old information of opam files. The
+      boolean is set to true if the package was previously pinned. *)
+
   (* Missing: a cache for
      - switch-global and package variables
      - the solver universe? *)

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1701,6 +1701,27 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:show.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-simulated-pin)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (action
+  (diff simulated-pin.test simulated-pin.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (deps (alias reftest-simulated-pin)))
+
+(rule
+ (targets simulated-pin.out)
+ (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:simulated-pin.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-source)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1427,3 +1427,98 @@ Pin and install them? [Y/n] y
 [pkg.dev] synchronised (no changes)
 [ERROR] No valid package definition found for pkg
 # Return code 5 #
+### :C:h: Checking the opam file update reinstall trigger
+### <pkg:reinst.1>
+opam-version: "2.0"
+depends: "dep-reinst" { = "1" }
+### <pkg:dep-reinst.1>
+opam-version: "2.0"
+### <pkg:dep-reinst.2>
+opam-version: "2.0"
+### <pkg:dep-reinst.3>
+opam-version: "2.0"
+### :C:h:1: Update opam file and install again
+### # simulated pin test in simulated-pin:I:
+### opam switch create reinst-1 --empty
+### <pin:reinst/reinst.opam>
+opam-version: "2.0"
+depends: "dep-reinst" { = "1" }
+### opam install ./reinst
+reinst is now pinned to file://${BASEDIR}/reinst (version 1)
+The following actions will be performed:
+=== install 2 packages
+  - install dep-reinst 1          [required by reinst]
+  - install reinst     1 (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-reinst.1
+-> retrieved reinst.1  (file://${BASEDIR}/reinst)
+-> installed reinst.1
+Done.
+### <pin:reinst/reinst.opam>
+opam-version: "2.0"
+depends: "dep-reinst" { = "2" }
+### opam install ./reinst
+reinst is now pinned to file://${BASEDIR}/reinst (version 1)
+[reinst.1] synchronised (file://${BASEDIR}/reinst)
+The following actions will be performed:
+=== recompile 1 package
+  - recompile reinst     1 (pinned)
+=== upgrade 1 package
+  - upgrade   dep-reinst 1 to 2     [required by reinst]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   dep-reinst.1
+-> installed dep-reinst.2
+-> retrieved reinst.1  (no changes)
+-> removed   reinst.1
+-> installed reinst.1
+Done.
+### :C:i: Checking the opam file update reinstall trigger, changing only with-test dependencies (variables)
+### # simulated pin test in simulated-pin:II:
+### <pkg:reinst.1>
+opam-version: "2.0"
+depends: [ "dep-reinst" { = "1" } "dep-test-reinst" { with-test & = "1" } ]
+### <pkg:dep-reinst.1>
+opam-version: "2.0"
+### <pkg:dep-reinst.2>
+opam-version: "2.0"
+### <pkg:dep-test-reinst.1>
+opam-version: "2.0"
+### <pkg:dep-test-reinst.2>
+opam-version: "2.0"
+### :C:i:1: Update opam file and install again
+### opam switch create reinst-wt-1 --empty
+### <pin:reinst/reinst.opam>
+opam-version: "2.0"
+depends: [ "dep-reinst" { = "1" } "dep-test-reinst" { with-test & = "1" } ]
+### opam install ./reinst
+reinst is now pinned to file://${BASEDIR}/reinst (version 1)
+The following actions will be performed:
+=== install 2 packages
+  - install dep-reinst 1          [required by reinst]
+  - install reinst     1 (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-reinst.1
+-> retrieved reinst.1  (file://${BASEDIR}/reinst)
+-> installed reinst.1
+Done.
+### <pin:reinst/reinst.opam>
+opam-version: "2.0"
+depends: [ "dep-reinst" { = "1" } "dep-test-reinst" { with-test & = "2" } ]
+### opam install ./reinst --with-test
+reinst is now pinned to file://${BASEDIR}/reinst (version 1)
+[reinst.1] synchronised (file://${BASEDIR}/reinst)
+The following actions will be performed:
+=== recompile 1 package
+  - recompile reinst          1 (pinned)
+=== install 1 package
+  - install   dep-test-reinst 2          [required by reinst]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-test-reinst.2
+-> retrieved reinst.1  (no changes)
+-> removed   reinst.1
+-> installed reinst.1
+Done.

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1132,25 +1132,15 @@ depends: "dependency" {= "2"}
 [NOTE] Ignoring uncommitted changes in ${BASEDIR}/pin-change (`--working-dir' not specified or specified with no argument).
 [pin-change.dev] synchronised (no changes)
 The following actions will be performed:
-=== recompile 1 package
-  - recompile pin-change dev (pinned) [uses dependency]
+=== remove 1 package
+  - remove  pin-change dev (pinned) [conflicts with dependency]
 === upgrade 1 package
-  - upgrade   dependency 1 to 2       [required by pin-change]
+  - upgrade dependency 1 to 2       [required by pin-change]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   pin-change.dev
 -> removed   dependency.1
 -> installed dependency.2
--> retrieved pin-change.dev  (no changes)
--> removed   pin-change.dev
--> installed pin-change.dev
-Done.
-### opam remove pin-change
-The following actions will be performed:
-=== remove 1 package
-  - remove pin-change dev (pinned)
-
-<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> removed   pin-change.dev
 Done.
 ### <pin:pin-change/opam>
 opam-version: "2.0"

--- a/tests/reftests/simulated-pin.test
+++ b/tests/reftests/simulated-pin.test
@@ -1,0 +1,246 @@
+N0REP0
+### OPAMYES=1
+### ::: Tests specific to simulated pinning behaviour, trigerred by `opam install ./localdir --deps-only`
+### :I: Checking the opam file update reinstall trigger
+### <pkg:reinst.1>
+opam-version: "2.0"
+depends: "dep-reinst" { = "1" }
+### <pkg:dep-reinst.1>
+opam-version: "2.0"
+### <pkg:dep-reinst.2>
+opam-version: "2.0"
+### <pkg:dep-reinst.3>
+opam-version: "2.0"
+### :I:1: Update opam file and install again
+### opam switch create reinst-1 --empty
+### <pin:reinst/reinst.opam>
+opam-version: "2.0"
+depends: "dep-reinst" { = "1" }
+### opam install ./reinst
+reinst is now pinned to file://${BASEDIR}/reinst (version 1)
+The following actions will be performed:
+=== install 2 packages
+  - install dep-reinst 1          [required by reinst]
+  - install reinst     1 (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-reinst.1
+-> retrieved reinst.1  (file://${BASEDIR}/reinst)
+-> installed reinst.1
+Done.
+### <pin:reinst/reinst.opam>
+opam-version: "2.0"
+depends: "dep-reinst" { = "2" }
+### opam install ./reinst --deps-only
+[reinst.1] synchronised (file://${BASEDIR}/reinst)
+[reinst] Installing new package description from upstream file://${BASEDIR}/reinst
+The following actions will be performed:
+=== recompile 1 package
+  - recompile reinst     1 (pinned) [uses dep-reinst]
+=== upgrade 1 package
+  - upgrade   dep-reinst 1 to 2     [required by reinst]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   dep-reinst.1
+-> installed dep-reinst.2
+-> retrieved reinst.1  (no changes)
+-> removed   reinst.1
+-> installed reinst.1
+Done.
+### :I:2: Install from repo and pin same opam file
+### opam switch create reinst-2 --empty
+### opam install reinst
+The following actions will be performed:
+=== install 2 packages
+  - install dep-reinst 1 [required by reinst]
+  - install reinst     1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-reinst.1
+-> installed reinst.1
+Done.
+### <pin:reinst/reinst.opam>
+opam-version: "2.0"
+depends: "dep-reinst" { = "1" }
+### opam install ./reinst --deps-only
+### :I:3: Install from repo and pin different same opam file
+### opam switch create reinst-3 --empty
+### opam install reinst
+The following actions will be performed:
+=== install 2 packages
+  - install dep-reinst 1 [required by reinst]
+  - install reinst     1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-reinst.1
+-> installed reinst.1
+Done.
+### <pin:reinst/reinst.opam>
+opam-version: "2.0"
+depends: "dep-reinst" { = "2" }
+### opam install ./reinst --deps-only
+### :II: Checking the opam file update reinstall trigger, changing only with-test dependencies (variables)
+### <pkg:reinst.1>
+opam-version: "2.0"
+depends: [ "dep-reinst" { = "1" } "dep-test-reinst" { with-test & = "1" } ]
+### <pkg:dep-reinst.1>
+opam-version: "2.0"
+### <pkg:dep-reinst.2>
+opam-version: "2.0"
+### <pkg:dep-reinst.3>
+opam-version: "2.0"
+### <pkg:dep-test-reinst.1>
+opam-version: "2.0"
+### <pkg:dep-test-reinst.2>
+opam-version: "2.0"
+### <pkg:dep-test-reinst.3>
+opam-version: "2.0"
+### :II:1: Update opam file and install again
+### opam switch create reinst-wt-1 --empty
+### <pin:reinst/reinst.opam>
+opam-version: "2.0"
+depends: [ "dep-reinst" { = "1" } "dep-test-reinst" { with-test & = "1" } ]
+### opam install ./reinst
+reinst is now pinned to file://${BASEDIR}/reinst (version 1)
+The following actions will be performed:
+=== install 2 packages
+  - install dep-reinst 1          [required by reinst]
+  - install reinst     1 (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-reinst.1
+-> retrieved reinst.1  (file://${BASEDIR}/reinst)
+-> installed reinst.1
+Done.
+### <pin:reinst/reinst.opam>
+opam-version: "2.0"
+depends: [ "dep-reinst" { = "1" } "dep-test-reinst" { with-test & = "2" } ]
+### opam install ./reinst --deps-only --with-test
+[reinst.1] synchronised (file://${BASEDIR}/reinst)
+[reinst] Installing new package description from upstream file://${BASEDIR}/reinst
+The following actions will be performed:
+=== install 1 package
+  - install dep-test-reinst 2 [required by reinst]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-test-reinst.2
+Done.
+### :II:2: Install from repo and simulated pin same opam file
+### opam switch create reinst-wt-2 --empty
+### opam install reinst
+The following actions will be performed:
+=== install 2 packages
+  - install dep-reinst 1 [required by reinst]
+  - install reinst     1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-reinst.1
+-> installed reinst.1
+Done.
+### <pin:reinst/reinst.opam>
+opam-version: "2.0"
+depends: [ "dep-reinst" { = "1" } "dep-test-reinst" { with-test & = "1" } ]
+### opam install ./reinst --deps-only --with-test
+### :II:3: Install from repo and simulated pin different same opam file
+### opam switch create reinst-wt-3 --empty
+### opam install reinst
+The following actions will be performed:
+=== install 2 packages
+  - install dep-reinst 1 [required by reinst]
+  - install reinst     1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep-reinst.1
+-> installed reinst.1
+Done.
+### <pin:reinst/reinst.opam>
+opam-version: "2.0"
+depends: [ "dep-reinst" { = "1" } "dep-test-reinst" { with-test & = "2" } ]
+### opam install ./reinst --deps-only --with-test
+### :III: Fetching of simulated pin
+### <pkg:fetch.0>
+opam-version: "2.0"
+### <pkg:fetch-dep.1>
+opam-version: "2.0"
+### <pkg:fetch-dep.2>
+opam-version: "2.0"
+### <pin:fetch/fetch.opam>
+opam-version: "2.0"
+version: "1"
+build: ["test" "-f" "pinned-file"]
+depends: "fetch-dep" { = "1" }
+### <fetch/pinned-file>
+I'm the first version of the file, trust me!
+### opam switch create fetch-sim --empty
+### opam pin ./fetch -n
+fetch is now pinned to file://${BASEDIR}/fetch (version 1)
+### opam-cat OPAM/fetch-sim/.opam-switch/overlay/fetch/opam
+authors: "the testing team"
+bug-reports: "https://nobug"
+build: ["test" "-f" "pinned-file"]
+depends: "fetch-dep" {= "1"}
+description: "Two words."
+dev-repo: "hg+https://pkg@op.am"
+homepage: "egapemoh"
+license: "MIT"
+maintainer: "maint@tain.er"
+name: "fetch"
+opam-version: "2.0"
+synopsis: "A word"
+version: "1"
+url {
+src: "file://${BASEDIR}/fetch"
+}
+### opam-cat OPAM/fetch-sim/.opam-switch/packages/fetch.1/opam
+# OPAM/fetch-sim/.opam-switch/packages/fetch.1/opam not found
+### find OPAM/fetch-sim/.opam-switch/sources/fetch | sort
+OPAM/fetch-sim/.opam-switch/sources/fetch
+OPAM/fetch-sim/.opam-switch/sources/fetch/fetch.opam
+OPAM/fetch-sim/.opam-switch/sources/fetch/pinned-file
+### cat OPAM/fetch-sim/.opam-switch/sources/fetch/pinned-file
+I'm the first version of the file, trust me!
+### # find OPAM/fetch-sim
+### <pin:fetch/fetch.opam>
+opam-version: "2.0"
+version: "2"
+build: ["test" "-f" "pinned-file2"]
+depends: "fetch-dep" { = "2" }
+### <fetch/pinned-file>
+I'm the second version of the file, trust me!
+### opam install ./fetch --deps-only
+[fetch.1] synchronised (file://${BASEDIR}/fetch)
+[fetch] Installing new package description from upstream file://${BASEDIR}/fetch
+The following actions will be performed:
+=== install 1 package
+  - install fetch-dep 2 [required by fetch]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed fetch-dep.2
+Done.
+### opam-cat OPAM/fetch-sim/.opam-switch/overlay/fetch/opam
+authors: "the testing team"
+bug-reports: "https://nobug"
+build: ["test" "-f" "pinned-file2"]
+depends: ["fetch-dep" {= "2"}]
+description: "Two words."
+dev-repo: "hg+https://pkg@op.am"
+homepage: "egapemoh"
+license: "MIT"
+maintainer: "maint@tain.er"
+name: "fetch"
+opam-version: "2.0"
+synopsis: "A word"
+version: "2"
+url {
+src: "file://${BASEDIR}/fetch"
+}
+### opam-cat OPAM/fetch-sim/.opam-switch/packages/fetch.1/opam
+# OPAM/fetch-sim/.opam-switch/packages/fetch.1/opam not found
+### opam-cat OPAM/fetch-sim/.opam-switch/packages/fetch.2/opam
+# OPAM/fetch-sim/.opam-switch/packages/fetch.2/opam not found
+### find OPAM/fetch-sim/.opam-switch/sources/fetch | sort
+OPAM/fetch-sim/.opam-switch/sources/fetch
+OPAM/fetch-sim/.opam-switch/sources/fetch/fetch.opam
+OPAM/fetch-sim/.opam-switch/sources/fetch/pinned-file
+### cat OPAM/fetch-sim/.opam-switch/sources/fetch/pinned-file
+I'm the second version of the file, trust me!

--- a/tests/reftests/simulated-pin.test
+++ b/tests/reftests/simulated-pin.test
@@ -35,17 +35,15 @@ depends: "dep-reinst" { = "2" }
 [reinst.1] synchronised (file://${BASEDIR}/reinst)
 [reinst] Installing new package description from upstream file://${BASEDIR}/reinst
 The following actions will be performed:
-=== recompile 1 package
-  - recompile reinst     1 (pinned) [uses dep-reinst]
+=== remove 1 package
+  - remove  reinst     1 (pinned) [conflicts with dep-reinst]
 === upgrade 1 package
-  - upgrade   dep-reinst 1 to 2     [required by reinst]
+  - upgrade dep-reinst 1 to 2     [required by reinst]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   reinst.1
 -> removed   dep-reinst.1
 -> installed dep-reinst.2
--> retrieved reinst.1  (no changes)
--> removed   reinst.1
--> installed reinst.1
 Done.
 ### :I:2: Install from repo and pin same opam file
 ### opam switch create reinst-2 --empty


### PR DESCRIPTION
When a package `pkg` is already installed and `opam install ./pkg --deps` is called, if there is a conflict between installed `pkg` dependencies and local `pkg` declaration, the conflict is not seen and the already installed `pkg` is kept.

For the code itself, the universe given to the solver was retrieving information from the simulated switch state, so the simulated pinned package information, not the good opam definition. We keep then the old information in the switch state, like that we can rearrange the package set given to the solver when creating the universe.

Fix #6529