### PR TITLE
GHA: Fix the expected location of git.exe

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -349,7 +349,7 @@ let main_build_job ~analyse_job ~cygwin_job ?section runner start_version ~oc ~w
           {|if "${{ matrix.host }}" equ "x86_64-pc-windows" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"|} ::
           {|if "${{ matrix.host }}" equ "i686-pc-windows" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat"|} ::
           run_or_fail [
-           {|opam init --yes --bare default git+file://D:/opam-repository#${{ env.OPAM_TEST_REPO_SHA }} --no-git-location|};
+           {|opam init --yes --bare default git+file://$GITHUB_WORKSPACE/opam-repository#${{ env.OPAM_TEST_REPO_SHA }} --no-git-location|};
            {|opam switch --yes create default ocaml-system|};
            {|opam env|};
            {|opam install --yes lwt|};

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -349,7 +349,7 @@ let main_build_job ~analyse_job ~cygwin_job ?section runner start_version ~oc ~w
           {|if "${{ matrix.host }}" equ "x86_64-pc-windows" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"|} ::
           {|if "${{ matrix.host }}" equ "i686-pc-windows" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat"|} ::
           run_or_fail [
-           {|opam init --yes --bare default git+file://$GITHUB_WORKSPACE/opam-repository#${{ env.OPAM_TEST_REPO_SHA }} --no-git-location|};
+           {|opam init --yes --bare default git+file://%HOME%/opam-repository#${{ env.OPAM_TEST_REPO_SHA }} --no-git-location|};
            {|opam switch --yes create default ocaml-system|};
            {|opam env|};
            {|opam install --yes lwt|};

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -349,7 +349,7 @@ let main_build_job ~analyse_job ~cygwin_job ?section runner start_version ~oc ~w
           {|if "${{ matrix.host }}" equ "x86_64-pc-windows" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"|} ::
           {|if "${{ matrix.host }}" equ "i686-pc-windows" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat"|} ::
           run_or_fail [
-           {|opam init --yes --bare default git+file://%HOME%/opam-repository#${{ env.OPAM_TEST_REPO_SHA }} --no-git-location|};
+           {|opam init --yes --bare default git+file://%UserProfile%/opam-repository#${{ env.OPAM_TEST_REPO_SHA }} --no-git-location|};
            {|opam switch --yes create default ocaml-system|};
            {|opam env|};
            {|opam install --yes lwt|};

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -236,7 +236,7 @@ jobs:
         set Path=D:\Cache\ocaml-local\bin;%Path%
         if "${{ matrix.host }}" equ "x86_64-pc-windows" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         if "${{ matrix.host }}" equ "i686-pc-windows" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
-        opam init --yes --bare default git+file://D:/opam-repository#${{ env.OPAM_TEST_REPO_SHA }} --no-git-location || exit /b 1
+        opam init --yes --bare default git+file://$GITHUB_WORKSPACE/opam-repository#${{ env.OPAM_TEST_REPO_SHA }} --no-git-location || exit /b 1
         opam switch --yes create default ocaml-system || exit /b 1
         opam env || exit /b 1
         opam install --yes lwt || exit /b 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -236,7 +236,7 @@ jobs:
         set Path=D:\Cache\ocaml-local\bin;%Path%
         if "${{ matrix.host }}" equ "x86_64-pc-windows" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         if "${{ matrix.host }}" equ "i686-pc-windows" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
-        opam init --yes --bare default git+file://$GITHUB_WORKSPACE/opam-repository#${{ env.OPAM_TEST_REPO_SHA }} --no-git-location || exit /b 1
+        opam init --yes --bare default git+file://%UserProfile%/opam-repository#${{ env.OPAM_TEST_REPO_SHA }} --no-git-location || exit /b 1
         opam switch --yes create default ocaml-system || exit /b 1
         opam env || exit /b 1
         opam install --yes lwt || exit /b 1


### PR DESCRIPTION
I'm not sure why it changed all of a sudden but github actions such as [this one](https://github.com/ocaml/opam/actions/runs/15619037509/job/44073804949?pr=6544) now fail with:
```
Getting Git version info
Working directory is 'C:\a\opam\opam'
"C:\Program Files\Git\bin\git.exe" version
git version [2.49.0.windows](http://2.49.0.windows/).1
[...]
Error: Could not update repository "default": "C:\Program Files\Git\cmd\git.exe fetch -q" exited with code 128
```