### PR TITLE
Fix the false-positive mismatch debug warning during "opam update" when faced with nested extra-files on Windows

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -51,6 +51,7 @@ users)
   * Make the computation of `pkg:opamfile` match its specification [#6659 @kit-ty-kate - fix #5346]
 
 ## Update / Upgrade
+  * Fix the false-positive mismatch debug warning during `opam update` when faced with nested extra-files on Windows [#6715 @kit-ty-kate]
 
 ## Tree
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -142,6 +142,7 @@ users)
   * Add a test showing the behaviour of `opam var <pkg>:opamfile` [#6659 @kit-ty-kate]
   * Add a test to show homogeneity of outputs on verbose between sandboxed and non sandboxed commands (with `-vv`) [#6675 @rjbou]
   * Update `sed-cmd` reftest reftest [#6675 @rjbou]
+  * Add a test showing the behaviour of nested extra-files [#6715 @kit-ty-kate]
 
 ### Engine
   * Fix gcc < 14.3 bug on mingw i686 [#6624 @kit-ty-kate]

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -1363,7 +1363,9 @@ let add_aux_files ?dir ?(files_subdir_hashes=false) opam =
         OpamFilename.rec_files dir
         |> List.map (fun file ->
             file,
-            OpamFilename.Base.of_string (OpamFilename.remove_prefix dir file))
+            OpamFilename.Base.of_string
+              (OpamSystem.back_to_forward
+                 (OpamFilename.remove_prefix dir file)))
       in
       match OpamFile.OPAM.extra_files opam, extra_files with
       | None, None -> opam

--- a/tests/reftests/extrafile.test
+++ b/tests/reftests/extrafile.test
@@ -661,3 +661,49 @@ The following actions will be performed:
 Successfully extracted to ${BASEDIR}/escape-good-md5.1
 ### test -f escape-good-md5.1/p.patch
 # Return code 1 #
+### ::::::::::::::::::::::::
+### : Nested extra-files
+### ::::::::::::::::::::::::
+### <pkg:good-nested-md5.1>
+opam-version: "2.0"
+maintainer: "nobody"
+authors: "nobody neither"
+homepage: "https://no.bo.dy"
+bug-reports: "https://still.nobo.dy"
+dev-repo: "git+https://no.were"
+license: "MIT"
+synopsis: "Initially empty"
+build: [ "test" "-f" "dir/p.patch" ]
+extra-files: [
+  ["dir/p.patch" "md5=patch-md5"]
+]
+### <add-nested-files.sh>
+set -ue
+pkg=$1
+pkgpath="REPO/packages/${pkg%.*}/$pkg"
+mkdir -p $pkgpath/files/dir
+cp p.patch $pkgpath/files/dir/
+### sh add-nested-files.sh good-nested-md5.1
+### sh update-hashes.sh
+### OPAMDEBUGSECTIONS=opam-file OPAMDEBUG=-1 opam update default | unordered
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/bad-md5/bad-md5.1: wrong checksum (1)
+opam-file                       Missing expected extra files /etc/passwdd at ${BASEDIR}/OPAM/repo/default/packages/escape-absolute/escape-absolute.1/files
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/escape-good-md5/escape-good-md5.1: missing from 'files' directory (1)
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/good-md5-bad-sha256/good-md5-bad-sha256.1: missing from 'files' directory (1)
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/good-md5-good-sha256/good-md5-good-sha256.1: missing from 'files' directory (1)
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/good-nested-md5/good-nested-md5.1: missing from 'files' directory (1) and missing from opam file (1)
+opam-file                       Missing extra-files field for p.patch for no-checksum.1, ignoring them.
+opam-file                       Missing extra-files field for p.patch for not-mentioned.1, ignoring them.
+opam-file                       Missing expected extra files p.patch at ${BASEDIR}/OPAM/repo/default/packages/not-present/not-present.1/files
+Now run 'opam upgrade' to apply any package updates.
+### opam install good-nested-md5.1
+The following actions will be performed:
+=== install 1 package
+  - install good-nested-md5 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed good-nested-md5.1
+Done.

--- a/tests/reftests/extrafile.test
+++ b/tests/reftests/extrafile.test
@@ -694,7 +694,6 @@ opam-file                       Missing expected extra files /etc/passwdd at ${B
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/escape-good-md5/escape-good-md5.1: missing from 'files' directory (1)
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/good-md5-bad-sha256/good-md5-bad-sha256.1: missing from 'files' directory (1)
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/good-md5-good-sha256/good-md5-good-sha256.1: missing from 'files' directory (1)
-opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/good-nested-md5/good-nested-md5.1: missing from 'files' directory (1) and missing from opam file (1)
 opam-file                       Missing extra-files field for p.patch for no-checksum.1, ignoring them.
 opam-file                       Missing extra-files field for p.patch for not-mentioned.1, ignoring them.
 opam-file                       Missing expected extra files p.patch at ${BASEDIR}/OPAM/repo/default/packages/not-present/not-present.1/files


### PR DESCRIPTION
Discovered in the tests of https://github.com/ocaml/opam/pull/6614

The extra-files loader on Windows breaks when the file is contained in a directory and thinks there is a mismatch between the files listed in the field and the files detected on disk. The faulty behaviour can't be seen in the tests as i'm running them on Unix but it can be seen in the tests results of https://github.com/ocaml/opam/pull/6614 on Windows.

```diff
diff --git a/_build/default/tests/reftests/update.test b/_build/default/tests/reftests/update.out
index 8f52cdb..cd9a0db 100644
--- a/_build/default/tests/reftests/update.test
+++ b/_build/default/tests/reftests/update.out
@@ -415,6 +415,8 @@ EOF
 
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [git-test] synchronised from git+file://${BASEDIR}/GITREPO
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/git-test/packages/pkg-a/pkg-a.1: missing from 'files' directory (1) and missing from opam file (1)
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/git-test/packages/prefix-pkg-b/pkg-b.1: missing from 'files' directory (1) and missing from opam file (1)
 Now run 'opam upgrade' to apply any package updates.
 ### opam list --all --repo=git-test -s
 new-pkg
```