### PR TITLE
on `opam switch create <version>`, use avoid-version compiler if it is the only one available

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -109,6 +109,7 @@ users)
 
 ## Reftests
 ### Tests
+  * Add test for switch creation `opam switch <version>` where all compilers are flagged `avoid-version` [#6571 @rjbou]
 
 ### Engine
   * `gawk` was re-added to the base fedora images [#6473 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -31,6 +31,7 @@ users)
 ## UI
 
 ## Switch
+  * Fix `opam switch <version>` where all compilers of that version are `avoid-version` [#6571 @rjbou - fix #6563]
 
 ## Config
 

--- a/tests/reftests/switch-creation.test
+++ b/tests/reftests/switch-creation.test
@@ -156,3 +156,98 @@ Switch invariant: ["ocaml-base-compiler" {= "4.14.0"}]
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed ocaml-base-compiler.4.14.0
 Done.
+### :c: switch create <version> should keep avoid version packages if only
+### ::: avoid version compiler packages are compliant
+### :c:1: Mimic opam repository compiler packages
+### rm -rf REPO/packages
+### <pkg:ocaml-variants.5.3.0+options>
+opam-version: "2.0"
+flags: [ compiler ]
+### <pkg:ocaml-base-compiler.5.3.0>
+opam-version: "2.0"
+flags: [ compiler ]
+### <pkg:ocaml.5.3.0>
+opam-version: "2.0"
+depends: [
+  "ocaml-base-compiler" {>= "5.3.0~" & < "5.3.1~"}
+  | "ocaml-variants" {>= "5.3.0~" & < "5.3.1~"}
+  | "ocaml-system" {>= "5.3.0~" & < "5.3.1~"}
+]
+flags: [ conf ]
+### <pkg:ocaml-system.5.3.0>
+opam-version: "2.0"
+flags: [ compiler avoid-version ]
+### <pkg:ocaml-variants.5.4.0~alpha1+options>
+opam-version: "2.0"
+flags: [compiler avoid-version]
+### <pkg:ocaml-base-compiler.5.4.0~alpha1>
+opam-version: "2.0"
+flags: [compiler avoid-version]
+### <pkg:ocaml.5.4.0>
+opam-version: "2.0"
+depends: [
+  "ocaml-base-compiler" {>= "5.4.0~" & < "5.4.1~"}
+  | "ocaml-variants" {>= "5.4.0~" & < "5.4.1~"}
+  | "ocaml-system" {>= "5.4.0~" & < "5.4.1~"}
+]
+flags: [ conf avoid-version ]
+### opam switch create 5.4.0~alpha1
+[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
+# Return code 5 #
+### opam switch create 5.4-alpha-default 5.4.0~alpha1
+[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
+# Return code 5 #
+### opam switch create --solver=builtin-mccs+glpk 5.4-alpha-mccs 5.4.0~alpha1
+[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
+# Return code 5 #
+### opam switch create --solver=builtin-0install 5.4.0~alpha1install 5.4.0~alpha1
+[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
+# Return code 5 #
+### :c:2: With 2 packages avoid version
+### rm -rf REPO/packages
+### <pkg:ocaml-variants.5.3.0>
+opam-version: "2.0"
+flags: [ compiler ]
+### <pkg:ocaml-base-compiler.5.3.0>
+opam-version: "2.0"
+flags: [ compiler ]
+### <pkg:ocaml.5.3.0>
+opam-version: "2.0"
+depends: [
+  "ocaml-base-compiler" {>= "5.3.0~" & < "5.3.1~"}
+  | "ocaml-variants" {>= "5.3.0~" & < "5.3.1~"}
+  | "ocaml-system" {>= "5.3.0~" & < "5.3.1~"}
+]
+flags: [ conf ]
+### <pkg:ocaml-system.5.3.0>
+opam-version: "2.0"
+flags: [ compiler avoid-version ]
+### <pkg:ocaml-variants.5.4.0~alpha1>
+opam-version: "2.0"
+flags: [compiler avoid-version]
+### <pkg:ocaml-base-compiler.5.4.0~alpha1>
+opam-version: "2.0"
+flags: [compiler avoid-version]
+### <pkg:ocaml.5.4.0>
+opam-version: "2.0"
+depends: [
+  "ocaml-base-compiler" {>= "5.4.0~" & < "5.4.1~"}
+  | "ocaml-variants" {>= "5.4.0~" & < "5.4.1~"}
+  | "ocaml-system" {>= "5.4.0~" & < "5.4.1~"}
+]
+flags: [ conf avoid-version ]
+### opam switch remove 5.4.0~alpha1 -y
+The compiler switch 5.4.0~alpha1 does not exist.
+# Return code 5 #
+### opam switch create 5.4.0~alpha1
+[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
+# Return code 5 #
+### opam switch create 5.4-alpha-default-2 5.4.0~alpha1
+[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
+# Return code 5 #
+### opam switch create --solver=builtin-mccs+glpk 5.4-alpha-mccs-2 5.4.0~alpha1
+[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
+# Return code 5 #
+### opam switch create --solver=builtin-0install 5.4.0~alpha1install-2 5.4.0~alpha1
+[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
+# Return code 5 #

--- a/tests/reftests/switch-creation.test
+++ b/tests/reftests/switch-creation.test
@@ -192,17 +192,37 @@ depends: [
 ]
 flags: [ conf avoid-version ]
 ### opam switch create 5.4.0~alpha1
-[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
-# Return code 5 #
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-base-compiler" {= "5.4.0~alpha1"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed ocaml-base-compiler.5.4.0~alpha1
+Done.
 ### opam switch create 5.4-alpha-default 5.4.0~alpha1
-[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
-# Return code 5 #
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-base-compiler" {= "5.4.0~alpha1"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed ocaml-base-compiler.5.4.0~alpha1
+Done.
 ### opam switch create --solver=builtin-mccs+glpk 5.4-alpha-mccs 5.4.0~alpha1
-[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
-# Return code 5 #
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-base-compiler" {= "5.4.0~alpha1"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed ocaml-base-compiler.5.4.0~alpha1
+Done.
 ### opam switch create --solver=builtin-0install 5.4.0~alpha1install 5.4.0~alpha1
-[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
-# Return code 5 #
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: ["ocaml-base-compiler" {= "5.4.0~alpha1"}]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed ocaml-base-compiler.5.4.0~alpha1
+Done.
 ### :c:2: With 2 packages avoid version
 ### rm -rf REPO/packages
 ### <pkg:ocaml-variants.5.3.0>
@@ -237,17 +257,56 @@ depends: [
 ]
 flags: [ conf avoid-version ]
 ### opam switch remove 5.4.0~alpha1 -y
-The compiler switch 5.4.0~alpha1 does not exist.
-# Return code 5 #
+Switch 5.4.0~alpha1 and all its packages will be wiped. Are you sure? [Y/n] y
 ### opam switch create 5.4.0~alpha1
-[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
-# Return code 5 #
+[NOTE] Compilers found for version 5.4.0~alpha1 are all flagged with 'avoid-version'.
+       It is better to use a more explicit command like 'opam switch create <switch-name> <package-name.version>'
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: [
+  "ocaml-base-compiler" {= "5.4.0~alpha1"} |
+  "ocaml-variants" {= "5.4.0~alpha1"}
+]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed ocaml-base-compiler.5.4.0~alpha1
+Done.
 ### opam switch create 5.4-alpha-default-2 5.4.0~alpha1
-[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
-# Return code 5 #
+[NOTE] Compilers found for version 5.4.0~alpha1 are all flagged with 'avoid-version'.
+       It is better to use a more explicit command like 'opam switch create <switch-name> <package-name.version>'
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: [
+  "ocaml-base-compiler" {= "5.4.0~alpha1"} |
+  "ocaml-variants" {= "5.4.0~alpha1"}
+]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed ocaml-base-compiler.5.4.0~alpha1
+Done.
 ### opam switch create --solver=builtin-mccs+glpk 5.4-alpha-mccs-2 5.4.0~alpha1
-[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
-# Return code 5 #
+[NOTE] Compilers found for version 5.4.0~alpha1 are all flagged with 'avoid-version'.
+       It is better to use a more explicit command like 'opam switch create <switch-name> <package-name.version>'
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: [
+  "ocaml-base-compiler" {= "5.4.0~alpha1"} |
+  "ocaml-variants" {= "5.4.0~alpha1"}
+]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed ocaml-base-compiler.5.4.0~alpha1
+Done.
 ### opam switch create --solver=builtin-0install 5.4.0~alpha1install-2 5.4.0~alpha1
-[ERROR] No compiler matching `5.4.0~alpha1' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
-# Return code 5 #
+[NOTE] Compilers found for version 5.4.0~alpha1 are all flagged with 'avoid-version'.
+       It is better to use a more explicit command like 'opam switch create <switch-name> <package-name.version>'
+
+<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
+Switch invariant: [
+  "ocaml-base-compiler" {= "5.4.0~alpha1"} |
+  "ocaml-variants" {= "5.4.0~alpha1"}
+]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed ocaml-base-compiler.5.4.0~alpha1
+Done.


### PR DESCRIPTION
fix #6563 
