### PR TITLE
doc: mention the compare-versions command in the manual

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -383,6 +383,24 @@ For quick sanity checks, you can compare package versions using the OCaml REPL:
 - : int = 1
 ```
 
+You can also compare package versions using the `opam` command line (available
+from opam version `2.4.0`):
+
+```shell
+$ opam admin compare-versions 1.2.10 1.2.9
+1.2.10 > 1.2.9
+```
+
+Note that this command also supports flags to check the result of the comparison
+against a specified expectation. For example:
+
+```shell
+$ opam admin compare-versions 0.0.9 --lt 0.0.10
+[0]
+```
+
+Refer to the command help page for more details.
+
 ### Variables
 
 #### Usage

--- a/master_changes.md
+++ b/master_changes.md
@@ -113,6 +113,8 @@ users)
 
 ## Doc
 
+* Add mention of `opam admin compare-versions` in the Manual. [#6596 @mbarbin]
+
 ## Security fixes
 
 # API updates


### PR DESCRIPTION
Add a mention of the `opam admin compare-versions` command in the manual.

This is a continuation of #6197 to improve discoverability (small qol).

Thanks!