### PR TITLE
GHA: update depext workflow

### DIFF
--- a/.github/scripts/depexts/generate-actions.sh
+++ b/.github/scripts/depexts/generate-actions.sh
@@ -18,7 +18,7 @@ runs:
 EOF
 
 ### Generate the Dockerfile
-mainlibs="m4 git rsync patch tar unzip bzip2 make wget"
+mainlibs="m4 git rsync tar unzip bzip2 make wget"
 ocaml="ocaml ocaml-compiler-libs"
 
 OCAML_CONSTRAINT=''

--- a/.github/workflows/depexts.yml
+++ b/.github/workflows/depexts.yml
@@ -17,7 +17,7 @@ defaults:
     shell: bash
 
 env:
-  OPAMVERSION: 2.4.0-alpha2
+  OPAMVERSION: 2.4.1
   OPAM_REPO: https://github.com/ocaml/opam-repository.git
   OPAM_REPO_SHA: 3dab8c734b15bf2b5c1d8b99bb134f51361a6bee
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -137,6 +137,7 @@ users)
   * Improve the revdeps test by ignoring non-released packages [#6657 @kit-ty-kate]
   * Avoid re-testing already tested repositories when testing the revdeps [#6657 @kit-ty-kate]
   * Fix duplication logic in revdeps script [#6666 @arozovyk]
+  * Remove patch dependency in depext actions [#6676 @rjbou]
 
 ## Doc
   * Update the installation documentation with the release of opam 2.4.1 [#6620 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -138,6 +138,7 @@ users)
   * Avoid re-testing already tested repositories when testing the revdeps [#6657 @kit-ty-kate]
   * Fix duplication logic in revdeps script [#6666 @arozovyk]
   * Remove patch dependency in depext actions [#6676 @rjbou]
+  * Bump opam binary used in depexts actions to 2.4.1 [#6676 @rjbou]
 
 ## Doc
   * Update the installation documentation with the release of opam 2.4.1 [#6620 @kit-ty-kate]


### PR DESCRIPTION
* bump opam binary version to 2.4.1
* no longer install patch
