### PR TITLE
Make the release archive reproducible

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -30,7 +30,9 @@ $(OUTDIR)/opam-full-$(VERSION).tar.gz:
 	mkdir -p "$(OUTDIR)"
 	git clone $(GIT_URL) -b $(TAG) "$(OUTDIR)/opam-full-$(VERSION)"
 	$(MAKE) -C "$(OUTDIR)/opam-full-$(VERSION)" OCAML=$(call pathsearch,ocaml) download-ext
-	cd "$(OUTDIR)" && tar cz -f $(notdir $@) --exclude .git --no-mac-metadata --no-xattrs opam-full-$(VERSION)
+	git -C "$(OUTDIR)/opam-full-$(VERSION)" add *
+	git -C "$(OUTDIR)/opam-full-$(VERSION)" commit -m "add vendored files"
+	git -C "$(OUTDIR)/opam-full-$(VERSION)" archive HEAD --prefix "opam-full-$(VERSION)/" --mtime "$$(git show -s --format=%cI "$(TAG)")" -o "$(notdir $@)"
 	rm -rf "$(OUTDIR)/opam-full-$(VERSION)"
 
 build/Dockerfile.x86_64-linux: Dockerfile.in

--- a/release/Makefile
+++ b/release/Makefile
@@ -30,7 +30,7 @@ $(OUTDIR)/opam-full-$(VERSION).tar.gz:
 	mkdir -p "$(OUTDIR)"
 	git clone $(GIT_URL) -b $(TAG) "$(OUTDIR)/opam-full-$(VERSION)"
 	$(MAKE) -C "$(OUTDIR)/opam-full-$(VERSION)" OCAML=$(call pathsearch,ocaml) download-ext
-	cd "$(OUTDIR)" && tar cz -f $(notdir $@) --exclude .git opam-full-$(VERSION)
+	cd "$(OUTDIR)" && tar cz -f $(notdir $@) --exclude .git --no-mac-metadata --no-xattrs opam-full-$(VERSION)
 	rm -rf "$(OUTDIR)/opam-full-$(VERSION)"
 
 build/Dockerfile.x86_64-linux: Dockerfile.in


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/6619

While testing #6705 i encountered some failures due to extra `._*` files in the archive (see https://superuser.com/questions/61185/why-do-i-get-files-like-foo-in-my-tarball-on-os-x) which made dune fail.

Using `--no-mac-metadata` fixes this problem but using `git archive` goes even further and should make the archive reproducible (same archive regardless of username, group, uid, gid, current time, …)