### PR TITLE
Update all the download-if-missing dependencies to their latest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ src_ext/opam-file-format/
 src_ext/re/
 src_ext/result/
 src_ext/secondary/
-src_ext/seq/
 src_ext/sha/
 src_ext/spdx_licenses/
 src_ext/stdlib-shims/

--- a/master_changes.md
+++ b/master_changes.md
@@ -78,6 +78,8 @@ users)
 
 ## Build
   * Update the dependency constraint on `patch` to now require its stable version [#6663 @kit-ty-kate]
+  * Update the download-if-missing dependencies to their latest version (re.1.14.0, dune.3.20.2, menhir.20250903) [#6700 @kit-ty-kate]
+  * Remove `seq` from the list of packages to download-if-missing as it is no longer a dependency of `re` [#6700 @kit-ty-kate]
 
 ## Infrastructure
 

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -23,7 +23,7 @@ ifndef FETCH
 endif
 
 SRC_EXTS = \
-  cppo base64 extlib re cmdliner ocamlgraph cudf dose3 opam-file-format seq \
+  cppo base64 extlib re cmdliner ocamlgraph cudf dose3 opam-file-format \
   stdlib-shims spdx_licenses opam-0install-cudf 0install-solver uutf \
   jsonm sha swhid_core menhir patch
 

--- a/src_ext/Makefile.dune
+++ b/src_ext/Makefile.dune
@@ -1,3 +1,3 @@
 # NB If minimum OCaml version for Dune changes, update DUNE_SECONDARY in configure.ac
-URL_dune-local = https://github.com/ocaml/dune/releases/download/3.19.1/dune-3.19.1.tbz
-MD5_dune-local = a47d91dccb8c8135e406724b8cc6755d
+URL_dune-local = https://github.com/ocaml/dune/releases/download/3.20.2/dune-3.20.2.tbz
+MD5_dune-local = 190feeb68d211655b70ed226bd600102

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -7,8 +7,8 @@ MD5_extlib = 43fb3bf2989671af1769147b1171d080
 URL_base64 = https://github.com/mirage/ocaml-base64/releases/download/v3.5.1/base64-3.5.1.tbz
 MD5_base64 = bfdd16aa8c136412878109df8791fc01
 
-URL_re = https://github.com/ocaml/ocaml-re/releases/download/1.11.0/re-1.11.0.tbz
-MD5_re = e0199e32947fd33fcc1b8e69de2308a1
+URL_re = https://github.com/ocaml/ocaml-re/archive/refs/tags/1.14.0.tar.gz
+MD5_re = 03f4a83100cb9229a796b85c698076e1
 
 URL_cmdliner = https://erratique.ch/software/cmdliner/releases/cmdliner-1.3.0.tbz
 MD5_cmdliner = 662936095a1613d7254815238e11793f
@@ -36,9 +36,6 @@ MD5_opam-file-format = 5b65ea84fa2e60e89c2c9f2ca3203e31
 
 include Makefile.dune
 
-URL_seq = https://github.com/c-cube/seq/archive/v0.3.1.tar.gz
-MD5_seq = de05d9dedd492fa4e3c0c87bc2792475
-
 URL_stdlib-shims = https://github.com/ocaml/stdlib-shims/releases/download/0.3.0/stdlib-shims-0.3.0.tbz
 MD5_stdlib-shims = 09db7af8b4a3a96048a61cb6ae2496ef
 
@@ -57,8 +54,8 @@ MD5_sha = 08bc953d9a26380bc220b05d680791fb
 URL_swhid_core = https://github.com/OCamlPro/swhid_core/archive/refs/tags/0.1.tar.gz
 MD5_swhid_core = 77d88d4b1d96261c866f140c64d89af8
 
-URL_menhir = https://gitlab.inria.fr/fpottier/menhir/-/archive/20240715/archive.tar.gz
-MD5_menhir = d39a8943fe1be28199e5ec1f4133504c
+URL_menhir = https://gitlab.inria.fr/fpottier/menhir/-/archive/20250903/archive.tar.gz
+MD5_menhir = 5ecb7f71cf374147d3d3137c6e2fe382
 
 URL_patch = https://github.com/hannesm/patch/releases/download/v3.0.0/patch-3.0.0.tar.gz
 MD5_patch = 75aca1ed79a9807e4d4fc6c85aa31b0f

--- a/src_ext/patches/re/0001-Backport-to-OCaml-4.12.patch
+++ b/src_ext/patches/re/0001-Backport-to-OCaml-4.12.patch
@@ -1,0 +1,30 @@
+diff -Naur a/lib/emacs.ml b/lib/emacs.ml
+--- a/lib/emacs.ml	2025-09-18 10:22:10.000000000 +0000
++++ b/lib/emacs.ml	2025-09-18 19:49:12.035021466 +0000
+@@ -21,6 +21,7 @@
+ *)
+ 
+ module Re = Core
++open Import
+ 
+ exception Parse_error
+ exception Not_supported
+diff -Naur a/lib/import.ml b/lib/import.ml
+--- a/lib/import.ml	2025-09-18 10:22:10.000000000 +0000
++++ b/lib/import.ml	2025-09-18 19:49:12.035091716 +0000
+@@ -13,12 +13,13 @@
+ let ( == ) = [ `Use_phys_equal ]
+ let ( < ) (x : int) (y : int) = x < y
+ let ( > ) (x : int) (y : int) = x > y
+-let min = Int.min
+-let max = Int.max
++let min (x : int) (y : int) = Stdlib.min x y
++let max (x : int) (y : int) = Stdlib.max x y
+ let compare = Int.compare
+ 
+ module Int = struct
+   let[@warning "-32"] hash (x : int) = Hashtbl.hash x
++  let[@warning "-32"] max = (max : int -> int -> int)
+ 
+   include Stdlib.Int
+ end

--- a/src_ext/patches/re/0002-Backport-to-OCaml-4.08.patch
+++ b/src_ext/patches/re/0002-Backport-to-OCaml-4.08.patch
@@ -1,0 +1,38 @@
+diff -Naur a/lib/fake/atomic.ml b/lib/fake/atomic.ml
+--- a/lib/fake/atomic.ml	1970-01-01 00:00:00.000000000 +0000
++++ b/lib/fake/atomic.ml	2025-09-18 19:49:12.046023121 +0000
+@@ -0,0 +1,10 @@
++type 'a t = 'a ref
++
++let make x = ref x
++let get x = !x
++let set atomic v = atomic := v
++
++let fetch_and_add atomic n =
++  let v = !atomic in
++  atomic := v + n;
++  v
+diff -Naur a/lib/import.ml b/lib/import.ml
+--- a/lib/import.ml	2025-09-18 19:49:12.035091716 +0000
++++ b/lib/import.ml	2025-09-18 19:49:12.046114163 +0000
+@@ -1,4 +1,19 @@
+-module List = Stdlib.ListLabels
++module List = struct
++  let[@warning "-32"] rec equal ~eq l1 l2 = match l1, l2 with
++    | [], [] -> true
++    | [], _::_ | _::_, [] -> false
++    | x::xs, y::ys -> if eq x y then equal ~eq xs ys else false
++
++  let[@warning "-32"] rec compare ~cmp l1 l2 = match l1, l2 with
++    | [], [] -> 0
++    | [], _::_ -> -1
++    | _::_, [] -> 1
++    | x::xs, y::ys ->
++        let r = cmp x y in
++        if r = 0 then compare ~cmp xs ys else r
++
++  include Stdlib.ListLabels
++end
+ 
+ module Poly = struct
+   let equal = ( = )


### PR DESCRIPTION
Queued on 
* https://github.com/ocaml/opam-repository/pull/28544

Changelogs:
* dune: https://github.com/ocaml/dune/releases/tag/3.20.0
* re: https://github.com/ocaml/ocaml-re/releases/tag/1.13.0 and https://github.com/ocaml/ocaml-re/releases/tag/1.14.0
* menhir: https://discuss.ocaml.org/t/ann-new-release-of-menhir-20250903/17212