### PR TITLE
GHA: gawk was re-added to the base fedora images

### DIFF
--- a/.github/scripts/depexts/generate-actions.sh
+++ b/.github/scripts/depexts/generate-actions.sh
@@ -70,7 +70,7 @@ EOF
   cat > "$dir/Dockerfile" << EOF
 FROM fedora:43
 RUN dnf install -y $mainlibs $ocaml diffutils
-RUN dnf install -y gcc-c++ gawk
+RUN dnf install -y gcc-c++
 EOF
     ;;
   gentoo)

--- a/master_changes.md
+++ b/master_changes.md
@@ -111,6 +111,7 @@ users)
 ### Tests
 
 ### Engine
+  * `gawk` was re-added to the base fedora images [#6473 @kit-ty-kate]
 
 ## Github Actions
 


### PR DESCRIPTION
See https://github.com/fedora-cloud/docker-brew-fedora/issues/119