### PR TITLE
Adjust packaging documentation

### DIFF
--- a/doc/pages/Packaging.md
+++ b/doc/pages/Packaging.md
@@ -110,7 +110,7 @@ definition, to specify where to retrieve the source of the package:
 ```
 url {
   src: "https://address/of/project.1.0.tar.gz"
-  checksum: "md5=3ffed1987a040024076c08f4a7af9b21"
+  checksum: "sha256=a42b21dc49a05be658391e63fe64c055d52ec67c0812cf6801f1de0f22733ce3"
 }
 ```
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -133,6 +133,7 @@ users)
   * Improve the `opam pin` man page by being more explicit about which arguments are optional [#6631 @kit-ty-kate]
   * Fix URL to Software Heritage [#6650 @gahr]
   * Clarify conditions in subsection titles in the Packaging page [#6653 @jmid]
+  * Upgrade the deprecated md5 `checksum` example to sha256 [#6653 @jmid]
 
 * Add mention of `opam admin compare-versions` in the Manual. [#6596 @mbarbin]
 


### PR DESCRIPTION
Helping a newcomer publish their first opam package in https://github.com/ocaml/opam-repository/pull/28395 I spotted a couple of nits in opam's Packaging page:
- The subsection titles could be a bit more descriptive to avoid misunderstandings
- The page is using a (now deprecated) md5-sum as its `checksum`
