### PR TITLE
GHA: Fix macOS builds by installing rsync

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -388,7 +388,7 @@ let main_test_job ~analyse_job ~build_linux_job ~build_windows_job:_ ~build_macO
   job ~oc ~workflow ?section ~runs_on:(Runner [runner])
     ~env:[("OPAM_TEST", "1"); ("GITHUB_PR_USER", "${{ github.event.pull_request.user.login }}")]
     ~matrix ~needs ("Test-" ^ name_of_platform platform)
-    ++ only_on MacOS (install_sys_packages ["coreutils"; "gpatch"] ~descr:"Install gnu coreutils" [MacOS])
+    ++ only_on MacOS (install_sys_packages ["coreutils"; "gpatch"; "rsync"] ~descr:"Install gnu coreutils" [MacOS])
     ++ checkout ()
     ++ only_on Linux (run "Install bubblewrap" ["sudo apt install bubblewrap"])
     ++ only_on Linux (run "Disable AppArmor" ["echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns"])

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -352,7 +352,7 @@ jobs:
       GITHUB_PR_USER: ${{ github.event.pull_request.user.login }}
     steps:
     - name: Install gnu coreutils
-      run: brew install coreutils gpatch
+      run: brew install coreutils gpatch rsync
     - name: Checkout tree
       uses: actions/checkout@v5
     - name: src_ext/archives and opam-repository Cache

--- a/master_changes.md
+++ b/master_changes.md
@@ -129,6 +129,7 @@ users)
   * Only run the `get-changed-files` action when in a PR [#6582 @kit-ty-kate]
   * Add a CI job to test reverse dependencies of opam. Track and report dependency and build failures, hard-failing only on maintained packages. [#6394 @rjbou @arozovyk]
   * Enhance changed files job dependant handling [#6394 @rjbou]
+  * Fix macOS builds by installing rsync [#6656 @kit-ty-kate]
 
 ## Doc
   * Update the installation documentation with the release of opam 2.4.1 [#6620 @kit-ty-kate]


### PR DESCRIPTION
opam isn't compatible with macOS 15's openrsync