### PR TITLE
GHA: Make the reftests pass with the macos GHA runner-images >= 20250928

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -148,6 +148,7 @@ users)
   * Update `sed-cmd` reftest reftest [#6675 @rjbou]
   * Add a test showing the behaviour of nested extra-files [#6715 @kit-ty-kate]
   * Add opam file loading tests to `update.test` to demonstrate current behaviour of loading full repository instead of only changed files. [#6614 @arozovyk @rjbou @kit-ty-kate]
+  * Fix `env.test` in cases where calling `env` inside of a script outputs a `__CF_USER_TEXT_ENCODING` environment variable that isn't present in `sh -c env` [#6719 @kit-ty-kate]
 
 ### Engine
   * Fix gcc < 14.3 bug on mingw i686 [#6624 @kit-ty-kate]

--- a/tests/reftests/env.test
+++ b/tests/reftests/env.test
@@ -581,7 +581,7 @@ opam-version: "2.0"
 build: [ "sh" "getenv.sh" "1" ]
 ### <pkg:to-build.2:getenv.sh>
 out=build-env
-fromtest="^PATH=\|^MANPATH=\|^LOCALENV=\|^TEMPDIR=\|^TMPDIR=\|^TMP=\|^TEMP=\|^SHLVL=\|^PWD=\|^_="
+fromtest="^PATH=\|^MANPATH=\|^LOCALENV=\|^TEMPDIR=\|^TMPDIR=\|^TMP=\|^TEMP=\|^SHLVL=\|^PWD=\|^_=\|^__CF_USER_TEXT_ENCODING="
 for v in $LOCALENV; do
   if echo "$v" | grep -q "=" ; then
     fromtest="$fromtest\\|^$(echo "$v" | cut -f 1 -d '=')="


### PR DESCRIPTION
Noticed in https://github.com/ocaml/opam/pull/6709
```diff
diff --git a/_build/default/tests/reftests/env.test b/_build/default/tests/reftests/env.out
index 981afd3..1bbb7e0 100644
--- a/_build/default/tests/reftests/env.test
+++ b/_build/default/tests/reftests/env.out
@@ -609,6 +609,7 @@ OPAMSWITCH=bd
 OPAM_PACKAGE_NAME=to-build
 OPAM_PACKAGE_VERSION=2
 OPAM_SWITCH_PREFIX=${BASEDIR}/OPAM/bd
+__CF_USER_TEXT_ENCODING=0x1F5:0x0:0x0
 PATH=${BASEDIR}/OPAM/bd/bin
 ### opam remove to-build
 The following actions will be performed:
@@ -650,4 +651,5 @@ OPAMSWITCH=bd
 OPAM_PACKAGE_NAME=another-package
 OPAM_PACKAGE_VERSION=another-version
 OPAM_SWITCH_PREFIX=${BASEDIR}/OPAM/bd
+__CF_USER_TEXT_ENCODING=0x1F5:0x0:0x0
 PATH=${BASEDIR}/OPAM/bd/bin:another-path
 ```
 
 Tested successfully in https://github.com/kit-ty-kate/opam/actions/runs/18236297859/job/51930560271?pr=22