### PR TITLE
Fix URL to Software Heritage

### DIFF
--- a/doc/pages/Usage.md
+++ b/doc/pages/Usage.md
@@ -95,7 +95,7 @@ opam install "ocamlfind>=1.4.0"
 ```
 
 If package source is not found, opam tries to retrieve it from [Software
-Heritage](www.softwareheritage.org) archives (see related [opam
+Heritage](https://www.softwareheritage.org) archives (see related [opam
 option](Manual.html#configfield-swh-fallback)).
 
 ### opam upgrade

--- a/master_changes.md
+++ b/master_changes.md
@@ -126,6 +126,7 @@ users)
   * Update the installation documentation with the release of opam 2.4.1 [#6620 @kit-ty-kate]
   * Swapped the use of sha384 for sha512 for the release tarball in the installation documentation [#6620 @kit-ty-kate]
   * Improve the `opam pin` man page by being more explicit about which arguments are optional [#6631 @kit-ty-kate]
+  * Fix URL to Software Heritage [#6650 @gahr]
 
 * Add mention of `opam admin compare-versions` in the Manual. [#6596 @mbarbin]
 


### PR DESCRIPTION
It's currently interpreted as a relative path, and in the rendered version over at https://opam.ocaml.org it points to https://opam.ocaml.org/doc/www.softwareheritage.org.

Please update `master_changes.md` file with your changes.
