### PR TITLE
Improve the error message of `opam pin list` when the internal source directory of the pinned package doesn't exist

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -45,6 +45,7 @@ users)
   * Fix `opam config subst` so it works with absolute paths [#6936 @NathanReb - fix #6925]
 
 ## Pin
+  * Improve the error message of `opam pin list` when the source of the pinned package doesn't exist [#6597 @kit-ty-kate]
 
 ## List
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -207,6 +207,7 @@ users)
   * Add in `repository` test cases for upgrade opam root from 2.5 with repo tarring or 2.1 to 2.6, with `OPAMREPOSITORYTARRING` enabled (trigger upgrade) [#6625 @rjbou]
   * Add 2.6 root test cases in opamroot-versions [#6625 @rjbou]
   * Add tests for `.install` fields handling [#6956 #67026 @rjbou]
+  * Add a test showing opam pin list not working when the source git directory is missing [#6597 @kit-ty-kate]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -766,12 +766,13 @@ let list st ~short =
         match url.OpamUrl.backend with
         | #OpamUrl.version_control ->
           let srcdir = OpamSwitchState.source_dir st nv in
-          let color, rev =
+          let prefix, color, rev =
             match OpamProcess.Job.run (OpamRepository.revision srcdir url) with
-            | None -> (`red, "error while fetching current revision")
-            | Some ver -> (`magenta, ver)
+            | None ->
+              ("", `red, "error while fetching current revision")
+            | Some ver -> ("at ", `magenta, ver)
           in
-          Some (Printf.sprintf "(at %s)" (OpamConsole.colorise color (rev)))
+          Some (Printf.sprintf "(%s%s)" prefix (OpamConsole.colorise color rev))
         | _ -> None
       in
       [ OpamPackage.to_string nv;

--- a/tests/reftests/autopin.test
+++ b/tests/reftests/autopin.test
@@ -459,4 +459,4 @@ The following actions will be performed:
 Proceed with 2 installations? [Y/n] n
 # Return code 10 #
 ### opam pin list
-abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at error while fetching current revision)
+abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (error while fetching current revision)

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1623,7 +1623,7 @@ Done.
 file1
 ### opam-cat OPAM/flag-edit/.opam-switch/overlay/tide/opam | grep install
 install: [["mkdir" "%{lib}%/%{name}%"] ["cp" "file1" "%{lib}%/%{name}%/file1"]]
-### :C:h: opam pin doesn't upgrade outdated dependencies
+### :C:k: opam pin doesn't upgrade outdated dependencies
 ### opam switch create no-upgrade --empty
 ### <pkg:dep.1>
 opam-version: "2.0"
@@ -1660,3 +1660,18 @@ The following actions will be performed:
 -> installed dep.2
 -> installed pkg.1
 Done.
+### :C:l: make sure opam pin list works even when the source git directory is missing
+### opam switch create no-source-dir --empty
+### <no-source-dir/opam>
+opam-version: "2.0"
+name: "pinned-pkg"
+### git -C no-source-dir init -q --initial-branch=master
+### git -C no-source-dir config core.autocrlf false
+### git -C no-source-dir add opam
+### git -C no-source-dir commit -qm 'init'
+### opam pin add -n ./no-source-dir
+[NOTE] Package pinned-pkg does not exist in opam repositories registered in the current switch.
+pinned-pkg is now pinned to git+file://${BASEDIR}/no-source-dir#master (version dev)
+### rm -r OPAM/no-source-dir/.opam-switch/sources/pinned-pkg
+### opam pin
+pinned-pkg.dev  (uninstalled)  git  git+file://${BASEDIR}/no-source-dir#master  (at error while fetching current revision)

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1674,4 +1674,4 @@ name: "pinned-pkg"
 pinned-pkg is now pinned to git+file://${BASEDIR}/no-source-dir#master (version dev)
 ### rm -r OPAM/no-source-dir/.opam-switch/sources/pinned-pkg
 ### opam pin
-pinned-pkg.dev  (uninstalled)  git  git+file://${BASEDIR}/no-source-dir#master  (at error while fetching current revision)
+pinned-pkg.dev  (uninstalled)  git  git+file://${BASEDIR}/no-source-dir#master  (error while fetching current revision)


### PR DESCRIPTION
Regression from https://github.com/ocaml/opam/pull/6274
```
$ opam install .
[...]
Would you like to install? [Y/n] n
$ opam pin
/usr/local/bin/opam: "chdir" failed on .../.opam-switch/sources/<pkg>: No such file or directory
```

Backported to the 2.4 branch in https://github.com/ocaml/opam/pull/6598

Update: https://github.com/ocaml/opam/pull/6597#issuecomment-4962790367