### PR TITLE
GHA: reverse dependencies job follow-up

### DIFF
--- a/.github/scripts/main/main.sh
+++ b/.github/scripts/main/main.sh
@@ -202,7 +202,10 @@ if [ "$OPAM_DEPENDS" = "1" ]; then
   VERSION="2.4.1"
   opam_libs=$(opam show . -f name 2>/dev/null)
   depends_on=$(echo "$opam_libs" | sed "s/\$/.${VERSION}/" | paste -sd, -)
-  packages=$(opam list --or --depends-on "$depends_on" --columns name | tail -n +3)
+  packages=$(echo "$opam_libs" | while read lib; do
+    opam list --depends-on "${lib}.${VERSION}"  --coinstallable-with \
+    "${lib}.${VERSION}" --depopts --column name -s 2>/dev/null
+    done | sort -u)
   set +x
   for exclude in $opam_libs; do
     packages=$(echo "$packages" | grep -vF "$exclude")

--- a/.github/scripts/main/main.sh
+++ b/.github/scripts/main/main.sh
@@ -168,11 +168,10 @@ if [ "$OPAM_TEST" = "1" ]; then
 fi
 
 test_project () {
-  url=$1
-  project=$2
+  project=$1
 
   (set +x; echo -en "::group::depends-$project\r") 2>/dev/null
-  opam pin "$url" --kind git -yn
+  opam pin . --kind path -yn
   for pkg_name in $(opam show . -f name); do
     echo "Installing dependencies for $pkg_name"
     deps_code=0
@@ -216,7 +215,7 @@ if [ "$OPAM_DEPENDS" = "1" ]; then
 
     if [[ -n "$dev_repo" ]]; then
       prepare_project "$dev_repo" "$pkg"
-      test_project "$dev_repo" "$pkg"
+      test_project "$pkg"
     fi
   done
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -131,6 +131,7 @@ users)
   * Enhance changed files job dependant handling [#6394 @rjbou]
   * Fix macOS builds by installing rsync [#6656 @kit-ty-kate]
   * Use local pin to correctly detect packages dev repo branch in reverse dependency test job [#6655 @arozovyk]
+  * Filter false positives in dependency test job using `--coinstallable-with` [#6655 @arozovyk]
 
 ## Doc
   * Update the installation documentation with the release of opam 2.4.1 [#6620 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -130,6 +130,7 @@ users)
   * Add a CI job to test reverse dependencies of opam. Track and report dependency and build failures, hard-failing only on maintained packages. [#6394 @rjbou @arozovyk]
   * Enhance changed files job dependant handling [#6394 @rjbou]
   * Fix macOS builds by installing rsync [#6656 @kit-ty-kate]
+  * Use local pin to correctly detect packages dev repo branch in reverse dependency test job [#6655 @arozovyk]
 
 ## Doc
   * Update the installation documentation with the release of opam 2.4.1 [#6620 @kit-ty-kate]


### PR DESCRIPTION
Follow-up to #6394  
- Pin local dev repo of a package that has correctly identified branch, (instead of pinning with `kind git`)
- Filter out packages that are not coinstallable with opam libs. 