### PR TITLE
GHA: Fix the nixos depexts tests

### DIFF
--- a/.github/scripts/depexts/generate-actions.sh
+++ b/.github/scripts/depexts/generate-actions.sh
@@ -108,6 +108,7 @@ EOF
     mainlibs=${mainlibs/m4/gnum4}
     mainlibs=${mainlibs/make/gnumake}
     mainlibs=${mainlibs/tar/}
+    mainlibs=${mainlibs/git/}
     mainlibs=$(echo "$mainlibs" | sed -E 's/([[:alnum:]]+)/nixpkgs.\1/g')
     additionallibs="gcc diffutils getconf gnused gawk"
     additionallibs=$(echo "$additionallibs" | sed -E 's/([[:alnum:]]+)/nixpkgs.\1/g')

--- a/master_changes.md
+++ b/master_changes.md
@@ -123,6 +123,7 @@ users)
 
 ## Github Actions
   * bump `actions/checkout` from 4 to 5 [#6643 @kit-ty-kate]
+  * Fix the nixos depexts tests (git is now already installed in the nix docker image) [#6652 @kit-ty-kate]
 
 ## Doc
   * Update the installation documentation with the release of opam 2.4.1 [#6620 @kit-ty-kate]


### PR DESCRIPTION
Noticed in https://github.com/ocaml/opam/pull/6648
```
#8 6.951 copying path '/nix/store/zhv8ib8y1zfi76afddfnp8fmm562bgaa-git-2.50.1' from 'https://cache.nixos.org/'...
#8 7.544 copying path '/nix/store/xipypc58mgavflc7am3m28sk9hpczwf6-git-2.50.1-debug' from 'https://cache.nixos.org/'...
#8 8.094 copying path '/nix/store/bcw9f6r9v2fm3kv7d15fcrya0mf34xds-gcc-wrapper-14.3.0' from 'https://cache.nixos.org/'...
#8 8.715 building '/nix/store/28lm0m00ki2l3306j9glqnqnxzpgzfvq-user-environment.drv'...
#8 8.871 error: Unable to build profile. There is a conflict for the following files:
#8 8.871 
#8 8.871          /nix/store/q1fl77bw1h5am01g1qg081f30gkg5ml8-git-minimal-2.50.1/libexec/git-core/git-branch
#8 8.871          /nix/store/zhv8ib8y1zfi76afddfnp8fmm562bgaa-git-2.50.1/libexec/git-core/git-branch
#8 8.913 error: Cannot build '/nix/store/28lm0m00ki2l3306j9glqnqnxzpgzfvq-user-environment.drv'.
#8 8.913        Reason: builder failed with exit code 1.
#8 8.913        Output paths:
#8 8.913          /nix/store/5jmk2lgxi9p10awb3an5x9lzi3b1x5i6-user-environment
#8 ERROR: process "/bin/sh -c nix-env -iA nixpkgs.gnum4 nixpkgs.git nixpkgs.rsync nixpkgs.patch  nixpkgs.unzip nixpkgs.bzip2 nixpkgs.gnumake nixpkgs.wget nixpkgs.gcc nixpkgs.diffutils nixpkgs.getconf nixpkgs.gnused nixpkgs.gawk nixpkgs.ocaml" did not complete successfully: exit code: 100
```
nixpkgs' git and git-minimal (the git already installed in the nix image) do not seem to be compatible with each others.