### PR TITLE
Clean cudf attributes

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -36,6 +36,7 @@ users)
 ## Config
 
 ## Pin
+  * [BUG] When using `--deps-only`, no longer take into account the simulated pin information. This is hit when a package `pkg` is already installed and `opam install ./pkg --deps` is called, if there is a conflict between installed `pkg` dependencies and local `pkg` declaration, the conflict is not seen and the already installed `pkg` is kept. [#XXX @rjbou]
 
 ## List
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -99,7 +99,7 @@ users)
 ## Shell
 
 ## Internal
-  * Cudf: remove unused attribute pinned [#XXX @rjbou]
+  * Cudf: remove unused attribute pinned and installed-roots [#XXX @rjbou]
 
 ## Internal: Unix
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -99,6 +99,7 @@ users)
 ## Shell
 
 ## Internal
+  * Cudf: remove unused attribute pinned [#XXX @rjbou]
 
 ## Internal: Unix
 

--- a/src/client/opamAdminCheck.ml
+++ b/src/client/opamAdminCheck.ml
@@ -56,7 +56,6 @@ let get_universe opams =
            OpamFile.OPAM.conflicts o |>
            OpamFilter.filter_formula ~default:false (env nv))
         opams;
-    u_installed_roots = OpamPackage.Set.empty;
     u_invariant = OpamFormula.Empty;
     u_attrs = [];
     u_reinstall = OpamPackage.Set.empty;

--- a/src/client/opamAdminCheck.ml
+++ b/src/client/opamAdminCheck.ml
@@ -57,7 +57,6 @@ let get_universe opams =
            OpamFilter.filter_formula ~default:false (env nv))
         opams;
     u_installed_roots = OpamPackage.Set.empty;
-    u_pinned = OpamPackage.Set.empty;
     u_invariant = OpamFormula.Empty;
     u_attrs = [];
     u_reinstall = OpamPackage.Set.empty;

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -390,6 +390,14 @@ let simulate_local_pinnings ?quiet ?(for_view=false) st to_pin =
       ++ local_packages
     else st.pinned
   in
+  let overwrote_opams =
+    if for_view then OpamPackage.Map.empty else
+      OpamPackage.Map.filter (fun nv _ ->
+          OpamPackage.Set.mem nv local_packages)
+        st.opams
+      |> OpamPackage.Map.mapi (fun nv opam ->
+          OpamPackage.Set.mem nv st.pinned, opam)
+  in
   let st = {
     st with
     opams =
@@ -429,6 +437,7 @@ let simulate_local_pinnings ?quiet ?(for_view=false) st to_pin =
         installed_pinned (Lazy.force st.reinstall)
     );
     pinned;
+    overwrote_opams;
   } in
   st, local_packages
 

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -395,8 +395,6 @@ let simulate_local_pinnings ?quiet ?(for_view=false) st to_pin =
       OpamPackage.Map.filter (fun nv _ ->
           OpamPackage.Set.mem nv local_packages)
         st.opams
-      |> OpamPackage.Map.mapi (fun nv opam ->
-          OpamPackage.Set.mem nv st.pinned, opam)
   in
   let st = {
     st with

--- a/src/client/opamListCommand.ml
+++ b/src/client/opamListCommand.ml
@@ -294,8 +294,7 @@ let apply_selector ~base st = function
     in
     let universe =
       { universe
-        with u_installed = OpamPackage.Set.empty;
-             u_installed_roots = OpamPackage.Set.empty }
+        with u_installed = OpamPackage.Set.empty; }
     in
     (match OpamSolver.resolve universe
              (OpamSolver.request ~install:atoms ()) with

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -307,7 +307,6 @@ type universe = {
   u_conflicts: formula package_map;
   u_action   : user_action;
   u_installed_roots: package_set;
-  u_pinned   : package_set;
   u_invariant: formula;
   u_reinstall: package_set;
   u_attrs    : (string * package_set Lazy.t) list;

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -306,7 +306,6 @@ type universe = {
   u_depopts  : filtered_formula package_map;
   u_conflicts: formula package_map;
   u_action   : user_action;
-  u_installed_roots: package_set;
   u_invariant: formula;
   u_reinstall: package_set;
   u_attrs    : (string * package_set Lazy.t) list;

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -20,7 +20,6 @@ let s_source = "opam-name"
 let s_source_number = "opam-version"
 let s_reinstall = "reinstall"
 let s_installed_root = "installed-root"
-let s_pinned = "pinned"
 let s_version_lag = "version-lag"
 
 let opam_invariant_package_name =
@@ -1273,7 +1272,6 @@ let default_preamble =
     (s_source_number,  `String None);
     (s_reinstall,      `Bool (Some false));
     (s_installed_root, `Bool (Some false));
-    (s_pinned,         `Bool (Some false));
     (s_version_lag,    `Nat (Some 0));
   ] in
   Dose_common.CudfAdd.add_properties Cudf.default_preamble l

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -19,7 +19,6 @@ let slog = OpamConsole.slog
 let s_source = "opam-name"
 let s_source_number = "opam-version"
 let s_reinstall = "reinstall"
-let s_installed_root = "installed-root"
 let s_version_lag = "version-lag"
 
 let opam_invariant_package_name =
@@ -1260,18 +1259,11 @@ let check flag p =
 
 let need_reinstall = check s_reinstall
 
-(*
-let is_installed_root = check s_installed_root
-
-let is_pinned = check s_pinned
-*)
-
 let default_preamble =
   let l = [
     (s_source,         `String None);
     (s_source_number,  `String None);
     (s_reinstall,      `Bool (Some false));
-    (s_installed_root, `Bool (Some false));
     (s_version_lag,    `Nat (Some 0));
   ] in
   Dose_common.CudfAdd.add_properties Cudf.default_preamble l

--- a/src/solver/opamCudf.mli
+++ b/src/solver/opamCudf.mli
@@ -176,10 +176,6 @@ val s_source_number: string
 (** a package to be reinstalled (a bool) *)
 val s_reinstall: string
 
-(** true if this package belongs to the roots ("installed manually")
-    packages *)
-val s_installed_root: string
-
 (** the number of versions of the package since this one, cubed *)
 val s_version_lag: string
 

--- a/src/solver/opamCudf.mli
+++ b/src/solver/opamCudf.mli
@@ -180,9 +180,6 @@ val s_reinstall: string
     packages *)
 val s_installed_root: string
 
-(** true if the package is pinned to this version *)
-val s_pinned: string
-
 (** the number of versions of the package since this one, cubed *)
 val s_version_lag: string
 

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -30,7 +30,6 @@ let empty_universe =
     u_conflicts = OpamPackage.Map.empty;
     u_action = Install;
     u_installed_roots = OpamPackage.Set.empty;
-    u_pinned = OpamPackage.Set.empty;
     u_invariant = OpamFormula.Empty;
     u_reinstall = OpamPackage.Set.empty;
     u_attrs = [];
@@ -187,7 +186,6 @@ let opam2cudf_map universe version_map packages =
   let installed_map = set_to_bool_map universe.u_installed in
   let reinstall_map = set_to_bool_map universe.u_reinstall in
   let installed_root_map = set_to_bool_map universe.u_installed_roots in
-  let pinned_to_current_version_map = set_to_bool_map universe.u_pinned in
   let avoid_versions =
     match
       OpamStd.List.assoc_opt String.equal "avoid-version" universe.u_attrs
@@ -249,9 +247,6 @@ let opam2cudf_map universe version_map packages =
     |> add installed_root_map (fun _ x cp ->
         {cp with Cudf.pkg_extra =
                    (OpamCudf.s_installed_root, `Bool x) :: cp.Cudf.pkg_extra})
-    |> add pinned_to_current_version_map (fun _ x cp ->
-        {cp with Cudf.pkg_extra =
-                   (OpamCudf.s_pinned, `Bool x) :: cp.Cudf.pkg_extra})
     |> add version_lag_map (fun _ x cp ->
         {cp with Cudf.pkg_extra =
                    (OpamCudf.s_version_lag, `Int x) :: cp.Cudf.pkg_extra})

--- a/src/solver/opamSolver.ml
+++ b/src/solver/opamSolver.ml
@@ -29,7 +29,6 @@ let empty_universe =
     u_depopts = OpamPackage.Map.empty;
     u_conflicts = OpamPackage.Map.empty;
     u_action = Install;
-    u_installed_roots = OpamPackage.Set.empty;
     u_invariant = OpamFormula.Empty;
     u_reinstall = OpamPackage.Set.empty;
     u_attrs = [];
@@ -185,7 +184,6 @@ let opam2cudf_map universe version_map packages =
   in
   let installed_map = set_to_bool_map universe.u_installed in
   let reinstall_map = set_to_bool_map universe.u_reinstall in
-  let installed_root_map = set_to_bool_map universe.u_installed_roots in
   let avoid_versions =
     match
       OpamStd.List.assoc_opt String.equal "avoid-version" universe.u_attrs
@@ -244,9 +242,6 @@ let opam2cudf_map universe version_map packages =
     |> add reinstall_map (fun _ x cp ->
         {cp with Cudf.pkg_extra =
                    (OpamCudf.s_reinstall, `Bool x) :: cp.Cudf.pkg_extra})
-    |> add installed_root_map (fun _ x cp ->
-        {cp with Cudf.pkg_extra =
-                   (OpamCudf.s_installed_root, `Bool x) :: cp.Cudf.pkg_extra})
     |> add version_lag_map (fun _ x cp ->
         {cp with Cudf.pkg_extra =
                    (OpamCudf.s_version_lag, `Int x) :: cp.Cudf.pkg_extra})

--- a/src/state/opamStateTypes.mli
+++ b/src/state/opamStateTypes.mli
@@ -166,6 +166,10 @@ type +'lock switch_state = {
       of removed system dependencies. Only packages which are unavailable end up
       in this set, they are otherwise put in {!field:reinstall}. *)
 
+  overwrote_opams: (bool * OpamFile.OPAM.t) package_map;
+  (** In case of simulated pins, keep the old information of opam files. The
+      boolean is set to true if the package was previously pinned. *)
+
   (* Missing: a cache for
      - switch-global and package variables
      - the solver universe? *)

--- a/src/state/opamStateTypes.mli
+++ b/src/state/opamStateTypes.mli
@@ -166,9 +166,8 @@ type +'lock switch_state = {
       of removed system dependencies. Only packages which are unavailable end up
       in this set, they are otherwise put in {!field:reinstall}. *)
 
-  overwrote_opams: (bool * OpamFile.OPAM.t) package_map;
-  (** In case of simulated pins, keep the old information of opam files. The
-      boolean is set to true if the package was previously pinned. *)
+  overwrote_opams: OpamFile.OPAM.t package_map;
+  (** In case of simulated pins, keep the old information of opam files *)
 
   (* Missing: a cache for
      - switch-global and package variables

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -616,6 +616,7 @@ let load lock_kind gt rt switch =
     installed; pinned; installed_roots;
     opams; conf_files;
     packages; available_packages; sys_packages; reinstall; invalidated;
+    overwrote_opams = OpamPackage.Map.empty;
   } in
   log "Switch state loaded in %.3fs" (chrono ());
   st
@@ -660,6 +661,7 @@ let load_virtual ?repos_list ?(avail_default=true) gt rt =
     available_packages;
     reinstall = lazy OpamPackage.Set.empty;
     invalidated = lazy (OpamPackage.Set.empty);
+    overwrote_opams = OpamPackage.Map.empty;
   }
 
 let selections st =
@@ -973,6 +975,18 @@ let universe st
       ~force_dev_deps ~test ~doc ~dev_setup
       ~requested_allpkgs
   in
+  (* We retrieve the previous opam files, package in this set are simulated
+     pins and we don't want the take the new definition into account for
+     solving *)
+  let overwrote_opams, overwrote_unpinned =
+    OpamPackage.Map.fold (fun nv (pinned, opam) (opams, unpinneds) ->
+        OpamPackage.Map.add nv opam opams,
+        if pinned then unpinneds else OpamPackage.Set.add nv unpinneds)
+      st.overwrote_opams OpamPackage.(Map.empty, Set.empty)
+  in
+    OpamPackage.Map.union (fun _ o -> o) st.opams overwrote_opams
+  in
+  let u_pinned = OpamPinned.packages st -- overwrote_unpinned in
   let u_depends =
     let depend =
       let ignored = OpamStateConfig.(!r.ignore_constraints_on) in
@@ -989,10 +1003,10 @@ let universe st
             else Atom atom)
           (OpamFile.OPAM.depends opam)
     in
-    get_deps depend st.opams
+    get_deps depend opams
   in
-  let u_depopts = get_deps OpamFile.OPAM.depopts st.opams in
-  let u_conflicts = get_conflicts st st.packages st.opams in
+  let u_depopts = get_deps OpamFile.OPAM.depopts opams in
+  let u_conflicts = get_conflicts st st.packages opams in
   let u_invariant =
     if OpamStateConfig.(!r.unlock_base) then OpamFormula.Empty
     else st.switch_invariant

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -1046,7 +1046,6 @@ let universe st
   u_depends;
   u_depopts;
   u_conflicts;
-  u_installed_roots = st.installed_roots;
   u_invariant;
   u_reinstall;
   u_attrs     = ["opam-query", lazy requested;

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -978,15 +978,9 @@ let universe st
   (* We retrieve the previous opam files, package in this set are simulated
      pins and we don't want the take the new definition into account for
      solving *)
-  let overwrote_opams, overwrote_unpinned =
-    OpamPackage.Map.fold (fun nv (pinned, opam) (opams, unpinneds) ->
-        OpamPackage.Map.add nv opam opams,
-        if pinned then unpinneds else OpamPackage.Set.add nv unpinneds)
-      st.overwrote_opams OpamPackage.(Map.empty, Set.empty)
+  let opams =
+    OpamPackage.Map.union (fun _ o -> o) st.opams st.overwrote_opams
   in
-    OpamPackage.Map.union (fun _ o -> o) st.opams overwrote_opams
-  in
-  let u_pinned = OpamPinned.packages st -- overwrote_unpinned in
   let u_depends =
     let depend =
       let ignored = OpamStateConfig.(!r.ignore_constraints_on) in

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -1047,7 +1047,6 @@ let universe st
   u_depopts;
   u_conflicts;
   u_installed_roots = st.installed_roots;
-  u_pinned    = OpamPinned.packages st;
   u_invariant;
   u_reinstall;
   u_attrs     = ["opam-query", lazy requested;

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1132,25 +1132,15 @@ depends: "dependency" {= "2"}
 [NOTE] Ignoring uncommitted changes in ${BASEDIR}/pin-change (`--working-dir' not specified or specified with no argument).
 [pin-change.dev] synchronised (no changes)
 The following actions will be performed:
-=== recompile 1 package
-  - recompile pin-change dev (pinned) [uses dependency]
+=== remove 1 package
+  - remove  pin-change dev (pinned) [conflicts with dependency]
 === upgrade 1 package
-  - upgrade   dependency 1 to 2       [required by pin-change]
+  - upgrade dependency 1 to 2       [required by pin-change]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   pin-change.dev
 -> removed   dependency.1
 -> installed dependency.2
--> retrieved pin-change.dev  (no changes)
--> removed   pin-change.dev
--> installed pin-change.dev
-Done.
-### opam remove pin-change
-The following actions will be performed:
-=== remove 1 package
-  - remove pin-change dev (pinned)
-
-<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> removed   pin-change.dev
 Done.
 ### <pin:pin-change/opam>
 opam-version: "2.0"

--- a/tests/reftests/reinstall.test
+++ b/tests/reftests/reinstall.test
@@ -118,9 +118,9 @@ The following actions would be performed:
   - install   c 1
   - install   d 1
 ### diff install-1.cudf reinstall-1.cudf
-20a21
+19a20
 > reinstall: true
-54c55
+53c54
 < install: d , a
 ---
 > install: d , a = 1


### PR DESCRIPTION
While looking at #XXX, I found out that there is several attributes given to the solver that are not needed : pinned status and is the package is installed as root. None of the solvers uses that attribute. Digging in the history, I guess that it may have been used before to handle pinned or roots via the solver. These addition date back to the very beginning of opam (#751 for pinned, and ce584b5d51894d11a9d185bb00bfd28fbc8ea34d -no pr- for installed roots).

I checked locally with opam lib rev deps, nothing broke.

TODO
* [ ] add a cudf test to highlight the changes
* [x] the may be queued on #6530, the last two commit are here to revert some changes. If this PR is merged before, they can be removed.
* [ ] update API changelog
