### PR TITLE
Add a test showing the behaviour of version pins when one of the dependencies isn't up-to-date

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -126,6 +126,7 @@ users)
   * Homogenise here document usage [#6671 @rjbou]
   * Add a test showing that `opam upgrade` allows downgrades when necessary [#6690 @kit-ty-kate]
   * Add a test showing the behaviour of `opam tree` on local packages that happen to be already pinned [#6688 @kit-ty-kate]
+  * Add a test showing the behaviour of version pins when one of the dependencies isn't up-to-date [#6691 @kit-ty-kate]
 
 ### Engine
   * Fix gcc < 14.3 bug on mingw i686 [#6624 @kit-ty-kate]

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -1623,3 +1623,40 @@ Done.
 file1
 ### opam-cat OPAM/flag-edit/.opam-switch/overlay/tide/opam | grep install
 install: [["mkdir" "%{lib}%/%{name}%"] ["cp" "file1" "%{lib}%/%{name}%/file1"]]
+### :C:h: opam pin doesn't upgrade outdated dependencies
+### opam switch create no-upgrade --empty
+### <pkg:dep.1>
+opam-version: "2.0"
+### <pkg:dep.2>
+opam-version: "2.0"
+### <pkg:pkg.1>
+opam-version: "2.0"
+depends: "dep"
+### opam install pkg dep.1
+The following actions will be performed:
+=== install 2 packages
+  - install dep 1
+  - install pkg 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed dep.1
+-> installed pkg.1
+Done.
+### opam pin add pkg 1
+pkg is now pinned to version 1
+
+Already up-to-date.
+Nothing to do.
+### opam upgrade
+The following actions will be performed:
+=== recompile 1 package
+  - recompile pkg 1 (pinned) [uses dep]
+=== upgrade 1 package
+  - upgrade   dep 1 to 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   pkg.1
+-> removed   dep.1
+-> installed dep.2
+-> installed pkg.1
+Done.


### PR DESCRIPTION
See https://github.com/ocaml/opam/issues/6111