### PR TITLE
Replace every polymorphic uses of List.mem by a version that doesn't use Repr.equal

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -102,6 +102,7 @@ users)
 ## Shell
 
 ## Internal
+  * Replace every polymorphic uses of `List.mem` by a version that doesn't use `Repr.equal` [#6644 @kit-ty-kate]
 
 ## Internal: Unix
 
@@ -170,6 +171,9 @@ users)
 ## opam-solver
 
 ## opam-format
+  * `OpamFormula.equal_relop`: was added [#6644 @kit-ty-kate]
+  * `OpamTypesBase.{action,pkg_flag,simple_arg,arg,filter,command}_equal`: were added [#6644 @kit-ty-kate]
+  * `OpamVariable.variable_contents_equal`: was added [#6644 @kit-ty-kate]
 
 ## opam-core
   * `OpamConsole.log`: does not keep log messages before initialization if the code is ran through a library [#6487 @kit-ty-kate]
@@ -177,12 +181,16 @@ users)
   * `OpamSystem.cpu_count`: now uses a C binding instead of system utilities to get the number of cores of the current machine [#6634 @kit-ty-kate]
   * `OpamSystem.is_reg_dir`: is now exposed, which returns `true` only if its parameter is a directory, exists and is not a symlink. It returns `false` otherwise [#6450 @kit-ty-kate]
   * `OpamCompat.List.fold_left_map`: was added [#6442 @kit-ty-kate]
+  * `OpamCompat.List.equal`: was added [#6644 @kit-ty-kate]
   * `OpamCompat.Map.filter_map`: was added [#6442 @kit-ty-kate]
   * `OpamCompat.MAP`: was added [#6442 @kit-ty-kate]
+  * `OpamCompat.Pair.equal`: was added [#6644 @kit-ty-kate]
   * `OpamCompat.String.{starts_with,ends_with,for_all,fold_left}`: were added [#6442 @kit-ty-kate]
   * `OpamHash.check_string`: was added [#6661 @kit-ty-kate]
+  * `OpamHash.equal_kind`: was added [#6644 @kit-ty-kate]
   * `OpamStd.List.fold_left_map`: was moved to `OpamCompat.List.fold_left_map` [#6442 @kit-ty-kate]
   * `OpamStd.List.{cons,find_opt,filter_map}`: were removed. Use `Stdlib.List` instead. [#6442 @kit-ty-kate]
+  * `OpamStd.List.mem`: was added, having as argument the equality function [#6644 @kit-ty-kate]
   * `OpamStd.Op.{(@@),(|>)}`: were removed. Use `Stdlib` instead. [#6442 @kit-ty-kate]
   * `OpamStd.Option.{map,iter,compare,equal,to_string,some}`: were removed. Use `Stdlib.Option` instead. [#6442 @kit-ty-kate]
   * `OpamStd.Map.filter_map`: is now the implementation from `Stdlib.Map` when using OCaml >= 4.11 [#6442 @kit-ty-kate]

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -271,7 +271,8 @@ let cache_command cli =
 
     let cache_dir_url = OpamFilename.remove_prefix_dir repo_root cache_dir in
     if not no_repo_update then
-      if not (List.mem cache_dir_url (OpamFile.Repo.dl_cache repo_def)) then
+      if not (OpamStd.List.mem String.equal
+                cache_dir_url (OpamFile.Repo.dl_cache repo_def)) then
         (OpamConsole.msg "Adding %s to %s...\n"
            cache_dir_url (OpamFile.to_string repo_file);
          OpamFile.Repo.write repo_file
@@ -671,7 +672,9 @@ let add_hashes_command cli =
             let hashes = OpamFile.URL.checksum urlf in
             let hashes =
               if replace then
-                List.filter (fun h -> List.mem (OpamHash.kind h) hash_types)
+                List.filter (fun h ->
+                    OpamStd.List.mem OpamHash.equal_kind
+                      (OpamHash.kind h) hash_types)
                   hashes
               else hashes
             in
@@ -822,10 +825,13 @@ let lint_command cli =
       OpamPackage.Map.fold (fun nv prefix ret ->
           let opam_file = OpamRepositoryPath.opam repo_root prefix nv in
           let w, _ = OpamFileTools.lint_file ~handle_dirname:true opam_file in
-          if List.exists (fun (n,_,_) -> List.mem n ign) w then ret else
+          if List.exists (fun (n,_,_) -> OpamStd.List.mem Int.equal n ign) w then
+            ret
+          else
           let w =
             List.filter (fun (n,_,_) ->
-                (incl = [] || List.mem n incl) && not (List.mem n excl))
+                (incl = [] || OpamStd.List.mem Int.equal n incl) &&
+                not (OpamStd.List.mem Int.equal n excl))
               w
           in
           if w <> [] then

--- a/src/client/opamAdminRepoUpgrade.ml
+++ b/src/client/opamAdminRepoUpgrade.ml
@@ -420,7 +420,8 @@ let do_upgrade repo_root =
       let opam0 = OpamFile.OPAM.read opam_file in
       OpamFile.OPAM.print_errors ~file:opam_file opam0;
       let nv = OpamFile.OPAM.package opam0 in
-      if not (List.mem nv.name ocaml_package_names) &&
+      if not (OpamStd.List.mem OpamPackage.Name.equal
+                nv.name ocaml_package_names) &&
          not (OpamPackage.Name.Set.mem nv.name all_base_packages) then
         let opam = OpamFileTools.add_aux_files ~files_subdir_hashes:true opam0 in
         let opam =

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -287,7 +287,7 @@ let autopin_aux st ?quiet ?recurse ?subpath ?locked
         in
         match OpamStd.Option.Op.( primary_url st nv >>= OpamUrl.local_dir) with
         | Some d ->
-          List.mem d pinning_dirs
+          OpamStd.List.mem OpamFilename.Dir.equal d pinning_dirs
         | None -> false)
       st.pinned
   in
@@ -555,7 +555,8 @@ let check_and_revert_sandboxing root config =
         OpamInitDefaults.sandbox_wrappers
       |> List.flatten
     in
-    List.filter (fun cmd -> List.mem cmd init_sdbx_cmds)
+    List.filter (fun cmd ->
+        OpamStd.List.mem OpamTypesBase.command_equal cmd init_sdbx_cmds)
       OpamFile.Wrappers.(wrap_build w @ wrap_install w @ wrap_remove w)
   in
   let env = fun v ->
@@ -596,7 +597,8 @@ let check_and_revert_sandboxing root config =
     if working_or_noop then config else
     let wrappers =
       let filter sdbx_cmd =
-        List.filter (fun cmd_l -> not (List.mem cmd_l sdbx_cmd))
+        List.filter (fun cmd_l ->
+            not (OpamStd.List.mem OpamTypesBase.command_equal cmd_l sdbx_cmd))
       in
       List.fold_left OpamFile.Wrappers.(fun w -> function
           | `build sdbx_build ->

--- a/src/client/opamCLIVersion.ml
+++ b/src/client/opamCLIVersion.ml
@@ -12,7 +12,9 @@ type t = int * int
 
 let supported_versions = [(2, 0); (2, 1); (2,2); (2,3); (2,4)]
 
-let is_supported v = List.mem v supported_versions
+let is_supported v =
+  OpamStd.List.mem (OpamCompat.Pair.equal Int.equal Int.equal)
+    v supported_versions
 
 let of_string s =
   match String.index s '.' with

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -432,8 +432,8 @@ let update
     let all_repos = OpamRepositoryName.Map.keys rt.repositories in
     if dev_only then []
     else if names <> [] then
-      List.filter
-        (fun r -> List.mem (OpamRepositoryName.to_string r) names)
+      List.filter (fun r ->
+          OpamStd.List.mem String.equal (OpamRepositoryName.to_string r) names)
         all_repos
     else if all then all_repos
     else OpamSwitchState.repos_list st
@@ -506,7 +506,8 @@ let update
   let remaining =
     let ps = packages ++ ignore_packages in
     List.filter (fun n -> not (
-        List.mem (OpamRepositoryName.of_string n) repo_names ||
+        OpamStd.List.mem OpamRepositoryName.equal
+          (OpamRepositoryName.of_string n) repo_names ||
         (try OpamPackage.has_name ps (OpamPackage.Name.of_string n)
          with Failure _ -> false) ||
         (try OpamPackage.Set.mem (OpamPackage.of_string n) ps

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2379,7 +2379,7 @@ let repository cli =
               OpamConsole.error_and_exit `Not_found
                 "No switch %s found"
                 (OpamSwitch.to_string sw)
-            else if List.mem sw acc then acc
+            else if OpamStd.List.mem OpamSwitch.equal sw acc then acc
             else acc @ [sw]
           | `Current_switch | `This_switch ->
             match OpamStateConfig.get_switch_opt () with
@@ -2388,7 +2388,7 @@ let repository cli =
                                    '--set-default'?";
               acc
             | Some sw ->
-              if List.mem sw acc then acc
+              if OpamStd.List.mem OpamSwitch.equal sw acc then acc
               else acc @ [sw])
         [] scope
     in
@@ -4286,7 +4286,9 @@ let clean cli =
                (OpamPackage.Set.elements st.pinned)
            in
            List.iter (fun d ->
-               if not (List.mem d pinning_overlay_dirs) then rmdir d)
+               if not (OpamStd.List.mem OpamFilename.Dir.equal
+                         d pinning_overlay_dirs) then
+                 rmdir d)
              (OpamFilename.dirs (OpamPath.Switch.Overlay.dir root sw));
            let keep_sources_dir =
              OpamPackage.Set.elements
@@ -4297,7 +4299,9 @@ let clean cli =
            in
            OpamFilename.dirs (OpamPath.Switch.sources_dir root sw) |>
            List.iter (fun d ->
-               if not (List.mem d keep_sources_dir) then rmdir d))
+               if not (OpamStd.List.mem OpamFilename.Dir.equal
+                         d keep_sources_dir) then
+                 rmdir d))
          switches);
     if repos then
       (OpamFilename.with_flock `Lock_write (OpamPath.repos_lock gt.root)

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -713,7 +713,12 @@ let switch_allowed_fields, switch_allowed_sections =
   in
   let allowed_sections =
     let rem_elem new_elems elems =
-      List.filter (fun n -> not (List.mem n new_elems)) elems
+      List.filter (fun n ->
+          not (OpamStd.List.mem
+                 (OpamCompat.Pair.equal
+                    OpamVariable.equal OpamVariable.variable_contents_equal)
+                 n new_elems))
+        elems
     in
     lazy (
       OpamFile.Switch_config.([

--- a/src/core/opamCompat.ml
+++ b/src/core/opamCompat.ml
@@ -207,6 +207,13 @@ module List = struct
     in
     s, List.rev l_rev
 
+  (* NOTE: OCaml >= 4.12 *)
+  let rec equal eq x y = match x, y with
+    | [], [] -> true
+    | [], _::_ | _::_, [] -> false
+    | x::_, y::_ when eq x y -> true
+    | _::xs, _::ys -> equal eq xs ys
+
   include Stdlib.List
 end
 
@@ -231,4 +238,10 @@ module Map(Ord : Stdlib.Map.OrderedType) = struct
       ) map M.empty
 
   include M
+end
+
+module Pair = struct
+  (** NOTE: OCaml >= 5.4 *)
+  let equal eq1 eq2 (x1, y1) (x2, y2) =
+    eq1 x1 x2 && eq2 y1 y2
 end

--- a/src/core/opamCompat.mli
+++ b/src/core/opamCompat.mli
@@ -59,6 +59,9 @@ end
 module List : sig
   (** NOTE: OCaml >= 4.11 *)
   val fold_left_map : ('acc -> 'a -> 'acc * 'b) -> 'acc -> 'a list -> 'acc * 'b list
+
+  (** NOTE: OCaml >= 4.12 *)
+  val equal : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
 end
 
 module type MAP = sig
@@ -69,3 +72,10 @@ module type MAP = sig
 end
 
 module Map(Ord : Stdlib.Map.OrderedType) : MAP with type key = Ord.t
+
+module Pair : sig
+  (** NOTE: OCaml >= 5.4 *)
+  val equal :
+    ('a -> 'a -> bool) -> ('b -> 'b -> bool) ->
+    ('a * 'b) -> ('a * 'b) -> bool
+end

--- a/src/core/opamHash.ml
+++ b/src/core/opamHash.ml
@@ -25,6 +25,8 @@ let compare_kind k l =
   | `MD5, _ | _, `SHA512 -> -1
   | `SHA512, _ | _, `MD5 -> 1
 
+let equal_kind k1 k2 = compare_kind k1 k2 = 0
+
 let compare (k,h) (l,i) =
   match compare_kind k l with
   | 0 -> String.compare h i

--- a/src/core/opamHash.mli
+++ b/src/core/opamHash.mli
@@ -31,6 +31,7 @@ include OpamStd.ABSTRACT with type t := t
 
 val of_string_opt: string -> t option
 val compare_kind: kind -> kind -> int
+val equal_kind: kind -> kind -> bool
 
 (** Check if [hash] contains only 0 *)
 val is_null: t -> bool

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -148,6 +148,10 @@ module OpamList = struct
     | l when index <= 0 -> value :: l
     | x::l -> x :: insert_at (index - 1) value l
 
+  let rec mem eq a = function
+    | [] -> false
+    | x::xs -> if eq a x then true else mem eq a xs
+
   let rec assoc eq x = function
     | [] -> raise Not_found
     | (a,b)::r -> if eq a x then b else assoc eq x r

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -200,6 +200,9 @@ module List : sig
       end if index < 0 or > length respectively). Not tail-recursive *)
   val insert_at: int -> 'a -> 'a list -> 'a list
 
+  (** Like {!List.mem} with an equality function. *)
+  val mem: ('a -> 'a -> bool) -> 'a -> 'a list -> bool
+
   (** Like {!List.assoc} with an equality function. *)
   val assoc: ('a -> 'a -> bool) -> 'a -> ('a * 'b) list -> 'b
 

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -2702,7 +2702,7 @@ module OPAMSyntax = struct
   let conflict_class t = t.conflict_class
   let available t = t.available
   let flags t = t.flags
-  let has_flag f t = List.mem f t.flags
+  let has_flag f t = OpamStd.List.mem OpamTypesBase.pkg_flag_equal f t.flags
   let env (t:t) =
     List.map
       (fun env -> match t.name, env with
@@ -3180,7 +3180,7 @@ module OPAMSyntax = struct
         List.fold_left (fun (flags, tags) tag ->
             match flag_of_tag tag with
             | Some flag ->
-              if List.mem flag flags then
+              if OpamStd.List.mem OpamTypesBase.pkg_flag_equal flag flags then
                 List.filter ((<>) flag) flags, tag::tags
               else flags, tags
             | None -> flags, tag::tags)
@@ -3433,7 +3433,8 @@ module OPAMSyntax = struct
   let to_list = Syntax.to_list pp
 
   let print_field_as_syntax field t =
-    if List.mem field deprecated_fields then raise Not_found;
+    if OpamStd.List.mem String.equal field deprecated_fields then
+      raise Not_found;
     let field =
       try OpamStd.List.assoc String.equal field alias_fields
       with Not_found -> field

--- a/src/format/opamFormat.ml
+++ b/src/format/opamFormat.ml
@@ -780,7 +780,7 @@ module I = struct
                | Bad_format (pos, msg) ->
                  (field, (pos, msg)) :: errs, acc
              with Not_found ->
-               (if List.mem field mandatory_fields
+               (if OpamStd.List.mem String.equal field mandatory_fields
                 then (field, (Some pos, "Missing field "^field)) :: errs
                 else errs),
                acc)

--- a/src/format/opamFormula.ml
+++ b/src/format/opamFormula.ml
@@ -35,8 +35,13 @@ let string_of_atom = function
       (string_of_relop r)
       (OpamPackage.Version.to_string c)
 
+(* TODO: upstream to opam-file-format *)
 let compare_relop x y =
   Stdlib.compare (x : [`Eq|`Neq|`Geq|`Gt|`Leq|`Lt]) (y : relop)
+
+(* TODO: upstream to opam-file-format *)
+let equal_relop x y =
+  compare_relop x y = 0
 
 let compare_version_constraint (relop1, v1) (relop2, v2) =
   let cmp = compare_relop relop1 relop2 in

--- a/src/format/opamFormula.mli
+++ b/src/format/opamFormula.mli
@@ -16,6 +16,7 @@
 type relop = OpamParserTypes.FullPos.relop_kind (* = [ `Eq | `Neq | `Geq | `Gt | `Leq | `Lt ] *)
 
 val compare_relop : relop -> relop -> int
+val equal_relop : relop -> relop -> bool
 
 (** A list containing each available operator once. *)
 val all_relop : relop list

--- a/src/format/opamTypesBase.mli
+++ b/src/format/opamTypesBase.mli
@@ -21,6 +21,8 @@ val string_of_std_path: std_path -> string
 val std_path_of_string: string -> std_path
 val all_std_paths: std_path list
 
+val action_equal : ('a -> 'a -> bool) -> 'a action -> 'a action -> bool
+
 (** Extract a package from a package action. *)
 val action_contents: [< 'a action ] -> 'a list
 
@@ -81,6 +83,8 @@ val filter_ident_of_string_interp:
 val string_of_filter_ident:
   name option list * variable * (string * string) option -> string
 
+val pkg_flag_equal: package_flag -> package_flag -> bool
+
 val pkg_flag_of_string: string -> package_flag
 
 val string_of_pkg_flag: package_flag -> string
@@ -119,3 +123,8 @@ val char_of_separator: separator -> char
 (* Switch selections *)
 val switch_selections_compare : switch_selections -> switch_selections -> int
 val switch_selections_equal : switch_selections -> switch_selections -> bool
+
+val simple_arg_equal : simple_arg -> simple_arg -> bool
+val arg_equal : arg -> arg -> bool
+val filter_equal : filter -> filter -> bool
+val command_equal : command -> command -> bool

--- a/src/format/opamVariable.ml
+++ b/src/format/opamVariable.ml
@@ -18,6 +18,14 @@ type variable_contents =
   | S of string
   | L of string list
 
+let variable_contents_equal vc1 vc2 = match vc1, vc2 with
+  | B b1, B b2 -> Bool.equal b1 b2
+  | S s1, S s2 -> String.equal s1 s2
+  | L l1, L l2 -> OpamCompat.List.equal String.equal l1 l2
+  | B _, _
+  | S _, _
+  | L _, _ -> false
+
 let string_of_variable_contents = function
   | B b -> string_of_bool b
   | S s -> s

--- a/src/format/opamVariable.mli
+++ b/src/format/opamVariable.mli
@@ -25,6 +25,8 @@ type variable_contents =
   | S of string
   | L of string list
 
+val variable_contents_equal: variable_contents -> variable_contents -> bool
+
 (** Pretty print of variable contents *)
 val string_of_variable_contents: variable_contents -> string
 

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -52,7 +52,7 @@ let link_files ~target f l =
 let fetch_from_cache =
   let currently_downloading = ref [] in
   let rec no_concurrent_dls key f x =
-    if List.mem key !currently_downloading then
+    if OpamStd.List.mem OpamHash.equal key !currently_downloading then
       Run (OpamProcess.command "sleep" ["1"],
            (fun _ -> no_concurrent_dls key f x))
     else

--- a/src/solver/opamCudf.ml
+++ b/src/solver/opamCudf.ml
@@ -1799,7 +1799,8 @@ let compute_root_causes g requested reinstall available =
     if c2 = Unknown || depth1 < depth2 then c1, depth1 else
     if c1 = Unknown || depth2 < depth1 then c2, depth2 else
     let (@) =
-      List.fold_left (fun l a -> if List.mem a l then l else a::l)
+      List.fold_left (fun l a ->
+          if OpamStd.List.mem Cudf.( =% ) a l then l else a::l)
     in
     match c1, c2 with
     | Required_by a, Required_by b -> Required_by (a @ b), depth1

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -520,8 +520,8 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
        a dependency towards the 'ocaml' package instead for availability, and \
        the 'ocaml:version' package variable for scripts"
       (t.ocaml_version <> None ||
-       List.mem (OpamVariable.Full.of_string "ocaml-version")
-         (all_variables t));
+       OpamStd.List.mem OpamVariable.Full.equal
+         (OpamVariable.Full.of_string "ocaml-version") (all_variables t));
     cond 33 `Error
       "Field 'os' is deprecated, use 'available' and the 'os' variable \
        instead"
@@ -691,7 +691,8 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
     cond 50 `Warning
       "The 'post' flag doesn't make sense with build or optional \
        dependencies"
-      (List.mem (OpamVariable.Full.of_string "post")
+      (OpamStd.List.mem OpamVariable.Full.equal
+         (OpamVariable.Full.of_string "post")
          (List.flatten
             (List.map OpamFilter.variables
                (filters_of_formula t.depopts))) ||
@@ -704,8 +705,10 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
                  | Filter fi -> OpamFilter.variables fi @ vars)
                [] f
            in
-           List.mem (OpamVariable.Full.of_string "build") vars &&
-           List.mem (OpamVariable.Full.of_string "post") vars)
+           OpamStd.List.mem OpamVariable.Full.equal
+             (OpamVariable.Full.of_string "build") vars &&
+           OpamStd.List.mem OpamVariable.Full.equal
+             (OpamVariable.Full.of_string "post") vars)
          false
          t.depends);
     cond 51 `Error

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -800,7 +800,8 @@ let from_2_0_alpha_to_2_0_alpha2 ~on_the_fly:_ root conf =
         ] in
       let remove_vars config =
         OpamFile.Dot_config.with_vars
-          (List.filter (fun (var, _) -> not (List.mem var to_remove_vars))
+          (List.filter (fun (var, _) ->
+               not (OpamStd.List.mem OpamVariable.equal var to_remove_vars))
              (OpamFile.Dot_config.bindings config))
           config
       in
@@ -1023,7 +1024,8 @@ let from_2_0_beta_to_2_0_beta5 ~on_the_fly:_ root conf =
       let config =
         { config with
           C.variables =
-            List.filter (fun (var,_) -> not (List.mem var rem_variables))
+            List.filter (fun (var,_) ->
+                not (OpamStd.List.mem OpamVariable.equal var rem_variables))
               config.C.variables;
         }
       in
@@ -1047,7 +1049,8 @@ let from_2_0_beta_to_2_0_beta5 ~on_the_fly:_ root conf =
     (OpamFile.Config.installed_switches conf);
   let rem_eval_variables = List.map OpamVariable.of_string ["arch"] in
   OpamFile.Config.with_eval_variables
-    (List.filter (fun (v,_,_) -> not (List.mem v rem_eval_variables))
+    (List.filter (fun (v,_,_) ->
+         not (OpamStd.List.mem OpamVariable.equal v rem_eval_variables))
        (OpamFile.Config.eval_variables conf))
     conf, gtc_none
 

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -160,7 +160,7 @@ let fold_switches f gt acc =
 let switch_exists gt switch =
   if OpamSwitch.is_external switch then
     OpamStateConfig.local_switch_exists gt.root switch
-  else List.mem switch (switches gt)
+  else OpamStd.List.mem OpamSwitch.equal switch (switches gt)
 
 let all_installed gt =
   fold_switches (fun _ sel acc ->
@@ -215,7 +215,8 @@ let fix_switch_list gt =
     match OpamStateConfig.get_switch_opt () with
     | None -> known_switches0
     | Some sw ->
-      if List.mem sw known_switches0 || not (switch_exists gt sw)
+      if OpamStd.List.mem OpamSwitch.equal sw known_switches0 ||
+         not (switch_exists gt sw)
       then known_switches0
       else sw::known_switches0
   in

--- a/src/state/opamPackageVar.ml
+++ b/src/state/opamPackageVar.ml
@@ -142,7 +142,8 @@ let filter_depends_formula
   =
   ff |>
   OpamFilter.partial_filter_formula (fun v ->
-      if List.mem v predefined_depends_variables then None
+      if OpamStd.List.mem OpamVariable.Full.equal v predefined_depends_variables
+      then None
       else env v) |>
   OpamFilter.filter_deps ~build ~post ~test ~doc ~dev_setup ~dev ?default
 

--- a/src/state/opamPinned.ml
+++ b/src/state/opamPinned.ml
@@ -261,7 +261,7 @@ let files_in_source_w_target ?locked ?recurse ?subpath
             OpamFilename.remove_prefix dir
               (OpamFile.filename name_and_file.pin.pin_file)
           in
-          if List.mem opamfile versioned_files
+          if OpamStd.List.mem String.equal opamfile versioned_files
           || not (OpamStd.String.contains opamfile ~sub:Filename.dir_sep) then
             url
           else

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -89,7 +89,8 @@ let infer_switch_invariant_raw
     else compiler
   in
   let env nv v =
-    if List.mem v OpamPackageVar.predefined_depends_variables then
+    if OpamStd.List.mem OpamVariable.Full.equal
+        v OpamPackageVar.predefined_depends_variables then
       match OpamVariable.Full.to_string v with
       | "dev" | "with-test" | "with-doc" | "with-dev-setup" -> Some (B false)
       | _ -> None
@@ -896,7 +897,8 @@ let undefined_filter_variable nv v =
 
 let package_env_t st ~force_dev_deps ~test ~doc ~dev_setup
     ~requested_allpkgs ?(err_undefined=true) nv v =
-  if List.mem v OpamPackageVar.predefined_depends_variables then
+  if OpamStd.List.mem OpamVariable.Full.equal
+      v OpamPackageVar.predefined_depends_variables then
     match OpamVariable.Full.to_string v with
     | "dev" ->
       Some (B (force_dev_deps || is_dev_package st nv))
@@ -917,7 +919,8 @@ let get_dependencies_t st ~force_dev_deps ~test ~doc ~dev_setup
     ~requested_allpkgs deps opams =
   let filter_undefined nv =
     let warn_undefined v =
-      if not (List.mem v OpamPackageVar.predefined_depends_variables) then
+      if not (OpamStd.List.mem OpamVariable.Full.equal
+                v OpamPackageVar.predefined_depends_variables) then
         undefined_filter_variable nv v
     in
     OpamFormula.map (fun (name, fc) ->
@@ -1336,7 +1339,8 @@ let update_repositories gt update_fun switch =
 
 let dependencies_filter_to_formula_t ~build ~post st nv =
   let env v =
-    if List.mem v OpamPackageVar.predefined_depends_variables then
+    if OpamStd.List.mem OpamVariable.Full.equal
+        v OpamPackageVar.predefined_depends_variables then
       match OpamVariable.Full.to_string v with
       | "build" -> Some (B build)
       | "post" -> Some (B post)

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -1060,7 +1060,7 @@ let install_packages_commands_t ?(env=OpamVariable.Map.empty) ~to_show st
        already setup when yum-install is called. Cf. opam-depext/#70,#76. *)
     let epel_release = "epel-release" in
     let install_epel rest =
-      if List.mem epel_release packages then
+      if OpamStd.List.mem String.equal epel_release packages then
         [pm, "install"::yes ["-y"] [epel_release]] @ rest
       else rest
     in

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -513,24 +513,28 @@ let active_caches st nvs =
         match OpamRepositoryState.find_package_opt rt repos_list nv with
         | None -> acc
         | Some (repo, _) ->
-          if List.mem repo repos then acc else
-          let repo_def = OpamRepositoryName.Map.find repo rt.repos_definitions in
-          let root_url = match OpamFile.Repo.root_url repo_def with
-            | None -> OpamSystem.internal_error "repo file of unknown origin"
-            | Some u -> u
-          in
-          let cache =
-            List.filter_map (fun rel ->
-                if OpamStd.String.contains ~sub:"://" rel
-                then
-                  let r = OpamUrl.parse_opt ~handle_suffix:false rel in
-                  if r = None then
-                    OpamConsole.warning "Invalid cache url %s, skipping" rel;
-                  r
-                else Some OpamUrl.Op.(root_url / rel))
-              (OpamFile.Repo.dl_cache repo_def)
-          in
-          repo::repos, cache::caches)
+          if OpamStd.List.mem OpamRepositoryName.equal repo repos then
+            acc
+          else
+            let repo_def =
+              OpamRepositoryName.Map.find repo rt.repos_definitions
+            in
+            let root_url = match OpamFile.Repo.root_url repo_def with
+              | None -> OpamSystem.internal_error "repo file of unknown origin"
+              | Some u -> u
+            in
+            let cache =
+              List.filter_map (fun rel ->
+                  if OpamStd.String.contains ~sub:"://" rel
+                  then
+                    let r = OpamUrl.parse_opt ~handle_suffix:false rel in
+                    if r = None then
+                      OpamConsole.warning "Invalid cache url %s, skipping" rel;
+                    r
+                  else Some OpamUrl.Op.(root_url / rel))
+                (OpamFile.Repo.dl_cache repo_def)
+            in
+            repo::repos, cache::caches)
       ([],[]) nvs
     |> snd
     |> List.rev

--- a/src/tools/opam_installer.ml
+++ b/src/tools/opam_installer.ml
@@ -110,7 +110,7 @@ let script_commands project_root ochan =
   let made_dirs = ref [] in
   Printf.fprintf ochan "#!/bin/sh\n";
   let mkdir d =
-    if not (List.mem d !made_dirs) then (
+    if not (OpamStd.List.mem OpamFilename.Dir.equal d !made_dirs) then (
       Printf.fprintf ochan "mkdir -p %S\n" (OpamFilename.Dir.to_string d);
       made_dirs := d :: !made_dirs
     ) in

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -206,7 +206,7 @@ let command
   if not silent && sort then
     List.iter print_endline out;
   let out = String.concat "\n" out in
-  if not (List.mem ret allowed_codes) then
+  if not (OpamStd.List.mem Int.equal ret allowed_codes) then
     raise (Command_failure (ret, String.concat " " (cmd :: args), out))
   else
     out
@@ -1148,7 +1148,7 @@ let run_test ?(vars=[]) ~opam t =
                  List.length (matching e) > List.length (matching acc)
                in
                match r, e with
-               | r, el::e when List.mem el acc ->
+               | r, el::e when OpamStd.List.mem String.equal el acc ->
                  print_endline el; diffl (list_remove el acc) r e
                | rl::r, el::e ->
                  if rl = el then (print_endline el; diffl acc r e)


### PR DESCRIPTION
Some clean up.

See https://github.com/ocaml/ocaml/pull/9928 for the underlying reason why `Repr`/`(=)`/`Stdlib.compare`/... should be avoided.

~Queued on top of https://github.com/ocaml/opam/pull/6442~