### PR TITLE
GHA: Only run the get-changed-files action when in a PR

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -475,7 +475,7 @@ let hygiene_job (type a) ~analyse_job (platform : a platform) ~oc ~workflow f =
     ++ install_sys_dune [os_of_platform platform]
     ++ checkout ()
     ++ cache Archives
-    ++ uses "Get changed files" ~id:"files" (* ~continue_on_error:true see https://github.com/jitterbit/get-changed-files/issues/19 *) "Ana06/get-changed-files@v2.3.0" (* see https://github.com/jitterbit/get-changed-files/issues/55 ; Ana06'fork contains #19 and #55 fixes *)
+    ++ uses "Get changed files" ~id:"files" ~cond:(Predicate(true, Compare("github.event_name", "pull_request"))) (* ~continue_on_error:true see https://github.com/jitterbit/get-changed-files/issues/19 *) "Ana06/get-changed-files@v2.3.0" (* see https://github.com/jitterbit/get-changed-files/issues/55 ; Ana06'fork contains #19 and #55 fixes *)
     ++ run "Changed files list" [
          "for changed_file in ${{ steps.files.outputs.modified }}; do";
          "  echo \"M  ${changed_file}.\"";

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -672,6 +672,7 @@ jobs:
         enableCrossOsArchive: true
     - name: Get changed files
       id: files
+      if: github.event_name == 'pull_request'
       uses: Ana06/get-changed-files@v2.3.0
     - name: Changed files list
       run: |

--- a/master_changes.md
+++ b/master_changes.md
@@ -125,6 +125,7 @@ users)
   * bump `actions/checkout` from 4 to 5 [#6643 @kit-ty-kate]
   * Fix the nixos depexts tests (git is now already installed in the nix docker image) [#6652 @kit-ty-kate]
   * Ensure every part of the scripts are run with `set -ue` [#6648 @kit-ty-kate]
+  * Only run the `get-changed-files` action when in a PR [#6582 @kit-ty-kate]
 
 ## Doc
   * Update the installation documentation with the release of opam 2.4.1 [#6620 @kit-ty-kate]


### PR DESCRIPTION
For some reason this action can sometimes fail on master (e.g. https://github.com/ocaml/opam/actions/runs/16059563611/job/45322179882)