### PR TITLE
Order build-env after setenv

### DIFF
--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -584,16 +584,14 @@ let compilation_env t opam =
   in
   let scrub = OpamClientConfig.(!r.scrubbed_environment_variables) in
   OpamEnv.get_full ~scrub ~set_opamroot:true ~set_opamswitch:true
-    ~force_path:true t ~updates:([
+    ~force_path:true ~build_env t ~updates:([
         cdpath;
         makeflags;
         makelevel;
         pkg_name;
         pkg_version;
         cli
-      ] @
-        build_env
-        @ cygwin_env)
+      ] @ cygwin_env)
 
 let installed_opam_opt st nv =
   OpamStd.Option.Op.(

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -220,7 +220,7 @@ let regenerate_env ~set_opamroot ~set_opamswitch ~force_path
     gt switch env_file =
   OpamSwitchState.with_ `Lock_none ~switch gt @@ fun st ->
   let upd =
-    OpamEnv.updates ~set_opamroot ~set_opamswitch ~force_path st
+    OpamEnv.updates ~set_opamroot ~set_opamswitch ~force_path ~build_env:[] st
   in
   if not (OpamCoreConfig.(!r.safe_mode)) then
     (let _, st =

--- a/src/client/opamSolution.ml
+++ b/src/client/opamSolution.ml
@@ -1101,7 +1101,8 @@ let confirmation ?ask requested solution =
   OpamConsole.confirm "\nProceed with %s?" (OpamSolver.string_of_stats stats)
 
 let run_hook_job t name ?(local=[]) ?(allow_stdout=false) w =
-  let shell_env = OpamEnv.get_full ~set_opamroot:true ~set_opamswitch:true ~force_path:true t in
+  (* TODO: ????? *)
+  let shell_env = OpamEnv.get_full ~set_opamroot:true ~set_opamswitch:true ~force_path:true ~build_env:[] t in
   let mk_cmd = function
     | cmd :: args ->
       let text = OpamProcess.make_command_text name ~args cmd in

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -200,7 +200,7 @@ let install_compiler
         not OpamStateConfig.(!r.dryrun) then
        OpamFile.Environment.write
          (OpamPath.Switch.environment t.switch_global.root t.switch)
-         (OpamEnv.compute_updates t);
+         (OpamEnv.compute_updates ~build_env:[] t);
      OpamEnv.check_and_print_env_warning t);
     t
   end else

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -27,7 +27,9 @@ val resolve_separator_and_format:
     remove from the environment. *)
 val get_full:
   set_opamroot:bool -> set_opamswitch:bool -> force_path:bool ->
-  ?updates: ('r, euok_internal) env_update list -> ?scrub:string list -> 'a switch_state -> env
+  build_env:('r, euok_internal) env_update list ->
+  ?updates: ('r, euok_internal) env_update list ->
+  ?scrub:string list -> 'a switch_state -> env
 
 (** Get only environment modified by OPAM. If [force_path], the PATH is modified
     to ensure opam dirs are leading. [set_opamroot] and [set_opamswitch] can be
@@ -76,7 +78,8 @@ val add: env -> (spf_resolved, euok_internal) env_update list -> env
     these [updates] instead of the new environment. *)
 val updates:
   set_opamroot:bool -> set_opamswitch:bool -> ?force_path:bool ->
-  'a switch_state -> (spf_resolved, [> euok_writeable ]) env_update list
+  build_env:(spf_resolved, 'k) env_update list ->
+  'a switch_state -> (spf_resolved, [> euok_writeable ] as 'k) env_update list
 
 (** Check if the shell environment is in sync with the current OPAM switch,
     unless [skip] is true (it's default value is OPAMNOENVNOTICE *)
@@ -89,7 +92,11 @@ val is_up_to_date_switch: dirname -> switch -> bool
 
 (** Returns the current environment updates to configure the current switch with
     its set of installed packages *)
-val compute_updates: ?force_path:bool -> 'a switch_state -> (spf_resolved, [> euok_writeable ]) env_update list
+val compute_updates:
+  ?force_path:bool ->
+  build_env:(spf_resolved, 'k) env_update list ->
+  'a switch_state ->
+  (spf_resolved, [> euok_writeable ] as 'k) env_update list
 
 (** Returns shell-appropriate statement to evaluate [cmd]. *)
 val shell_eval_invocation:

--- a/src/state/opamSwitchAction.ml
+++ b/src/state/opamSwitchAction.ml
@@ -95,7 +95,7 @@ let write_selections st =
     let f = OpamPath.Switch.selections st.switch_global.root st.switch in
     let env = OpamPath.Switch.environment st.switch_global.root st.switch in
     OpamFile.SwitchSelections.write f (OpamSwitchState.selections st);
-    OpamFile.Environment.write env (OpamEnv.compute_updates st)
+    OpamFile.Environment.write env (OpamEnv.compute_updates ~build_env:[] st)
 
 let add_to_reinstall st ~unpinned_only packages =
   log "add-to-reinstall unpinned_only:%b packages:%a" unpinned_only

--- a/tests/reftests/env.test
+++ b/tests/reftests/env.test
@@ -44,8 +44,8 @@ NV_VARS='hej!!'; export NV_VARS;
 NV_VARS='hej!!'; export NV_VARS;
 OPAM_SWITCH_PREFIX='${BASEDIR}/OPAM/conffile'; export OPAM_SWITCH_PREFIX;
 ### opam exec -- opam env --revert | grep "^NV_VARS|^OPAM_SWITCH_PREFIX|${OPAM}"
-OPAM_SWITCH_PREFIX=''; export OPAM_SWITCH_PREFIX;
 NV_VARS=''; export NV_VARS;
+OPAM_SWITCH_PREFIX=''; export OPAM_SWITCH_PREFIX;
 ### opam exec -- env | grep '^NV_VARS|^OPAM_SWITCH_PREFIX|${OPAM}'
 NV_VARS=hej!!
 OPAM=${OPAM}


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/6574

I'm not too happy with the code but it should work.

The order between build-end and setenv has been that way since at least opam 2.0: https://github.com/ocaml/opam/commit/be714e9b0ccd0ba9af34421e28425c894648459e