### PR TITLE
Static linking for OpenBSD

### DIFF
--- a/configure
+++ b/configure
@@ -1379,9 +1379,9 @@ Optional Features:
   --enable-developer-mode Enable developer features
 
   --enable-static         Compile the opam binary statically. Only Musl-based
-                          Linux distributions and Windows with MinGW is
-                          currently supported. This is the default on Windows
-                          with MinGW
+                          Linux distributions, Windows with MinGW, and OpenBSD
+                          are currently supported. This is the default on
+                          Windows with MinGW
   --enable-cold-check     Fail on some check necessary for make cold
   --disable-certificate-check
                           Do not check the certificate of opam's dependency
@@ -5874,6 +5874,11 @@ fi
 then :
   platform_dependent_stuff="${platform_dependent_stuff} -cclib -lwindowsapp"
 fi
+   ;; #(
+  *-*-openbsd*) :
+
+    support_static=yes
+    platform_dependent_stuff="-cclib -lc++ -cclib -lc++abi -cclib -static"
    ;; #(
   *) :
      ;;

--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,7 @@ AC_ARG_WITH([private_runtime],
 
 AC_ARG_ENABLE([static],
   AS_HELP_STRING([--enable-static],
-    [Compile the opam binary statically. Only Musl-based Linux distributions and Windows with MinGW is currently supported. This is the default on Windows with MinGW]),
+    [Compile the opam binary statically. Only Musl-based Linux distributions, Windows with MinGW, and OpenBSD are currently supported. This is the default on Windows with MinGW]),
   [],
   [enable_static=auto])
 
@@ -360,6 +360,10 @@ AS_CASE([$TARGET],
     # which still depends on the DLL at runtime instead of libstdc++.a (that looks like a bug in flexlink)
     platform_dependent_stuff="-cclib -l:libstdc++.a -cclib -l:libpthread.a -cclib -Wl,-static -cclib -ladvapi32 -cclib -lgdi32 -cclib -luser32 -cclib -lshell32 -cclib -lole32 -cclib -luuid -cclib -luserenv"
     AS_IF([test "x${SYSTEM}" = "xmingw"], [platform_dependent_stuff="${platform_dependent_stuff} -cclib -lwindowsapp"])
+  ],
+  [*-*-openbsd*],[
+    support_static=yes
+    platform_dependent_stuff="-cclib -lc++ -cclib -lc++abi -cclib -static"
   ])
 AS_CASE([${support_static},${enable_static}],
   [no,yes],[AC_MSG_ERROR([--enable-static is not available on this platform (${TARGET}).])],

--- a/master_changes.md
+++ b/master_changes.md
@@ -90,6 +90,7 @@ users)
 ## Infrastructure
 
 ## Release scripts
+  * The OpenBSD binary now a full static binary [#6705 @flumf @kit-ty-kate - fix #6241]
 
 ## Install script
   * Add 2.4.1 to the install scripts [#6617 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -85,6 +85,7 @@ users)
   * Update the dependency constraint on `patch` to now require its stable version [#6663 @kit-ty-kate]
   * Update the download-if-missing dependencies to their latest version (re.1.14.0, dune.3.20.2, menhir.20250903) [#6700 @kit-ty-kate]
   * Remove `seq` from the list of packages to download-if-missing as it is no longer a dependency of `re` [#6700 @kit-ty-kate]
+  * `./configure --enable-static` is now supported on OpenBSD [#6705 @flumf]
 
 ## Infrastructure
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -67,9 +67,12 @@ CLINKING_macos = \
 -lunix -lmccs_stubs -lmccs_glpk_stubs -lsha_stubs -lopam_core_stubs \
 -lstdc++
 
-CLINKING_openbsd = $(CLINKING_macos)
 CLINKING_freebsd = $(CLINKING_macos)
 CLINKING_netbsd = $(CLINKING_macos)
+
+CLINKING_openbsd = \
+-lunix -lmccs_stubs -lmccs_glpk_stubs -lsha_stubs -lopam_core_stubs \
+-lstdc++ -lc++ -lc++abi -static
 
 CLINKING_windows = \
 -lunix -lmccs_stubs -lmccs_glpk_stubs -lsha_stubs -lopam_core_stubs \


### PR DESCRIPTION
Building with `./configure --enable-static --with-vendored-deps` on an OpenBSD 7.7 system results in a statically linked `opam` binary. Brief testing of the binary shows no problems, although I've admittedly not strenuously tested it, nor have I tried building with non-vendored dependencies.

Resolves #6241.