### PR TITLE
Add  `opam repo show <reponame>` support

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2582,10 +2582,14 @@ let repository cli =
            '--all' to see all configured repositories.";
       OpamRepositoryCommand.list rt ~global ~switches ~short;
       `Ok ()
+    | Some `show_repo, [] ->
+      OpamRepositoryState.with_ `Lock_none gt @@ fun rt ->
+      OpamRepositoryCommand.show_repo rt ~switches None;
+      `Ok ()
     | Some `show_repo, [ repo_name ] ->
       OpamRepositoryState.with_ `Lock_none gt @@ fun rt ->
-      OpamRepositoryCommand.show_repo rt ~switches
-        (OpamRepositoryName.of_string repo_name);
+      let repo_name = if scope = [ `All ] then None else Some (OpamRepositoryName.of_string repo_name) in
+      OpamRepositoryCommand.show_repo rt ~switches repo_name;
       `Ok ()
     | command, params -> bad_subcommand ~cli commands ("repository", command, params)
   in

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2276,6 +2276,8 @@ let repository cli =
      where they are active.";
     cli_original, "priority", `priority, ["NAME"; "RANK"],
     "Synonym to $(b,add NAME --rank RANK)";
+    cli_original, "show", `show_repo, [],
+    "Show the URL and priority of a repository";
   ] in
   let man = [
     `S Manpage.s_description;
@@ -2579,6 +2581,19 @@ let repository cli =
           "These are the repositories in use by the current switch. Use \
            '--all' to see all configured repositories.";
       OpamRepositoryCommand.list rt ~global ~switches ~short;
+      `Ok ()
+    | Some `show_repo, [ repo_name ] ->
+      OpamRepositoryState.with_ `Lock_none gt @@ fun rt ->
+      let switches =
+        if scope = [] ||
+           List.exists (function
+               | `This_switch | `Current_switch | `Switch _ -> true
+               | _ -> false)
+             scope
+        then switches
+        else all_switches
+      in
+      OpamRepositoryCommand.show_repo rt ~switches (OpamRepositoryName.of_string repo_name);
       `Ok ()
     | command, params -> bad_subcommand ~cli commands ("repository", command, params)
   in

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2276,7 +2276,7 @@ let repository cli =
      where they are active.";
     cli_original, "priority", `priority, ["NAME"; "RANK"],
     "Synonym to $(b,add NAME --rank RANK)";
-    cli_original, "show", `show_repo, [],
+    cli_from cli2_5, "show", `show_repo, [],
     "Show the URL and priority of a repository";
   ] in
   let man = [
@@ -2584,15 +2584,6 @@ let repository cli =
       `Ok ()
     | Some `show_repo, [ repo_name ] ->
       OpamRepositoryState.with_ `Lock_none gt @@ fun rt ->
-      let switches =
-        if scope = [] ||
-           List.exists (function
-               | `This_switch | `Current_switch | `Switch _ -> true
-               | _ -> false)
-             scope
-        then switches
-        else all_switches
-      in
       OpamRepositoryCommand.show_repo rt ~switches
         (OpamRepositoryName.of_string repo_name);
       `Ok ()

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -2593,7 +2593,8 @@ let repository cli =
         then switches
         else all_switches
       in
-      OpamRepositoryCommand.show_repo rt ~switches (OpamRepositoryName.of_string repo_name);
+      OpamRepositoryCommand.show_repo rt ~switches
+        (OpamRepositoryName.of_string repo_name);
       `Ok ()
     | command, params -> bad_subcommand ~cli commands ("repository", command, params)
   in

--- a/src/client/opamRepositoryCommand.ml
+++ b/src/client/opamRepositoryCommand.ml
@@ -220,23 +220,30 @@ let list_all rt ~short =
   OpamConsole.print_table stdout ~sep:" "
 
 let show_repo rt ~switches repo_name =
-  let repos = List.filter_map (fun sw ->
-    let sw_name = OpamSwitch.to_string sw in
-    match switch_repos rt sw |> List.mapi (fun i repo -> (i+1, repo)) |> List.filter (fun (_, repo) -> repo = repo_name) with
-    | [] -> None
-    | repos -> Some (sw_name, repos)
-  ) switches in
-  List.iter (fun (sw_name, repos)  ->
+  let repos =
+    List.filter_map (fun sw ->
+        let repos =
+          switch_repos rt sw |>
+          List.mapi (fun i repo -> (i+1, repo)) |>
+          List.filter (fun (_, repo) -> OpamRepositoryName.equal repo repo_name)
+        in
+        match repos with
+        | [] -> None
+        | repos -> Some (sw, repos)
+      ) switches
+  in
+  List.iter (fun (sw, repos)  ->
     List.iter (fun (rank, repo) ->
           try
             let r = OpamRepositoryName.Map.find repo rt.repositories in
-            let url = if r.repo_url = OpamUrl.empty then "-" else
-              OpamUrl.to_string r.repo_url |> OpamConsole.colorise `underline in
-            OpamConsole.msg "switch: %s\n" sw_name;
+            let url =
+              OpamConsole.colorise `underline (OpamUrl.to_string r.repo_url)
+            in
+            OpamConsole.msg "switch: %s\n" (OpamSwitch.to_string sw);
             OpamConsole.msg "url: %s\n" url;
             OpamConsole.msg "rank: %d\n" rank;
-            ()
-          with Not_found -> "not found" |> OpamConsole.colorise `red |> OpamConsole.msg "%s")
+          with Not_found ->
+            OpamConsole.msg "%s" (OpamConsole.colorise `red "not found"))
       repos)
     repos
 

--- a/src/client/opamRepositoryCommand.ml
+++ b/src/client/opamRepositoryCommand.ml
@@ -234,16 +234,13 @@ let show_repo rt ~switches repo_name =
   in
   List.iter (fun (sw, repos)  ->
     List.iter (fun (rank, repo) ->
-          try
-            let r = OpamRepositoryName.Map.find repo rt.repositories in
-            let url =
-              OpamConsole.colorise `underline (OpamUrl.to_string r.repo_url)
-            in
-            OpamConsole.msg "switch: %s\n" (OpamSwitch.to_string sw);
-            OpamConsole.msg "url: %s\n" url;
-            OpamConsole.msg "rank: %d\n" rank;
-          with Not_found ->
-            OpamConsole.msg "%s" (OpamConsole.colorise `red "not found"))
+        let r = OpamRepositoryName.Map.find repo rt.repositories in
+        let url =
+          OpamConsole.colorise `underline (OpamUrl.to_string r.repo_url)
+        in
+        OpamConsole.msg "switch: %s\n" (OpamSwitch.to_string sw);
+        OpamConsole.msg "url: %s\n" url;
+        OpamConsole.msg "rank: %d\n" rank)
       repos)
     repos
 

--- a/src/client/opamRepositoryCommand.ml
+++ b/src/client/opamRepositoryCommand.ml
@@ -220,29 +220,51 @@ let list_all rt ~short =
   OpamConsole.print_table stdout ~sep:" "
 
 let show_repo rt ~switches repo_name =
-  let repos =
-    List.filter_map (fun sw ->
-        let repos =
-          switch_repos rt sw |>
-          List.mapi (fun i repo -> (i+1, repo)) |>
-          List.filter (fun (_, repo) -> OpamRepositoryName.equal repo repo_name)
-        in
-        match repos with
-        | [] -> None
-        | repos -> Some (sw, repos)
-      ) switches
+  let repos_to_table repos =
+    List.fold_left (fun acc (rank, repo) ->
+      let r = OpamRepositoryName.Map.find repo rt.repositories in
+      [ OpamConsole.colorise `blue "rank"; string_of_int rank ]
+      :: [ OpamConsole.colorise `blue "url"; OpamUrl.to_string r.repo_url ]
+      :: [ OpamConsole.colorise `blue "name"; OpamRepositoryName.to_string repo ]
+      :: [ "\n" ]
+      :: acc)
+      [] repos
+    |> List.rev
   in
-  List.iter (fun (sw, repos)  ->
-    List.iter (fun (rank, repo) ->
-        let r = OpamRepositoryName.Map.find repo rt.repositories in
-        let url =
-          OpamConsole.colorise `underline (OpamUrl.to_string r.repo_url)
-        in
-        OpamConsole.msg "switch: %s\n" (OpamSwitch.to_string sw);
-        OpamConsole.msg "url: %s\n" url;
-        OpamConsole.msg "rank: %d\n" rank)
-      repos)
-    repos
+  let repos_per_switch =
+    List.filter_map (fun sw ->
+      let repos = switch_repos rt sw |> List.mapi (fun i repo -> (i+1, repo)) in
+      match repos with
+      | [] -> None
+      | repos -> Some (sw, repos)
+    ) switches
+  in
+  let repos =
+    match repo_name with
+    | None -> List.map (fun (sw, repos) -> sw, repos_to_table repos) repos_per_switch
+    | Some repo_name ->
+      List.filter_map (fun (sw, repos) ->
+          match List.filter (fun (_, repo) ->
+              OpamRepositoryName.equal repo repo_name) repos with
+          | [] -> None
+          | repos -> Some (sw, repos_to_table repos)
+        ) repos_per_switch
+  in
+  match repos with
+  | [] -> begin
+      match repo_name with
+      | None ->
+        OpamConsole.error_and_exit `Bad_arguments "No repository found";
+      | Some repo_name ->
+        OpamConsole.error_and_exit `Bad_arguments
+          "No repository called %s was found" (OpamRepositoryName.to_string repo_name);
+    end
+  | repos ->
+    List.iter (fun (sw, tbl)  ->
+        OpamConsole.header_msg "switch: %s" (OpamSwitch.to_string sw);
+        OpamStd.Format.align_table tbl |>
+        OpamConsole.print_table ~cut:`Truncate stdout ~sep:" ")
+      repos
 
 let update_with_auto_upgrade rt repo_names =
   let repos = List.map (OpamRepositoryState.get_repo rt) repo_names in

--- a/src/client/opamRepositoryCommand.mli
+++ b/src/client/opamRepositoryCommand.mli
@@ -27,6 +27,9 @@ val list:
     are selected in. *)
 val list_all: 'a repos_state -> short:bool -> unit
 
+(** Show the URL and priority (rank) of the given repository *)
+val show_repo: 'a repos_state -> switches:switch list -> repository_name -> unit
+
 (** Add a new repository to ~/.opam/repos, without updating any selections *)
 val add:
   rw repos_state -> repository_name -> url -> trust_anchors option ->

--- a/src/client/opamRepositoryCommand.mli
+++ b/src/client/opamRepositoryCommand.mli
@@ -28,7 +28,7 @@ val list:
 val list_all: 'a repos_state -> short:bool -> unit
 
 (** Show the URL and priority (rank) of the given repository *)
-val show_repo: 'a repos_state -> switches:switch list -> repository_name -> unit
+val show_repo: 'a repos_state -> switches:switch list -> repository_name option -> unit
 
 (** Add a new repository to ~/.opam/repos, without updating any selections *)
 val add:


### PR DESCRIPTION
Related to issue https://github.com/ocaml/opam/issues/6235.

Adding a new command that will allow us to get the URL and Rank of a specific repo.

Also supports `all` (will display the url and rank of a repo for every switch):
```sh
$ opam repo show default --all
```