### PR TITLE
[2.4] Fix opam pin when the source of the pinned package doesn't exist

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -104,6 +104,7 @@ users)
 
 ## Reftests
 ### Tests
+  * Add a test showing opam pin list not working when the source git directory is missing [#6597 @kit-ty-kate]
 
 ### Engine
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -35,6 +35,7 @@ users)
 ## Config
 
 ## Pin
+  * [BUG] Fix `opam pin list` when the source of the pinned package doesn't exist [#6597 @kit-ty-kate]
 
 ## List
 

--- a/src/client/opamPinCommand.ml
+++ b/src/client/opamPinCommand.ml
@@ -765,12 +765,13 @@ let list st ~short =
         match url.OpamUrl.backend with
         | #OpamUrl.version_control ->
           let srcdir = OpamSwitchState.source_dir st nv in
-          let color, rev =
+          let prefix, color, rev =
             match OpamProcess.Job.run (OpamRepository.revision srcdir url) with
-            | None -> (`red, "error while fetching current revision")
-            | Some ver -> (`magenta, ver)
+            | None | exception _ ->
+              ("", `red, "error while fetching current revision")
+            | Some ver -> ("at ", `magenta, ver)
           in
-          Some (Printf.sprintf "(at %s)" (OpamConsole.colorise color (rev)))
+          Some (Printf.sprintf "(%s%s)" prefix (OpamConsole.colorise color rev))
         | _ -> None
       in
       [ OpamPackage.to_string nv;

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1623,3 +1623,20 @@ Done.
 file1
 ### opam-cat OPAM/flag-edit/.opam-switch/overlay/tide/opam | grep install
 install: [["mkdir" "%{lib}%/%{name}%"] ["cp" "file1" "%{lib}%/%{name}%/file1"]]
+### :C:k: make sure opam pin list works even when the source git directory is missing
+### opam switch create no-source-dir --empty
+### <no-source-dir/opam>
+opam-version: "2.0"
+name: "pinned-pkg"
+### git -C no-source-dir init -q --initial-branch=master
+### git -C no-source-dir config core.autocrlf false
+### git -C no-source-dir add opam
+### git -C no-source-dir commit -qm 'init'
+### opam pin add -n ./no-source-dir
+[NOTE] Package pinned-pkg does not exist in opam repositories registered in the current switch.
+pinned-pkg is now pinned to git+file://${BASEDIR}/no-source-dir#master (version dev)
+### rm -r OPAM/no-source-dir/.opam-switch/sources/pinned-pkg
+### opam pin
+Fatal error:
+${OPAM}: "chdir" failed on ${BASEDIR}/OPAM/no-source-dir/.opam-switch/sources/pinned-pkg: No such file or directory
+# Return code 99 #

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1637,6 +1637,4 @@ name: "pinned-pkg"
 pinned-pkg is now pinned to git+file://${BASEDIR}/no-source-dir#master (version dev)
 ### rm -r OPAM/no-source-dir/.opam-switch/sources/pinned-pkg
 ### opam pin
-Fatal error:
-${OPAM}: "chdir" failed on ${BASEDIR}/OPAM/no-source-dir/.opam-switch/sources/pinned-pkg: No such file or directory
-# Return code 99 #
+pinned-pkg.dev  (uninstalled)  git  git+file://${BASEDIR}/no-source-dir#master  (error while fetching current revision)


### PR DESCRIPTION
Backport of #6597 to the 2.4 branch