### PR TITLE
Update the dependency constraint on patch to now require its stable version

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -545,7 +545,7 @@ let main oc : unit =
     (* These should be identical to the values in appveyor.yml *)
     ("OPAM_REPO", "https://github.com/ocaml/opam-repository.git");
     ("OPAM_TEST_REPO_SHA", "3dab8c734b15bf2b5c1d8b99bb134f51361a6bee");
-    ("OPAM_REPO_SHA", "e9ce8525130a382fac004612302b2f2268f4188c");
+    ("OPAM_REPO_SHA", "3dab8c734b15bf2b5c1d8b99bb134f51361a6bee");
     ("SOLVER", "");
     (* Cygwin configuration *)
     ("CYGWIN_MIRROR", "http://mirrors.kernel.org/sourceware/cygwin/");

--- a/.github/workflows/depexts.yml
+++ b/.github/workflows/depexts.yml
@@ -19,7 +19,7 @@ defaults:
 env:
   OPAMVERSION: 2.4.0-alpha2
   OPAM_REPO: https://github.com/ocaml/opam-repository.git
-  OPAM_REPO_SHA: fc511aa5a8d6ff4f1d8397e5f375c5a5af2aa3c0
+  OPAM_REPO_SHA: 3dab8c734b15bf2b5c1d8b99bb134f51361a6bee
 
 jobs:
   opam-cache:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ env:
   OPAM12CACHE: ~/.cache/opam1.2/cache
   OPAM_REPO: https://github.com/ocaml/opam-repository.git
   OPAM_TEST_REPO_SHA: 3dab8c734b15bf2b5c1d8b99bb134f51361a6bee
-  OPAM_REPO_SHA: e9ce8525130a382fac004612302b2f2268f4188c
+  OPAM_REPO_SHA: 3dab8c734b15bf2b5c1d8b99bb134f51361a6bee
   SOLVER:
   CYGWIN_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
   CYGWIN_ROOT: D:\cygwin

--- a/master_changes.md
+++ b/master_changes.md
@@ -77,6 +77,7 @@ users)
 ## VCS
 
 ## Build
+  * Update the dependency constraint on `patch` to now require its stable version [#6663 @kit-ty-kate]
 
 ## Infrastructure
 
@@ -119,8 +120,9 @@ users)
   * Add a test showing the error message when faced with an UTF-8 character in the package version [#6640 @kit-ty-kate]
 
 ### Engine
- * Fix gcc < 14.3 bug on mingw i686 [#6624 @kit-ty-kate]
+  * Fix gcc < 14.3 bug on mingw i686 [#6624 @kit-ty-kate]
   * Fix support for removing local link directories [#6450 @kit-ty-kate]
+  * Bump `OPAM_REPO_SHA` in the github action workflows to allow patch 3.0.0 [#6663 @kit-ty-kate]
 
 ## Github Actions
   * bump `actions/checkout` from 4 to 5 [#6643 @kit-ty-kate]

--- a/opam-core.opam
+++ b/opam-core.opam
@@ -30,7 +30,7 @@ depends: [
   "sha" {>= "1.13"}
   "jsonm"
   "swhid_core"
-  "patch" {>= "3.0.0~alpha2"}
+  "patch" {>= "3.0.0"}
   "uutf"
   (("host-system-mingw" {os = "win32" & os-distribution != "cygwinports"} &
     "conf-mingw-w64-gcc-i686" {os = "win32" & os-distribution != "cygwinports"} &

--- a/opam-repository.opam
+++ b/opam-repository.opam
@@ -30,6 +30,6 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "opam-format" {= version}
-  "patch" {>= "3.0.0~alpha1"}
+  "patch" {>= "3.0.0"}
   "dune" {>= "2.8.0"}
 ]


### PR DESCRIPTION
I somehow forgot to update the constraint in https://github.com/ocaml/opam/pull/6580