### PR TITLE
Bash support: write to the .bashrc instead of the .profile file

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -23,6 +23,7 @@ users)
 ## Init
   * Remove `getconf` from the list of required runtime tools, which allows `opam init` to work out-of-the-box on Haiku [#6634 @kit-ty-kate - fix #6632]
   * The variables scripts now only updates the environment if `OPAM_SWITCH_PREFIX` is unset-or-empty [#6729 @dra27 - fix dbuenzli/topkg#142, #4649, #5761]
+  * Default to the `.bashrc` file instead of the `.profile` when writing the shell hook with `bash` [#6603 @kit-ty-kate]
 
 ## Config report
 

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1049,6 +1049,28 @@ module OpamSys = struct
       in
       Option.default unix_default_shell shell
 
+  let guess_bash_dot_profile () =
+    let home f =
+      try Filename.concat (home ()) f
+      with Not_found -> f
+    in
+    try
+      List.find Sys.file_exists [
+        (* Bash looks up these 3 files in order and only loads the first,
+           for LOGIN shells *)
+        home ".bash_profile";
+        home ".bash_login";
+        home ".profile";
+        (* Bash loads .bashrc INSTEAD, for interactive NON login shells only;
+           but it's often included from the above.
+           We may include our variables in both to be sure ; for now we rely
+           on non-login shells inheriting their env from a login shell
+           somewhere... *)
+      ]
+    with Not_found ->
+      (* iff none of the above exist, creating this should be safe *)
+      home ".bash_profile"
+
   let guess_dot_profile shell =
     let home f =
       try Filename.concat (home ()) f
@@ -1062,25 +1084,7 @@ module OpamSys = struct
         with Not_found -> home f in
       Some (zsh_home ".zshrc")
     | SH_bash ->
-      let shell =
-        (try
-           List.find Sys.file_exists [
-             (* Bash looks up these 3 files in order and only loads the first,
-                for LOGIN shells *)
-             home ".bash_profile";
-             home ".bash_login";
-             home ".profile";
-             (* Bash loads .bashrc INSTEAD, for interactive NON login shells only;
-                but it's often included from the above.
-                We may include our variables in both to be sure ; for now we rely
-                on non-login shells inheriting their env from a login shell
-                somewhere... *)
-           ]
-         with Not_found ->
-           (* iff none of the above exist, creating this should be safe *)
-           home ".bash_profile")
-      in
-      Some shell
+      Some (home ".bashrc")
     | SH_csh ->
       let cshrc = home ".cshrc" in
       let tcshrc = home ".tcshrc" in

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -516,6 +516,9 @@ module Sys : sig
       support the concept of a .profile file. *)
   val guess_dot_profile: shell -> string option
 
+  (** Guess the location of the .profile file for bash. *)
+  val guess_bash_dot_profile : unit -> string
+
   (** The separator character used in the PATH variable (varies depending on
       OS) *)
   val path_sep: char

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -1274,11 +1274,13 @@ let dot_profile_needs_update root dot_profile =
 let update_dot_profile root dot_profile shell =
   let pretty_dot_profile = OpamFilename.prettify dot_profile in
   let bash_src () =
-    if (shell = SH_bash || shell = SH_sh)
-    && OpamFilename.(Base.to_string (basename dot_profile)) <> ".bashrc" then
-      OpamConsole.note "Make sure that %s is well %s in your ~/.bashrc.\n"
-        pretty_dot_profile
-        (OpamConsole.colorise `underline "sourced")
+    if shell = SH_bash then
+      let bash_dot_profile =
+        OpamFilename.prettify
+          (OpamFilename.of_string (OpamStd.Sys.guess_bash_dot_profile ()))
+      in
+      OpamConsole.note "Make sure that ~/.bashrc is well %s in your %s.\n"
+        (OpamConsole.colorise `underline "sourced") bash_dot_profile
   in
   match dot_profile_needs_update root dot_profile with
   | `no        -> OpamConsole.msg "  %s is already up-to-date.\n" pretty_dot_profile; bash_src()

--- a/tests/reftests/env-idempotent.test
+++ b/tests/reftests/env-idempotent.test
@@ -14,6 +14,7 @@ export SHELL=$(command -v bash)
 bash -lc "export PATH=\"\$PATH:$PATH\" HOME=\"$HOME\" SHELL=\"$SHELL\" && $@"
 ### <.bash_profile>
 export PATH=/usr/bin
+source "$HOME/.bashrc"
 ### bash locally-in-bash.sh opam init -a --bypass-checks --bare REPO --root root --shell=bash | '\\' -> '/'
 No configuration file found, using built-in defaults.
 
@@ -21,10 +22,10 @@ No configuration file found, using built-in defaults.
 [default] Initialised
 
 User configuration:
-  Updating ~/.bash_profile.
-[NOTE] Make sure that ~/.bash_profile is well sourced in your ~/.bashrc.
+  Updating ~/.bashrc.
+[NOTE] Make sure that ~/.bashrc is well sourced in your ~/.bash_profile.
 
-  Added 9 lines after line 2 in ~/.bash_profile.
+  Added 9 lines after line 1 in ~/.bashrc.
 ### # we need the switch for variables file
 ### opam switch create fake --empty --root root
 ### bash bash-lc.sh "bash bash-lc.sh \"'$OPAMBIN' exec --root root --no-switch -- env\"" | grep -v MANPATH | grep /root/fake/ | '=.*' -> ''


### PR DESCRIPTION
On some systems, the .profile file already sources .bashrc so telling the user to source .profile in their .bashrc creates a loop. Furthermore, given that on some systems the .bashrc is already sourced in the .profile, it makes it more like for users to copy the opam incantation in their .bashrc but forget to remove it from the .profile, leading to a doubling of some environment variables and a loss of track of some of them by `opam env` (aka. https://github.com/ocaml/opam/issues/6455)

Fixes https://github.com/ocaml/opam/issues/5819
Fixes https://github.com/ocaml/opam/issues/4201
Fixes https://github.com/ocaml/opam/issues/3990