### PR TITLE
reftests: Harden the regexp used for substituting variable checksums

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -148,6 +148,7 @@ users)
   * Fix support for removing local link directories [#6450 @kit-ty-kate]
   * Bump `OPAM_REPO_SHA` in the github action workflows to allow patch 3.0.0 [#6663 @kit-ty-kate]
   * Allow `sed-cmd` to parse even if no space is after the command [#6675 @rjbou]
+  * Harden the regexp used for substituting variable checksums [#6710 @kit-ty-kate]
 
 ## Github Actions
   * bump `actions/checkout` from 4 to 5 [#6643 @kit-ty-kate]

--- a/tests/reftests/action-disk.test
+++ b/tests/reftests/action-disk.test
@@ -132,7 +132,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (write => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/lock (write => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
-### opam install main-repo.1 | grep -v '^- ./$' | sed-cmd rsync tar cp touch mkdir | "${PRE_MD5}..?${MD5}" -> pre/hash | "md5..?${PRE_MD5}" -> md5/pre
+### opam install main-repo.1 | grep -v '^- ./$' | sed-cmd rsync tar cp touch mkdir | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash | "md5[^[:alnum:]].?${PRE_MD5}" -> md5/pre
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -205,7 +205,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-swi
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/backup/state-today.export
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
-### opam reinstall main-repo.1 | sed-cmd tar cp touch mkdir | "${PRE_MD5}..?${MD5}" -> pre/hash | unordered
+### opam reinstall main-repo.1 | sed-cmd tar cp touch mkdir | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -290,7 +290,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-swi
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/backup/state-today.export
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
-### opam upgrade main-repo | sed-cmd tar touch mkdir cp | "${PRE_MD5}..?${MD5}" -> pre/hash | unordered
+### opam upgrade main-repo | sed-cmd tar touch mkdir cp | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -387,7 +387,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-swi
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/backup/state-today.export
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
-### opam remove main-repo | sed-cmd tar touch | "${PRE_MD5}..?${MD5}" -> pre/hash | unordered
+### opam remove main-repo | sed-cmd tar touch | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -1855,7 +1855,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.o
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/backup/state-today.export
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
-### opam install main-repo | grep -v '^- ./$' | sed-cmd tar rsync cp touch mkdir | "${PRE_MD5}..?${MD5}" -> pre/hash
+### opam install main-repo | grep -v '^- ./$' | sed-cmd tar rsync cp touch mkdir | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -1917,7 +1917,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.o
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/backup/state-today.export
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
-### opam reinstall main-repo | grep -v '^- ./$' | sed-cmd tar rsync cp touch mkdir | "${PRE_MD5}..?${MD5}" -> pre/hash | unordered
+### opam reinstall main-repo | grep -v '^- ./$' | sed-cmd tar rsync cp touch mkdir | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -2002,7 +2002,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.o
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/backup/state-today.export
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
-### opam remove main-repo | grep -v '^- ./$' | sed-cmd tar rsync touch | "${PRE_MD5}..?${MD5}" -> pre/hash | unordered
+### opam remove main-repo | grep -v '^- ./$' | sed-cmd tar rsync touch | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -2104,7 +2104,7 @@ Usage: opam switch [OPTION]… [COMMAND] [ARG]…
 Try 'opam switch --help' or 'opam --help' for more information.
 # Return code 2 #
 ### :III:2: with package
-### opam switch create package-switch --package main-repo | grep -v '^- ./$' | sed-cmd rsync tar cp touch mkdir | "${PRE_MD5}..?${MD5}" -> pre/hash | "md5..?${PRE_MD5}" -> md5/pre
+### opam switch create package-switch --package main-repo | grep -v '^- ./$' | sed-cmd rsync tar cp touch mkdir | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash | "md5[^[:alnum:]].?${PRE_MD5}" -> md5/pre
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => write)

--- a/tests/reftests/hooks-variables.test
+++ b/tests/reftests/hooks-variables.test
@@ -287,7 +287,7 @@ Processing  3/3: [i-am-a-repo-pkg: bash ...post-installing...]
 - installed-files:etc etc/i-am-a-repo-pkg etc/i-am-a-repo-pkg/printer
 -> installed i-am-a-repo-pkg.1
 Done.
-### opam remove i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | '${PRE_MD5}..?${MD5}' -> pre/+archive-hash+ | $MD5 -> +archive-hash+ | sed-cmd bash tar
+### opam remove i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | $MD5 -> +archive-hash+ | sed-cmd bash tar
 The following actions will be performed:
 === remove 1 package
   - remove i-am-a-repo-pkg 1
@@ -411,7 +411,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed dep.1
 Done.
-### opam install i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | '${PRE_MD5}..?${MD5}' -> pre/+archive-hash+ | $MD5 -> +archive-hash+ | sed-cmd bash tar | etc -> etc
+### opam install i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | $MD5 -> +archive-hash+ | sed-cmd bash tar | etc -> etc
 The following actions will be performed:
 === install 1 package
   - install i-am-a-repo-pkg 1
@@ -588,7 +588,7 @@ Processing  3/3: [i-am-a-repo-pkg: bash ...post-installing...]
 - installed-files:etc etc/i-am-a-repo-pkg etc/i-am-a-repo-pkg/printer
 -> installed i-am-a-repo-pkg.1
 Done.
-### opam remove i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | '${PRE_MD5}..?${MD5}' -> pre/+archive-hash+ | $MD5 -> +archive-hash+ | sed-cmd bash tar
+### opam remove i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | $MD5 -> +archive-hash+ | sed-cmd bash tar
 The following actions will be performed:
 === remove 1 package
   - remove i-am-a-repo-pkg 1
@@ -744,7 +744,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed dep.1
 Done.
-### opam install i-am-a-repo-pkg | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | '${PRE_MD5}..?${MD5}' -> pre/+archive-hash+ | $MD5 -> +archive-hash+ | sed-cmd bash tar | etc -> etc
+### opam install i-am-a-repo-pkg | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | $MD5 -> +archive-hash+ | sed-cmd bash tar | etc -> etc
 The following actions will be performed:
 === install 1 package
   - install i-am-a-repo-pkg 1
@@ -783,7 +783,7 @@ Done.
    success:true
    failure:false
    installed-files:
-### opam remove i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | '${PRE_MD5}..?${MD5}' -> pre/+archive-hash+ | $MD5 -> +archive-hash+ | sed-cmd bash tar
+### opam remove i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | $MD5 -> +archive-hash+ | sed-cmd bash tar
 The following actions will be performed:
 === remove 1 package
   - remove i-am-a-repo-pkg 1

--- a/tests/reftests/hooks-variables.win32.test
+++ b/tests/reftests/hooks-variables.win32.test
@@ -99,7 +99,7 @@ Processing  3/3: [i-am-a-repo-pkg: bash ...post-installing...]
 - exe:.exe
 -> installed i-am-a-repo-pkg.1
 Done.
-### opam remove i-am-a-repo-pkg | '${PRE_MD5}..?${MD5}' -> pre/+archive-hash+ | sed-cmd bash tar
+### opam remove i-am-a-repo-pkg | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | sed-cmd bash tar
 The following actions will be performed:
 === remove 1 package
   - remove i-am-a-repo-pkg 1
@@ -146,7 +146,7 @@ Set to '[ "bash" "%{hooks}%/printer.sh" "...post-building..." "exe:%{exe}%" ]' t
 Set to '[ "bash" "%{hooks}%/printer.sh" "...post-installing..." "exe:%{exe}%" ]' the field post-install-commands in switch switch-wrappers
 ### opam option --switch switch-wrappers 'post-remove-commands=[ "bash" "%{hooks}%/printer.sh" "...post-removing..." "exe:%{exe}%" ]'
 Set to '[ "bash" "%{hooks}%/printer.sh" "...post-removing..." "exe:%{exe}%" ]' the field post-remove-commands in switch switch-wrappers
-### opam install i-am-a-repo-pkg | '${PRE_MD5}..?${MD5}' -> pre/+archive-hash+ | sed-cmd bash tar
+### opam install i-am-a-repo-pkg | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | sed-cmd bash tar
 The following actions will be performed:
 === install 1 package
   - install i-am-a-repo-pkg 1
@@ -184,7 +184,7 @@ Processing  3/3: [i-am-a-repo-pkg: bash ...post-installing...]
 - exe:.exe
 -> installed i-am-a-repo-pkg.1
 Done.
-### opam remove i-am-a-repo-pkg | '${PRE_MD5}..?${MD5}' -> pre/+archive-hash+ | sed-cmd bash tar
+### opam remove i-am-a-repo-pkg | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | sed-cmd bash tar
 The following actions will be performed:
 === remove 1 package
   - remove i-am-a-repo-pkg 1
@@ -237,7 +237,7 @@ EOF
 Processing: [default: loading data]
 Now run 'opam upgrade' to apply any package updates.
 ### opam switch create pkg-from-repo --empty
-### opam install i-am-a-repo-pkg | '${PRE_MD5}..?${MD5}' -> pre/+archive-hash+ | sed-cmd bash tar
+### opam install i-am-a-repo-pkg | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | sed-cmd bash tar
 The following actions will be performed:
 === install 1 package
   - install i-am-a-repo-pkg 1
@@ -261,7 +261,7 @@ Done.
 <><> i-am-a-repo-pkg.1 installed successfully <><><><><><><><><><><><><><><><><>
 => ...A last message...
    exe:.exe
-### opam remove i-am-a-repo-pkg | '${PRE_MD5}..?${MD5}' -> pre/+archive-hash+ | sed-cmd bash tar
+### opam remove i-am-a-repo-pkg | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | sed-cmd bash tar
 The following actions will be performed:
 === remove 1 package
   - remove i-am-a-repo-pkg 1

--- a/tests/reftests/opam-repo-ci.test
+++ b/tests/reftests/opam-repo-ci.test
@@ -52,7 +52,7 @@ main is now pinned to version 1
 ### # emulate '(cache (opam-archives (target /home/opam/.opam/download-cache)))'
 ### mkdir -p OPAM/download-cache/md5/$PRE_MD5
 ### cp archive.tgz OPAM/download-cache/md5/$PRE_MD5/$MD5
-### opam reinstall main.1 | sed-cmd tar | "${PRE_MD5}..?${MD5}" -> pre/hash
+### opam reinstall main.1 | sed-cmd tar | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash
 main.1 is not installed. Install it? [Y/n] y
 The following actions will be performed:
 === install 2 packages
@@ -85,7 +85,7 @@ The following actions will be performed:
 Done.
 ### # Third reinstall
 ### # no change in source on cache archive
-### opam reinstall main.1 --with-test -vv | sed-cmd rsync tar | "${PRE_MD5}..?${MD5}" -> pre/hash
+### opam reinstall main.1 --with-test -vv | sed-cmd rsync tar | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash
 The following actions will be performed:
 === recompile 1 package
   - recompile main 1 (pinned)


### PR DESCRIPTION
e.g. in hooks-variables.test, a failure can occur if the checksum starts with 'md' as it matches 'md5=${MD5}'