### PR TITLE
OpamLocal.rsync_* doesn't use its return value

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -149,6 +149,7 @@ users)
 ## opam-client
 
 ## opam-repository
+  * `OpamLocal.rsync_*`: Change the return type from `OpamFilename.*` to `unit` [#6658 @kit-ty-kate]
 
 ## opam-state
 

--- a/src/repository/opamLocal.mli
+++ b/src/repository/opamLocal.mli
@@ -17,7 +17,7 @@ open OpamTypes
 
 val rsync_dirs: ?args:string list -> ?exclude_vcdirs:bool ->
   OpamUrl.t -> OpamFilename.Dir.t ->
-  OpamFilename.Dir.t download OpamProcess.job
+  unit download OpamProcess.job
 val rsync_file: ?args:string list ->
   OpamUrl.t -> OpamFilename.t ->
-  OpamFilename.t download OpamProcess.job
+  unit download OpamProcess.job

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -91,7 +91,7 @@ let fetch_from_cache =
           OpamProcess.Job.Op.Done ()
         | None ->
           (OpamLocal.rsync_file url file @@| function
-            | Result _ | Up_to_date _-> ()
+            | Result () | Up_to_date () -> ()
             | Not_available (s,l) -> raise (OpamDownload.Download_fail (s,l)))
       end
     | #OpamUrl.version_control ->

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -176,8 +176,8 @@ module Make (VCS: VCS) = struct
       OpamLocal.rsync_dirs ~args repo_url repo_root @@+ fun result ->
       OpamSystem.remove stdout_file;
       Done (match result with
-          | Up_to_date _ when rm_list = [] -> Up_to_date None
-          | Up_to_date _ | Result _ -> Result None
+          | Up_to_date () when rm_list = [] -> Up_to_date None
+          | Up_to_date () | Result () -> Result None
           | Not_available _ as na -> na)
 
   let get_remote_url = VCS.get_remote_url

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -874,7 +874,7 @@ let t_lint ?check_extra_files ?(check_upstream=false) ?(all=false) t =
            in
            OpamLocal.rsync_file url filename
            @@| function
-           | Up_to_date f | Result f -> check_checksum f
+           | Up_to_date () | Result () -> check_checksum filename
            | Not_available (_,src) ->
              Some ("Source not found: "^src)
      in


### PR DESCRIPTION
This is the first PR extracted from https://github.com/ocaml/opam/pull/6625
Quite simple so far but it is only the basis for the rest