### PR TITLE
Make the tests even more resistant to user git configuration

### DIFF
--- a/.github/scripts/main/opam-rt.sh
+++ b/.github/scripts/main/opam-rt.sh
@@ -10,7 +10,10 @@ export PATH=~/local/bin:$PATH
 export OPAMKEEPLOGS=1
 
 # TODO: Make opam-rt compatible with non-master initial branches
-git config --global init.defaultBranch master
+sudo git config --system init.defaultBranch master
+# TODO: Make opam-rt compatible with a hermetic git configuration
+sudo git config --system user.name 'OPAM test environment'
+sudo git config --system user.email 'noreply@ocaml.org'
 
 cd $CACHE/opam-rt
 make KINDS="local git" run

--- a/.github/scripts/main/preamble.sh
+++ b/.github/scripts/main/preamble.sh
@@ -3,9 +3,11 @@
 CWD=$PWD
 if [ "$RUNNER_OS" = Windows ]; then
   CACHE="$(cygpath 'D:\Cache')"
+  SUDO=''
 else
   CACHE=~/.cache
   CACHE=$(eval echo $CACHE)
+  SUDO=sudo
 fi
 echo "Cache -> $CACHE"
 OCAML_LOCAL=$CACHE/ocaml-local
@@ -31,11 +33,7 @@ OPAMBSSWITCH=opam-build
 
 export OPAMCONFIRMLEVEL=unsafe-yes
 
-git config --global user.email "gha@example.com"
-git config --global user.name "Github Actions CI"
-git config --global gc.autoDetach false
-git config --global init.defaultBranch thisShouldNotHappen
-git config --global protocol.file.allow always
+$SUDO git config --system gc.autoDetach false
 
 if [ -d ~/opam-repository ]; then
   OPAM_REPO_CACHE=file://$HOME/opam-repository

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -35,7 +35,7 @@ module VCS : OpamVCS.VCS = struct
   let init repo_root repo_url =
     OpamFilename.mkdir repo_root;
     OpamProcess.Job.of_list [
-      git repo_root [ "init" ];
+      git repo_root [ "-c"; "init.defaultBranch=main"; "init" ];
       (* Enforce this option, it can break our use of git if set *)
       git repo_root [ "config" ; "--local" ; "fetch.prune"; "false"];
       (* We reset diff.noprefix to ensure we get a `-p1` patch and avoid <https://github.com/ocaml/opam/issues/3627>. *)

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -340,7 +340,13 @@ let template nv =
         | _ -> [email]
       with Not_found -> match email with
         | Some e -> [e]
-        | None -> []
+        | None ->
+            if Sys.win32 then
+              match Sys.getenv_opt "USERNAME", Sys.getenv_opt "USERDOMAIN" with
+              | Some name, Some domain -> [name ^ "@" ^ domain]
+              | _ -> []
+            else
+              []
   in
   create nv
   |> with_name_opt None

--- a/tests/lib/patchDiff.ml
+++ b/tests/lib/patchDiff.ml
@@ -298,14 +298,16 @@ let git_cmds repo_root commands error_msg =
           ("-C"::(OpamFilename.Dir.to_string repo_root)::args))
       commands
   in
-  try
-    List.iter (fun command ->
-        match OpamProcess.run command with
-        | {OpamProcess.r_code = 0; _ } -> ()
-        | _ -> failwith (OpamProcess.string_of_command command))
-      commands
-  with Failure e ->
-    print "ERROR:%s: %s\n" error_msg (rm_hex e)
+  List.exists (fun command ->
+      match OpamProcess.run command with
+      | {OpamProcess.r_code = 0; _ } -> false
+      | {OpamProcess.r_stderr; _ } ->
+          let cmd = rm_hex (OpamProcess.string_of_command command) in
+          print "ERROR:%s: %s\n" error_msg cmd;
+          List.iter print_endline r_stderr;
+          true)
+    commands
+  |> ignore
 
 let make_git_repo dir =
   let first_root = dir / first in

--- a/tests/lib/patchDiff.ml
+++ b/tests/lib/patchDiff.ml
@@ -312,7 +312,9 @@ let git_cmds repo_root commands error_msg =
 let make_git_repo dir =
   let first_root = dir / first in
   let commands = [
-    [ "init"];
+    [ "init" ];
+    [ "config"; "user.name"; "OPAM test environment" ];
+    [ "config"; "user.email"; "noreply@ocaml.org" ];
     [ "add"; "--all" ];
     [ "commit"; "-qm"; "first" ];
   ] in

--- a/tests/reftests/action-disk.test
+++ b/tests/reftests/action-disk.test
@@ -1099,7 +1099,7 @@ install: [
 ]
 remove: [ "touch" "removal-file" ]
 ### cp content main-gpin/content
-### git -C main-gpin init -q --initial-branch=master
+### git -C main-gpin init -q --initial-branch=main
 ### git -C main-gpin config core.autocrlf false
 ### git -C main-gpin add -A
 ### git -C main-gpin commit -qm 'content'
@@ -1153,7 +1153,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
 ### opam pin ./main-gpin -n | sed-cmd git | grep -v "HEAD is now"
 + git "symbolic-ref" "--quiet" "--short" "HEAD" (CWD=${BASEDIR}/main-gpin)
-- master
+- main
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(opam)                      Read ${BASEDIR}/main-gpin/main-gpin.opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
@@ -1183,8 +1183,8 @@ Processing  1/1: [main-gpin: git]
 + git "config" "--local" "color.ui" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 + git "remote" "add" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 + git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "reset" "--hard" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+main:refs/remotes/opam-ref-main" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "reset" "--hard" "refs/remotes/opam-ref-main" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 + git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
 [NOTE] Package main-gpin does not exist in opam repositories registered in the current switch.
@@ -1193,7 +1193,7 @@ SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state atomically in 0.000s
 FILE(environment)               Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/environment atomically in 0.000s
-main-gpin is now pinned to git+file://${BASEDIR}/main-gpin#master (version dev)
+main-gpin is now pinned to git+file://${BASEDIR}/main-gpin#main (version dev)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (write => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => none)
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/backup/state-today.export
@@ -1222,15 +1222,15 @@ FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.o
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/main-gpin.opam in 0.000s
 Processing  1/1:
 + git "symbolic-ref" "--quiet" "--short" "HEAD" (CWD=${BASEDIR}/main-gpin)
-- master
+- main
 + git "diff" "--no-ext-diff" "--quiet" "HEAD" (CWD=${BASEDIR}/main-gpin)
 + git "ls-files" "--others" "--exclude-standard" (CWD=${BASEDIR}/main-gpin)
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [main-gpin.dev: git]
 + git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 + git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+main:refs/remotes/opam-ref-main" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-main" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
 [main-gpin.dev] synchronised (no changes)
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/reinstall
@@ -1246,8 +1246,8 @@ SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/3: [main-gpin.dev: git]
 + git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 + git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+main:refs/remotes/opam-ref-main" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-main" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
 -> retrieved main-gpin.dev  (no changes)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/build/main-gpin.dev
@@ -1304,15 +1304,15 @@ FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.o
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/main-gpin.opam in 0.000s
 Processing  1/1:
 + git "symbolic-ref" "--quiet" "--short" "HEAD" (CWD=${BASEDIR}/main-gpin)
-- master
+- main
 + git "diff" "--no-ext-diff" "--quiet" "HEAD" (CWD=${BASEDIR}/main-gpin)
 + git "ls-files" "--others" "--exclude-standard" (CWD=${BASEDIR}/main-gpin)
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [main-gpin.dev: git]
 + git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 + git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+main:refs/remotes/opam-ref-main" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-main" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
 [main-gpin.dev] synchronised (no changes)
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/reinstall
@@ -1328,8 +1328,8 @@ SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/4: [main-gpin.dev: git]
 + git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 + git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+main:refs/remotes/opam-ref-main" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-main" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
 -> retrieved main-gpin.dev  (no changes)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/build/main-gpin.dev
@@ -1418,8 +1418,8 @@ SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/2: [main-gpin.dev: git]
 + git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 + git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+main:refs/remotes/opam-ref-main" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-main" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
 -> retrieved main-gpin.dev  (no changes)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/remove/main-gpin.dev
@@ -1483,7 +1483,7 @@ SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state atomically in 0.000s
 FILE(environment)               Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/environment atomically in 0.000s
-Ok, main-gpin is no longer pinned to git+file://${BASEDIR}/main-gpin#master (version dev)
+Ok, main-gpin is no longer pinned to git+file://${BASEDIR}/main-gpin#main (version dev)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (write => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => none)
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/backup/state-today.export
@@ -1521,14 +1521,14 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.o
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config atomically in 0.000s
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 + git "symbolic-ref" "--quiet" "--short" "HEAD" (CWD=${BASEDIR}/main-gpin)
-- master
+- main
 FILE(opam)                      Read ${BASEDIR}/main-gpin/main-gpin.opam in 0.000s
 [NOTE] Package main-gpin does not exist in opam repositories registered in the current switch.
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state atomically in 0.000s
 FILE(environment)               Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/environment atomically in 0.000s
-main-gpin is now pinned to git+file://${BASEDIR}/main-gpin#master (version dev)
+main-gpin is now pinned to git+file://${BASEDIR}/main-gpin#main (version dev)
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/reinstall
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/reinstall
 The following actions will be performed:
@@ -1548,11 +1548,11 @@ Processing  1/3: [main-gpin.dev: git]
 + git "config" "--local" "color.ui" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 + git "remote" "add" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 + git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "reset" "--hard" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+main:refs/remotes/opam-ref-main" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "reset" "--hard" "refs/remotes/opam-ref-main" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 + git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
--> retrieved main-gpin.dev  (git+file://${BASEDIR}/main-gpin#master)
+-> retrieved main-gpin.dev  (git+file://${BASEDIR}/main-gpin#main)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/build/main-gpin.dev
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/build/main-gpin.dev/content
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/build/main-gpin.dev/main-gpin.opam
@@ -1610,15 +1610,15 @@ FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.o
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/main-gpin.opam in 0.000s
 Processing  1/1:
 + git "symbolic-ref" "--quiet" "--short" "HEAD" (CWD=${BASEDIR}/main-gpin)
-- master
+- main
 + git "diff" "--no-ext-diff" "--quiet" "HEAD" (CWD=${BASEDIR}/main-gpin)
 + git "ls-files" "--others" "--exclude-standard" (CWD=${BASEDIR}/main-gpin)
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [main-gpin.dev: git]
 + git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 + git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+main:refs/remotes/opam-ref-main" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-main" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
 [main-gpin.dev] synchronised (no changes)
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/reinstall
@@ -1634,8 +1634,8 @@ SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/4: [main-gpin.dev: git]
 + git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 + git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+main:refs/remotes/opam-ref-main" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-main" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
 -> retrieved main-gpin.dev  (no changes)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/build/main-gpin.dev
@@ -1719,7 +1719,7 @@ SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state atomically in 0.000s
 FILE(environment)               Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/environment atomically in 0.000s
-Ok, main-gpin is no longer pinned to git+file://${BASEDIR}/main-gpin#master (version dev)
+Ok, main-gpin is no longer pinned to git+file://${BASEDIR}/main-gpin#main (version dev)
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/reinstall
 The following actions will be performed:
 === remove 1 package
@@ -1738,11 +1738,11 @@ Processing  1/2: [main-gpin.dev: git]
 + git "config" "--local" "color.ui" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
 + git "remote" "add" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
 + git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
-+ git "reset" "--hard" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
++ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+main:refs/remotes/opam-ref-main" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
++ git "reset" "--hard" "refs/remotes/opam-ref-main" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
 + git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
 SYSTEM                          rmdir ${OPAMTMP}
--> retrieved main-gpin.dev  (git+file://${BASEDIR}/main-gpin#master)
+-> retrieved main-gpin.dev  (git+file://${BASEDIR}/main-gpin#main)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/remove/main-gpin.dev
 SYSTEM                          copydir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev -> ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/remove/main-gpin.dev
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/remove/main-gpin.dev

--- a/tests/reftests/action-disk.test
+++ b/tests/reftests/action-disk.test
@@ -1174,7 +1174,7 @@ SYSTEM                          mkdir ${OPAMTMP}
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin
 Processing  1/1: [main-gpin: git]
-+ git "init" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "-c" "init.defaultBranch=main" "init" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 - Initialized empty Git repository in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/.git/
 + git "config" "--local" "fetch.prune" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 + git "config" "--local" "diff.noprefix" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
@@ -1539,7 +1539,7 @@ The following actions will be performed:
 SYSTEM                          mkdir ${OPAMTMP}
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin
 Processing  1/3: [main-gpin.dev: git]
-+ git "init" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "-c" "init.defaultBranch=main" "init" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 - Initialized empty Git repository in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/.git/
 + git "config" "--local" "fetch.prune" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 + git "config" "--local" "diff.noprefix" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
@@ -1729,7 +1729,7 @@ The following actions will be performed:
 SYSTEM                          mkdir ${OPAMTMP}
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev
 Processing  1/2: [main-gpin.dev: git]
-+ git "init" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
++ git "-c" "init.defaultBranch=main" "init" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
 - Initialized empty Git repository in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev/.git/
 + git "config" "--local" "fetch.prune" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
 + git "config" "--local" "diff.noprefix" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)

--- a/tests/reftests/action-disk.test
+++ b/tests/reftests/action-disk.test
@@ -1101,6 +1101,8 @@ remove: [ "touch" "removal-file" ]
 ### cp content main-gpin/content
 ### git -C main-gpin init -q --initial-branch=main
 ### git -C main-gpin config core.autocrlf false
+### git -C main-gpin config user.name 'OPAM test environment'
+### git -C main-gpin config user.email 'noreply@ocaml.org'
 ### git -C main-gpin add -A
 ### git -C main-gpin commit -qm 'content'
 ### :II:2:a: all operations

--- a/tests/reftests/assume-built.test
+++ b/tests/reftests/assume-built.test
@@ -8,6 +8,8 @@ install: [ ["test" "-f" "out" ] ["touch" "installed"] ]
 versionned
 ### git -C ./ongoing init -q --initial-branch=main
 ### git -C ./ongoing config core.autocrlf false
+### git -C ./ongoing config user.name 'OPAM test environment'
+### git -C ./ongoing config user.email 'noreply@ocaml.org'
 ### git -C ./ongoing add -A
 ### git -C ./ongoing commit -qm "inplace test"
 ### <ongoing/newfile.txt>

--- a/tests/reftests/assume-built.test
+++ b/tests/reftests/assume-built.test
@@ -6,7 +6,7 @@ build: [[ "test" "-f" "ongoing.txt" ] [ "sh" "-c" "cat ongoing.txt > out" ]]
 install: [ ["test" "-f" "out" ] ["touch" "installed"] ]
 ### <ongoing/ongoing.txt>
 versionned
-### git -C ./ongoing init -q --initial-branch=master
+### git -C ./ongoing init -q --initial-branch=main
 ### git -C ./ongoing config core.autocrlf false
 ### git -C ./ongoing add -A
 ### git -C ./ongoing commit -qm "inplace test"
@@ -15,7 +15,7 @@ new!
 ### opam switch create assume-built --empty
 ### opam pin ./ongoing -n
 [NOTE] Package ongoing does not exist in opam repositories registered in the current switch.
-ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
+ongoing is now pinned to git+file://${BASEDIR}/ongoing#main (version dev)
 ### : assume built
 ### opam install ongoing -v | sed-cmd test sh touch
 
@@ -151,8 +151,8 @@ Done.
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [ongoing.dev: git]
-[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)
-[ongoing] Installing new package description from upstream git+file://${BASEDIR}/ongoing#master
+[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#main)
+[ongoing] Installing new package description from upstream git+file://${BASEDIR}/ongoing#main
 
 The following actions will be performed:
 === install 1 package
@@ -168,7 +168,7 @@ Done.
 ### test -f ./ongoing/installed
 ### : assume built & opam file variables :
 ### opam unpin ongoing
-Ok, ongoing is no longer pinned to git+file://${BASEDIR}/ongoing#master (version dev)
+Ok, ongoing is no longer pinned to git+file://${BASEDIR}/ongoing#main (version dev)
 The following actions will be performed:
 === remove 1 package
   - remove ongoing dev
@@ -200,7 +200,7 @@ install: [
 ### git -C ongoing clean -fdqx
 ### opam pin ./ongoing -n
 [NOTE] Package ongoing does not exist in opam repositories registered in the current switch.
-ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version 1.0)
+ongoing is now pinned to git+file://${BASEDIR}/ongoing#main (version 1.0)
 ### touch ongoing/out
 ### opam install qux
 The following actions will be performed:
@@ -228,7 +228,7 @@ Done.
 ### : assume built & undefined opam file variables :
 ### OPAMSTRICT=0
 ### opam unpin ongoing
-Ok, ongoing is no longer pinned to git+file://${BASEDIR}/ongoing#master (version 1.0)
+Ok, ongoing is no longer pinned to git+file://${BASEDIR}/ongoing#main (version 1.0)
 The following actions will be performed:
 === remove 1 package
   - remove ongoing 1.0
@@ -254,7 +254,7 @@ install: [
 ### git -C ongoing clean -fdqx
 ### opam pin ./ongoing -n
 [NOTE] Package ongoing does not exist in opam repositories registered in the current switch.
-ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
+ongoing is now pinned to git+file://${BASEDIR}/ongoing#main (version dev)
 ### touch ongoing/out
 ### opam install ongoing --assume-built --with-test
 

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -209,6 +209,8 @@ opam-version: "2.0"
 content
 ### git -C bar init -q --initial-branch=main
 ### git -C bar config core.autocrlf false
+### git -C bar config user.name 'OPAM test environment'
+### git -C bar config user.email 'noreply@ocaml.org'
 ### git -C bar add opam a-file
 ### git -C bar commit -qm "init"
 ### <pkg:bar.1>

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -236,7 +236,7 @@ The following actions will be performed:
 SYSTEM                          mkdir ${OPAMTMP}
 SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1
 Processing  1/1: [bar.1: git]
-+ git "init" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
++ git "-c" "init.defaultBranch=main" "init" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
 + git "config" "--local" "fetch.prune" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
 + git "config" "--local" "diff.noprefix" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
 + git "config" "--local" "core.autocrlf" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
@@ -295,7 +295,7 @@ The following actions will be performed:
 SYSTEM                          mkdir ${OPAMTMP}
 SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1
 Processing  1/1: [qux.1: git]
-+ git "init" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
++ git "-c" "init.defaultBranch=main" "init" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
 + git "config" "--local" "fetch.prune" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
 + git "config" "--local" "diff.noprefix" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
 + git "config" "--local" "core.autocrlf" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -207,7 +207,7 @@ Done.
 opam-version: "2.0"
 ### <bar/a-file>
 content
-### git -C bar init -q --initial-branch=master
+### git -C bar init -q --initial-branch=main
 ### git -C bar config core.autocrlf false
 ### git -C bar add opam a-file
 ### git -C bar commit -qm "init"

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -12,7 +12,7 @@
 
 (rule
  (targets action-disk.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -33,7 +33,7 @@
 
 (rule
  (targets admin-cache.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -54,7 +54,7 @@
 
 (rule
  (targets admin-migrate-extrafiles.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -75,7 +75,7 @@
 
 (rule
  (targets admin.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -96,7 +96,7 @@
 
 (rule
  (targets archive.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -117,7 +117,7 @@
 
 (rule
  (targets assume-built.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -138,7 +138,7 @@
 
 (rule
  (targets autopin.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -159,7 +159,7 @@
 
 (rule
  (targets avoid-version.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -180,7 +180,7 @@
 
 (rule
  (targets best-effort.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -201,7 +201,7 @@
 
 (rule
  (targets cache.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -222,7 +222,7 @@
 
 (rule
  (targets clean.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -243,7 +243,7 @@
 
 (rule
  (targets cli-versioning.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -264,7 +264,7 @@
 
 (rule
  (targets config.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -285,7 +285,7 @@
 
 (rule
  (targets conflict-badversion.out)
- (deps root-f372039d)
+ (deps gitconfig root-f372039d)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -306,7 +306,7 @@
 
 (rule
  (targets conflict-camlp4.out)
- (deps root-f372039d)
+ (deps gitconfig root-f372039d)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -327,7 +327,7 @@
 
 (rule
  (targets conflict-core.out)
- (deps root-f372039d)
+ (deps gitconfig root-f372039d)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -348,7 +348,7 @@
 
 (rule
  (targets conflict-resto.out)
- (deps root-a5d7cdc0)
+ (deps gitconfig root-a5d7cdc0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -369,7 +369,7 @@
 
 (rule
  (targets conflict-solo5.out)
- (deps root-f372039d)
+ (deps gitconfig root-f372039d)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -390,7 +390,7 @@
 
 (rule
  (targets core-config.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -411,7 +411,7 @@
 
 (rule
  (targets core-system.unix.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -432,7 +432,7 @@
 
 (rule
  (targets cudf-preprocess.out)
- (deps root-ad4dd344)
+ (deps gitconfig root-ad4dd344)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -453,7 +453,7 @@
 
 (rule
  (targets depexts.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -474,7 +474,7 @@
 
 (rule
  (targets deprecated.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -495,7 +495,7 @@
 
 (rule
  (targets deps-only.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -516,7 +516,7 @@
 
 (rule
  (targets dot-install.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -537,7 +537,7 @@
 
 (rule
  (targets download.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -558,7 +558,7 @@
 
 (rule
  (targets effectively-equal.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -579,7 +579,7 @@
 
 (rule
  (targets empty-conflicts-001.out)
- (deps root-297366c)
+ (deps gitconfig root-297366c)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -600,7 +600,7 @@
 
 (rule
  (targets empty-conflicts-002.out)
- (deps root-11ea1cb)
+ (deps gitconfig root-11ea1cb)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -621,7 +621,7 @@
 
 (rule
  (targets empty-conflicts-003.out)
- (deps root-3235916)
+ (deps gitconfig root-3235916)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -642,7 +642,7 @@
 
 (rule
  (targets empty-conflicts-004.out)
- (deps root-0070613707)
+ (deps gitconfig root-0070613707)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -663,7 +663,7 @@
 
 (rule
  (targets empty-conflicts-005.out)
- (deps root-de897adf36c4230dfea812f40c98223b31c4521a)
+ (deps gitconfig root-de897adf36c4230dfea812f40c98223b31c4521a)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -684,7 +684,7 @@
 
 (rule
  (targets empty-conflicts-006.out)
- (deps root-c1842d168d)
+ (deps gitconfig root-c1842d168d)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -705,7 +705,7 @@
 
 (rule
  (targets empty-conflicts-007.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -726,7 +726,7 @@
 
 (rule
  (targets env.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -747,7 +747,7 @@
 
 (rule
  (targets env.unix.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -768,7 +768,7 @@
 
 (rule
  (targets env.win32.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -789,7 +789,7 @@
 
 (rule
  (targets extrafile.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -810,7 +810,7 @@
 
 (rule
  (targets extrasource.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -831,7 +831,7 @@
 
 (rule
  (targets fetch-package.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -852,7 +852,7 @@
 
 (rule
  (targets filter-operators.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -873,7 +873,7 @@
 
 (rule
  (targets filter-variable-resolution.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -894,7 +894,7 @@
 
 (rule
  (targets git.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -915,7 +915,7 @@
 
 (rule
  (targets hooks-variables.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -936,7 +936,7 @@
 
 (rule
  (targets hooks-variables.unix.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -957,7 +957,7 @@
 
 (rule
  (targets hooks-variables.win32.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -978,7 +978,7 @@
 
 (rule
  (targets init-ocaml-eval-variables.unix.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -999,7 +999,7 @@
 
 (rule
  (targets init-ocaml-eval-variables.win32.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1020,7 +1020,7 @@
 
 (rule
  (targets init-scripts.unix.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1041,7 +1041,7 @@
 
 (rule
  (targets init-scripts.win32.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1062,7 +1062,7 @@
 
 (rule
  (targets init.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1083,7 +1083,7 @@
 
 (rule
  (targets inplace.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1104,7 +1104,7 @@
 
 (rule
  (targets install-check.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1125,7 +1125,7 @@
 
 (rule
  (targets install-formula.out)
- (deps root-f372039d)
+ (deps gitconfig root-f372039d)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -1146,7 +1146,7 @@
 
 (rule
  (targets install-pgocaml.out)
- (deps root-f372039d)
+ (deps gitconfig root-f372039d)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -1167,7 +1167,7 @@
 
 (rule
  (targets json.unix.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1188,7 +1188,7 @@
 
 (rule
  (targets keep-build-dir.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1209,7 +1209,7 @@
 
 (rule
  (targets legacy-git.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1230,7 +1230,7 @@
 
 (rule
  (targets legacy-local.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1251,7 +1251,7 @@
 
 (rule
  (targets lint.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1272,7 +1272,7 @@
 
 (rule
  (targets list-coinstallable.out)
- (deps root-7371c1d9)
+ (deps gitconfig root-7371c1d9)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -1293,7 +1293,7 @@
 
 (rule
  (targets list-large-dependencies.out)
- (deps root-7371c1d9)
+ (deps gitconfig root-7371c1d9)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -1314,7 +1314,7 @@
 
 (rule
  (targets list.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1335,7 +1335,7 @@
 
 (rule
  (targets list.unix.out)
- (deps root-f372039d)
+ (deps gitconfig root-f372039d)
  (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -1356,7 +1356,7 @@
 
 (rule
  (targets lock.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1377,7 +1377,7 @@
 
 (rule
  (targets opam-pkgvar-with-plus.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1398,7 +1398,7 @@
 
 (rule
  (targets opam-repo-ci.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1419,7 +1419,7 @@
 
 (rule
  (targets opamroot-versions.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1440,7 +1440,7 @@
 
 (rule
  (targets opamrt-big-upgrade.out)
- (deps root-7090735c)
+ (deps gitconfig root-7090735c)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -1461,7 +1461,7 @@
 
 (rule
  (targets opamrt-dep-cycle.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1482,7 +1482,7 @@
 
 (rule
  (targets opamrt-reinstall.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1503,7 +1503,7 @@
 
 (rule
  (targets orphans.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1524,7 +1524,7 @@
 
 (rule
  (targets parallel.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1545,7 +1545,7 @@
 
 (rule
  (targets pat-sub.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1566,7 +1566,7 @@
 
 (rule
  (targets pin-depsonly-wtest-6501.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1587,7 +1587,7 @@
 
 (rule
  (targets pin-legacy.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1608,7 +1608,7 @@
 
 (rule
  (targets pin.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1629,7 +1629,7 @@
 
 (rule
  (targets process-output.unix.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1650,7 +1650,7 @@
 
 (rule
  (targets rebuild.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1671,7 +1671,7 @@
 
 (rule
  (targets rec-pin.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1692,7 +1692,7 @@
 
 (rule
  (targets reftests.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1713,7 +1713,7 @@
 
 (rule
  (targets reinstall.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1734,7 +1734,7 @@
 
 (rule
  (targets remove.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1755,7 +1755,7 @@
 
 (rule
  (targets repository-patchdiff.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1776,7 +1776,7 @@
 
 (rule
  (targets repository.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1797,7 +1797,7 @@
 
 (rule
  (targets resolve-variables.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1818,7 +1818,7 @@
 
 (rule
  (targets shared-fetch.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1839,7 +1839,7 @@
 
 (rule
  (targets show.out)
- (deps root-009e00fa)
+ (deps gitconfig root-009e00fa)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -1860,7 +1860,7 @@
 
 (rule
  (targets simulated-pin.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1881,7 +1881,7 @@
 
 (rule
  (targets source.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1902,7 +1902,7 @@
 
 (rule
  (targets sources-directory-cleaning.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1923,7 +1923,7 @@
 
 (rule
  (targets swhid.unix.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1944,7 +1944,7 @@
 
 (rule
  (targets switch-creation.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1965,7 +1965,7 @@
 
 (rule
  (targets switch-import.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -1986,7 +1986,7 @@
 
 (rule
  (targets switch-invariant.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -2007,7 +2007,7 @@
 
 (rule
  (targets switch-link.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -2028,7 +2028,7 @@
 
 (rule
  (targets switch-list-available.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -2049,7 +2049,7 @@
 
 (rule
  (targets switch-list.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -2070,7 +2070,7 @@
 
 (rule
  (targets switch-remove.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -2091,7 +2091,7 @@
 
 (rule
  (targets switch-set.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -2112,7 +2112,7 @@
 
 (rule
  (targets tree.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -2133,7 +2133,7 @@
 
 (rule
  (targets unhelpful-conflicts-001.out)
- (deps root-c1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a)
+ (deps gitconfig root-c1ba97dafe95c865d37ad4d88f6e57c9ffbe7f0a)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -2154,7 +2154,7 @@
 
 (rule
  (targets unhelpful-conflicts-002.out)
- (deps root-143dd2a2f59f5befbf3cb90bb2667f911737fbf8)
+ (deps gitconfig root-143dd2a2f59f5befbf3cb90bb2667f911737fbf8)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -2175,7 +2175,7 @@
 
 (rule
  (targets update-upgrade.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -2196,7 +2196,7 @@
 
 (rule
  (targets update.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -2217,7 +2217,7 @@
 
 (rule
  (targets upgrade-format.out)
- (deps root-009e00fa)
+ (deps gitconfig root-009e00fa)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) )))
  (package opam)
  (action
@@ -2238,7 +2238,7 @@
 
 (rule
  (targets upgrade-two-point-o.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -2259,7 +2259,7 @@
 
 (rule
  (targets upgrade.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -2280,7 +2280,7 @@
 
 (rule
  (targets var-option.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -2301,7 +2301,7 @@
 
 (rule
  (targets variables-sh.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -2322,7 +2322,7 @@
 
 (rule
  (targets verbose-on.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -2343,7 +2343,7 @@
 
 (rule
  (targets with-dev-setup.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
@@ -2364,7 +2364,7 @@
 
 (rule
  (targets working-dir.out)
- (deps root-N0REP0)
+ (deps gitconfig root-N0REP0)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action

--- a/tests/reftests/fetch-package.test
+++ b/tests/reftests/fetch-package.test
@@ -12,7 +12,7 @@ install: [
   [ "cp" "hist" "%{lib}%/%{name}%-hist" ]
 ]
 ### tar czf arch.tgz a-dev
-### git -C ./a-dev init -q --initial-branch=master
+### git -C ./a-dev init -q --initial-branch=main
 ### git -C ./a-dev config core.autocrlf false
 ### git -C ./a-dev add opam
 ### git -C ./a-dev commit -qm "init"
@@ -109,8 +109,8 @@ opam
 root.ml
 ### opam pin foo-git-pin ./a-dev -y
 [NOTE] Package foo-git-pin does not exist in opam repositories registered in the current switch.
-[foo-git-pin.dev] synchronised (git+file://${BASEDIR}/a-dev#master)
-foo-git-pin is now pinned to git+file://${BASEDIR}/a-dev#master (version dev)
+[foo-git-pin.dev] synchronised (git+file://${BASEDIR}/a-dev#main)
+foo-git-pin is now pinned to git+file://${BASEDIR}/a-dev#main (version dev)
 
 The following actions will be performed:
 === install 1 package

--- a/tests/reftests/fetch-package.test
+++ b/tests/reftests/fetch-package.test
@@ -14,6 +14,8 @@ install: [
 ### tar czf arch.tgz a-dev
 ### git -C ./a-dev init -q --initial-branch=main
 ### git -C ./a-dev config core.autocrlf false
+### git -C ./a-dev config user.name 'OPAM test environment'
+### git -C ./a-dev config user.email 'noreply@ocaml.org'
 ### git -C ./a-dev add opam
 ### git -C ./a-dev commit -qm "init"
 ### git -C ./a-dev add root.ml

--- a/tests/reftests/gen.ml
+++ b/tests/reftests/gen.ml
@@ -34,7 +34,7 @@ let run_rule ~base_name ~archive_hash ~condition =
   Format.sprintf {|
 (rule
  (targets %s)
- (deps %s)%s
+ (deps gitconfig %s)%s
  (package opam)
  (action
   (with-stdout-to

--- a/tests/reftests/git.test
+++ b/tests/reftests/git.test
@@ -3,12 +3,16 @@ N0REP0
 ### mkdir submodule
 ### git -C ./submodule init -q
 ### git -C ./submodule config core.autocrlf false
+### git -C ./submodule config user.name 'OPAM test environment'
+### git -C ./submodule config user.email 'noreply@ocaml.org'
 ### touch ./submodule/some-file
 ### git -C ./submodule add ./some-file
 ### git -C ./submodule commit -qm "first commit"
 ### mkdir use-submodule
 ### git -C ./use-submodule init -q
 ### git -C ./use-submodule config core.autocrlf false
+### git -C ./use-submodule config user.name 'OPAM test environment'
+### git -C ./use-submodule config user.email 'noreply@ocaml.org'
 ### ### This test may fail locally depending on your git version
 ### ### File protocol is removed locally since git 2.38,
 ### ### to fix a CVE: https://www.cve.org/CVERecord?id=CVE-2022-39253

--- a/tests/reftests/git.test
+++ b/tests/reftests/git.test
@@ -13,9 +13,6 @@ N0REP0
 ### git -C ./use-submodule config core.autocrlf false
 ### git -C ./use-submodule config user.name 'OPAM test environment'
 ### git -C ./use-submodule config user.email 'noreply@ocaml.org'
-### ### This test may fail locally depending on your git version
-### ### File protocol is removed locally since git 2.38,
-### ### to fix a CVE: https://www.cve.org/CVERecord?id=CVE-2022-39253
 ### git -C ./use-submodule submodule add ../submodule ./vendor
 Cloning into '${BASEDIR}/use-submodule/vendor'...
 done.

--- a/tests/reftests/gitconfig
+++ b/tests/reftests/gitconfig
@@ -1,0 +1,2 @@
+[protocol "file"]
+	allow = always

--- a/tests/reftests/inplace.test
+++ b/tests/reftests/inplace.test
@@ -6,7 +6,7 @@ build: [[ "test" "-f" "ongoing.txt" ] [ "cat" "ongoing.txt" ]]
 install: [ "touch" "installed"]
 ### <ongoing/ongoing.txt>
 versionned
-### git -C ./ongoing init -q --initial-branch=master
+### git -C ./ongoing init -q --initial-branch=main
 ### git -C ./ongoing config core.autocrlf false
 ### git -C ./ongoing add -A
 ### git -C ./ongoing commit -qm "inplace test"
@@ -15,7 +15,7 @@ new!
 ### opam switch create inplace --empty
 ### opam pin ./ongoing -n
 [NOTE] Package ongoing does not exist in opam repositories registered in the current switch.
-ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
+ongoing is now pinned to git+file://${BASEDIR}/ongoing#main (version dev)
 ### opam install ongoing -v | sed-cmd test cat touch
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
@@ -55,7 +55,7 @@ Done.
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [ongoing.dev: git]
-[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)
+[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#main)
 
 The following actions will be performed:
 === install 1 package
@@ -93,8 +93,8 @@ Done.
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [ongoing.dev: git]
-[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)
-[ongoing] Installing new package description from upstream git+file://${BASEDIR}/ongoing#master
+[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#main)
+[ongoing] Installing new package description from upstream git+file://${BASEDIR}/ongoing#main
 
 The following actions will be performed:
 === install 1 package
@@ -126,7 +126,7 @@ Done.
 ### opam install ongoing qux --inplace | unordered
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
-[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)
+[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#main)
 
 The following actions will be performed:
 === install 2 packages
@@ -134,7 +134,7 @@ The following actions will be performed:
   - install qux     u
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved ongoing.dev  (git+file://${BASEDIR}/ongoing#master)
+-> retrieved ongoing.dev  (git+file://${BASEDIR}/ongoing#main)
 -> installed qux.u
 -> installed ongoing.dev
 Done.

--- a/tests/reftests/inplace.test
+++ b/tests/reftests/inplace.test
@@ -8,6 +8,8 @@ install: [ "touch" "installed"]
 versionned
 ### git -C ./ongoing init -q --initial-branch=main
 ### git -C ./ongoing config core.autocrlf false
+### git -C ./ongoing config user.name 'OPAM test environment'
+### git -C ./ongoing config user.email 'noreply@ocaml.org'
 ### git -C ./ongoing add -A
 ### git -C ./ongoing commit -qm "inplace test"
 ### <ongoing/newfile.txt>

--- a/tests/reftests/keep-build-dir.test
+++ b/tests/reftests/keep-build-dir.test
@@ -156,6 +156,8 @@ Done.
 ### rm -rf OPAM/keepbuilddir0/.opam-switch/build
 ### mkdir local-git-no-keep-build-dir
 ### git -C ./local-git-no-keep-build-dir init -q --initial-branch=main
+### git -C ./local-git-no-keep-build-dir config user.name 'OPAM test environment'
+### git -C ./local-git-no-keep-build-dir config user.email 'noreply@ocaml.org'
 ### git -C ./local-git-no-keep-build-dir commit -qm init --allow-empty
 ### <pkg:local-git-no-keep-build-dir.1>
 opam-version: "2.0"
@@ -343,6 +345,8 @@ local-src-keep-build-dir.1
 ### rm -rf OPAM/keepbuilddir1/.opam-switch/build
 ### mkdir local-git-keep-build-dir
 ### git -C ./local-git-keep-build-dir init -q --initial-branch=main
+### git -C ./local-git-keep-build-dir config user.name 'OPAM test environment'
+### git -C ./local-git-keep-build-dir config user.email 'noreply@ocaml.org'
 ### git -C ./local-git-keep-build-dir commit -qm init --allow-empty
 ### <pkg:local-git-keep-build-dir.1>
 opam-version: "2.0"
@@ -533,6 +537,8 @@ local-src-keep-build-dir.1
 ### rm -rf local-git-keep-build-dir
 ### mkdir local-git-keep-build-dir
 ### git -C ./local-git-keep-build-dir init -q --initial-branch=main
+### git -C ./local-git-keep-build-dir config user.name 'OPAM test environment'
+### git -C ./local-git-keep-build-dir config user.email 'noreply@ocaml.org'
 ### git -C ./local-git-keep-build-dir commit -qm init --allow-empty
 ### <pkg:local-git-keep-build-dir.1>
 opam-version: "2.0"

--- a/tests/reftests/keep-build-dir.test
+++ b/tests/reftests/keep-build-dir.test
@@ -155,7 +155,7 @@ Done.
 ### :I:6: Repository package with local git source
 ### rm -rf OPAM/keepbuilddir0/.opam-switch/build
 ### mkdir local-git-no-keep-build-dir
-### git -C ./local-git-no-keep-build-dir init -q --initial-branch=master
+### git -C ./local-git-no-keep-build-dir init -q --initial-branch=main
 ### git -C ./local-git-no-keep-build-dir commit -qm init --allow-empty
 ### <pkg:local-git-no-keep-build-dir.1>
 opam-version: "2.0"
@@ -342,7 +342,7 @@ local-src-keep-build-dir.1
 ### :II:6: Repository package with local git source
 ### rm -rf OPAM/keepbuilddir1/.opam-switch/build
 ### mkdir local-git-keep-build-dir
-### git -C ./local-git-keep-build-dir init -q --initial-branch=master
+### git -C ./local-git-keep-build-dir init -q --initial-branch=main
 ### git -C ./local-git-keep-build-dir commit -qm init --allow-empty
 ### <pkg:local-git-keep-build-dir.1>
 opam-version: "2.0"
@@ -532,7 +532,7 @@ local-src-keep-build-dir.1
 ### rm -rf OPAM/keepbuilddir2/.opam-switch/build
 ### rm -rf local-git-keep-build-dir
 ### mkdir local-git-keep-build-dir
-### git -C ./local-git-keep-build-dir init -q --initial-branch=master
+### git -C ./local-git-keep-build-dir init -q --initial-branch=main
 ### git -C ./local-git-keep-build-dir commit -qm init --allow-empty
 ### <pkg:local-git-keep-build-dir.1>
 opam-version: "2.0"

--- a/tests/reftests/legacy-git.test
+++ b/tests/reftests/legacy-git.test
@@ -5,6 +5,8 @@ set -ue
 cd $1
 git init >/dev/null 2>&1
 git config --local core.autocrlf false
+git config --local user.name 'OPAM test environment'
+git config --local user.email 'noreply@ocaml.org'
 echo '*.sh text eol=lf' >.gitattributes
 [ $# -lt 2 ] || touch "$2"
 git add -A

--- a/tests/reftests/lock.test
+++ b/tests/reftests/lock.test
@@ -526,20 +526,20 @@ version: "locked-version"
 ### opam pin scan ./tolock-scan --locked | grep -v '# Name'
 tolock-scan  locked-version  file://${BASEDIR}/tolock-scan  -
 ### : git pin with lock file :
-### git -C tolock init -q --initial-branch=master
+### git -C tolock init -q --initial-branch=main
 ### git -C tolock config core.autocrlf false
 ### git -C tolock add content
 ### git -C tolock commit -qm "init"
 ### opam switch create locking3 --empty
 ### opam pin -n ./tolock --locked
 [NOTE] Package tolock does not exist in opam repositories registered in the current switch.
-tolock is now pinned to git+file://${BASEDIR}/tolock#master (version 1)
+tolock is now pinned to git+file://${BASEDIR}/tolock#main (version 1)
 ### opam show --normalise tolock --field depends:,depopts:,conflicts:
 depends:   ["bar" {= "1"} "baz" {= "1"} "foo" {= "1"}]
 depopts:
 conflicts:
 ### opam unpin -n tolock
-Ok, tolock is no longer pinned to git+file://${BASEDIR}/tolock#master (version 1)
+Ok, tolock is no longer pinned to git+file://${BASEDIR}/tolock#main (version 1)
 ### opam install ./tolock --show
 The following actions would be performed:
 === install 3 packages
@@ -555,7 +555,7 @@ The following actions would be performed:
   - install tolock 1 (pinned)
 ### opam pin ./tolock -n
 [NOTE] Package tolock does not exist in opam repositories registered in the current switch.
-tolock is now pinned to git+file://${BASEDIR}/tolock#master (version dev)
+tolock is now pinned to git+file://${BASEDIR}/tolock#main (version dev)
 ### opam install ./tolock --show
 The following actions would be performed:
 === install 3 packages
@@ -570,7 +570,7 @@ The following actions would be performed:
   - install foo    1          [required by tolock]
   - install tolock 1 (pinned)
 ### opam install ./tolock --locked
-tolock is now pinned to git+file://${BASEDIR}/tolock#master (version 1)
+tolock is now pinned to git+file://${BASEDIR}/tolock#main (version 1)
 [NOTE] Ignoring uncommitted changes in ${BASEDIR}/tolock (`--working-dir' not specified or specified with no argument).
 [tolock.1] synchronised (no changes)
 The following actions will be performed:
@@ -593,13 +593,13 @@ Done.
 ### opam switch create locking4 --empty
 ### opam pin -n ./tolock --locked
 [NOTE] Package tolock does not exist in opam repositories registered in the current switch.
-tolock is now pinned to git+file://${BASEDIR}/tolock#master (version 1)
+tolock is now pinned to git+file://${BASEDIR}/tolock#main (version 1)
 ### opam show --normalise tolock --field depends:,depopts:,conflicts:
 depends:   ["bar" {= "1"} "baz" {= "1"} "foo" {= "1"}]
 depopts:
 conflicts:
 ### opam unpin -n tolock
-Ok, tolock is no longer pinned to git+file://${BASEDIR}/tolock#master (version 1)
+Ok, tolock is no longer pinned to git+file://${BASEDIR}/tolock#main (version 1)
 ### opam install ./tolock --show
 The following actions would be performed:
 === install 3 packages
@@ -615,7 +615,7 @@ The following actions would be performed:
   - install tolock 1 (pinned)
 ### opam pin ./tolock -n
 [NOTE] Package tolock does not exist in opam repositories registered in the current switch.
-tolock is now pinned to git+file://${BASEDIR}/tolock#master (version dev)
+tolock is now pinned to git+file://${BASEDIR}/tolock#main (version dev)
 ### opam install ./tolock --show
 The following actions would be performed:
 === install 3 packages
@@ -630,7 +630,7 @@ The following actions would be performed:
   - install foo    1          [required by tolock]
   - install tolock 1 (pinned)
 ### opam install ./tolock --locked
-tolock is now pinned to git+file://${BASEDIR}/tolock#master (version 1)
+tolock is now pinned to git+file://${BASEDIR}/tolock#main (version 1)
 [NOTE] Ignoring uncommitted changes in ${BASEDIR}/tolock (`--working-dir' not specified or specified with no argument).
 [tolock.1] synchronised (no changes)
 The following actions will be performed:
@@ -653,13 +653,13 @@ Done.
 ### opam switch create locking5 --empty
 ### opam pin -n ./tolock --locked
 [NOTE] Package tolock does not exist in opam repositories registered in the current switch.
-tolock is now pinned to git+file://${BASEDIR}/tolock#master (version 1)
+tolock is now pinned to git+file://${BASEDIR}/tolock#main (version 1)
 ### opam show --normalise tolock --field depends:,depopts:,conflicts:
 depends:   ["bar" {= "1"} "baz" {= "1"} "foo" {= "1"}]
 depopts:
 conflicts:
 ### opam unpin -n tolock
-Ok, tolock is no longer pinned to git+file://${BASEDIR}/tolock#master (version 1)
+Ok, tolock is no longer pinned to git+file://${BASEDIR}/tolock#main (version 1)
 ### opam install ./tolock --show
 The following actions would be performed:
 === install 3 packages
@@ -675,7 +675,7 @@ The following actions would be performed:
   - install tolock 1 (pinned)
 ### opam pin ./tolock -n
 [NOTE] Package tolock does not exist in opam repositories registered in the current switch.
-tolock is now pinned to git+file://${BASEDIR}/tolock#master (version dev)
+tolock is now pinned to git+file://${BASEDIR}/tolock#main (version dev)
 ### opam install ./tolock --show
 The following actions would be performed:
 === install 3 packages
@@ -690,7 +690,7 @@ The following actions would be performed:
   - install foo    1          [required by tolock]
   - install tolock 1 (pinned)
 ### opam install ./tolock --locked
-tolock is now pinned to git+file://${BASEDIR}/tolock#master (version 1)
+tolock is now pinned to git+file://${BASEDIR}/tolock#main (version 1)
 [tolock.1] synchronised (no changes)
 The following actions will be performed:
 === install 4 packages
@@ -707,7 +707,7 @@ The following actions will be performed:
 Done.
 ### : check no repin in case of double 'install .' - with locked :
 ### opam unpin tolock
-Ok, tolock is no longer pinned to git+file://${BASEDIR}/tolock#master (version 1)
+Ok, tolock is no longer pinned to git+file://${BASEDIR}/tolock#main (version 1)
 The following actions will be performed:
 === remove 1 package
   - remove tolock 1
@@ -717,13 +717,13 @@ The following actions will be performed:
 Done.
 ### opam install ./tolock --locked
 [NOTE] Package tolock does not exist in opam repositories registered in the current switch.
-tolock is now pinned to git+file://${BASEDIR}/tolock#master (version 1)
+tolock is now pinned to git+file://${BASEDIR}/tolock#main (version 1)
 The following actions will be performed:
 === install 1 package
   - install tolock 1 (pinned)
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved tolock.1  (git+file://${BASEDIR}/tolock#master)
+-> retrieved tolock.1  (git+file://${BASEDIR}/tolock#main)
 -> installed tolock.1
 Done.
 ### opam remove tolock
@@ -1252,7 +1252,7 @@ EOF
 it's here
 ### : -- :
 ### mkdir simple-dep
-### git -C simple-dep init -q --initial-branch=master
+### git -C simple-dep init -q --initial-branch=main
 ### git -C simple-dep config core.autocrlf false
 ### <pin:simple-dep/a-simple-dep.opam>
 opam-version: "2.0"
@@ -1260,7 +1260,7 @@ version: "dev"
 ### git -C simple-dep add a-simple-dep.opam
 ### git -C simple-dep commit -qm "simple"
 ### mkdir doc-dep
-### git -C doc-dep init -q --initial-branch=master
+### git -C doc-dep init -q --initial-branch=main
 ### git -C doc-dep config core.autocrlf false
 ### <pin:doc-dep/a-doc-dep.opam>
 opam-version: "2.0"
@@ -1268,7 +1268,7 @@ version: "dev"
 ### git -C doc-dep add a-doc-dep.opam
 ### git -C doc-dep commit -qm "doc"
 ### mkdir test-dep
-### git -C test-dep init -q --initial-branch=master
+### git -C test-dep init -q --initial-branch=main
 ### git -C test-dep config core.autocrlf false
 ### <pin:test-dep/a-test-dep.opam>
 opam-version: "2.0"

--- a/tests/reftests/lock.test
+++ b/tests/reftests/lock.test
@@ -527,6 +527,8 @@ version: "locked-version"
 tolock-scan  locked-version  file://${BASEDIR}/tolock-scan  -
 ### : git pin with lock file :
 ### git -C tolock init -q --initial-branch=main
+### git -C tolock config --local user.name 'OPAM test environment'
+### git -C tolock config --local user.email 'noreply@ocaml.org'
 ### git -C tolock config core.autocrlf false
 ### git -C tolock add content
 ### git -C tolock commit -qm "init"
@@ -1254,6 +1256,8 @@ it's here
 ### mkdir simple-dep
 ### git -C simple-dep init -q --initial-branch=main
 ### git -C simple-dep config core.autocrlf false
+### git -C simple-dep config --local user.name 'OPAM test environment'
+### git -C simple-dep config --local user.email 'noreply@ocaml.org'
 ### <pin:simple-dep/a-simple-dep.opam>
 opam-version: "2.0"
 version: "dev"
@@ -1262,6 +1266,8 @@ version: "dev"
 ### mkdir doc-dep
 ### git -C doc-dep init -q --initial-branch=main
 ### git -C doc-dep config core.autocrlf false
+### git -C doc-dep config --local user.name 'OPAM test environment'
+### git -C doc-dep config --local user.email 'noreply@ocaml.org'
 ### <pin:doc-dep/a-doc-dep.opam>
 opam-version: "2.0"
 version: "dev"
@@ -1270,6 +1276,8 @@ version: "dev"
 ### mkdir test-dep
 ### git -C test-dep init -q --initial-branch=main
 ### git -C test-dep config core.autocrlf false
+### git -C test-dep config --local user.name 'OPAM test environment'
+### git -C test-dep config --local user.email 'noreply@ocaml.org'
 ### <pin:test-dep/a-test-dep.opam>
 opam-version: "2.0"
 version: "dev"

--- a/tests/reftests/pin-legacy.test
+++ b/tests/reftests/pin-legacy.test
@@ -251,6 +251,8 @@ Done.
 ### :::::::::::::::::::::::
 ### mkdir pin-empty
 ### git -C pin-empty init -q --initial-branch=main
+### git -C pin-empty config --local user.name 'OPAM test environment'
+### git -C pin-empty config --local user.email 'noreply@ocaml.org'
 ### git -C pin-empty config core.autocrlf false
 ### <pin:pin-empty/opam>
 opam-version: "2.0"

--- a/tests/reftests/pin-legacy.test
+++ b/tests/reftests/pin-legacy.test
@@ -250,15 +250,15 @@ Done.
 ### :6: Error retrieving git pin :
 ### :::::::::::::::::::::::
 ### mkdir pin-empty
-### git -C pin-empty init -q --initial-branch=master
+### git -C pin-empty init -q --initial-branch=main
 ### git -C pin-empty config core.autocrlf false
 ### <pin:pin-empty/opam>
 opam-version: "2.0"
 ### opam pin --no-action ./pin-empty
-[ERROR] Could not synchronize ${BASEDIR}/OPAM/pinning/.opam-switch/sources/pin-empty from "git+file://${BASEDIR}/pin-empty#master":
+[ERROR] Could not synchronize ${BASEDIR}/OPAM/pinning/.opam-switch/sources/pin-empty from "git+file://${BASEDIR}/pin-empty#main":
         Git repository seems just initialized, try again after your first commit
 Could not retrieve some package sources, they will not be pinned nor installed:
-  - pin-empty:git+file://${BASEDIR}/pin-empty#master
+  - pin-empty:git+file://${BASEDIR}/pin-empty#main
 
 Continue anyway? [Y/n] y
 ### opam pin
@@ -266,9 +266,9 @@ Continue anyway? [Y/n] y
 ### git -C pin-empty commit -qm 'opam'
 ### opam pin --no-action ./pin-empty
 [NOTE] Package pin-empty does not exist in opam repositories registered in the current switch.
-pin-empty is now pinned to git+file://${BASEDIR}/pin-empty#master (version dev)
+pin-empty is now pinned to git+file://${BASEDIR}/pin-empty#main (version dev)
 ### opam unpin pin-empty
-Ok, pin-empty is no longer pinned to git+file://${BASEDIR}/pin-empty#master (version dev)
+Ok, pin-empty is no longer pinned to git+file://${BASEDIR}/pin-empty#main (version dev)
 ### opam pin --no-action ./pin-empty#inexistant
 [ERROR] Could not synchronize ${BASEDIR}/OPAM/pinning/.opam-switch/sources/pin-empty from "git+file://${BASEDIR}/pin-empty#inexistant":
         Branch inexistant not found

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -35,6 +35,8 @@ echo piou >> "$n/$nv.t"
 if [ "x$git" = "xgit" ]; then
   test -d "$n/.git" || git -C "./$n" init -q --initial-branch=main
   git -C "./$n" config core.autocrlf false
+  git -C "./$n" config user.name 'OPAM test environment'
+  git -C "./$n" config user.email 'noreply@ocaml.org'
   git -C "./$n" add "$n.opam" "$nv.t" "$n.install"
   git -C "./$n" commit -qm "add $nv package"
 fi
@@ -917,6 +919,8 @@ dev3
 opam-version: "2.0"
 ### git -C vcs-local init -q --initial-branch=main
 ### git -C vcs-local config core.autocrlf false
+### git -C vcs-local config --local user.name 'OPAM test environment'
+### git -C vcs-local config --local user.email 'noreply@ocaml.org'
 ### git -C vcs-local add vcs-local.opam
 ### git -C vcs-local commit -qm 'init'
 ### git -C vcs-local ls-files
@@ -1077,6 +1081,8 @@ opam-version: "2.0"
 ### mkdir pin-change
 ### git -C pin-change init -q --initial-branch=main
 ### git -C pin-change config core.autocrlf false
+### git -C pin-change config --local user.name 'OPAM test environment'
+### git -C pin-change config --local user.email 'noreply@ocaml.org'
 ### <pin:pin-change/opam>
 opam-version: "2.0"
 ### git -C pin-change add opam

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -33,7 +33,7 @@ lib: ["$nv.t"]
 EOF
 echo piou >> "$n/$nv.t"
 if [ "x$git" = "xgit" ]; then
-  test -d "$n/.git" || git -C "./$n" init -q --initial-branch=master
+  test -d "$n/.git" || git -C "./$n" init -q --initial-branch=main
   git -C "./$n" config core.autocrlf false
   git -C "./$n" add "$n.opam" "$nv.t" "$n.install"
   git -C "./$n" commit -qm "add $nv package"
@@ -90,8 +90,8 @@ Now run 'opam upgrade' to apply any package updates.
 ### : pin with url
 ### opam pin add nip-git git+file://$BASEDIR/nip-git
 [NOTE] Package nip-git does not exist in opam repositories registered in the current switch.
-[nip-git.dev] synchronised (git+file://${BASEDIR}/nip-git#master)
-nip-git is now pinned to git+file://${BASEDIR}/nip-git#master (version ved)
+[nip-git.dev] synchronised (git+file://${BASEDIR}/nip-git#main)
+nip-git is now pinned to git+file://${BASEDIR}/nip-git#main (version ved)
 
 The following actions will be performed:
 === install 1 package
@@ -102,7 +102,7 @@ The following actions will be performed:
 Done.
 ### opam pin add git+file://$BASEDIR/nip-git2
 [NOTE] Package nip-git2 does not exist in opam repositories registered in the current switch.
-nip-git2 is now pinned to git+file://${BASEDIR}/nip-git2#master (version ved)
+nip-git2 is now pinned to git+file://${BASEDIR}/nip-git2#main (version ved)
 
 The following actions will be performed:
 === install 1 package
@@ -183,8 +183,8 @@ The following actions will be performed:
 Done.
 ### : list
 ### opam pin list | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-nip-git.ved      git      git+file://${BASEDIR}/nip-git#master   (at HASH)
-nip-git2.ved     git      git+file://${BASEDIR}/nip-git2#master  (at HASH)
+nip-git.ved      git      git+file://${BASEDIR}/nip-git#main   (at HASH)
+nip-git2.ved     git      git+file://${BASEDIR}/nip-git2#main  (at HASH)
 nip-path.ved     rsync    file://${BASEDIR}/nip-path
 nip-path2.ved    rsync    file://${BASEDIR}/nip-path2
 nip-path3.ved    rsync    file://${BASEDIR}/nip-path3
@@ -231,7 +231,7 @@ Done.
 ### : vcs
 ### opam pin add ./nip-git2 --kind git
 [NOTE] Package nip-git2 does not exist in opam repositories registered in the current switch.
-nip-git2 is now pinned to git+file://${BASEDIR}/nip-git2#master (version ved)
+nip-git2 is now pinned to git+file://${BASEDIR}/nip-git2#main (version ved)
 
 The following actions will be performed:
 === install 1 package
@@ -247,7 +247,7 @@ Done.
 ### : auto
 ### opam pin add ./nip-git3 --kind auto
 [NOTE] Package nip-git3 does not exist in opam repositories registered in the current switch.
-nip-git3 is now pinned to git+file://${BASEDIR}/nip-git3#master (version ved)
+nip-git3 is now pinned to git+file://${BASEDIR}/nip-git3#main (version ved)
 
 The following actions will be performed:
 === install 1 package
@@ -335,8 +335,8 @@ The following actions will be performed:
 ### opam pin list | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
 nip.1                         version           1
 nip-git.ved                   rsync             file://${BASEDIR}/nip-git
-nip-git2.ved                  git               git+file://${BASEDIR}/nip-git2#master  (at HASH)
-nip-git3.ved                  git               git+file://${BASEDIR}/nip-git3#master  (at HASH)
+nip-git2.ved                  git               git+file://${BASEDIR}/nip-git2#main  (at HASH)
+nip-git3.ved                  git               git+file://${BASEDIR}/nip-git3#main  (at HASH)
 nip-path.ved                  rsync             file://${BASEDIR}/nip-path
 nip-path3.ved                 rsync             file://${BASEDIR}/nip-path3
 no-url.1       (uninstalled)  local definition
@@ -362,7 +362,7 @@ nip-path3
 ### OPAMPINKINDAUTO=1
 ### opam pin add ./nip-git
 [NOTE] Package nip-git does not exist in opam repositories registered in the current switch.
-nip-git is now pinned to git+file://${BASEDIR}/nip-git#master (version ved)
+nip-git is now pinned to git+file://${BASEDIR}/nip-git#main (version ved)
 
 The following actions will be performed:
 === install 1 package
@@ -408,7 +408,7 @@ The following actions will be performed:
 Done.
 ### : list
 ### opam pin list | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-nip-git.ved      git    git+file://${BASEDIR}/nip-git#master  (at HASH)
+nip-git.ved      git    git+file://${BASEDIR}/nip-git#main  (at HASH)
 nip-git2.ved     rsync  file://${BASEDIR}/nip-git2
 nip-path.ved     rsync  file://${BASEDIR}/nip-path
 nip-path2.ved    rsync  file://${BASEDIR}/nip-path2
@@ -424,7 +424,7 @@ OPAM/env-kinds/lib/nip-path2/nip-path2.ved.t
 ### opam switch create actions --empty
 ### opam pin add ./nip-git4 --no-action
 [NOTE] Package nip-git4 does not exist in opam repositories registered in the current switch.
-nip-git4 is now pinned to git+file://${BASEDIR}/nip-git4#master (version ved)
+nip-git4 is now pinned to git+file://${BASEDIR}/nip-git4#main (version ved)
 ### opam pin add ./nip-path
 [NOTE] Package nip-path does not exist in opam repositories registered in the current switch.
 nip-path is now pinned to file://${BASEDIR}/nip-path (version ved)
@@ -453,14 +453,14 @@ Done.
 nip-path  ved         pinned to version ved at file://${BASEDIR}/nip-path
 nip-path2 ved         pinned to version ved at file://${BASEDIR}/nip-path2
 ### opam pin list | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-nip-git4.ved   (uninstalled)  git    git+file://${BASEDIR}/nip-git4#master  (at HASH)
+nip-git4.ved   (uninstalled)  git    git+file://${BASEDIR}/nip-git4#main  (at HASH)
 nip-path.ved                  rsync  file://${BASEDIR}/nip-path
 nip-path2.ved                 rsync  file://${BASEDIR}/nip-path2
 ### find OPAM/actions/lib -name '*.t' | sort
 OPAM/actions/lib/nip-path/nip-path.ved.t
 OPAM/actions/lib/nip-path2/nip-path2.ved.t
 ### opam pin remove ./nip-git4
-Ok, nip-git4 is no longer pinned to git+file://${BASEDIR}/nip-git4#master (version ved)
+Ok, nip-git4 is no longer pinned to git+file://${BASEDIR}/nip-git4#main (version ved)
 ### opam pin remove ./nip-path --no-action
 Ok, nip-path is no longer pinned to file://${BASEDIR}/nip-path (version ved)
 ### opam pin remove ./nip-path2
@@ -543,7 +543,7 @@ The following actions will be performed:
 ### opam pin add ./nip-git --edit
 [NOTE] Package nip-git does not exist in opam repositories registered in the current switch.
 You can edit this file again with "opam pin edit nip-git", export it with "opam show nip-git --raw"
-nip-git is now pinned to git+file://${BASEDIR}/nip-git#master (version ved)
+nip-git is now pinned to git+file://${BASEDIR}/nip-git#main (version ved)
 
 The following actions will be performed:
 === install 1 package
@@ -573,8 +573,8 @@ The following actions will be performed:
 ### opam pin list | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
 nip.1                         version           1
 nip-git.ved                   rsync             file://${BASEDIR}/nip-git
-nip-git2.ved                  git               git+file://${BASEDIR}/nip-git2#master  (at HASH)
-nip-git3.ved                  git               git+file://${BASEDIR}/nip-git3#master  (at HASH)
+nip-git2.ved                  git               git+file://${BASEDIR}/nip-git2#main  (at HASH)
+nip-git3.ved                  git               git+file://${BASEDIR}/nip-git3#main  (at HASH)
 nip-path.ved                  rsync             file://${BASEDIR}/nip-path
 nip-path3.ved                 rsync             file://${BASEDIR}/nip-path3
 no-url.1       (uninstalled)  local definition
@@ -595,7 +595,7 @@ no-url2
 ### : pin scan
 ### opam switch create scans --empty
 ### opam pin scan ./nip-git | grep -v '^#'
-nip-git  ved        git+file://${BASEDIR}/nip-git#master  -
+nip-git  ved        git+file://${BASEDIR}/nip-git#main  -
 ### opam pin scan ./nip-path | grep -v '^#'
 nip-path  ved        file://${BASEDIR}/nip-path  -
 ### mkdir lot_of_pkgs
@@ -768,14 +768,14 @@ Done.
 ### sh add-pin.sh nip-mixed.dev4 git
 ### opam pin nip-mixed
 [NOTE] Package nip-mixed is currently pinned to file://${BASEDIR}/nip-mixed (version dev3).
-nip-mixed is now pinned to git+file://${BASEDIR}/nip-mixed#master (version dev4)
+nip-mixed is now pinned to git+file://${BASEDIR}/nip-mixed#main (version dev4)
 
 The following actions will be performed:
 === upgrade 1 package
   - upgrade nip-mixed dev3 to dev4 (pinned)
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved nip-mixed.dev4  (git+file://${BASEDIR}/nip-mixed#master)
+-> retrieved nip-mixed.dev4  (git+file://${BASEDIR}/nip-mixed#main)
 -> removed   nip-mixed.dev3
 -> installed nip-mixed.dev4
 Done.
@@ -784,8 +784,8 @@ Done.
 "add nip-mixed.dev1 package"
 "add nip-mixed.dev4 package"
 ### opam pin nip-mixed
-[NOTE] Package nip-mixed is already pinned to git+file://${BASEDIR}/nip-mixed#master (version dev4).
-nip-mixed is now pinned to git+file://${BASEDIR}/nip-mixed#master (version dev1)
+[NOTE] Package nip-mixed is already pinned to git+file://${BASEDIR}/nip-mixed#main (version dev4).
+nip-mixed is now pinned to git+file://${BASEDIR}/nip-mixed#main (version dev1)
 
 The following actions will be performed:
 === downgrade 1 package
@@ -805,7 +805,7 @@ Done.
 ### git -C ./nip-of commit -qm "remove opam file"
 ### opam pin ./nip-of
 [NOTE] Package nip-of does not exist in opam repositories registered in the current switch.
-nip-of is now pinned to git+file://${BASEDIR}/nip-of#master (version dev1)
+nip-of is now pinned to git+file://${BASEDIR}/nip-of#main (version dev1)
 
 The following actions will be performed:
 === install 1 package
@@ -819,8 +819,8 @@ Done.
 dev1
 ### sh add-pin.sh nip-of.dev2 git
 ### opam install ./nip-of
-nip-of is now pinned to git+file://${BASEDIR}/nip-of#master (version dev2)
-[nip-of.dev2] synchronised (git+file://${BASEDIR}/nip-of#master)
+nip-of is now pinned to git+file://${BASEDIR}/nip-of#main (version dev2)
+[nip-of.dev2] synchronised (git+file://${BASEDIR}/nip-of#main)
 The following actions will be performed:
 === upgrade 1 package
   - upgrade nip-of dev1 to dev2 (pinned)
@@ -835,8 +835,8 @@ dev2
 ### git -C ./nip-of add nip-of.dev3.t
 ### git -C ./nip-of commit -qm "add install file"
 ### opam pin ./nip-of
-[NOTE] Package nip-of is already pinned to git+file://${BASEDIR}/nip-of#master (version dev2).
-nip-of is now pinned to git+file://${BASEDIR}/nip-of#master (version dev3)
+[NOTE] Package nip-of is already pinned to git+file://${BASEDIR}/nip-of#main (version dev2).
+nip-of is now pinned to git+file://${BASEDIR}/nip-of#main (version dev3)
 
 The following actions will be performed:
 === upgrade 1 package
@@ -855,21 +855,21 @@ dev3
 ### git -C ./nip-fo commit -qm "remove opam file"
 ### opam install ./nip-fo
 [NOTE] Package nip-fo does not exist in opam repositories registered in the current switch.
-nip-fo is now pinned to git+file://${BASEDIR}/nip-fo#master (version dev1)
+nip-fo is now pinned to git+file://${BASEDIR}/nip-fo#main (version dev1)
 The following actions will be performed:
 === install 1 package
   - install nip-fo dev1 (pinned)
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved nip-fo.dev1  (git+file://${BASEDIR}/nip-fo#master)
+-> retrieved nip-fo.dev1  (git+file://${BASEDIR}/nip-fo#main)
 -> installed nip-fo.dev1
 Done.
 ### opam show nip-fo --field=version
 dev1
 ### sh add-pin.sh nip-fo.dev2 git
 ### opam install ./nip-fo
-nip-fo is now pinned to git+file://${BASEDIR}/nip-fo#master (version dev2)
-[nip-fo.dev2] synchronised (git+file://${BASEDIR}/nip-fo#master)
+nip-fo is now pinned to git+file://${BASEDIR}/nip-fo#main (version dev2)
+[nip-fo.dev2] synchronised (git+file://${BASEDIR}/nip-fo#main)
 The following actions will be performed:
 === upgrade 1 package
   - upgrade nip-fo dev1 to dev2 (pinned)
@@ -884,9 +884,9 @@ dev2
 ### git -C ./nip-fo add nip-fo.dev3.t
 ### git -C ./nip-fo commit -qm "add install file"
 ### opam install ./nip-fo
-nip-fo is now pinned to git+file://${BASEDIR}/nip-fo#master (version dev3)
+nip-fo is now pinned to git+file://${BASEDIR}/nip-fo#main (version dev3)
 [NOTE] Ignoring uncommitted changes in ${BASEDIR}/nip-fo (`--working-dir' not specified or specified with no argument).
-[nip-fo.dev3] synchronised (git+file://${BASEDIR}/nip-fo#master)
+[nip-fo.dev3] synchronised (git+file://${BASEDIR}/nip-fo#main)
 The following actions will be performed:
 === upgrade 1 package
   - upgrade nip-fo dev2 to dev3 (pinned)
@@ -915,7 +915,7 @@ dev3
 ### opam switch create vcs-local --empty
 ### <pin:vcs-local/vcs-local.opam>
 opam-version: "2.0"
-### git -C vcs-local init -q --initial-branch=master
+### git -C vcs-local init -q --initial-branch=main
 ### git -C vcs-local config core.autocrlf false
 ### git -C vcs-local add vcs-local.opam
 ### git -C vcs-local commit -qm 'init'
@@ -928,13 +928,13 @@ opam-version: "2.0"
 build: "false"
 ### opam pin vcs-local ./vcs-local --no-action
 [NOTE] Package vcs-local does not exist in opam repositories registered in the current switch.
-[vcs-local.dev] synchronised (git+file://${BASEDIR}/vcs-local#master)
-vcs-local is now pinned to git+file://${BASEDIR}/vcs-local#master (version dev)
+[vcs-local.dev] synchronised (git+file://${BASEDIR}/vcs-local#main)
+vcs-local is now pinned to git+file://${BASEDIR}/vcs-local#main (version dev)
 ### test -f OPAM/vcs-local/.opam-switch/sources/vcs-local/untracked
 # Return code 1 #
 ### opam show vcs-local --field build:,url.src:
 build:   "false"
-url.src: "git+file://${BASEDIR}/vcs-local#master"
+url.src: "git+file://${BASEDIR}/vcs-local#main"
 ### :C:b: double pinning when the opam file is opam/opam
 ### <pin:double/opam/opam>
 opam-version: "2.0"
@@ -1075,7 +1075,7 @@ opam-version: "2.0"
 ### <pkg:dependency.3>
 opam-version: "2.0"
 ### mkdir pin-change
-### git -C pin-change init -q --initial-branch=master
+### git -C pin-change init -q --initial-branch=main
 ### git -C pin-change config core.autocrlf false
 ### <pin:pin-change/opam>
 opam-version: "2.0"
@@ -1096,13 +1096,13 @@ The following actions would be performed:
 opam-version: "2.0"
 ### opam install ./pin-change
 [NOTE] Package pin-change does not exist in opam repositories registered in the current switch.
-pin-change is now pinned to git+file://${BASEDIR}/pin-change#master (version dev)
+pin-change is now pinned to git+file://${BASEDIR}/pin-change#main (version dev)
 The following actions will be performed:
 === install 1 package
   - install pin-change dev (pinned)
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved pin-change.dev  (git+file://${BASEDIR}/pin-change#master)
+-> retrieved pin-change.dev  (git+file://${BASEDIR}/pin-change#main)
 -> installed pin-change.dev
 Done.
 ### <pin:pin-change/opam>
@@ -1110,7 +1110,7 @@ opam-version: "2.0"
 depends: "dependency" {= "1"}
 ### :C:e:3: behaviour when the package is not pinned
 ### opam install ./pin-change
-pin-change is now pinned to git+file://${BASEDIR}/pin-change#master (version dev)
+pin-change is now pinned to git+file://${BASEDIR}/pin-change#main (version dev)
 [NOTE] Ignoring uncommitted changes in ${BASEDIR}/pin-change (`--working-dir' not specified or specified with no argument).
 [pin-change.dev] synchronised (no changes)
 The following actions will be performed:
@@ -1153,7 +1153,7 @@ The following actions will be performed:
 -> installed dependency.3
 Done.
 ### opam pin | '\(at [a-f0-9]+\)' -> '(at HASH)'
-pin-change.dev  (uninstalled)  git  git+file://${BASEDIR}/pin-change#master  (at HASH)
+pin-change.dev  (uninstalled)  git  git+file://${BASEDIR}/pin-change#main  (at HASH)
 ### :C:f: stored overlay opam file
 ### opam switch create --empty overlays
 ### :C:f:1: Common case

--- a/tests/reftests/rec-pin.test
+++ b/tests/reftests/rec-pin.test
@@ -55,7 +55,7 @@ build: [ "test" "-f" "%{name}%.t" ]
 piou
 ### <pinnes/b/root-b_g.install>
 lib: ["root-b_g.t"]
-### git -C ./pinnes init -q --initial-branch=master
+### git -C ./pinnes init -q --initial-branch=main
 ### git -C ./pinnes config core.autocrlf false
 ### git -C ./pinnes add a/i b root_g.opam root_g.t root_g.install
 ### git -C ./pinnes commit -qm "fst"
@@ -63,32 +63,32 @@ lib: ["root-b_g.t"]
 ### opam pin -n --recursive pinnes
 This will pin the following packages: root_g, root-a_p, root-a-i_g, root-a-i-j_g, root-a-k_p, root-b_g. Continue? [Y/n] y
 [NOTE] Package root_g does not exist in opam repositories registered in the current switch.
-root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version dev)
+root_g is now pinned to git+file://${BASEDIR}/pinnes#main (version dev)
 [NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version dev)
 [NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
-root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version dev)
+root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version dev)
 [NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
-root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version dev)
+root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version dev)
 [NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version dev)
 [NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
-root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version dev)
+root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#main (version dev)
 ### opam list -s
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-root-a-i-j_g.dev  (uninstalled)  git    directory /a/i/j in git+file://${BASEDIR}/pinnes#master  (at HASH)
-root-a-i_g.dev    (uninstalled)  git    directory /a/i in git+file://${BASEDIR}/pinnes#master    (at HASH)
+root-a-i-j_g.dev  (uninstalled)  git    directory /a/i/j in git+file://${BASEDIR}/pinnes#main  (at HASH)
+root-a-i_g.dev    (uninstalled)  git    directory /a/i in git+file://${BASEDIR}/pinnes#main    (at HASH)
 root-a-k_p.dev    (uninstalled)  rsync  directory /a/k in file://${BASEDIR}/pinnes
 root-a_p.dev      (uninstalled)  rsync  directory /a in file://${BASEDIR}/pinnes
-root-b_g.dev      (uninstalled)  git    directory /b in git+file://${BASEDIR}/pinnes#master      (at HASH)
-root_g.dev        (uninstalled)  git    git+file://${BASEDIR}/pinnes#master                      (at HASH)
+root-b_g.dev      (uninstalled)  git    directory /b in git+file://${BASEDIR}/pinnes#main      (at HASH)
+root_g.dev        (uninstalled)  git    git+file://${BASEDIR}/pinnes#main                      (at HASH)
 ### opam unpin -n --recursive pinnes
-Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version dev)
-Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version dev)
+Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version dev)
+Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version dev)
 Ok, root-a-k_p is no longer pinned to directory /a/k in file://${BASEDIR}/pinnes (version dev)
 Ok, root-a_p is no longer pinned to directory /a in file://${BASEDIR}/pinnes (version dev)
-Ok, root-b_g is no longer pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version dev)
-Ok, root_g is no longer pinned to git+file://${BASEDIR}/pinnes#master (version dev)
+Ok, root-b_g is no longer pinned to directory /b in git+file://${BASEDIR}/pinnes#main (version dev)
+Ok, root_g is no longer pinned to git+file://${BASEDIR}/pinnes#main (version dev)
 ### opam list -s
 ### opam pin
 ### opam pin  --recursive pinnes | unordered
@@ -99,12 +99,12 @@ This will pin the following packages: root_g, root-a_p, root-a-i_g, root-a-i-j_g
 [NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
 [NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 [NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
-root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version dev)
+root_g is now pinned to git+file://${BASEDIR}/pinnes#main (version dev)
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version dev)
-root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version dev)
-root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version dev)
+root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version dev)
+root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version dev)
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version dev)
-root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version dev)
+root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#main (version dev)
 -> retrieved root-a-k_p.dev  (directory /a/k in file://${BASEDIR}/pinnes)
 -> retrieved root-a_p.dev  (directory /a in file://${BASEDIR}/pinnes)
 
@@ -139,12 +139,12 @@ root-a_p     ${BASEDIR}/OPAM/devnull/lib/root-a_p ${BASEDIR}/OPAM/devnull/lib/ro
 root-b_g     ${BASEDIR}/OPAM/devnull/lib/root-b_g ${BASEDIR}/OPAM/devnull/lib/root-b_g/root-b_g.t
 root_g       ${BASEDIR}/OPAM/devnull/lib/root_g ${BASEDIR}/OPAM/devnull/lib/root_g/root_g.t
 ### opam remove --recursive ./pinnes | unordered
-Ok, root-b_g is no longer pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version dev)
+Ok, root-b_g is no longer pinned to directory /b in git+file://${BASEDIR}/pinnes#main (version dev)
 Ok, root-a_p is no longer pinned to directory /a in file://${BASEDIR}/pinnes (version dev)
 Ok, root-a-k_p is no longer pinned to directory /a/k in file://${BASEDIR}/pinnes (version dev)
-Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version dev)
-Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version dev)
-Ok, root_g is no longer pinned to git+file://${BASEDIR}/pinnes#master (version dev)
+Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version dev)
+Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version dev)
+Ok, root_g is no longer pinned to git+file://${BASEDIR}/pinnes#main (version dev)
 The following actions will be performed:
 === remove 6 packages
   - remove root-a-i-j_g dev
@@ -169,19 +169,19 @@ Done.
 # No matches found
 ### opam install ./pinnes | unordered
 [NOTE] Package root_g does not exist in opam repositories registered in the current switch.
-root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version dev)
+root_g is now pinned to git+file://${BASEDIR}/pinnes#main (version dev)
 The following actions will be performed:
 === install 1 package
   - install root_g dev (pinned)
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved root_g.dev  (git+file://${BASEDIR}/pinnes#master)
+-> retrieved root_g.dev  (git+file://${BASEDIR}/pinnes#main)
 -> installed root_g.dev
 Done.
 ### opam list -s
 root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-root_g.dev    git  git+file://${BASEDIR}/pinnes#master  (at HASH)
+root_g.dev    git  git+file://${BASEDIR}/pinnes#main  (at HASH)
 ### opam install ./pinnes --subpath a | unordered
 [NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version dev)
@@ -198,11 +198,11 @@ root-a_p
 root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
 root-a_p.dev    rsync  directory /a in file://${BASEDIR}/pinnes
-root_g.dev      git    git+file://${BASEDIR}/pinnes#master       (at HASH)
+root_g.dev      git    git+file://${BASEDIR}/pinnes#main         (at HASH)
 ### opam install ./pinnes --subpath b | unordered
 [NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
-root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version dev)
--> retrieved root-b_g.dev  (directory /b in git+file://${BASEDIR}/pinnes#master)
+root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#main (version dev)
+-> retrieved root-b_g.dev  (directory /b in git+file://${BASEDIR}/pinnes#main)
 The following actions will be performed:
 === install 1 package
   - install root-b_g dev (pinned)
@@ -216,12 +216,12 @@ root-b_g
 root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
 root-a_p.dev    rsync  directory /a in file://${BASEDIR}/pinnes
-root-b_g.dev    git    directory /b in git+file://${BASEDIR}/pinnes#master  (at HASH)
-root_g.dev      git    git+file://${BASEDIR}/pinnes#master                  (at HASH)
+root-b_g.dev    git    directory /b in git+file://${BASEDIR}/pinnes#main  (at HASH)
+root_g.dev      git    git+file://${BASEDIR}/pinnes#main                  (at HASH)
 ### opam install ./pinnes --subpath a/i | unordered
 [NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
-root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version dev)
--> retrieved root-a-i_g.dev  (directory /a/i in git+file://${BASEDIR}/pinnes#master)
+root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version dev)
+-> retrieved root-a-i_g.dev  (directory /a/i in git+file://${BASEDIR}/pinnes#main)
 The following actions will be performed:
 === install 1 package
   - install root-a-i_g dev (pinned)
@@ -235,14 +235,14 @@ root-a_p
 root-b_g
 root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-root-a-i_g.dev    git    directory /a/i in git+file://${BASEDIR}/pinnes#master  (at HASH)
+root-a-i_g.dev    git    directory /a/i in git+file://${BASEDIR}/pinnes#main  (at HASH)
 root-a_p.dev      rsync  directory /a in file://${BASEDIR}/pinnes
-root-b_g.dev      git    directory /b in git+file://${BASEDIR}/pinnes#master    (at HASH)
-root_g.dev        git    git+file://${BASEDIR}/pinnes#master                    (at HASH)
+root-b_g.dev      git    directory /b in git+file://${BASEDIR}/pinnes#main    (at HASH)
+root_g.dev        git    git+file://${BASEDIR}/pinnes#main                    (at HASH)
 ### opam install ./pinnes --subpath a/i/j | unordered
 [NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
-root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version dev)
--> retrieved root-a-i-j_g.dev  (directory /a/i/j in git+file://${BASEDIR}/pinnes#master)
+root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version dev)
+-> retrieved root-a-i-j_g.dev  (directory /a/i/j in git+file://${BASEDIR}/pinnes#main)
 The following actions will be performed:
 === install 1 package
   - install root-a-i-j_g dev (pinned)
@@ -257,11 +257,11 @@ root-a_p
 root-b_g
 root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-root-a-i-j_g.dev    git    directory /a/i/j in git+file://${BASEDIR}/pinnes#master  (at HASH)
-root-a-i_g.dev      git    directory /a/i in git+file://${BASEDIR}/pinnes#master    (at HASH)
+root-a-i-j_g.dev    git    directory /a/i/j in git+file://${BASEDIR}/pinnes#main  (at HASH)
+root-a-i_g.dev      git    directory /a/i in git+file://${BASEDIR}/pinnes#main    (at HASH)
 root-a_p.dev        rsync  directory /a in file://${BASEDIR}/pinnes
-root-b_g.dev        git    directory /b in git+file://${BASEDIR}/pinnes#master      (at HASH)
-root_g.dev          git    git+file://${BASEDIR}/pinnes#master                      (at HASH)
+root-b_g.dev        git    directory /b in git+file://${BASEDIR}/pinnes#main      (at HASH)
+root_g.dev          git    git+file://${BASEDIR}/pinnes#main                      (at HASH)
 ### opam install ./pinnes --subpath a/k | unordered
 [NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version dev)
@@ -281,12 +281,12 @@ root-a_p
 root-b_g
 root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-root-a-i-j_g.dev    git    directory /a/i/j in git+file://${BASEDIR}/pinnes#master  (at HASH)
-root-a-i_g.dev      git    directory /a/i in git+file://${BASEDIR}/pinnes#master    (at HASH)
+root-a-i-j_g.dev    git    directory /a/i/j in git+file://${BASEDIR}/pinnes#main  (at HASH)
+root-a-i_g.dev      git    directory /a/i in git+file://${BASEDIR}/pinnes#main    (at HASH)
 root-a-k_p.dev      rsync  directory /a/k in file://${BASEDIR}/pinnes
 root-a_p.dev        rsync  directory /a in file://${BASEDIR}/pinnes
-root-b_g.dev        git    directory /b in git+file://${BASEDIR}/pinnes#master      (at HASH)
-root_g.dev          git    git+file://${BASEDIR}/pinnes#master                      (at HASH)
+root-b_g.dev        git    directory /b in git+file://${BASEDIR}/pinnes#main      (at HASH)
+root_g.dev          git    git+file://${BASEDIR}/pinnes#main                      (at HASH)
 ### opam list --all --installed --columns=name,installed-files --normalise
 # Packages matching: any & installed
 # Name       # Installed files
@@ -311,12 +311,12 @@ version: "2"
 ### git -C pinnes add a/i b root_g.opam
 ### git -C pinnes commit -qm "snd"
 ### opam update | grep synchronised
-[root-a-i-j_g.dev] synchronised (directory /a/i/j in git+file://${BASEDIR}/pinnes#master)
-[root-a-i_g.dev] synchronised (directory /a/i in git+file://${BASEDIR}/pinnes#master)
+[root-a-i-j_g.dev] synchronised (directory /a/i/j in git+file://${BASEDIR}/pinnes#main)
+[root-a-i_g.dev] synchronised (directory /a/i in git+file://${BASEDIR}/pinnes#main)
 [root-a-k_p.dev] synchronised (directory /a/k in file://${BASEDIR}/pinnes)
 [root-a_p.dev] synchronised (directory /a in file://${BASEDIR}/pinnes)
-[root-b_g.dev] synchronised (directory /b in git+file://${BASEDIR}/pinnes#master)
-[root_g.dev] synchronised (git+file://${BASEDIR}/pinnes#master)
+[root-b_g.dev] synchronised (directory /b in git+file://${BASEDIR}/pinnes#main)
+[root_g.dev] synchronised (git+file://${BASEDIR}/pinnes#main)
 ### opam upgrade | unordered
 The following actions will be performed:
 === downgrade 6 packages
@@ -354,11 +354,11 @@ hoj
 ### git -C pinnes commit -qm "thd"
 ### opam update | grep synchronised
 [root-a-i-j_g.2] synchronised (no changes)
-[root-a-i_g.2] synchronised (directory /a/i in git+file://${BASEDIR}/pinnes#master)
+[root-a-i_g.2] synchronised (directory /a/i in git+file://${BASEDIR}/pinnes#main)
 [root-a-k_p.2] synchronised (directory /a/k in file://${BASEDIR}/pinnes)
 [root-a_p.2] synchronised (directory /a in file://${BASEDIR}/pinnes)
 [root-b_g.2] synchronised (no changes)
-[root_g.2] synchronised (git+file://${BASEDIR}/pinnes#master)
+[root_g.2] synchronised (git+file://${BASEDIR}/pinnes#main)
 ### opam upgrade | unordered
 The following actions will be performed:
 === recompile 4 packages
@@ -388,14 +388,14 @@ root-a_p
 root-b_g
 root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-root-a-i-j_g.2    git    directory /a/i/j in git+file://${BASEDIR}/pinnes#master  (at HASH)
-root-a-i_g.2      git    directory /a/i in git+file://${BASEDIR}/pinnes#master    (at HASH)
+root-a-i-j_g.2    git    directory /a/i/j in git+file://${BASEDIR}/pinnes#main  (at HASH)
+root-a-i_g.2      git    directory /a/i in git+file://${BASEDIR}/pinnes#main    (at HASH)
 root-a-k_p.2      rsync  directory /a/k in file://${BASEDIR}/pinnes
 root-a_p.2        rsync  directory /a in file://${BASEDIR}/pinnes
-root-b_g.2        git    directory /b in git+file://${BASEDIR}/pinnes#master      (at HASH)
-root_g.2          git    git+file://${BASEDIR}/pinnes#master                      (at HASH)
+root-b_g.2        git    directory /b in git+file://${BASEDIR}/pinnes#main      (at HASH)
+root_g.2          git    git+file://${BASEDIR}/pinnes#main                      (at HASH)
 ### opam remove ./pinnes
-Ok, root_g is no longer pinned to git+file://${BASEDIR}/pinnes#master (version 2)
+Ok, root_g is no longer pinned to git+file://${BASEDIR}/pinnes#main (version 2)
 The following actions will be performed:
 === remove 1 package
   - remove root_g 2
@@ -413,7 +413,7 @@ The following actions will be performed:
 -> removed   root-a_p.2
 Done.
 ### opam remove ./pinnes --subpath b
-Ok, root-b_g is no longer pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version 2)
+Ok, root-b_g is no longer pinned to directory /b in git+file://${BASEDIR}/pinnes#main (version 2)
 The following actions will be performed:
 === remove 1 package
   - remove root-b_g 2
@@ -422,7 +422,7 @@ The following actions will be performed:
 -> removed   root-b_g.2
 Done.
 ### opam remove ./pinnes --subpath a/i
-Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version 2)
+Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version 2)
 The following actions will be performed:
 === remove 1 package
   - remove root-a-i_g 2
@@ -431,7 +431,7 @@ The following actions will be performed:
 -> removed   root-a-i_g.2
 Done.
 ### opam remove ./pinnes --subpath a/i/j
-Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version 2)
+Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version 2)
 The following actions will be performed:
 === remove 1 package
   - remove root-a-i-j_g 2
@@ -455,14 +455,14 @@ This will pin the following packages: root-a_p, root-a-i_g, root-a-i-j_g, root-a
 [NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version 2)
 [NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
-root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version 2)
+root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version 2)
 [NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
-root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version 2)
+root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version 2)
 [NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version 2)
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-root-a-i-j_g.2  (uninstalled)  git    directory /a/i/j in git+file://${BASEDIR}/pinnes#master  (at HASH)
-root-a-i_g.2    (uninstalled)  git    directory /a/i in git+file://${BASEDIR}/pinnes#master    (at HASH)
+root-a-i-j_g.2  (uninstalled)  git    directory /a/i/j in git+file://${BASEDIR}/pinnes#main  (at HASH)
+root-a-i_g.2    (uninstalled)  git    directory /a/i in git+file://${BASEDIR}/pinnes#main    (at HASH)
 root-a-k_p.2    (uninstalled)  rsync  directory /a/k in file://${BASEDIR}/pinnes
 root-a_p.2      (uninstalled)  rsync  directory /a in file://${BASEDIR}/pinnes
 ### opam-cat $OPAMROOT/devnull/.opam-switch/overlay/root-a_p/opam
@@ -495,63 +495,63 @@ synopsis: "A word"
 version: "2"
 x-subpath: "a/i"
 url {
-src: "git+file://${BASEDIR}/pinnes#master"
+src: "git+file://${BASEDIR}/pinnes#main"
 }
 ### opam unpin ./pinnes --recursive
-Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version 2)
-Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version 2)
+Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version 2)
+Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version 2)
 Ok, root-a-k_p is no longer pinned to directory /a/k in file://${BASEDIR}/pinnes (version 2)
 Ok, root-a_p is no longer pinned to directory /a in file://${BASEDIR}/pinnes (version 2)
 ### opam pin scan ./pinnes | '# Name.*' -> '\c'
-root_g  2          git+file://${BASEDIR}/pinnes#master  -
+root_g  2          git+file://${BASEDIR}/pinnes#main  -
 ### opam pin scan ./pinnes --recursive | '# Name.*' -> '\c'
-root-b_g      2          git+file://${BASEDIR}/pinnes#master  b
-root-a-k_p    2          file://${BASEDIR}/pinnes             a/k
-root-a-i-j_g  2          git+file://${BASEDIR}/pinnes#master  a/i/j
-root-a-i_g    2          git+file://${BASEDIR}/pinnes#master  a/i
-root-a_p      2          file://${BASEDIR}/pinnes             a
-root_g        2          git+file://${BASEDIR}/pinnes#master  -
+root-b_g      2          git+file://${BASEDIR}/pinnes#main  b
+root-a-k_p    2          file://${BASEDIR}/pinnes           a/k
+root-a-i-j_g  2          git+file://${BASEDIR}/pinnes#main  a/i/j
+root-a-i_g    2          git+file://${BASEDIR}/pinnes#main  a/i
+root-a_p      2          file://${BASEDIR}/pinnes           a
+root_g        2          git+file://${BASEDIR}/pinnes#main  -
 ### opam pin scan ./pinnes --subpath a | '# Name.*' -> '\c'
 root-a_p  2          file://${BASEDIR}/pinnes  a
 ### opam pin scan ./pinnes --subpath a --recursive | '# Name.*' -> '\c'
-root-a-k_p    2          file://${BASEDIR}/pinnes             a/k
-root-a-i-j_g  2          git+file://${BASEDIR}/pinnes#master  a/i/j
-root-a-i_g    2          git+file://${BASEDIR}/pinnes#master  a/i
-root-a_p      2          file://${BASEDIR}/pinnes             a
+root-a-k_p    2          file://${BASEDIR}/pinnes           a/k
+root-a-i-j_g  2          git+file://${BASEDIR}/pinnes#main  a/i/j
+root-a-i_g    2          git+file://${BASEDIR}/pinnes#main  a/i
+root-a_p      2          file://${BASEDIR}/pinnes           a
 ### opam pin scan ./pinnes --recursive --normalise
-root-b_g.2^git+file://${BASEDIR}/pinnes#master^b
+root-b_g.2^git+file://${BASEDIR}/pinnes#main^b
 root-a-k_p.2^file://${BASEDIR}/pinnes^a/k
-root-a-i-j_g.2^git+file://${BASEDIR}/pinnes#master^a/i/j
-root-a-i_g.2^git+file://${BASEDIR}/pinnes#master^a/i
+root-a-i-j_g.2^git+file://${BASEDIR}/pinnes#main^a/i/j
+root-a-i_g.2^git+file://${BASEDIR}/pinnes#main^a/i
 root-a_p.2^file://${BASEDIR}/pinnes^a
-root_g.2^git+file://${BASEDIR}/pinnes#master
-### opam pin -n --with-version 3 root-b_g.2^git+file://${BASEDIR}/pinnes#master^b root-a-i-j_g.2^git+file://${BASEDIR}/pinnes#master^a/i/j root-a-i_g.2^git+file://${BASEDIR}/pinnes#master^a/i root-a_p.2^file://${BASEDIR}/pinnes^a root_g^git+file://${BASEDIR}/pinnes#master root-a-k_p.2^file://${BASEDIR}/pinnes^a/k
+root_g.2^git+file://${BASEDIR}/pinnes#main
+### opam pin -n --with-version 3 root-b_g.2^git+file://${BASEDIR}/pinnes#main^b root-a-i-j_g.2^git+file://${BASEDIR}/pinnes#main^a/i/j root-a-i_g.2^git+file://${BASEDIR}/pinnes#main^a/i root-a_p.2^file://${BASEDIR}/pinnes^a root_g^git+file://${BASEDIR}/pinnes#main root-a-k_p.2^file://${BASEDIR}/pinnes^a/k
 This will pin the following packages: root-b_g, root-a-i-j_g, root-a-i_g, root-a_p, root_g, root-a-k_p. Continue? [Y/n] y
 [NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
 [root-b_g.3] synchronised (no changes)
-root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version 3)
+root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#main (version 3)
 [NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
 [root-a-i-j_g.3] synchronised (no changes)
-root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version 3)
+root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version 3)
 [NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
 [root-a-i_g.3] synchronised (no changes)
-root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version 3)
+root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version 3)
 [NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 [root-a_p.3] synchronised (no changes)
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version 3)
 [NOTE] Package root_g does not exist in opam repositories registered in the current switch.
 [root_g.3] synchronised (no changes)
-root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version 3)
+root_g is now pinned to git+file://${BASEDIR}/pinnes#main (version 3)
 [NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 [root-a-k_p.3] synchronised (no changes)
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version 3)
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-root-a-i-j_g.3  (uninstalled)  git    directory /a/i/j in git+file://${BASEDIR}/pinnes#master  (at HASH)
-root-a-i_g.3    (uninstalled)  git    directory /a/i in git+file://${BASEDIR}/pinnes#master    (at HASH)
+root-a-i-j_g.3  (uninstalled)  git    directory /a/i/j in git+file://${BASEDIR}/pinnes#main  (at HASH)
+root-a-i_g.3    (uninstalled)  git    directory /a/i in git+file://${BASEDIR}/pinnes#main    (at HASH)
 root-a-k_p.3    (uninstalled)  rsync  directory /a/k in file://${BASEDIR}/pinnes
 root-a_p.3      (uninstalled)  rsync  directory /a in file://${BASEDIR}/pinnes
-root-b_g.3      (uninstalled)  git    directory /b in git+file://${BASEDIR}/pinnes#master      (at HASH)
-root_g.3        (uninstalled)  git    git+file://${BASEDIR}/pinnes#master                      (at HASH)
+root-b_g.3      (uninstalled)  git    directory /b in git+file://${BASEDIR}/pinnes#main      (at HASH)
+root_g.3        (uninstalled)  git    git+file://${BASEDIR}/pinnes#main                      (at HASH)
 ### ############################
 ### #     same with lock files #
 ### ############################
@@ -602,7 +602,7 @@ version: "l1"
 build: [ "false" ]
 ### <pin:pinnes/b/root-b_g.opam.locked>
 version: "l1"
-### git -C ./pinnes init -q --initial-branch=master
+### git -C ./pinnes init -q --initial-branch=main
 ### git -C ./pinnes config core.autocrlf false
 ### git -C ./pinnes add a/i b root_g.opam root_g.opam.locked
 ### git -C ./pinnes commit -qm "fst"
@@ -610,32 +610,32 @@ version: "l1"
 ### opam pin -n --recursive pinnes
 This will pin the following packages: root_g, root-a_p, root-a-i_g, root-a-i-j_g, root-a-k_p, root-b_g. Continue? [Y/n] y
 [NOTE] Package root_g does not exist in opam repositories registered in the current switch.
-root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version l1)
+root_g is now pinned to git+file://${BASEDIR}/pinnes#main (version l1)
 [NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version l1)
 [NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
-root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version l1)
+root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version l1)
 [NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
-root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version l1)
+root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version l1)
 [NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version l1)
 [NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
-root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version l1)
+root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#main (version l1)
 ### opam list -s
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-root-a-i-j_g.l1  (uninstalled)  git    directory /a/i/j in git+file://${BASEDIR}/pinnes#master  (at HASH)
-root-a-i_g.l1    (uninstalled)  git    directory /a/i in git+file://${BASEDIR}/pinnes#master    (at HASH)
+root-a-i-j_g.l1  (uninstalled)  git    directory /a/i/j in git+file://${BASEDIR}/pinnes#main  (at HASH)
+root-a-i_g.l1    (uninstalled)  git    directory /a/i in git+file://${BASEDIR}/pinnes#main    (at HASH)
 root-a-k_p.l1    (uninstalled)  rsync  directory /a/k in file://${BASEDIR}/pinnes
 root-a_p.l1      (uninstalled)  rsync  directory /a in file://${BASEDIR}/pinnes
-root-b_g.l1      (uninstalled)  git    directory /b in git+file://${BASEDIR}/pinnes#master      (at HASH)
-root_g.l1        (uninstalled)  git    git+file://${BASEDIR}/pinnes#master                      (at HASH)
+root-b_g.l1      (uninstalled)  git    directory /b in git+file://${BASEDIR}/pinnes#main      (at HASH)
+root_g.l1        (uninstalled)  git    git+file://${BASEDIR}/pinnes#main                      (at HASH)
 ### opam unpin -n --recursive pinnes
-Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version l1)
-Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version l1)
+Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version l1)
+Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version l1)
 Ok, root-a-k_p is no longer pinned to directory /a/k in file://${BASEDIR}/pinnes (version l1)
 Ok, root-a_p is no longer pinned to directory /a in file://${BASEDIR}/pinnes (version l1)
-Ok, root-b_g is no longer pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version l1)
-Ok, root_g is no longer pinned to git+file://${BASEDIR}/pinnes#master (version l1)
+Ok, root-b_g is no longer pinned to directory /b in git+file://${BASEDIR}/pinnes#main (version l1)
+Ok, root_g is no longer pinned to git+file://${BASEDIR}/pinnes#main (version l1)
 ### opam list -s
 ### opam pin
 ### opam pin  --recursive pinnes | unordered
@@ -646,12 +646,12 @@ This will pin the following packages: root_g, root-a_p, root-a-i_g, root-a-i-j_g
 [NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
 [NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 [NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
-root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version l1)
+root_g is now pinned to git+file://${BASEDIR}/pinnes#main (version l1)
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version l1)
-root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version l1)
-root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version l1)
+root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version l1)
+root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version l1)
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version l1)
-root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version l1)
+root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#main (version l1)
 -> retrieved root-a-k_p.l1  (directory /a/k in file://${BASEDIR}/pinnes)
 -> retrieved root-a_p.l1  (directory /a in file://${BASEDIR}/pinnes)
 
@@ -676,12 +676,12 @@ The following actions will be performed:
 -> installed root-b_g.l1
 Done.
 ### opam remove --recursive ./pinnes | unordered
-Ok, root-b_g is no longer pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version l1)
+Ok, root-b_g is no longer pinned to directory /b in git+file://${BASEDIR}/pinnes#main (version l1)
 Ok, root-a_p is no longer pinned to directory /a in file://${BASEDIR}/pinnes (version l1)
 Ok, root-a-k_p is no longer pinned to directory /a/k in file://${BASEDIR}/pinnes (version l1)
-Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version l1)
-Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version l1)
-Ok, root_g is no longer pinned to git+file://${BASEDIR}/pinnes#master (version l1)
+Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version l1)
+Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version l1)
+Ok, root_g is no longer pinned to git+file://${BASEDIR}/pinnes#main (version l1)
 The following actions will be performed:
 === remove 6 packages
   - remove root-a-i-j_g l1
@@ -703,19 +703,19 @@ Done.
 ### opam pin
 ### opam install ./pinnes | unordered
 [NOTE] Package root_g does not exist in opam repositories registered in the current switch.
-root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version l1)
+root_g is now pinned to git+file://${BASEDIR}/pinnes#main (version l1)
 The following actions will be performed:
 === install 1 package
   - install root_g l1 (pinned)
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved root_g.l1  (git+file://${BASEDIR}/pinnes#master)
+-> retrieved root_g.l1  (git+file://${BASEDIR}/pinnes#main)
 -> installed root_g.l1
 Done.
 ### opam list -s
 root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-root_g.l1    git  git+file://${BASEDIR}/pinnes#master  (at HASH)
+root_g.l1    git  git+file://${BASEDIR}/pinnes#main  (at HASH)
 ### opam install ./pinnes --subpath a | unordered
 [NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version l1)
@@ -732,11 +732,11 @@ root-a_p
 root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
 root-a_p.l1    rsync  directory /a in file://${BASEDIR}/pinnes
-root_g.l1      git    git+file://${BASEDIR}/pinnes#master       (at HASH)
+root_g.l1      git    git+file://${BASEDIR}/pinnes#main         (at HASH)
 ### opam install ./pinnes --subpath b | unordered
 [NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
-root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version l1)
--> retrieved root-b_g.l1  (directory /b in git+file://${BASEDIR}/pinnes#master)
+root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#main (version l1)
+-> retrieved root-b_g.l1  (directory /b in git+file://${BASEDIR}/pinnes#main)
 The following actions will be performed:
 === install 1 package
   - install root-b_g l1 (pinned)
@@ -750,12 +750,12 @@ root-b_g
 root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
 root-a_p.l1    rsync  directory /a in file://${BASEDIR}/pinnes
-root-b_g.l1    git    directory /b in git+file://${BASEDIR}/pinnes#master  (at HASH)
-root_g.l1      git    git+file://${BASEDIR}/pinnes#master                  (at HASH)
+root-b_g.l1    git    directory /b in git+file://${BASEDIR}/pinnes#main  (at HASH)
+root_g.l1      git    git+file://${BASEDIR}/pinnes#main                  (at HASH)
 ### opam install ./pinnes --subpath a/i | unordered
 [NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
-root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version l1)
--> retrieved root-a-i_g.l1  (directory /a/i in git+file://${BASEDIR}/pinnes#master)
+root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version l1)
+-> retrieved root-a-i_g.l1  (directory /a/i in git+file://${BASEDIR}/pinnes#main)
 The following actions will be performed:
 === install 1 package
   - install root-a-i_g l1 (pinned)
@@ -769,14 +769,14 @@ root-a_p
 root-b_g
 root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-root-a-i_g.l1    git    directory /a/i in git+file://${BASEDIR}/pinnes#master  (at HASH)
+root-a-i_g.l1    git    directory /a/i in git+file://${BASEDIR}/pinnes#main  (at HASH)
 root-a_p.l1      rsync  directory /a in file://${BASEDIR}/pinnes
-root-b_g.l1      git    directory /b in git+file://${BASEDIR}/pinnes#master    (at HASH)
-root_g.l1        git    git+file://${BASEDIR}/pinnes#master                    (at HASH)
+root-b_g.l1      git    directory /b in git+file://${BASEDIR}/pinnes#main    (at HASH)
+root_g.l1        git    git+file://${BASEDIR}/pinnes#main                    (at HASH)
 ### opam install ./pinnes --subpath a/i/j | unordered
 [NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
-root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version l1)
--> retrieved root-a-i-j_g.l1  (directory /a/i/j in git+file://${BASEDIR}/pinnes#master)
+root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version l1)
+-> retrieved root-a-i-j_g.l1  (directory /a/i/j in git+file://${BASEDIR}/pinnes#main)
 The following actions will be performed:
 === install 1 package
   - install root-a-i-j_g l1 (pinned)
@@ -791,11 +791,11 @@ root-a_p
 root-b_g
 root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-root-a-i-j_g.l1    git    directory /a/i/j in git+file://${BASEDIR}/pinnes#master  (at HASH)
-root-a-i_g.l1      git    directory /a/i in git+file://${BASEDIR}/pinnes#master    (at HASH)
+root-a-i-j_g.l1    git    directory /a/i/j in git+file://${BASEDIR}/pinnes#main  (at HASH)
+root-a-i_g.l1      git    directory /a/i in git+file://${BASEDIR}/pinnes#main    (at HASH)
 root-a_p.l1        rsync  directory /a in file://${BASEDIR}/pinnes
-root-b_g.l1        git    directory /b in git+file://${BASEDIR}/pinnes#master      (at HASH)
-root_g.l1          git    git+file://${BASEDIR}/pinnes#master                      (at HASH)
+root-b_g.l1        git    directory /b in git+file://${BASEDIR}/pinnes#main      (at HASH)
+root_g.l1          git    git+file://${BASEDIR}/pinnes#main                      (at HASH)
 ### opam install ./pinnes --subpath a/k | unordered
 [NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version l1)
@@ -815,12 +815,12 @@ root-a_p
 root-b_g
 root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-root-a-i-j_g.l1    git    directory /a/i/j in git+file://${BASEDIR}/pinnes#master  (at HASH)
-root-a-i_g.l1      git    directory /a/i in git+file://${BASEDIR}/pinnes#master    (at HASH)
+root-a-i-j_g.l1    git    directory /a/i/j in git+file://${BASEDIR}/pinnes#main  (at HASH)
+root-a-i_g.l1      git    directory /a/i in git+file://${BASEDIR}/pinnes#main    (at HASH)
 root-a-k_p.l1      rsync  directory /a/k in file://${BASEDIR}/pinnes
 root-a_p.l1        rsync  directory /a in file://${BASEDIR}/pinnes
-root-b_g.l1        git    directory /b in git+file://${BASEDIR}/pinnes#master      (at HASH)
-root_g.l1          git    git+file://${BASEDIR}/pinnes#master                      (at HASH)
+root-b_g.l1        git    directory /b in git+file://${BASEDIR}/pinnes#main      (at HASH)
+root_g.l1          git    git+file://${BASEDIR}/pinnes#main                      (at HASH)
 ### <pin:pinnes/root_g.opam>
 version: "2"
 build: [ "false" ]
@@ -854,12 +854,12 @@ version: "l2"
 ### git -C pinnes add root_g.opam root_g.opam.locked a/i b
 ### git -C pinnes commit -qm "snd"
 ### opam update | grep synchronised
-[root-a-i-j_g.l1] synchronised (directory /a/i/j in git+file://${BASEDIR}/pinnes#master)
-[root-a-i_g.l1] synchronised (directory /a/i in git+file://${BASEDIR}/pinnes#master)
+[root-a-i-j_g.l1] synchronised (directory /a/i/j in git+file://${BASEDIR}/pinnes#main)
+[root-a-i_g.l1] synchronised (directory /a/i in git+file://${BASEDIR}/pinnes#main)
 [root-a-k_p.l1] synchronised (directory /a/k in file://${BASEDIR}/pinnes)
 [root-a_p.l1] synchronised (directory /a in file://${BASEDIR}/pinnes)
-[root-b_g.l1] synchronised (directory /b in git+file://${BASEDIR}/pinnes#master)
-[root_g.l1] synchronised (git+file://${BASEDIR}/pinnes#master)
+[root-b_g.l1] synchronised (directory /b in git+file://${BASEDIR}/pinnes#main)
+[root_g.l1] synchronised (git+file://${BASEDIR}/pinnes#main)
 ### opam upgrade | unordered
 The following actions will be performed:
 === upgrade 6 packages
@@ -897,11 +897,11 @@ hoj
 ### git -C pinnes commit -qm "thd"
 ### opam update | grep synchronised
 [root-a-i-j_g.l2] synchronised (no changes)
-[root-a-i_g.l2] synchronised (directory /a/i in git+file://${BASEDIR}/pinnes#master)
+[root-a-i_g.l2] synchronised (directory /a/i in git+file://${BASEDIR}/pinnes#main)
 [root-a-k_p.l2] synchronised (directory /a/k in file://${BASEDIR}/pinnes)
 [root-a_p.l2] synchronised (directory /a in file://${BASEDIR}/pinnes)
 [root-b_g.l2] synchronised (no changes)
-[root_g.l2] synchronised (git+file://${BASEDIR}/pinnes#master)
+[root_g.l2] synchronised (git+file://${BASEDIR}/pinnes#main)
 ### opam upgrade | unordered
 The following actions will be performed:
 === recompile 4 packages
@@ -931,19 +931,19 @@ root-a_p
 root-b_g
 root_g
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-root-a-i-j_g.l2    git    directory /a/i/j in git+file://${BASEDIR}/pinnes#master  (at HASH)
-root-a-i_g.l2      git    directory /a/i in git+file://${BASEDIR}/pinnes#master    (at HASH)
+root-a-i-j_g.l2    git    directory /a/i/j in git+file://${BASEDIR}/pinnes#main  (at HASH)
+root-a-i_g.l2      git    directory /a/i in git+file://${BASEDIR}/pinnes#main    (at HASH)
 root-a-k_p.l2      rsync  directory /a/k in file://${BASEDIR}/pinnes
 root-a_p.l2        rsync  directory /a in file://${BASEDIR}/pinnes
-root-b_g.l2        git    directory /b in git+file://${BASEDIR}/pinnes#master      (at HASH)
-root_g.l2          git    git+file://${BASEDIR}/pinnes#master                      (at HASH)
+root-b_g.l2        git    directory /b in git+file://${BASEDIR}/pinnes#main      (at HASH)
+root_g.l2          git    git+file://${BASEDIR}/pinnes#main                      (at HASH)
 ### opam remove ./pinnes --recursive
-Ok, root_g is no longer pinned to git+file://${BASEDIR}/pinnes#master (version l2)
-Ok, root-b_g is no longer pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version l2)
+Ok, root_g is no longer pinned to git+file://${BASEDIR}/pinnes#main (version l2)
+Ok, root-b_g is no longer pinned to directory /b in git+file://${BASEDIR}/pinnes#main (version l2)
 Ok, root-a_p is no longer pinned to directory /a in file://${BASEDIR}/pinnes (version l2)
 Ok, root-a-k_p is no longer pinned to directory /a/k in file://${BASEDIR}/pinnes (version l2)
-Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version l2)
-Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version l2)
+Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version l2)
+Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version l2)
 The following actions will be performed:
 === remove 6 packages
   - remove root-a-i-j_g l2
@@ -966,14 +966,14 @@ This will pin the following packages: root-a_p, root-a-i_g, root-a-i-j_g, root-a
 [NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version l2)
 [NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
-root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version l2)
+root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version l2)
 [NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
-root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version l2)
+root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version l2)
 [NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version l2)
 ### opam pin | '  \(at [0-9a-f]+\)$' -> '  (at HASH)'
-root-a-i-j_g.l2  (uninstalled)  git    directory /a/i/j in git+file://${BASEDIR}/pinnes#master  (at HASH)
-root-a-i_g.l2    (uninstalled)  git    directory /a/i in git+file://${BASEDIR}/pinnes#master    (at HASH)
+root-a-i-j_g.l2  (uninstalled)  git    directory /a/i/j in git+file://${BASEDIR}/pinnes#main  (at HASH)
+root-a-i_g.l2    (uninstalled)  git    directory /a/i in git+file://${BASEDIR}/pinnes#main    (at HASH)
 root-a-k_p.l2    (uninstalled)  rsync  directory /a/k in file://${BASEDIR}/pinnes
 root-a_p.l2      (uninstalled)  rsync  directory /a in file://${BASEDIR}/pinnes
 ### opam-cat $OPAMROOT/devnull/.opam-switch/overlay/root-a_p/opam
@@ -1008,54 +1008,54 @@ version: "l2"
 x-locked: "locked"
 x-subpath: "a/i"
 url {
-src: "git+file://${BASEDIR}/pinnes#master"
+src: "git+file://${BASEDIR}/pinnes#main"
 }
 ### opam unpin ./pinnes --recursive
-Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version l2)
-Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version l2)
+Ok, root-a-i-j_g is no longer pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version l2)
+Ok, root-a-i_g is no longer pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version l2)
 Ok, root-a-k_p is no longer pinned to directory /a/k in file://${BASEDIR}/pinnes (version l2)
 Ok, root-a_p is no longer pinned to directory /a in file://${BASEDIR}/pinnes (version l2)
 ### opam pin
 ### opam pin scan ./pinnes | grep -v '# Name.*'
-root_g  l2         git+file://${BASEDIR}/pinnes#master  -
+root_g  l2         git+file://${BASEDIR}/pinnes#main  -
 ### opam pin scan ./pinnes --recursive | '# Name.*' -> '\c'
-root-b_g      l2         git+file://${BASEDIR}/pinnes#master  b
-root-a-k_p    l2         file://${BASEDIR}/pinnes             a/k
-root-a-i-j_g  l2         git+file://${BASEDIR}/pinnes#master  a/i/j
-root-a-i_g    l2         git+file://${BASEDIR}/pinnes#master  a/i
-root-a_p      l2         file://${BASEDIR}/pinnes             a
-root_g        l2         git+file://${BASEDIR}/pinnes#master  -
+root-b_g      l2         git+file://${BASEDIR}/pinnes#main  b
+root-a-k_p    l2         file://${BASEDIR}/pinnes           a/k
+root-a-i-j_g  l2         git+file://${BASEDIR}/pinnes#main  a/i/j
+root-a-i_g    l2         git+file://${BASEDIR}/pinnes#main  a/i
+root-a_p      l2         file://${BASEDIR}/pinnes           a
+root_g        l2         git+file://${BASEDIR}/pinnes#main  -
 ### opam pin scan ./pinnes --subpath a | grep -v '# Name.*'
 root-a_p  l2         file://${BASEDIR}/pinnes  a
 ### opam pin scan ./pinnes --subpath a --recursive | '# Name.*' -> '\c'
-root-a-k_p    l2         file://${BASEDIR}/pinnes             a/k
-root-a-i-j_g  l2         git+file://${BASEDIR}/pinnes#master  a/i/j
-root-a-i_g    l2         git+file://${BASEDIR}/pinnes#master  a/i
-root-a_p      l2         file://${BASEDIR}/pinnes             a
+root-a-k_p    l2         file://${BASEDIR}/pinnes           a/k
+root-a-i-j_g  l2         git+file://${BASEDIR}/pinnes#main  a/i/j
+root-a-i_g    l2         git+file://${BASEDIR}/pinnes#main  a/i
+root-a_p      l2         file://${BASEDIR}/pinnes           a
 ### opam pin scan ./pinnes --recursive --normalise
-root-b_g.l2^git+file://${BASEDIR}/pinnes#master^b
+root-b_g.l2^git+file://${BASEDIR}/pinnes#main^b
 root-a-k_p.l2^file://${BASEDIR}/pinnes^a/k
-root-a-i-j_g.l2^git+file://${BASEDIR}/pinnes#master^a/i/j
-root-a-i_g.l2^git+file://${BASEDIR}/pinnes#master^a/i
+root-a-i-j_g.l2^git+file://${BASEDIR}/pinnes#main^a/i/j
+root-a-i_g.l2^git+file://${BASEDIR}/pinnes#main^a/i
 root-a_p.l2^file://${BASEDIR}/pinnes^a
-root_g.l2^git+file://${BASEDIR}/pinnes#master
-### opam pin --with-version 3 root-b_g^git+file://${BASEDIR}/pinnes#master^b root-a-i-j_g^git+file://${BASEDIR}/pinnes#master^a/i/j root-a-i_g^git+file://${BASEDIR}/pinnes#master^a/i root-a_p^file://${BASEDIR}/pinnes^a root_g^git+file://${BASEDIR}/pinnes#master root-a-k_p^file://${BASEDIR}/pinnes^a/k -n
+root_g.l2^git+file://${BASEDIR}/pinnes#main
+### opam pin --with-version 3 root-b_g^git+file://${BASEDIR}/pinnes#main^b root-a-i-j_g^git+file://${BASEDIR}/pinnes#main^a/i/j root-a-i_g^git+file://${BASEDIR}/pinnes#main^a/i root-a_p^file://${BASEDIR}/pinnes^a root_g^git+file://${BASEDIR}/pinnes#main root-a-k_p^file://${BASEDIR}/pinnes^a/k -n
 This will pin the following packages: root-b_g, root-a-i-j_g, root-a-i_g, root-a_p, root_g, root-a-k_p. Continue? [Y/n] y
 [NOTE] Package root-b_g does not exist in opam repositories registered in the current switch.
 [root-b_g.3] synchronised (no changes)
-root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#master (version 3)
+root-b_g is now subpath-pinned to directory /b in git+file://${BASEDIR}/pinnes#main (version 3)
 [NOTE] Package root-a-i-j_g does not exist in opam repositories registered in the current switch.
 [root-a-i-j_g.3] synchronised (no changes)
-root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#master (version 3)
+root-a-i-j_g is now subpath-pinned to directory /a/i/j in git+file://${BASEDIR}/pinnes#main (version 3)
 [NOTE] Package root-a-i_g does not exist in opam repositories registered in the current switch.
 [root-a-i_g.3] synchronised (no changes)
-root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#master (version 3)
+root-a-i_g is now subpath-pinned to directory /a/i in git+file://${BASEDIR}/pinnes#main (version 3)
 [NOTE] Package root-a_p does not exist in opam repositories registered in the current switch.
 [root-a_p.3] synchronised (no changes)
 root-a_p is now subpath-pinned to directory /a in file://${BASEDIR}/pinnes (version 3)
 [NOTE] Package root_g does not exist in opam repositories registered in the current switch.
 [root_g.3] synchronised (no changes)
-root_g is now pinned to git+file://${BASEDIR}/pinnes#master (version 3)
+root_g is now pinned to git+file://${BASEDIR}/pinnes#main (version 3)
 [NOTE] Package root-a-k_p does not exist in opam repositories registered in the current switch.
 [root-a-k_p.3] synchronised (no changes)
 root-a-k_p is now subpath-pinned to directory /a/k in file://${BASEDIR}/pinnes (version 3)
@@ -1116,7 +1116,7 @@ EOF
 Now run 'opam upgrade' to apply any package updates.
 ### <subpath-git/inner/inner_file>
 I'm here!
-### git -C ./subpath-git init -q --initial-branch=master
+### git -C ./subpath-git init -q --initial-branch=main
 ### git -C ./subpath-git config core.autocrlf false
 ### git -C ./subpath-git add inner/
 ### git -C ./subpath-git commit -qm "fst"

--- a/tests/reftests/rec-pin.test
+++ b/tests/reftests/rec-pin.test
@@ -57,6 +57,8 @@ piou
 lib: ["root-b_g.t"]
 ### git -C ./pinnes init -q --initial-branch=main
 ### git -C ./pinnes config core.autocrlf false
+### git -C ./pinnes config --local user.name 'OPAM test environment'
+### git -C ./pinnes config --local user.email 'noreply@ocaml.org'
 ### git -C ./pinnes add a/i b root_g.opam root_g.t root_g.install
 ### git -C ./pinnes commit -qm "fst"
 ### opam switch create devnull --empty
@@ -604,6 +606,8 @@ build: [ "false" ]
 version: "l1"
 ### git -C ./pinnes init -q --initial-branch=main
 ### git -C ./pinnes config core.autocrlf false
+### git -C ./pinnes config --local user.name 'OPAM test environment'
+### git -C ./pinnes config --local user.email 'noreply@ocaml.org'
 ### git -C ./pinnes add a/i b root_g.opam root_g.opam.locked
 ### git -C ./pinnes commit -qm "fst"
 ### opam switch create devnull --empty
@@ -1118,6 +1122,8 @@ Now run 'opam upgrade' to apply any package updates.
 I'm here!
 ### git -C ./subpath-git init -q --initial-branch=main
 ### git -C ./subpath-git config core.autocrlf false
+### git -C ./subpath-git config --local user.name 'OPAM test environment'
+### git -C ./subpath-git config --local user.email 'noreply@ocaml.org'
 ### git -C ./subpath-git add inner/
 ### git -C ./subpath-git commit -qm "fst"
 ### opam install subpath-git

--- a/tests/reftests/repository-patchdiff.test
+++ b/tests/reftests/repository-patchdiff.test
@@ -10,6 +10,8 @@ I'm some content
 ### :I: Git updates
 ### git -C ./REPO init -q
 ### git -C ./REPO config core.autocrlf false
+### git -C ./REPO config --local user.name 'OPAM test environment'
+### git -C ./REPO config --local user.email 'noreply@ocaml.org'
 ### git -C ./REPO add repo
 ### git -C ./REPO add packages/first
 ### git -C ./REPO commit -qm "first"

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -314,6 +314,8 @@ first  --
 ### ::: git - rsync :::
 ### git -C ./OPER init -q
 ### git -C ./OPER config core.autocrlf false
+### git -C ./OPER config --local user.name 'OPAM test environment'
+### git -C ./OPER config --local user.email 'noreply@ocaml.org'
 ### git -C ./OPER add repo
 ### git -C ./OPER add packages/first
 ### git -C ./OPER commit -qm "third"
@@ -480,6 +482,8 @@ first  --
 ### :::: git - rsync ::::
 ### git -C ./OPER init -q
 ### git -C ./OPER config core.autocrlf false
+### git -C ./OPER config --local user.name 'OPAM test environment'
+### git -C ./OPER config --local user.email 'noreply@ocaml.org'
 ### git -C ./OPER add repo
 ### git -C ./OPER add packages/first
 ### git -C ./OPER commit -qm "third"
@@ -593,6 +597,8 @@ opam-version: "2.0"
 opam-version: "2.0"
 ### git -C ./TMCS init -q
 ### git -C ./TMCS config core.autocrlf false
+### git -C ./TMCS config --local user.name 'OPAM test environment'
+### git -C ./TMCS config --local user.email 'noreply@ocaml.org'
 ### git -C ./TMCS add repo
 ### git -C ./TMCS add packages/first
 ### git -C ./TMCS commit -qm "init"
@@ -890,6 +896,8 @@ oper3
 ### opam switch create local-nongit-git --empty
 ### git init -q --initial-branch=main GIT
 ### git -C GIT config core.autocrlf false
+### git -C GIT config --local user.name 'OPAM test environment'
+### git -C GIT config --local user.email 'noreply@ocaml.org'
 ### <GIT/repo>
 opam-version: "2.0"
 ### <GIT/packages/test/test.1/opam>

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -888,7 +888,7 @@ to-many-commits
 oper3
 ### : Make sure the .git directory is not taken into account when synching local non-git repositories
 ### opam switch create local-nongit-git --empty
-### git init -q --initial-branch=master GIT
+### git init -q --initial-branch=main GIT
 ### git -C GIT config core.autocrlf false
 ### <GIT/repo>
 opam-version: "2.0"

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -78,6 +78,17 @@ let base_env =
   propagate "TMPDIR" @
   propagate "TMP" @
   propagate "TEMP" @
+  (* Override the user's Git configuration with the one in gitconfig. Allow the
+     system Git configuration to be read. On a correctly configured system, that
+     should mean that settings required for normal Git operation will be
+     applied. Propagate GIT_CONFIG_NOSYSTEM so that the user can easily override
+     this (i.e. set GIT_CONFIG_NOSYSTEM=1 and have the system configuration
+     ignored as well). *)
+  propagate "GIT_CONFIG_NOSYSTEM" @
+  ["GIT_CONFIG_GLOBAL", Filename.concat (Sys.getcwd ()) "gitconfig"] @
+  (* On Windows, allow USERNAME and USERDOMAIN to propagate as Unix.getpwduid
+     isn't available in the pin tests *)
+  (if Sys.win32 then propagate "USERNAME" @ propagate "USERDOMAIN" else []) @
   (if Sys.win32 then ["SHELL", "/bin/sh"] else []) @
   [
     "OPAMKEEPBUILDDIR", "1";

--- a/tests/reftests/shared-fetch.test
+++ b/tests/reftests/shared-fetch.test
@@ -329,6 +329,8 @@ Done.
 ### cp shared.ml shared-vcs
 ### git -C shared-vcs init -q --initial-branch=main
 ### git -C shared-vcs config core.autocrlf false
+### git -C shared-vcs config --local user.name 'OPAM test environment'
+### git -C shared-vcs config --local user.email 'noreply@ocaml.org'
 ### git -C shared-vcs add shared.ml
 ### git -C shared-vcs commit -qm 'init'
 ### <pkg:foo-vcs.1>

--- a/tests/reftests/shared-fetch.test
+++ b/tests/reftests/shared-fetch.test
@@ -327,7 +327,7 @@ Done.
 ### opam switch create vcs-shared --empty
 ### mkdir shared-vcs
 ### cp shared.ml shared-vcs
-### git -C shared-vcs init -q --initial-branch=master
+### git -C shared-vcs init -q --initial-branch=main
 ### git -C shared-vcs config core.autocrlf false
 ### git -C shared-vcs add shared.ml
 ### git -C shared-vcs commit -qm 'init'

--- a/tests/reftests/source.test
+++ b/tests/reftests/source.test
@@ -4,7 +4,7 @@ print_endline "I am a source code"
 ### <pandev/root.ml>
 print_endline "i'm root"
 ### tar czf origin.tgz pandev
-### git -C ./pandev init -q --initial-branch=master
+### git -C ./pandev init -q --initial-branch=main
 ### git -C ./pandev config core.autocrlf false
 ### git -C ./pandev add -A
 ### git -C ./pandev commit -qm "init"

--- a/tests/reftests/source.test
+++ b/tests/reftests/source.test
@@ -6,6 +6,8 @@ print_endline "i'm root"
 ### tar czf origin.tgz pandev
 ### git -C ./pandev init -q --initial-branch=main
 ### git -C ./pandev config core.autocrlf false
+### git -C ./pandev config --local user.name 'OPAM test environment'
+### git -C ./pandev config --local user.email 'noreply@ocaml.org'
 ### git -C ./pandev add -A
 ### git -C ./pandev commit -qm "init"
 ### <pkg:pandore.3>

--- a/tests/reftests/switch-import.test
+++ b/tests/reftests/switch-import.test
@@ -6,6 +6,8 @@ opam-version: "2.0"
 install: [ "cp" "fst.out" "%{lib}%" ]
 ### git -C nip init -q --initial-branch=fst-head
 ### git -C nip config core.autocrlf false
+### git -C nip config --local user.name 'OPAM test environment'
+### git -C nip config --local user.email 'noreply@ocaml.org'
 ### git -C nip add -A
 ### git -C nip commit -qm "init"
 ### git -C nip branch snd-head

--- a/tests/reftests/update-upgrade.test
+++ b/tests/reftests/update-upgrade.test
@@ -427,13 +427,13 @@ opam-version: "2.0"
 build: [[ "test" "-f" "ongoing.txt" ] [ "cat" "ongoing.txt" ]]
 ### <ongoing/ongoing.txt>
 versionned
-### git -C ./ongoing init -q --initial-branch=master
+### git -C ./ongoing init -q --initial-branch=main
 ### git -C ./ongoing config core.autocrlf false
 ### git -C ./ongoing add -A
 ### git -C ./ongoing commit -qm "init"
 ### opam pin ./ongoing
 [NOTE] Package ongoing does not exist in opam repositories registered in the current switch.
-ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
+ongoing is now pinned to git+file://${BASEDIR}/ongoing#main (version dev)
 
 The following actions will be performed:
 === install 1 package
@@ -471,8 +471,8 @@ build: [[ "test" "-f" "newfile.txt" ] [ "cat" "newfile.txt" ]]
 ### opam update --working-dir ongoing
 
 <><> Synchronising development packages <><><><><><><><><><><><><><><><><><><><>
-[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)
-[ongoing] Installing new package description from upstream git+file://${BASEDIR}/ongoing#master
+[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#main)
+[ongoing] Installing new package description from upstream git+file://${BASEDIR}/ongoing#main
 Now run 'opam upgrade' to apply any package updates.
 ### opam upgrade --working-dir
 The following actions will be performed:
@@ -481,7 +481,7 @@ The following actions will be performed:
 [NOTE] --working-dir is given but no requested package is pinned
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved ongoing.dev  (git+file://${BASEDIR}/ongoing#master)
+-> retrieved ongoing.dev  (git+file://${BASEDIR}/ongoing#main)
 [ERROR] The compilation of ongoing.dev failed at "test -f newfile.txt".
 
 
@@ -496,7 +496,7 @@ The following actions will be performed:
 ### opam upgrade --working-dir ongoing
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
-[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)
+[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#main)
 
 The following actions will be performed:
 === recompile 1 package

--- a/tests/reftests/update-upgrade.test
+++ b/tests/reftests/update-upgrade.test
@@ -429,6 +429,8 @@ build: [[ "test" "-f" "ongoing.txt" ] [ "cat" "ongoing.txt" ]]
 versionned
 ### git -C ./ongoing init -q --initial-branch=main
 ### git -C ./ongoing config core.autocrlf false
+### git -C ./ongoing config --local user.name 'OPAM test environment'
+### git -C ./ongoing config --local user.email 'noreply@ocaml.org'
 ### git -C ./ongoing add -A
 ### git -C ./ongoing commit -qm "init"
 ### opam pin ./ongoing

--- a/tests/reftests/update.test
+++ b/tests/reftests/update.test
@@ -220,7 +220,7 @@ opam-file                       Missing expected extra files qux.installl at ${B
 "qux.installl" "md5=hash"
 ### :II: Git repo
 ### opam switch create repo-git-update --empty
-### git init -q --initial-branch=master GITREPO
+### git init -q --initial-branch=main GITREPO
 ### git -C GITREPO config core.autocrlf false
 ### <GITREPO/repo>
 opam-version: "2.0"

--- a/tests/reftests/update.test
+++ b/tests/reftests/update.test
@@ -222,6 +222,8 @@ opam-file                       Missing expected extra files qux.installl at ${B
 ### opam switch create repo-git-update --empty
 ### git init -q --initial-branch=main GITREPO
 ### git -C GITREPO config core.autocrlf false
+### git -C GITREPO config --local user.name 'OPAM test environment'
+### git -C GITREPO config --local user.email 'noreply@ocaml.org'
 ### <GITREPO/repo>
 opam-version: "2.0"
 ### <GITREPO/packages/rename-pkg/rename-pkg.1/opam>

--- a/tests/reftests/working-dir.test
+++ b/tests/reftests/working-dir.test
@@ -7,6 +7,8 @@ build: [[ "test" "-f" "ongoing.txt" ] [ "cat" "ongoing.txt" ]]
 versionned
 ### git -C ./ongoing init -q --initial-branch=main
 ### git -C ./ongoing config core.autocrlf false
+### git -C ./ongoing config --local user.name 'OPAM test environment'
+### git -C ./ongoing config --local user.email 'noreply@ocaml.org'
 ### git -C ./ongoing add -A
 ### git -C ./ongoing commit -qm "init"
 ### opam switch create working-dir --empty
@@ -296,6 +298,8 @@ build: [
 I'm a normal file
 ### git -C ./new-url init -q --initial-branch=main
 ### git -C ./new-url config core.autocrlf false
+### git -C ./new-url config --local user.name 'OPAM test environment'
+### git -C ./new-url config --local user.email 'noreply@ocaml.org'
 ### git -C ./new-url add -A
 ### git -C ./new-url commit -qm "init"
 ### <new-url/new-file>

--- a/tests/reftests/working-dir.test
+++ b/tests/reftests/working-dir.test
@@ -5,14 +5,14 @@ opam-version: "2.0"
 build: [[ "test" "-f" "ongoing.txt" ] [ "cat" "ongoing.txt" ]]
 ### <ongoing/ongoing.txt>
 versionned
-### git -C ./ongoing init -q --initial-branch=master
+### git -C ./ongoing init -q --initial-branch=main
 ### git -C ./ongoing config core.autocrlf false
 ### git -C ./ongoing add -A
 ### git -C ./ongoing commit -qm "init"
 ### opam switch create working-dir --empty
 ### opam pin ./ongoing
 [NOTE] Package ongoing does not exist in opam repositories registered in the current switch.
-ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
+ongoing is now pinned to git+file://${BASEDIR}/ongoing#main (version dev)
 
 The following actions will be performed:
 === install 1 package
@@ -62,8 +62,8 @@ Done.
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [ongoing.dev: git]
-[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)
-[ongoing] Installing new package description from upstream git+file://${BASEDIR}/ongoing#master
+[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#main)
+[ongoing] Installing new package description from upstream git+file://${BASEDIR}/ongoing#main
 
 The following actions will be performed:
 === recompile 1 package
@@ -122,7 +122,7 @@ Processing  2/3: [ongoing: test newfile.txt]
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
 Processing  1/1: [ongoing.dev: git]
-[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)
+[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#main)
 
 The following actions will be performed:
 === install 1 package
@@ -207,7 +207,7 @@ build: [[ "test" "-f" "newfile.txt" ] [ "cat" "newfile.txt" ]]
 ### opam install qux ongoing --working-dir -v | '^Processing .+$' -> '\c' | sed-cmd test cat | grep -v "switch import" | unordered
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
-[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)
+[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#main)
 
 The following actions will be performed:
 === install 2 packages
@@ -228,7 +228,7 @@ Done.
 ### : Shows that opam correctly handles updated constraints with --working-dir
 ### : See https://github.com/ocaml/opam/issues/5178
 ### opam pin remove ./ongoing
-Ok, ongoing is no longer pinned to git+file://${BASEDIR}/ongoing#master (version dev)
+Ok, ongoing is no longer pinned to git+file://${BASEDIR}/ongoing#main (version dev)
 The following actions will be performed:
 === remove 1 package
   - remove ongoing dev
@@ -243,8 +243,8 @@ opam-version: "2.0"
 depends: ["qux"]
 ### opam install ./ongoing --working-dir
 [NOTE] Package ongoing does not exist in opam repositories registered in the current switch.
-ongoing is now pinned to git+file://${BASEDIR}/ongoing#master (version dev)
-[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)
+ongoing is now pinned to git+file://${BASEDIR}/ongoing#main (version dev)
+[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#main)
 The following actions will be performed:
 === install 1 package
   - install ongoing dev (pinned)
@@ -264,8 +264,8 @@ The following actions would be performed:
 ### opam reinstall ./ongoing --working-dir --show-action
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
-[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#master)
-[ongoing] Installing new package description from upstream git+file://${BASEDIR}/ongoing#master
+[ongoing.dev] synchronised (git+file://${BASEDIR}/ongoing#main)
+[ongoing] Installing new package description from upstream git+file://${BASEDIR}/ongoing#main
 
 The following actions would be performed:
 === downgrade 1 package
@@ -294,7 +294,7 @@ build: [
 ]
 ### <new-url/file>
 I'm a normal file
-### git -C ./new-url init -q --initial-branch=master
+### git -C ./new-url init -q --initial-branch=main
 ### git -C ./new-url config core.autocrlf false
 ### git -C ./new-url add -A
 ### git -C ./new-url commit -qm "init"
@@ -309,8 +309,8 @@ I'm a new file, huhu
 change-url is now pinned to file://${BASEDIR}/old-url (version a)
 ### opam install ./new-url --working-dir
 [NOTE] Package change-url is currently pinned to file://${BASEDIR}/old-url (version a).
-change-url is now pinned to git+file://${BASEDIR}/new-url#master (version a)
-[change-url.a] synchronised (git+file://${BASEDIR}/new-url#master)
+change-url is now pinned to git+file://${BASEDIR}/new-url#main (version a)
+[change-url.a] synchronised (git+file://${BASEDIR}/new-url#main)
 The following actions will be performed:
 === install 1 package
   - install change-url a (pinned)
@@ -333,8 +333,8 @@ The following actions will be performed:
 Done.
 ### opam install ./new-url --working-dir
 [NOTE] Package change-url is currently pinned to file://${BASEDIR}/old-url (version a).
-change-url is now pinned to git+file://${BASEDIR}/new-url#master (version a)
-[change-url.a] synchronised (git+file://${BASEDIR}/new-url#master)
+change-url is now pinned to git+file://${BASEDIR}/new-url#main (version a)
+[change-url.a] synchronised (git+file://${BASEDIR}/new-url#main)
 The following actions will be performed:
 === recompile 1 package
   - recompile change-url a (pinned)


### PR DESCRIPTION
I got mildly bitten by reftests failures that were nothing to do with what I was breaking, but in fact my local configuration (or lack of it!). I paused for a bit and tried to tweak things. This might want breaking up further:

- The first commit hardens `opam` itself against the user not having configured `init.defaultBranch`. Mostly doesn't matter, as the message isn't normally displayed. `--initial-branch` I think is Git 2.28, but by expressing it as `-c init.defaultBranch=main` it actually maintains compatibility with even older gits than that.
- The second commit hardens the template generator on Windows if Git's `user.name` and `user.email` are not set. The fallback on Unix is to look at `getpwuid`, which isn't implemented on Windows. As a simple fallback, just using `$USERNAME@$USERDOMAIN` is a pretty good default. This showed up as otherwise it means the template doesn't actually have maintainer or email fields set by default.
- While working on later commits, I broke the `patchDiff.ml` test, at which point it would have been nice to see the messages on stderr... which this next commit adds
- Next is a mechanical hardening of `patchDiff.ml` to explicitly set `user.name` and `user.email` on the repo created
- The next commit arose as a result of doing something else that I haven't kept, but I think we should keep this. While I don't propose renaming any branches, it seems a shame to be explicitly specifying `master` as a default for various tests when Git is trying to tend towards `main` - this commit mechanically updates the tests to use `main` wherever possible. (the commit actually arose from removing the `--initial-branch` completely, but I subsequently reverted that)
- Next up is a similar hardening as for `patchDiff.ml` - all the tests now explicitly set `user.name` and `user.email` where needed

The final commit is the point - when running the reftests, the user's global Git configuration is now completely ignored and replaced with one in the reftests itself. This has two benefits:
1. It's hermetic!
2. We don't need to encourage users either to ignore a test failure or to set `protocol.file.allow=always` (see the change in `git.test` in the last commit)

In a similar vein, the last commit also removes most of the manual configuration in CI, so this gets fully tested as well.

Originally, I used this new `tests/reftests/gitconfig` file to include `core.autorcrlf=false`, `init.defaultBranch=main`, `user.name` and `user.email` automatically, thus _removing_ all of them from the tests. But then I decided that was a bad idea and it was better to have every explicit.

No urgency, although I'd quite like the tests to pass first time next time I'm sat at a VM where I happen never to have run `git init` before...!