### PR TITLE
Switch the default solver from builtin-mccs+glpk to builtin-0install

### DIFF
--- a/src/solver/opamCudfSolver.ml
+++ b/src/solver/opamCudfSolver.ml
@@ -230,9 +230,9 @@ let make_custom_solver name args criteria =
 
 
 let default_solver_selection =
+  (module OpamBuiltin0install: S) ::
   OpamBuiltinMccs.all_backends @ [
     (module OpamBuiltinZ3: S);
-    (module OpamBuiltin0install: S);
     (module Aspcud: S);
     (module Mccs: S);
     (module Aspcud_old: S);

--- a/tests/reftests/avoid-version.test
+++ b/tests/reftests/avoid-version.test
@@ -73,13 +73,6 @@ The following actions will be faked:
 Faking installation of b.1
 Done.
 ### opam upgrade
-Everything as up-to-date as possible
-
-The following packages are not being upgraded because the new versions conflict with other installed packages:
-  - b.2
-However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade b.2"), which will ask permission to downgrade or uninstall the conflicting packages.
-Nothing to do.
-### opam upgrade b
 The following actions will be faked:
 === downgrade 1 package
   - downgrade a 3 to 2 [required by b]
@@ -90,17 +83,17 @@ The following actions will be faked:
 Faking installation of a.2
 Faking installation of b.2
 Done.
+### opam upgrade b
+Already up-to-date.
+Nothing to do.
 ### opam upgrade
-The following actions will be faked:
-=== downgrade 1 package
-  - downgrade b 2 to 1 [uses a]
-=== upgrade 1 package
-  - upgrade   a 2 to 3
+Everything as up-to-date as possible
 
-<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-Faking installation of a.3
-Faking installation of b.1
-Done.
+The following packages are not being upgraded because the new versions conflict with other installed packages:
+  - a.3
+    -- b.2 is installed and requires a = 2
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade a.3"), which will ask permission to downgrade or uninstall the conflicting packages.
+Nothing to do.
 ### <pkg:a.4>
 opam-version: "2.0"
 flags: avoid-version
@@ -111,25 +104,20 @@ flags: avoid-version
 Everything as up-to-date as possible
 
 The following packages are not being upgraded because the new versions conflict with other installed packages:
-  - b.2
-However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade b.2"), which will ask permission to downgrade or uninstall the conflicting packages.
+  - a.3
+    -- b.2 is installed and requires a = 2
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade a.3"), which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.
 ### opam upgrade b.3
 The following actions will be faked:
 === upgrade 1 package
-  - upgrade b 1 to 3
+  - upgrade b 2 to 3
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Faking installation of b.3
 Done.
 ### opam install a.2
-The following actions will be faked:
-=== downgrade 1 package
-  - downgrade a 3 to 2
-
-<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-Faking installation of a.2
-Done.
+[NOTE] Package a is already installed (current version is 2).
 ### opam upgrade
 The following actions will be faked:
 === upgrade 1 package

--- a/tests/reftests/best-effort.test
+++ b/tests/reftests/best-effort.test
@@ -10,4 +10,11 @@ opam-version: "2.0"
 opam-version: "2.0"
 depends: ["unavailable"]
 ### opam install --show --best-effort test.2
-Nothing to do.
+[WARNING] Your solver configuration does not support --best-effort, the option was ignored (you need to specify variable OPAMBESTEFFORTCRITERIA, or set your criteria to maximise the count for cudf attribute 'opam-query')
+[ERROR] Package conflict!
+  * Missing dependency:
+    - test >= 2 -> unavailable
+    unmet availability conditions: 'false'
+
+No solution found, exiting
+# Return code 20 #

--- a/tests/reftests/deprecated.test
+++ b/tests/reftests/deprecated.test
@@ -76,13 +76,6 @@ The following actions will be faked:
 Faking installation of b.1
 Done.
 ### opam upgrade
-Everything as up-to-date as possible
-
-The following packages are not being upgraded because the new versions conflict with other installed packages:
-  - b.2
-However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade b.2"), which will ask permission to downgrade or uninstall the conflicting packages.
-Nothing to do.
-### opam upgrade b
 The following actions will be faked:
 === downgrade 1 package
   - downgrade a 3 to 2 (deprecated) [required by b]
@@ -96,17 +89,17 @@ Done.
 
 <><> a.2 installed successfully <><><><><><><><><><><><><><><><><><><><><><><><>
 => Note: This package is deprecated.
+### opam upgrade b
+Already up-to-date.
+Nothing to do.
 ### opam upgrade
-The following actions will be faked:
-=== downgrade 1 package
-  - downgrade b 2 to 1              [uses a]
-=== upgrade 1 package
-  - upgrade   a 2 (deprecated) to 3
+Everything as up-to-date as possible
 
-<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-Faking installation of a.3
-Faking installation of b.1
-Done.
+The following packages are not being upgraded because the new versions conflict with other installed packages:
+  - a.3
+    -- b.2 is installed and requires a = 2
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade a.3"), which will ask permission to downgrade or uninstall the conflicting packages.
+Nothing to do.
 ### <pkg:a.4>
 opam-version: "2.0"
 flags: deprecated
@@ -117,13 +110,14 @@ flags: deprecated
 Everything as up-to-date as possible
 
 The following packages are not being upgraded because the new versions conflict with other installed packages:
-  - b.2
-However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade b.2"), which will ask permission to downgrade or uninstall the conflicting packages.
+  - a.3
+    -- b.2 is installed and requires a = 2
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade a.3"), which will ask permission to downgrade or uninstall the conflicting packages.
 Nothing to do.
 ### opam upgrade b.3
 The following actions will be faked:
 === upgrade 1 package
-  - upgrade b 1 to 3 (deprecated)
+  - upgrade b 2 to 3 (deprecated)
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Faking installation of b.3
@@ -132,16 +126,7 @@ Done.
 <><> b.3 installed successfully <><><><><><><><><><><><><><><><><><><><><><><><>
 => Note: This package is deprecated.
 ### opam install a.2
-The following actions will be faked:
-=== downgrade 1 package
-  - downgrade a 3 to 2 (deprecated)
-
-<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-Faking installation of a.2
-Done.
-
-<><> a.2 installed successfully <><><><><><><><><><><><><><><><><><><><><><><><>
-=> Note: This package is deprecated.
+[NOTE] Package a is already installed (current version is 2).
 ### opam upgrade
 The following actions will be faked:
 === upgrade 1 package

--- a/tests/reftests/deps-only.test
+++ b/tests/reftests/deps-only.test
@@ -437,14 +437,11 @@ The following actions will be performed:
 Done.
 ### opam install --deps-only lorem dolor
 The following actions will be performed:
-=== install 2 packages
+=== install 1 package
   - install ipsum 1 [required by dolor]
-  - install sit   1 [required by lorem]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> removed   deps-of-lorem.1
 -> installed ipsum.1
--> installed sit.1
 Done.
 ### :III:5: deps of same packages, good version specified, already installed package
 ### opam switch create deps-conflicts-5 --empty
@@ -536,10 +533,10 @@ opam-version: "2.0"
 ### opam install --deps-only lorem dolor
 The following actions will be performed:
 === install 1 package
-  - install sit 2 [required by lorem]
+  - install ipsum 1 [required by lorem]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> installed sit.2
+-> installed ipsum.1
 Done.
 ### opam switch create deps-conflicts-7b --empty
 ### # it takes lorem.1

--- a/tests/reftests/install-formula.test
+++ b/tests/reftests/install-formula.test
@@ -20,27 +20,27 @@ Done.
 [WARNING] Flag --formula is experimental, there is no guarantee that it will be kept; avoid using it in scripts.
 The following actions will be faked:
 === install 21 packages
-  - install astring               0.8.3   [required by ocb-stubblr]
-  - install base-bytes            base    [required by astring]
-  - install bigarray-compat       1.0.0   [required by cstruct]
-  - install conf-m4               1       [required by ocamlfind]
-  - install conf-pkg-config       1.1     [required by ocaml-freestanding]
-  - install cppo                  1.6.6   [required by lwt]
-  - install cstruct               5.0.0   [required by mirage-solo5]
-  - install dune                  1.10.0  [required by cstruct]
-  - install logs                  0.6.3   [required by mirage-solo5]
-  - install lwt                   4.2.1   [required by mirage-solo5]
-  - install mirage-solo5          0.5.0
-  - install mmap                  1.1.0   [required by lwt]
-  - install ocaml-freestanding    0.4.5   [required by mirage-solo5]
-  - install ocaml-src             4.08.0  [required by ocaml-freestanding]
-  - install ocamlbuild            0.14.0  [required by mirage-solo5]
-  - install ocamlfind             1.8.0   [required by mirage-solo5]
-  - install ocb-stubblr           0.1.1-1 [required by mirage-solo5]
-  - install result                1.4     [required by lwt, topkg]
-  - install seq                   base    [required by lwt]
-  - install solo5-bindings-virtio 0.4.1   [required by mirage-solo5]
-  - install topkg                 1.0.0   [required by mirage-solo5]
+  - install astring            0.8.3   [required by ocb-stubblr]
+  - install base-bytes         base    [required by astring]
+  - install bigarray-compat    1.0.0   [required by cstruct]
+  - install conf-m4            1       [required by ocamlfind]
+  - install conf-pkg-config    1.1     [required by ocaml-freestanding]
+  - install cppo               1.6.6   [required by lwt]
+  - install cstruct            5.0.0   [required by mirage-solo5]
+  - install dune               1.10.0  [required by cstruct]
+  - install logs               0.6.3   [required by mirage-solo5]
+  - install lwt                4.2.1   [required by mirage-solo5]
+  - install mirage-solo5       0.5.0
+  - install mmap               1.1.0   [required by lwt]
+  - install ocaml-freestanding 0.4.5   [required by mirage-solo5]
+  - install ocaml-src          4.08.0  [required by ocaml-freestanding]
+  - install ocamlbuild         0.14.0  [required by mirage-solo5]
+  - install ocamlfind          1.8.0   [required by mirage-solo5]
+  - install ocb-stubblr        0.1.1-1 [required by mirage-solo5]
+  - install result             1.4     [required by lwt, topkg]
+  - install seq                base    [required by lwt]
+  - install solo5-bindings-hvt 0.4.1   [required by mirage-solo5]
+  - install topkg              1.0.0   [required by mirage-solo5]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Faking installation of conf-m4.1
@@ -57,7 +57,7 @@ Faking installation of base-bytes.base
 Faking installation of result.1.4
 Faking installation of seq.base
 Faking installation of lwt.4.2.1
-Faking installation of solo5-bindings-virtio.0.4.1
+Faking installation of solo5-bindings-hvt.0.4.1
 Faking installation of ocaml-freestanding.0.4.5
 Faking installation of topkg.1.0.0
 Faking installation of astring.0.8.3
@@ -136,11 +136,13 @@ However, you may "opam upgrade" these packages explicitly at these versions (e.g
 Nothing to do.
 ### opam upgrade mirage-solo5 --formula '"mirage-no-solo5"' --best-effort
 [WARNING] Flag --formula is experimental, there is no guarantee that it will be kept; avoid using it in scripts.
-The following actions would be faked:
-=== remove 1 package
-  - remove  mirage-solo5    0.5.0
-=== install 1 package
-  - install mirage-no-solo5 1
+[WARNING] Your solver configuration does not support --best-effort, the option was ignored (you need to specify variable OPAMBESTEFFORTCRITERIA, or set your criteria to maximise the count for cudf attribute 'opam-query')
+[ERROR] Package conflict!
+  * Incompatible packages:
+    - mirage-no-solo5
+    - mirage-solo5 >= 0.5.0
+
+# Return code 20 #
 ### OPAMSHOW=0 opam switch create test --empty
 ### opam install --formula '"ocaml-base-compiler" | "ocaml-system"'
 [WARNING] Flag --formula is experimental, there is no guarantee that it will be kept; avoid using it in scripts.
@@ -156,12 +158,12 @@ The following actions would be faked:
 [WARNING] Flag --formula is experimental, there is no guarantee that it will be kept; avoid using it in scripts.
 The following actions would be faked:
 === install 6 packages
-  - install base-bigarray base
-  - install base-threads  base
-  - install base-unix     base
-  - install ocaml         4.08.0
-  - install ocaml-config  1      [required by ocaml]
-  - install ocaml-system  4.08.0
+  - install base-bigarray  base
+  - install base-threads   base
+  - install base-unix      base
+  - install ocaml          4.08.0
+  - install ocaml-config   1                [required by ocaml]
+  - install ocaml-variants 4.08.0+spacetime
 ### opam install ocaml.4.07.0 --formula '"ocaml-base-compiler" | "ocaml-system"'
 [WARNING] Flag --formula is experimental, there is no guarantee that it will be kept; avoid using it in scripts.
 The following actions would be faked:
@@ -194,10 +196,10 @@ The following actions would be faked:
 ### opam install genet --formula '["mysql" ("conf-mariadb" & "mariadb" | "conf-postgresql")]'
 [WARNING] Flag --formula is experimental, there is no guarantee that it will be kept; avoid using it in scripts.
 The following actions would be faked:
-=== install 67 packages
+=== install 71 packages
   - install base                    v0.12.2    [required by pcre]
   - install base-bigarray           base
-  - install base-bytes              base       [required by ocamlnet]
+  - install base-bytes              base       [required by ocamlnet, ctypes]
   - install base-threads            base       [required by dune]
   - install base-unix               base       [required by cppo]
   - install biniou                  1.2.0      [required by yojson]
@@ -211,18 +213,21 @@ The following actions would be faked:
   - install conf-gtksourceview      2          [required by lablgtk, lablgtk-extras]
   - install conf-libpcre            1          [required by pcre]
   - install conf-m4                 1          [required by ocamlfind]
+  - install conf-mariadb            1
   - install conf-perl               1          [required by zarith]
-  - install conf-pkg-config         1.1        [required by conf-glade, conf-gnomecanvas]
-  - install conf-postgresql         1
+  - install conf-pkg-config         1.1        [required by conf-mariadb]
   - install conf-which              1          [required by biniou]
   - install conf-zlib               1          [required by cryptokit]
   - install config-file             1.2        [required by genet]
   - install cppo                    1.6.6      [required by yojson]
   - install cryptokit               1.13       [required by rdf]
+  - install ctypes                  0.14.0     [required by mariadb]
+  - install ctypes-foreign          0.4.0      [required by mariadb]
   - install dune                    1.10.0     [required by js_of_ocaml, uri, pcre, etc.]
   - install easy-format             1.3.1      [required by yojson]
   - install gen                     0.5.2      [required by sedlex]
   - install genet                   0.6
+  - install integers                0.2.2      [required by ctypes]
   - install iri                     0.4.0      [required by rdf, xtmpl]
   - install jbuilder                transition [required by biniou]
   - install js_of_ocaml             3.3.0      [required by xtmpl]
@@ -231,28 +236,29 @@ The following actions would be faked:
   - install jsonm                   1.0.1      [required by rdf]
   - install lablgtk                 2.18.8     [required by genet]
   - install lablgtk-extras          1.6        [required by genet]
+  - install mariadb                 1.1.2
   - install menhir                  20190626   [required by genet]
   - install mysql                   1.2.2
-  - install ocaml                   4.05.0     [required by genet, mysql]
+  - install ocaml                   4.05.0     [required by mariadb, genet, mysql]
   - install ocaml-base-compiler     4.05.0     [required by ocaml]
   - install ocaml-config            1          [required by ocaml]
-  - install ocaml-migrate-parsetree 1.4.0      [required by js_of_ocaml, js_of_ocaml-ppx]
-  - install ocamlbuild              0.14.0     [required by menhir, ocamlnet]
+  - install ocaml-migrate-parsetree 1.2.0      [required by js_of_ocaml, js_of_ocaml-ppx]
+  - install ocamlbuild              0.14.0     [required by mariadb]
   - install ocamldot                1.0        [required by genet]
-  - install ocamlfind               1.8.0      [required by genet, mysql]
+  - install ocamlfind               1.8.0      [required by mariadb, genet, mysql]
   - install ocamlnet                4.1.6      [required by genet]
   - install pcre                    7.4.1      [required by genet]
   - install ppx_derivers            1.2.1      [required by ocaml-migrate-parsetree]
   - install ppx_tools               5.0+4.05.0 [required by xtmpl]
-  - install ppx_tools_versioned     5.2.3      [required by js_of_ocaml, js_of_ocaml-ppx]
+  - install ppx_tools_versioned     5.2        [required by js_of_ocaml, js_of_ocaml-ppx]
   - install rdf                     0.11.0     [required by genet]
   - install re                      1.9.0      [required by xtmpl]
-  - install result                  1.4        [required by topkg, ocaml-migrate-parsetree]
-  - install sedlex                  1.99.3     [required by rdf, xtmpl]
+  - install result                  1.4        [required by topkg]
+  - install sedlex                  1.99.4     [required by rdf, xtmpl]
   - install seq                     0.1        [required by re]
   - install sexplib0                v0.12.0    [required by base]
   - install stringext               1.6.0      [required by uri]
-  - install topkg                   1.0.0      [required by jsonm, xmlm, uuidm]
+  - install topkg                   1.0.0      [required by uuidm, xmlm, jsonm, integers]
   - install uchar                   0.0.2      [required by jsonm, js_of_ocaml]
   - install uri                     3.0.0      [required by rdf]
   - install uuidm                   0.9.7      [required by rdf]

--- a/tests/reftests/json.unix.test
+++ b/tests/reftests/json.unix.test
@@ -84,7 +84,7 @@ Done.
     "remove": [],
     "upgrade": [],
     "all": [],
-    "criteria": "-removed,-count[avoid-version,changed],-count[version-lag,request],-count[version-lag,changed],-count[missing-depexts,changed],-changed"
+    "criteria": "-changed,-count[avoid-version,solution]"
   },
   "solution": [
     {
@@ -143,7 +143,7 @@ Done.
     "remove": [],
     "upgrade": [],
     "all": [],
-    "criteria": "-removed,-count[avoid-version,changed],-count[version-lag,request],-count[version-lag,changed],-count[missing-depexts,changed],-changed"
+    "criteria": "-changed,-count[avoid-version,solution]"
   },
   "solution": [
     {
@@ -241,7 +241,7 @@ Done.
     "all": [
       "ok"
     ],
-    "criteria": "-removed,-count[avoid-version,changed],-count[version-lag,request],-count[version-lag,changed],-count[missing-depexts,changed],-changed"
+    "criteria": "-changed,-count[avoid-version,solution]"
   },
   "solution": [
     {
@@ -311,7 +311,7 @@ The following actions will be performed:
     "all": [
       "ko"
     ],
-    "criteria": "-removed,-count[avoid-version,changed],-count[version-lag,request],-count[version-lag,changed],-count[missing-depexts,changed],-changed"
+    "criteria": "-changed,-count[avoid-version,solution]"
   },
   "solution": [
     {
@@ -397,7 +397,7 @@ Done.
     "all": [
       "ok"
     ],
-    "criteria": "-removed,-count[avoid-version,changed],-count[version-lag,request],-count[version-lag,changed],-count[missing-depexts,changed],-changed"
+    "criteria": "-changed,-count[avoid-version,solution]"
   },
   "solution": [
     {
@@ -466,7 +466,7 @@ The former state can be restored with:
       "ok",
       "ko"
     ],
-    "criteria": "-removed,-count[avoid-version,changed],-count[version-lag,request],-count[version-lag,changed],-count[missing-depexts,changed],-changed"
+    "criteria": "-changed,-count[avoid-version,solution]"
   },
   "solution": [
     {
@@ -581,7 +581,7 @@ Done.
     "all": [
       "nip"
     ],
-    "criteria": "-removed,-count[avoid-version,changed],-count[version-lag,request],-count[version-lag,changed],-count[missing-depexts,changed],-changed"
+    "criteria": "-changed,-count[avoid-version,solution]"
   },
   "solution": [
     {
@@ -641,7 +641,7 @@ Done.
     "all": [
       "nip"
     ],
-    "criteria": "-removed,-count[avoid-version,changed],-count[version-lag,request],-count[version-lag,changed],-count[missing-depexts,changed],-changed"
+    "criteria": "-changed,-count[avoid-version,solution]"
   },
   "solution": [
     {
@@ -695,7 +695,7 @@ Done.
     "all": [
       "nip.dev"
     ],
-    "criteria": "-removed,-count[avoid-version,changed],-count[version-lag,request],-count[version-lag,changed],-count[missing-depexts,changed],-changed"
+    "criteria": "-changed,-count[avoid-version,solution]"
   },
   "solution": [
     {

--- a/tests/reftests/list-large-dependencies.test
+++ b/tests/reftests/list-large-dependencies.test
@@ -344,13 +344,13 @@ abt
 ### opam install abella --show
 The following actions would be performed:
 === install 10 packages
-  - install abella                2.0.7
-  - install base-bigarray         base
-  - install base-threads          base
-  - install base-unix             base
-  - install ocaml                 4.12.1 [required by abella]
-  - install ocaml-base-compiler   4.12.1 [required by ocaml]
-  - install ocaml-config          2      [required by ocaml]
-  - install ocaml-options-vanilla 1
-  - install ocamlbuild            0.14.0 [required by abella]
-  - install ocamlfind             1.9.1  [required by abella]
+  - install abella         2.0.2
+  - install base-bigarray  base
+  - install base-domains   base
+  - install base-threads   base
+  - install base-unix      base
+  - install ocaml          5.00.0       [required by abella]
+  - install ocaml-config   2            [required by ocaml]
+  - install ocaml-variants 5.00.0+trunk [required by ocaml]
+  - install ocamlbuild     0.14.0       [required by abella]
+  - install ocamlfind      1.9.1        [required by abella]

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -802,10 +802,13 @@ STATE                           Inferred invariant: from base packages { i-am-sy
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 -> installed i-am-package.2
 STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
@@ -849,7 +852,7 @@ variables {
 }
 ### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
@@ -882,10 +885,13 @@ STATE                           Inferred invariant: from base packages { i-am-sy
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 -> installed i-am-package.2
 STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
@@ -929,7 +935,7 @@ variables {
 }
 ### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:1:d: Upgraded root and local 2.0 switch not recorded
@@ -956,10 +962,13 @@ STATE                           Inferred invariant: from base packages { i-am-sy
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 -> installed i-am-package.2
 STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
@@ -996,7 +1005,7 @@ variables {
 }
 ### opam-cat _opam/.opam-switch/switch-state
 compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:1:e: reinit from 2.0
@@ -1033,6 +1042,7 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 # Packages matching: installed
 # Name            # Installed # Synopsis
+i-am-compiler     2           One-line description
 i-am-package      2           One-line description
 i-am-sys-compiler 2           One-line description
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables | grep -v eval-variables:
@@ -1177,12 +1187,15 @@ STATE                           Definition missing for installed package i-am-sy
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables | grep -v eval-variables:
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
@@ -1213,8 +1226,8 @@ paths {
 variables {
 }
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
@@ -1253,12 +1266,15 @@ STATE                           Definition missing for installed package i-am-sy
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables | grep -v eval-variables:
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
@@ -1289,8 +1305,8 @@ paths {
 variables {
 }
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:2:d: Upgraded root and local 2.1~alpha switch not recorded
@@ -1316,12 +1332,15 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4
@@ -1355,8 +1374,8 @@ paths {
 variables {
 }
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:2:e: reinit from 2.1~alpha
@@ -1398,6 +1417,7 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 # Packages matching: installed
 # Name            # Installed # Synopsis
+i-am-compiler     2           One-line description
 i-am-package      2           One-line description
 i-am-sys-compiler 2           One-line description
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables | grep -v eval-variables:
@@ -1547,12 +1567,15 @@ STATE                           Definition missing for installed package i-am-sy
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables | grep -v eval-variables:
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
@@ -1583,8 +1606,8 @@ paths {
 variables {
 }
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
@@ -1625,12 +1648,15 @@ STATE                           Definition missing for installed package i-am-sy
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables | grep -v eval-variables:
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
@@ -1661,8 +1687,8 @@ paths {
 variables {
 }
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:3:d: Upgraded root and local 2.1~alpha2 switch not recorded
@@ -1688,12 +1714,15 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4
@@ -1727,8 +1756,8 @@ paths {
 variables {
 }
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:3:e: reinit from 2.1~alpha2
@@ -1770,6 +1799,7 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 # Packages matching: installed
 # Name            # Installed # Synopsis
+i-am-compiler     2           One-line description
 i-am-package      2           One-line description
 i-am-sys-compiler 2           One-line description
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables | grep -v eval-variables:
@@ -1894,12 +1924,15 @@ STATE                           Definition missing for installed package i-am-sy
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
@@ -1937,8 +1970,8 @@ opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### rm -rf _opam
@@ -1968,12 +2001,15 @@ STATE                           Definition missing for installed package i-am-sy
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
@@ -2011,8 +2047,8 @@ opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:4:d: Upgraded root and local 2.1~rc switch not recorded
@@ -2037,12 +2073,15 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4
@@ -2072,8 +2111,8 @@ opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:4:e: reinit from 2.1~rc
@@ -2110,6 +2149,7 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 # Packages matching: installed
 # Name            # Installed # Synopsis
+i-am-compiler     2           One-line description
 i-am-package      2           One-line description
 i-am-sys-compiler 2           One-line description
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables | grep -v eval-variables:
@@ -2244,12 +2284,15 @@ STATE                           Definition missing for installed package i-am-sy
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
@@ -2287,8 +2330,8 @@ opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:5:c: From 2.1 root, local unknown from config
@@ -2317,12 +2360,15 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
@@ -2360,8 +2406,8 @@ opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:5:d: Upgraded root and local 2.1 switch not recorded
@@ -2390,12 +2436,15 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
@@ -2433,8 +2482,8 @@ opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:5:e: reinit from 2.1
@@ -2487,6 +2536,7 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 # Packages matching: installed
 # Name            # Installed # Synopsis
+i-am-compiler     2           One-line description
 i-am-package      2           One-line description
 i-am-sys-compiler 2           One-line description
 ### rm -rf _opam
@@ -2607,12 +2657,15 @@ STATE                           Definition missing for installed package i-am-sy
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
@@ -2651,8 +2704,8 @@ opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:6:c: From 2.2~alpha root, local unknown from config
@@ -2680,12 +2733,15 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
@@ -2724,8 +2780,8 @@ opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:6:d: Upgraded root and local 2.2~alpha switch not recorded
@@ -2754,12 +2810,15 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
@@ -2798,8 +2857,8 @@ opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:6:e: reinit from 2.2~alpha
@@ -2853,6 +2912,7 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 # Packages matching: installed
 # Name            # Installed # Synopsis
+i-am-compiler     2           One-line description
 i-am-package      2           One-line description
 i-am-sys-compiler 2           One-line description
 ### rm -rf _opam
@@ -2971,12 +3031,15 @@ STATE                           Definition missing for installed package i-am-sy
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}$" -> "current"
@@ -3013,8 +3076,8 @@ opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:7:c: From 2.2~beta root, local unknown from config
@@ -3042,12 +3105,15 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}$" -> "current"
@@ -3084,8 +3150,8 @@ opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:7:d: Upgraded root and local 2.2~beta switch not recorded
@@ -3114,12 +3180,15 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4 | "${OPAMROOTVERSION}$" -> "current"
@@ -3156,8 +3225,8 @@ opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:7:e: reinit from 2.2~beta
@@ -3209,6 +3278,7 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 # Packages matching: installed
 # Name            # Installed # Synopsis
+i-am-compiler     2           One-line description
 i-am-package      2           One-line description
 i-am-sys-compiler 2           One-line description
 ### rm -rf _opam
@@ -3308,12 +3378,15 @@ STATE                           Definition missing for installed package i-am-sy
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4
@@ -3343,8 +3416,8 @@ opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:8:c: From 2.2 root, local unknown from config
@@ -3368,12 +3441,15 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4
@@ -3403,8 +3479,8 @@ opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:8:d: Upgraded root and local 2.2 switch not recorded
@@ -3429,12 +3505,15 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 STATE                           Detected changed packages (marked for reinstall): {}
 The following actions will be performed:
-=== install 1 package
-  - install i-am-package 2
+=== install 2 packages
+  - install i-am-compiler 2 [required by i-am-package]
+  - install i-am-package  2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed i-am-compiler.2
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 -> installed i-am-package.2
-STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
+STATE                           dependencies (0.000) result={ i-am-compiler.2, i-am-sys-compiler.2 }
 Done.
 ### # rw global state
 ### opam option jobs=4
@@ -3464,8 +3543,8 @@ opam-root: "${BASEDIR}/OPAM"
 opam-version: "2.0"
 synopsis: "local switch"
 ### opam-cat _opam/.opam-switch/switch-state
-compiler: ["i-am-sys-compiler.2"]
-installed: ["i-am-package.2" "i-am-sys-compiler.2"]
+compiler: ["i-am-compiler.2" "i-am-sys-compiler.2"]
+installed: ["i-am-compiler.2" "i-am-package.2" "i-am-sys-compiler.2"]
 opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:8:e: reinit from 2.2
@@ -3511,5 +3590,6 @@ STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
 STATE                           Switch state loaded in 0.000s
 # Packages matching: installed
 # Name            # Installed # Synopsis
+i-am-compiler     2           One-line description
 i-am-package      2           One-line description
 i-am-sys-compiler 2           One-line description

--- a/tests/reftests/opamrt-big-upgrade.test
+++ b/tests/reftests/opamrt-big-upgrade.test
@@ -222,26 +222,27 @@ Faking installation of utop.1.8
 Done.
 ### opam upgrade --fake
 The following actions will be faked:
+=== remove 1 package
+  - remove    async_core     109.47.00              [conflicts with pa_ounit, fieldslib, bin_prot, etc.]
 === recompile 5 packages
   - recompile async_graphics 0.5.1                  [uses async]
   - recompile dyntype        0.9.0                  [uses type_conv]
   - recompile mirari         0.9.7                  [uses ipaddr]
   - recompile ocplib-endian  0.4                    [uses optcomp]
   - recompile tuntap         0.7.0                  [uses ipaddr]
-=== upgrade 33 packages
-  - upgrade   async          109.42.00 to 109.53.02
-  - upgrade   async_core     109.47.00 to 109.55.02
-  - upgrade   async_extra    109.47.00 to 109.55.02
-  - upgrade   async_unix     109.47.00 to 109.55.02
+=== upgrade 32 packages
+  - upgrade   async          109.42.00 to 109.58.00
+  - upgrade   async_extra    109.47.00 to 109.58.00
+  - upgrade   async_unix     109.47.00 to 109.58.00
   - upgrade   atd            1.0.3 to 1.1.0
   - upgrade   atdgen         1.2.4 to 1.3.0
   - upgrade   bin_prot       109.47.00 to 109.53.02
   - upgrade   cohttp         0.9.11 to 0.9.14
   - upgrade   comparelib     109.27.00 to 109.27.02
-  - upgrade   core           109.47.00 to 109.55.02
-  - upgrade   core_bench     109.47.00 to 109.55.02
-  - upgrade   core_extended  109.47.00 to 109.55.02
-  - upgrade   core_kernel    109.47.00 to 109.55.02
+  - upgrade   core           109.47.00 to 109.58.00
+  - upgrade   core_bench     109.47.00 to 109.58.00
+  - upgrade   core_extended  109.47.00 to 109.58.00
+  - upgrade   core_kernel    109.47.00 to 109.58.00
   - upgrade   cow            0.7.0 to 0.9.1
   - upgrade   cstruct        0.8.1 to 1.0.1
   - upgrade   custom_printf  109.27.00 to 109.27.02
@@ -256,15 +257,16 @@ The following actions will be faked:
   - upgrade   pipebang       109.28.00 to 109.28.02
   - upgrade   re2            109.45.02 to 109.55.02
   - upgrade   res            4.0.3 to 4.0.4
-  - upgrade   sexplib        109.47.00 to 109.55.02
+  - upgrade   sexplib        109.47.00 to 109.58.00
   - upgrade   textutils      109.36.00 to 109.53.02
   - upgrade   type_conv      109.47.00 to 109.53.02
   - upgrade   uri            1.3.11 to 1.3.12
   - upgrade   utop           1.8 to 1.10
   - upgrade   variantslib    109.15.00 to 109.15.02
-=== install 3 packages
-  - install   pa_bench       109.55.02              [required by core_kernel]
-  - install   pa_test        109.53.02              [required by core, async_core, core_extended]
+=== install 4 packages
+  - install   async_kernel   109.58.00              [required by async_extra, async, async_unix]
+  - install   pa_bench       109.55.02              [required by core, core_kernel]
+  - install   pa_test        109.53.02              [required by core, async_unix, core_extended]
   - install   typerep        109.55.02              [required by core_kernel]
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
@@ -287,28 +289,28 @@ Faking installation of dyntype.0.9.0
 Faking installation of fieldslib.109.20.02
 Faking installation of pa_ounit.109.53.02
 Faking installation of pa_bench.109.55.02
-Faking installation of sexplib.109.55.02
+Faking installation of sexplib.109.58.00
 Faking installation of custom_printf.109.27.02
 Faking installation of typerep.109.55.02
 Faking installation of uri.1.3.12
 Faking installation of cow.0.9.1
 Faking installation of utop.1.10
 Faking installation of variantslib.109.15.02
-Faking installation of core_kernel.109.55.02
+Faking installation of core_kernel.109.58.00
 Faking installation of pa_test.109.53.02
-Faking installation of core.109.55.02
-Faking installation of async_core.109.55.02
-Faking installation of async_unix.109.55.02
-Faking installation of async_extra.109.55.02
-Faking installation of async.109.53.02
+Faking installation of core.109.58.00
+Faking installation of async_kernel.109.58.00
+Faking installation of async_unix.109.58.00
+Faking installation of async_extra.109.58.00
+Faking installation of async.109.58.00
 Faking installation of async_graphics.0.5.1
 Faking installation of cstruct.1.0.1
 Faking installation of cohttp.0.9.14
 Faking installation of github.0.7.0
 Faking installation of re2.109.55.02
 Faking installation of textutils.109.53.02
-Faking installation of core_bench.109.55.02
-Faking installation of core_extended.109.55.02
+Faking installation of core_bench.109.58.00
+Faking installation of core_extended.109.58.00
 Done.
 ### opam switch export -
 opam-version: "2.0"
@@ -320,15 +322,15 @@ compiler: [
   "ocaml-base-compiler.4.01.0beta1"
 ]
 roots: [
-  "async.109.53.02"
+  "async.109.58.00"
   "async_graphics.0.5.1"
   "base-bigarray.base"
   "base-threads.base"
   "base-unix.base"
   "cohttp.0.9.14"
-  "core.109.55.02"
-  "core_bench.109.55.02"
-  "core_extended.109.55.02"
+  "core.109.58.00"
+  "core_bench.109.58.00"
+  "core_extended.109.58.00"
   "cow.0.9.1"
   "cryptokit.1.9"
   "ctypes.0.2.2"
@@ -343,11 +345,11 @@ roots: [
   "yojson.1.1.6"
 ]
 installed: [
-  "async.109.53.02"
-  "async_core.109.55.02"
-  "async_extra.109.55.02"
+  "async.109.58.00"
+  "async_extra.109.58.00"
   "async_graphics.0.5.1"
-  "async_unix.109.55.02"
+  "async_kernel.109.58.00"
+  "async_unix.109.58.00"
   "atd.1.1.0"
   "atdgen.1.3.0"
   "base-bigarray.base"
@@ -359,10 +361,10 @@ installed: [
   "cmdliner.0.9.2"
   "cohttp.0.9.14"
   "comparelib.109.27.02"
-  "core.109.55.02"
-  "core_bench.109.55.02"
-  "core_extended.109.55.02"
-  "core_kernel.109.55.02"
+  "core.109.58.00"
+  "core_bench.109.58.00"
+  "core_extended.109.58.00"
+  "core_kernel.109.58.00"
   "cow.0.9.1"
   "cppo.0.9.3"
   "cryptokit.1.9"
@@ -396,7 +398,7 @@ installed: [
   "re2.109.55.02"
   "react.0.9.4"
   "res.4.0.4"
-  "sexplib.109.55.02"
+  "sexplib.109.58.00"
   "ssl.0.4.6"
   "textutils.109.53.02"
   "tuntap.0.7.0"

--- a/tests/reftests/reftests.test
+++ b/tests/reftests/reftests.test
@@ -330,7 +330,7 @@ Done.
     "all": [
       "foo"
     ],
-    "criteria": "-removed,-count[avoid-version,changed],-count[version-lag,request],-count[version-lag,changed],-count[missing-depexts,changed],-changed"
+    "criteria": "-changed,-count[avoid-version,solution]"
   },
   "solution": [
     {

--- a/tests/reftests/upgrade.test
+++ b/tests/reftests/upgrade.test
@@ -107,24 +107,15 @@ The following actions will be performed:
 -> installed foo.1
 Done.
 ### opam upgrade "foo<3"
-The following actions will be performed:
-=== upgrade 1 package
-  - upgrade foo 1 to 2
+Everything as up-to-date as possible
 
-<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> removed   foo.1
--> installed foo.2
-Done.
+The following packages are not being upgraded because the new versions conflict with other installed packages:
+  - foo.3
+However, you may "opam upgrade" these packages explicitly at these versions (e.g. "opam upgrade foo.3"), which will ask permission to downgrade or uninstall the conflicting packages.
+Nothing to do.
 ### # pinned packages
 ### opam install foo.1
-The following actions will be performed:
-=== downgrade 1 package
-  - downgrade foo 2 to 1
-
-<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> removed   foo.2
--> installed foo.1
-Done.
+[NOTE] Package foo is already installed (current version is 1).
 ### <pin:quux/quux.opam>
 opam-version: "2.0"
 ### opam install ./quux


### PR DESCRIPTION
I've personally been using `builtin-0install` as my default solver for the past year and i haven't noticed any issues.
The CI for opam-repository also uses it daily without any noticed issues from the opam-repository maintainers.

I'd like to switch to it by default for the sake of performance, and eventually in the future (3.0?), reduced dependencies (mccs depends on C++ which causes us problems on platforms such as macOS or Windows quite often) when builtin-0install is accepted by everyone and mccs can become an optional solver.

This PR is a draft at the moment because some of the accompanying changes in the testsuite seem to be highlighting some missing feature or changes that i'd like to understand first.