### PR TITLE
Simplify the src_ext/update-sources.sh script

### DIFF
--- a/.github/scripts/main/hygiene.sh
+++ b/.github/scripts/main/hygiene.sh
@@ -141,6 +141,12 @@ else
   (set +x; echo -e ".github/scripts/depexts/generate-actions.sh: \e[31mERROR\e[0m") 2>/dev/null
   ERROR=1
 fi
+if shellcheck src_ext/update-sources.sh ; then
+  (set +x; echo "src_ext/update-sources.sh: OK") 2>/dev/null
+else
+  (set +x; echo -e "src_ext/update-sources.sh: \e[31mERROR\e[0m") 2>/dev/null
+  ERROR=1
+fi
 (set +x ; echo -en "::endgroup::check shell scripts using shellcheck\r") 2>/dev/null
 
 exit $ERROR

--- a/master_changes.md
+++ b/master_changes.md
@@ -103,6 +103,7 @@ users)
 
 ## Internal
   * Replace every polymorphic uses of `List.mem` by a version that doesn't use `Repr.equal` [#6644 @kit-ty-kate]
+  * Simplify the `src_ext/update-sources.sh` script [#6701 @kit-ty-kate]
 
 ## Internal: Unix
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -147,6 +147,7 @@ users)
   * Fix duplication logic in revdeps script [#6666 @arozovyk]
   * Remove patch dependency in depext actions [#6676 @rjbou]
   * Bump opam binary used in depexts actions to 2.4.1 [#6676 @rjbou]
+  * Check `src_ext/update-sources.sh` using shellcheck [#6701 @kit-ty-kate]
 
 ## Doc
   * Update the installation documentation with the release of opam 2.4.1 [#6620 @kit-ty-kate]

--- a/src_ext/update-sources.sh
+++ b/src_ext/update-sources.sh
@@ -1,53 +1,36 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 function process
 {
-  while read name prefix version url; do
+  while read -r name; do
     package=$name
     case "$package" in
       findlib) package=ocamlfind;;
       dune-local) package=dune;;
     esac
-    latest=$(opam show $package -f all-versions | sed -e 's/  base//')
+    latest=$(opam show "$package" -f all-versions | sed -e 's/  base//')
     latest=${latest##* }
-    package_url=$(opam show $package.$latest -f url.src: | sed -e 's/"//g')
-    md5=$(sed -n -e "s/MD5$prefix$name *= *\(.*\)/\1/p" "$1")
-    package_md5=$(opam show $package.$latest -f url.checksum: | sed -n -e "/md5/s/.*md5=\([a-fA-F0-9]\{32\}\).*/\1/p")
+    package_url=$(opam show "$package.$latest" -f url.src: | sed -e 's/"//g')
+    md5=$(sed -n -e "s/MD5_$name *= *\(.*\)/\1/p" "$1")
+    package_md5=$(opam show "$package.$latest" -f url.checksum: | sed -n -e "/md5/s/.*md5=\([a-fA-F0-9]\{32\}\).*/\1/p")
     if [[ -z $package_md5 ]] ; then
-      echo -e "\n$name: [\033[1;33mWARN\033[m] no md5 given in opam, downloading $package_url to check"
-      package_md5=$(curl -LSs $package_url | md5sum | cut -f1 -d' ')
+      echo -e "$name: [\033[1;33mWARN\033[m] no md5 given in opam, downloading $package_url to check"
+      package_md5=$(curl -LSs "$package_url" | md5sum | cut -f1 -d' ')
     fi
-    if [[ $package_url = $url ]] ; then
-      if [[ $package_md5 = $md5 ]] ; then
-        echo -ne "[\033[0;32m$name\033[m] "
-        if [[ $latest != $version ]] ; then
-          DISAGREEMENTS+=" $name ($version vs $latest in opam)"
-        fi
-      else
-        echo -e "\n$name: [\033[1;33mWARN\033[m] MD5 is wrong for (should be $package_md5 according to opam)"
-      fi
+    if [[ $package_md5 = "$md5" ]] ; then
+      echo -e "$name: [\033[1;32mNOTE\033[m] $name is up-to-date"
     else
-      if [[ $package_md5 = $md5 ]] ; then
-        echo -e "\n$name: [\033[1;33mWARN\033[m] URL is wrong for $name (should be $package_url according to opam)"
-      else
-        if [[ $latest = $version ]] ; then
-          echo -e "\n$name: [\033[1;33mWARN\033[m] URL and MD5 are wrong for $name (should be $package_url (md5=$package_md5) according to opam)"
-        else
-          echo -ne "[\033[0;31m$name\033[m: \033[1m$latest\033[m] "
-          sed -e "s/\(URL$prefix$name *= *\).*/\1${package_url////\\/}/" -e "s/\(MD5$prefix$name *= *\).*/\1$package_md5/" "$1" > "$1.tmp"
-          mv "$1.tmp" "$1"
-        fi
-      fi
+      echo -e "[\033[0;31m$name\033[m: \033[1m$latest\033[m] is being updated"
+      sed -e "s/\(URL_$name *= *\).*/\1${package_url////\\/}/" -e "s/\(MD5_$name *= *\).*/\1$package_md5/" "$1" > "$1.tmp"
+      mv "$1.tmp" "$1"
     fi
-  done < <(grep -F URL_ "$1" | sed -e "s/URL\(_\(PKG_\)\?\)\([^ =]*\) *= *\(.*\/\(\([^0-9][^-]*\)*-\)\?v\?\)\([0-9.]\+\([-+.][^\/]*\)\?\)\(\.tbz\|\.tar\.gz\)/\3 \1 \7 \4\7\9/" | sort)
+  done < <(grep -F URL_ "$1" | sed -e "s/URL_\([^ =]*\) *=.*/\1/" | sort)
 }
 
-cd $(dirname $0)
-echo -n "Checking packages for new versions in opam: "
-DISAGREEMENTS=()
+cd "$(dirname "$0")"
+echo "Checking packages for new versions in opam:"
 process Makefile.sources
 process Makefile.dune
-echo -e "\nComplete."
-if [[ ${#DISAGREEMENTS[@]} -gt 0 ]] ; then
-  echo "Disagreements over version:${DISAGREEMENTS[@]}"
-fi
+echo "Complete."


### PR DESCRIPTION
Required during #6700 to update menhir as the URL couldn't be parsed.
While trying to fix that i found the script too complex so i chose to simplify it instead.