### PR TITLE
reftest: add 'sed-hash' command to replace single hashes and hashes paths in opam outputs

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -172,6 +172,7 @@ users)
   * Allow `sed-cmd` to parse even if no space is after the command [#6675 @rjbou]
   * Harden the regexp used for substituting variable checksums [#6710 @kit-ty-kate]
   * Add the `unset` builtin [#6708 @kit-ty-kate]
+  * Add the `sed-hash` command to replace hashes in opam output [#XXX @rjbou]
 
 ## Github Actions
   * bump `actions/checkout` from 4 to 5 [#6643 @kit-ty-kate]

--- a/tests/reftests/action-disk.test
+++ b/tests/reftests/action-disk.test
@@ -29,10 +29,8 @@ I'm an extra-file
 I'm an extra-source
 ### tar czf archive.tgz content
 ### openssl md5 archive.tgz | '.*= ' -> '' >$ MD5
-### sh -c "echo '$MD5' | cut -c 1-2" >$ PRE_MD5
 ### openssl md5 x-file | '.*= ' -> '' >$ XMD5
 ### openssl md5 x-source | '.*= ' -> '' >$ XSMD5
-### sh -c "echo '$XSMD5' | cut -c 1-2" >$ PRE_XSMD5
 ### <add-url.sh>
 basedir=$(printf '%s' "$BASEDIR" | sed 's/\\/\\\\/g')
 for nv in "$@"; do
@@ -178,7 +176,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (write => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/lock (write => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
-### opam install main-repo.1 | grep -v '^- ./$' | sed-cmd rsync tar cp touch mkdir | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash | "md5[^[:alnum:]].?${PRE_MD5}" -> md5/pre | "${PRE_XSMD5}[^[:alnum:]].?${XSMD5}" -> xspre/xshash | "md5[^[:alnum:]].?${PRE_XSMD5}" -> md5/prexs
+### opam install main-repo.1 | grep -v '^- ./$' | sed-cmd rsync tar cp touch mkdir | sed-hash $MD5 md5 | sed-hash $XSMD5 xs-hash
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -209,7 +207,7 @@ Processing  1/3: [main-repo.1: rsync]
 SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache
 SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5
 SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5/pre
-SYSTEM                          copy ${OPAMTMP}/archive.tgz -> ${BASEDIR}/OPAM/download-cache/md5/pre/hash
+SYSTEM                          copy ${OPAMTMP}/archive.tgz -> ${BASEDIR}/OPAM/download-cache/md5/pre/+md5+
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/3: [main-repo.1: extract]
 + tar "xfz" "${OPAMTMP}/archive.tgz" "-C" "${OPAMTMP}"
@@ -226,8 +224,8 @@ Processing  1/3: [main-repo.1/x-source.main-repo.1: dl]
 + rsync "-rLptgoDvc" "--exclude" ".git" "--exclude" "_darcs" "--exclude" ".hg" "--exclude" ".#*" "--exclude" "_opam*" "--exclude" "_build" "--delete" "--delete-excluded" "${BASEDIR}/x-source" "${OPAMTMP}"
 - x-source
 - 
-SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5/prexs
-SYSTEM                          copy ${OPAMTMP}/x-source -> ${BASEDIR}/OPAM/download-cache/md5/xspre/xshash
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5/pre
+SYSTEM                          copy ${OPAMTMP}/x-source -> ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+
 SYSTEM                          rmdir ${OPAMTMP}
 SYSTEM                          rm ${OPAMTMP}/x-source
 -> retrieved main-repo.1  (file://${BASEDIR}/archive.tgz)
@@ -235,7 +233,7 @@ SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-sw
 SYSTEM                          copydir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1 -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1
 SYSTEM                          copy ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1/content -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/content
-SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/xspre/xshash -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/x-source.main-repo.1
+SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/x-source.main-repo.1
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/x-file.main-repo.1
 Processing  2/3: [main-repo: touch build-file]
@@ -266,7 +264,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-swi
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/backup/state-today.export
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
-### opam reinstall main-repo.1 | sed-cmd tar cp touch mkdir | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash | "${PRE_XSMD5}[^[:alnum:]].?${XSMD5}" -> xspre/xshash | unordered
+### opam reinstall main-repo.1 | sed-cmd tar cp touch mkdir | sed-hash $MD5 md5 | sed-hash $XSMD5 xs-hash | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -293,7 +291,7 @@ SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switc
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/4: [main-repo.1: extract]
-+ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/hash" "-C" "${OPAMTMP}"
++ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/+md5+" "-C" "${OPAMTMP}"
 SYSTEM                          copydir ${OPAMTMP} -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1
 SYSTEM                          copy ${OPAMTMP}/content -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1/content
 SYSTEM                          rmdir ${OPAMTMP}
@@ -302,10 +300,10 @@ SYSTEM                          rm ${OPAMTMP}/content
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/content
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/x-source.main-repo.1
-SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/xspre/xshash -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/x-source.main-repo.1
+SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/x-source.main-repo.1
+SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1/x-source.main-repo.1
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/x-file.main-repo.1
-SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/xspre/xshash -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1/x-source.main-repo.1
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1/x-file.main-repo.1
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
@@ -363,7 +361,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-swi
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/backup/state-today.export
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
-### opam upgrade main-repo | sed-cmd tar touch mkdir cp | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash | "${PRE_XSMD5}[^[:alnum:]].?${XSMD5}" -> xspre/xshash | unordered
+### opam upgrade main-repo | sed-cmd tar touch mkdir cp | sed-hash $MD5 md5 | sed-hash $XSMD5 xs-hash | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -389,7 +387,7 @@ SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-sw
 SYSTEM                          mkdir ${OPAMTMP}
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/4: [main-repo.1, main-repo.2: extract]
-+ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/hash" "-C" "${OPAMTMP}"
++ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/+md5+" "-C" "${OPAMTMP}"
 SYSTEM                          copydir ${OPAMTMP} -> ${OPAMTMP}
 SYSTEM                          copy ${OPAMTMP}/content -> ${OPAMTMP}/content
 SYSTEM                          rmdir ${OPAMTMP}
@@ -409,10 +407,10 @@ SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-sw
 SYSTEM                          copydir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2 -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2
 SYSTEM                          copy ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2/content -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2/content
-SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/xspre/xshash -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2/x-source.main-repo.2
+SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2/x-source.main-repo.2
+SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1/x-source.main-repo.1
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files/x-file.main-repo.2
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2/x-file.main-repo.2
-SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/xspre/xshash -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1/x-source.main-repo.1
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1/x-file.main-repo.1
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files/x-file.main-repo.2
@@ -472,7 +470,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-swi
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/backup/state-today.export
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
-### opam remove main-repo | sed-cmd tar touch | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash | "${PRE_XSMD5}[^[:alnum:]].?${XSMD5}" -> xspre/xshash | unordered
+### opam remove main-repo | sed-cmd tar touch | sed-hash $MD5 md5 | sed-hash $XSMD5 xs-hash | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -501,7 +499,7 @@ SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switc
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/2: [main-repo.2: extract]
-+ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/hash" "-C" "${OPAMTMP}"
++ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/+md5+" "-C" "${OPAMTMP}"
 SYSTEM                          copydir ${OPAMTMP} -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2
 SYSTEM                          copy ${OPAMTMP}/content -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2/content
 SYSTEM                          rmdir ${OPAMTMP}
@@ -511,7 +509,7 @@ SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-sw
 SYSTEM                          copydir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2 -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2
 SYSTEM                          copy ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.2/content -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2/content
-SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/xspre/xshash -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2/x-source.main-repo.2
+SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2/x-source.main-repo.2
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files/x-file.main-repo.2
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2/x-file.main-repo.2
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2/x-source.main-repo.2
@@ -677,6 +675,7 @@ SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [main-ppin.dev: rsync]
 + rsync "-rLptgoDvc" "--exclude" ".git" "--exclude" "_darcs" "--exclude" ".hg" "--exclude" ".#*" "--exclude" "_opam*" "--exclude" "_build" "--delete" "--delete-excluded" "${BASEDIR}/main-ppin/" "${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin"
 - 
+- 
 SYSTEM                          rmdir ${OPAMTMP}
 [main-ppin.dev] synchronised (no changes)
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/reinstall
@@ -697,7 +696,6 @@ Processing  1/3: [main-ppin.dev: rsync]
 + rsync "-rLptgoDvc" "--exclude" ".git" "--exclude" "_darcs" "--exclude" ".hg" "--exclude" ".#*" "--exclude" "_opam*" "--exclude" "_build" "--delete" "--delete-excluded" "${BASEDIR}/main-ppin/" "${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin"
 - content
 - main-ppin.opam
-- 
 SYSTEM                          rmdir ${OPAMTMP}
 -> retrieved main-ppin.dev  (file://${BASEDIR}/main-ppin)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/build/main-ppin.dev
@@ -755,6 +753,7 @@ SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [main-ppin.dev: rsync]
 + rsync "-rLptgoDvc" "--exclude" ".git" "--exclude" "_darcs" "--exclude" ".hg" "--exclude" ".#*" "--exclude" "_opam*" "--exclude" "_build" "--delete" "--delete-excluded" "${BASEDIR}/main-ppin/" "${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin"
 - 
+- 
 SYSTEM                          rmdir ${OPAMTMP}
 [main-ppin.dev] synchronised (no changes)
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/reinstall
@@ -769,7 +768,6 @@ FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-path-pin-all/.
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/4: [main-ppin.dev: rsync]
 + rsync "-rLptgoDvc" "--exclude" ".git" "--exclude" "_darcs" "--exclude" ".hg" "--exclude" ".#*" "--exclude" "_opam*" "--exclude" "_build" "--delete" "--delete-excluded" "${BASEDIR}/main-ppin/" "${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin"
-- 
 SYSTEM                          rmdir ${OPAMTMP}
 -> retrieved main-ppin.dev  (no changes)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/build/main-ppin.dev
@@ -1039,6 +1037,7 @@ SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [main-ppin.dev: rsync]
 + rsync "-rLptgoDvc" "--exclude" ".git" "--exclude" "_darcs" "--exclude" ".hg" "--exclude" ".#*" "--exclude" "_opam*" "--exclude" "_build" "--delete" "--delete-excluded" "${BASEDIR}/main-ppin/" "${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin"
 - 
+- 
 SYSTEM                          rmdir ${OPAMTMP}
 [main-ppin.dev] synchronised (no changes)
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/reinstall
@@ -1053,7 +1052,6 @@ FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-path-pin-all/.
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/4: [main-ppin.dev: rsync]
 + rsync "-rLptgoDvc" "--exclude" ".git" "--exclude" "_darcs" "--exclude" ".hg" "--exclude" ".#*" "--exclude" "_opam*" "--exclude" "_build" "--delete" "--delete-excluded" "${BASEDIR}/main-ppin/" "${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin"
-- 
 SYSTEM                          rmdir ${OPAMTMP}
 -> retrieved main-ppin.dev  (no changes)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/build/main-ppin.dev
@@ -1976,7 +1974,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.o
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/backup/state-today.export
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
-### opam install main-repo | grep -v '^- ./$' | sed-cmd tar rsync cp touch mkdir | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash | "${PRE_XSMD5}[^[:alnum:]].?${XSMD5}" -> xspre/xshash
+### opam install main-repo | grep -v '^- ./$' | sed-cmd tar rsync cp touch mkdir | sed-hash $MD5 md5 | sed-hash $XSMD5 xs-hash
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -2001,7 +1999,7 @@ The following actions will be performed:
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/3: [main-repo.1: extract]
-+ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/hash" "-C" "${OPAMTMP}"
++ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/+md5+" "-C" "${OPAMTMP}"
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources
 SYSTEM                          copydir ${OPAMTMP} -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo
@@ -2013,7 +2011,7 @@ SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-version-pin/.
 SYSTEM                          copydir ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1
 SYSTEM                          copy ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo/content -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1/content
-SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/xspre/xshash -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1/x-source.main-repo.1
+SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1/x-source.main-repo.1
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1/x-file.main-repo.1
 Processing  2/3: [main-repo: touch build-file]
@@ -2044,7 +2042,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.o
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/backup/state-today.export
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
-### opam reinstall main-repo | grep -v '^- ./$' | sed-cmd tar rsync cp touch mkdir | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash | "${PRE_XSMD5}[^[:alnum:]].?${XSMD5}" -> xspre/xshash | unordered
+### opam reinstall main-repo | grep -v '^- ./$' | sed-cmd tar rsync cp touch mkdir | sed-hash $MD5 md5 | sed-hash $XSMD5 xs-hash | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -2071,7 +2069,7 @@ SYSTEM                          rm ${BASEDIR}/OPAM/install-from-version-pin/.opa
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/4: [main-repo.1: extract]
-+ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/hash" "-C" "${OPAMTMP}"
++ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/+md5+" "-C" "${OPAMTMP}"
 SYSTEM                          copydir ${OPAMTMP} -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo
 SYSTEM                          copy ${OPAMTMP}/content -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo/content
 SYSTEM                          rmdir ${OPAMTMP}
@@ -2080,10 +2078,10 @@ SYSTEM                          rm ${OPAMTMP}/content
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1/content
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1/x-source.main-repo.1
-SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/xspre/xshash -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1/x-source.main-repo.1
+SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1/x-source.main-repo.1
+SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/remove/main-repo.1/x-source.main-repo.1
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1/x-file.main-repo.1
-SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/xspre/xshash -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/remove/main-repo.1/x-source.main-repo.1
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/remove/main-repo.1/x-file.main-repo.1
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
@@ -2141,7 +2139,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.o
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/backup/state-today.export
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
-### opam remove main-repo | grep -v '^- ./$' | sed-cmd tar rsync touch | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash | "${PRE_XSMD5}[^[:alnum:]].?${XSMD5}" -> xspre/xshash | unordered
+### opam remove main-repo | grep -v '^- ./$' | sed-cmd tar rsync touch | sed-hash $MD5 md5 | sed-hash $XSMD5 xs-hash | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -2168,7 +2166,7 @@ SYSTEM                          rm ${BASEDIR}/OPAM/install-from-version-pin/.opa
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/2: [main-repo.1: extract]
-+ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/hash" "-C" "${OPAMTMP}"
++ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/+md5+" "-C" "${OPAMTMP}"
 SYSTEM                          copydir ${OPAMTMP} -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo
 SYSTEM                          copy ${OPAMTMP}/content -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo/content
 SYSTEM                          rmdir ${OPAMTMP}
@@ -2178,7 +2176,7 @@ SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-version-pin/.
 SYSTEM                          copydir ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/remove/main-repo.1
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/remove/main-repo.1
 SYSTEM                          copy ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo/content -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/remove/main-repo.1/content
-SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/xspre/xshash -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/remove/main-repo.1/x-source.main-repo.1
+SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/remove/main-repo.1/x-source.main-repo.1
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/remove/main-repo.1/x-file.main-repo.1
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/remove/main-repo.1/x-source.main-repo.1
@@ -2249,7 +2247,7 @@ Usage: opam switch [OPTION]… [COMMAND] [ARG]…
 Try 'opam switch --help' or 'opam --help' for more information.
 # Return code 2 #
 ### :III:2: with package
-### opam switch create package-switch --package main-repo | grep -v '^- ./$' | sed-cmd rsync tar cp touch mkdir | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash | "md5[^[:alnum:]].?${PRE_MD5}" -> md5/pre | "${PRE_XSMD5}[^[:alnum:]].?${XSMD5}" -> xspre/xshash
+### opam switch create package-switch --package main-repo | grep -v '^- ./$' | sed-cmd rsync tar cp touch mkdir | sed-hash $MD5 md5 | sed-hash $XSMD5 xs-hash
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => write)
@@ -2298,7 +2296,7 @@ FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/package-switch/.opam
 SYSTEM                          rmdir ${BASEDIR}/OPAM/package-switch/.opam-switch/sources/main-repo.2
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/3: [main-repo.2: extract]
-+ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/hash" "-C" "${OPAMTMP}"
++ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/+md5+" "-C" "${OPAMTMP}"
 SYSTEM                          mkdir ${BASEDIR}/OPAM/package-switch/.opam-switch/sources
 SYSTEM                          copydir ${OPAMTMP} -> ${BASEDIR}/OPAM/package-switch/.opam-switch/sources/main-repo.2
 SYSTEM                          mkdir ${BASEDIR}/OPAM/package-switch/.opam-switch/sources/main-repo.2
@@ -2310,7 +2308,7 @@ SYSTEM                          rmdir ${BASEDIR}/OPAM/package-switch/.opam-switc
 SYSTEM                          copydir ${BASEDIR}/OPAM/package-switch/.opam-switch/sources/main-repo.2 -> ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2
 SYSTEM                          mkdir ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2
 SYSTEM                          copy ${BASEDIR}/OPAM/package-switch/.opam-switch/sources/main-repo.2/content -> ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2/content
-SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/xspre/xshash -> ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2/x-source.main-repo.2
+SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2/x-source.main-repo.2
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files/x-file.main-repo.2
 SYSTEM                          write ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2/x-file.main-repo.2
 Processing  2/3: [main-repo: touch build-file]

--- a/tests/reftests/admin-cache.test
+++ b/tests/reftests/admin-cache.test
@@ -53,29 +53,17 @@ done
 ### rm -rf cache
 ### : computes hashes
 ### openssl md5 arch-ipsum.tgz | '.*= ' -> '' >$ IP_MD5
-### sh -c "echo '$IP_MD5' | cut -c 1-2" >$ PRE_IP_MD5
 ### openssl sha256 arch-ipsum.tgz | '.*= ' -> '' >$ IP_SHA256
-### sh -c "echo '$IP_SHA256' | cut -c 1-2" >$ PRE_IP_SHA256
 ### openssl sha512 arch-ipsum.tgz | '.*= ' -> '' >$ IP_SHA512
-### sh -c "echo '$IP_SHA512' | cut -c 1-2" >$ PRE_IP_SHA512
 ### openssl md5 arch-dolor.tgz | '.*= ' -> '' >$ DL_MD5
-### sh -c "echo '$DL_MD5' | cut -c 1-2" >$ PRE_DL_MD5
 ### openssl sha256 arch-dolor.tgz | '.*= ' -> '' >$ DL_SHA256
-### sh -c "echo '$DL_SHA256' | cut -c 1-2" >$ PRE_DL_SHA256
 ### openssl sha512 arch-dolor.tgz | '.*= ' -> '' >$ DL_SHA512
-### sh -c "echo '$DL_SHA512' | cut -c 1-2" >$ PRE_DL_SHA512
 ### openssl md5 arch-sit.tgz | '.*= ' -> '' >$ ST_MD5
-### sh -c "echo '$ST_MD5' | cut -c 1-2" >$ PRE_ST_MD5
 ### openssl sha256 arch-sit.tgz | '.*= ' -> '' >$ ST_SHA256
-### sh -c "echo '$ST_SHA256' | cut -c 1-2" >$ PRE_ST_SHA256
 ### openssl sha512 arch-sit.tgz | '.*= ' -> '' >$ ST_SHA512
-### sh -c "echo '$ST_SHA512' | cut -c 1-2" >$ PRE_ST_SHA512
 ### openssl md5 arch-amet.tgz | '.*= ' -> '' >$ MT_MD5
-### sh -c "echo '$MT_MD5' | cut -c 1-2" >$ PRE_MT_MD5
 ### openssl sha256 arch-amet.tgz | '.*= ' -> '' >$ MT_SHA256
-### sh -c "echo '$MT_SHA256' | cut -c 1-2" >$ PRE_MT_SHA256
 ### openssl sha512 arch-amet.tgz | '.*= ' -> '' >$ MT_SHA512
-### sh -c "echo '$MT_SHA512' | cut -c 1-2" >$ PRE_MT_SHA512
 ### <analysi.sh>
 pkg=$1
 kind=$2
@@ -269,15 +257,15 @@ mv "$file.tmp" "$file"
 ### sh sedi.sh '/"sha512=.*/d' packages/dolor/dolor.1/opam
 ### sh sedi.sh '/"md5=.*/d' packages/sit/sit.1/opam
 ### sh sedi.sh '/"sha512=.*/d' packages/sit/sit.1/opam
-### opam show --just-file ./packages/ipsum/ipsum.1/opam --field url.src,url.checksum | "${IP_MD5}" -> IP_MD5
+### opam show --just-file ./packages/ipsum/ipsum.1/opam --field url.src,url.checksum | sed-hash $IP_MD5 ip-md5
 url.src:      file://${BASEDIR}/arch-ipsum.tgz
-url.checksum: md5=IP_MD5
-### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | "${DL_MD5}" -> DL_MD5 | "${DL_SHA256}" -> DL_SHA256
+url.checksum: md5=+ip-md5+
+### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | sed-hash $DL_MD5 dl-md5 | sed-hash $DL_SHA256 dl-sha256
 url.src:      file://${BASEDIR}/arch-dolor.tgz
-url.checksum: md5=DL_MD5, sha256=DL_SHA256
-### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | "${ST_SHA256}" -> ST_SHA256
+url.checksum: md5=+dl-md5+, sha256=+dl-sha256+
+### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | sed-hash $ST_SHA256 st-sha256
 url.src:      file://${BASEDIR}/arch-sit.tgz
-url.checksum: sha256=ST_SHA256
+url.checksum: sha256=+st-sha256+
 ### rm -rf cache
 ### opam admin cache | unordered
 [dolor.1] synchronised (file://${BASEDIR}/arch-dolor.tgz)
@@ -307,15 +295,15 @@ amet : sha512 : exists
 ### opam admin add-hashes md5    --package sit
 [file://${BASEDIR}/arch-sit.tgz] found in cache
 ### opam admin add-hashes sha512 --package sit
-### opam show --just-file ./packages/ipsum/ipsum.1/opam --field url.src,url.checksum | "${IP_MD5}" -> IP_MD5 | "${IP_SHA512}" -> IP_SHA512
+### opam show --just-file ./packages/ipsum/ipsum.1/opam --field url.src,url.checksum | sed-hash $IP_MD5 ip-md5 | sed-hash $IP_SHA512 ip-sha512
 url.src:      file://${BASEDIR}/arch-ipsum.tgz
-url.checksum: md5=IP_MD5, sha512=IP_SHA512
-### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | "${DL_MD5}" -> DL_MD5 | "${DL_SHA256}" -> DL_SHA256 | "${DL_SHA512}" -> DL_SHA512
+url.checksum: md5=+ip-md5+, sha512=+ip-sha512+
+### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | sed-hash $DL_MD5 dl-md5 | sed-hash $DL_SHA256 dl-sha256 | sed-hash $DL_SHA512 dl-sha512
 url.src:      file://${BASEDIR}/arch-dolor.tgz
-url.checksum: md5=DL_MD5, sha256=DL_SHA256, sha512=DL_SHA512
-### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | "${ST_MD5}" -> ST_MD5 | "${ST_SHA256}" -> ST_SHA256 | "${ST_SHA512}" -> ST_SHA512
+url.checksum: md5=+dl-md5+, sha256=+dl-sha256+, sha512=+dl-sha512+
+### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | sed-hash $ST_SHA256 st-sha256 | sed-hash $ST_MD5 st-md5 | sed-hash $ST_SHA512 st-sha512
 url.src:      file://${BASEDIR}/arch-sit.tgz
-url.checksum: sha256=ST_SHA256, md5=ST_MD5, sha512=ST_SHA512
+url.checksum: sha256=+st-sha256+, md5=+st-md5+, sha512=+st-sha512+
 ### sh cache-analysi.sh
 ipsum : md5 : exists
 ipsum : sha256 : not found
@@ -368,9 +356,7 @@ opam-version: "2.0"
 ### openssl md5 arch-lorem.tgz | '.*= ' -> '' >$ LR_MD5
 ### sh -c "echo '$LR_MD5' | cut -c 1-2" >$ PRE_LR_MD5
 ### openssl sha256 arch-lorem.tgz | '.*= ' -> '' >$ LR_SHA256
-### sh -c "echo '$LR_SHA256' | cut -c 1-2" >$ PRE_LR_SHA256
 ### openssl sha512 arch-lorem.tgz | '.*= ' -> '' >$ LR_SHA512
-### sh -c "echo '$LR_SHA512' | cut -c 1-2" >$ PRE_LR_SHA512
 ### openssl md5 arch-evil.tgz | "${LR_MD5}" -> LR_MD5
 MD5(arch-evil.tgz)= LR_MD5
 ### sh add-urls.sh lorem
@@ -401,11 +387,11 @@ lorem : sha512 : not found
 lorem : md5 : exists
 lorem : sha256 : exists, link to md5
 lorem : sha512 : not found
-### opam admin cache | "${LR_MD5}" -> LR_MD5 | "${LR_SHA256}" -> LR_SHA256 | "${LR_SHA512}" -> LR_SHA512
+### opam admin cache | sed-hash $LR_SHA512 lr-sha512 | sed-hash $LR_SHA256 lr-sha256 | sed-hash $LR_MD5 lr-md5
 [ERROR] Conflicting file hashes, or broken or compromised cache!
-          - sha512=LR_SHA512 (MISMATCH)
-          - sha256=LR_SHA256 (MISMATCH)
-          - md5=LR_MD5 (match)
+          - sha512=+lr-sha512+ (MISMATCH)
+          - sha256=+lr-sha256+ (MISMATCH)
+          - md5=+lr-md5+ (match)
 
 [lorem.1] synchronised (file://${BASEDIR}/arch-lorem.tgz)
 Done.

--- a/tests/reftests/admin.test
+++ b/tests/reftests/admin.test
@@ -589,12 +589,18 @@ else
 fi
 ### sh add-urls.sh arch1 0 dolor
 ### sh add-urls.sh arch2 1 sit
-### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | "=[0-9a-f]\+\(,\|$\)" -> =HASH
+### openssl md5 arch1.tgz | '.*= ' -> '' >$ ARCH1_MD5
+### openssl sha256 arch1.tgz | '.*= ' -> '' >$ ARCH1_SHA256
+### openssl sha512 arch1.tgz | '.*= ' -> '' >$ ARCH1_SHA512
+### openssl md5 arch2.tgz | '.*= ' -> '' >$ ARCH2_MD5
+### openssl sha256 arch2.tgz | '.*= ' -> '' >$ ARCH2_SHA256
+### openssl sha512 arch2.tgz | '.*= ' -> '' >$ ARCH2_SHA512
+### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum
 url.src:      file://${BASEDIR}/arch1.tgz
 url.checksum:
-### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | "=[0-9a-f]\+\(,\|$\)" -> =HASH
+### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | sed-hash $ARCH2_MD5 arch2-md5
 url.src:      file://${BASEDIR}/arch2.tgz
-url.checksum: md5=HASH
+url.checksum: md5=+arch2-md5+
 ### sh check-hash-ca.sh
 root: OPAM
 no hash-cache
@@ -607,12 +613,12 @@ sha256_to_md5: 0
 sha256_to_sha512: 0
 sha512_to_md5: 0
 sha512_to_sha256: 0
-### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | "=[0-9a-f]\+\(,\|$\)" -> =HASH
+### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | sed-hash $ARCH1_MD5 arch1-md5
 url.src:      file://${BASEDIR}/arch1.tgz
-url.checksum: md5=HASH
-### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | "=[0-9a-f]\+\(,\|$\)" -> =HASH
+url.checksum: md5=+arch1-md5+
+### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | sed-hash $ARCH2_MD5 arch2-md5
 url.src:      file://${BASEDIR}/arch2.tgz
-url.checksum: md5=HASH
+url.checksum: md5=+arch2-md5+
 ### opam admin add-hashes sha256 --packages not-found,dolor,sit.1,sit.2,sed,sed.2
 [WARNING] Not found packages not-found, sit.2 and sed.2. Ignoring them.
 ### sh check-hash-ca.sh
@@ -623,13 +629,13 @@ sha256_to_md5: 0
 sha256_to_sha512: 0
 sha512_to_md5: 0
 sha512_to_sha256: 0
-### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | "=[0-9a-f]\+\(,\|$\)" -> =HASH
+### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | sed-hash $ARCH1_MD5 arch1-md5 | sed-hash $ARCH1_SHA256 arch1-sha256
 url.src:      file://${BASEDIR}/arch1.tgz
-url.checksum: md5=HASH sha256=HASH
-### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | "=[0-9a-f]\+\(,\|$\)" -> =HASH
+url.checksum: md5=+arch1-md5+, sha256=+arch1-sha256+
+### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | sed-hash $ARCH2_MD5 arch2-md5 | sed-hash $ARCH2_SHA256 arch2-sha256
 url.src:      file://${BASEDIR}/arch2.tgz
-url.checksum: md5=HASH sha256=HASH
-### opam show --just-file ./packages/sed/sed.1/opam --field url.src,url.checksum | "=[0-9a-f]\+\(,\|$\)" -> =HASH
+url.checksum: md5=+arch2-md5+, sha256=+arch2-sha256+
+### opam show --just-file ./packages/sed/sed.1/opam --field url.src,url.checksum
 url.src:
 url.checksum:
 ### rm -r packages/an-old-package
@@ -644,12 +650,12 @@ sha256_to_md5: 0
 sha256_to_sha512: 2
 sha512_to_md5: 0
 sha512_to_sha256: 0
-### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | "=[0-9a-f]\+\(,\|$\)" -> =HASH
+### opam show --just-file ./packages/dolor/dolor.1/opam --field url.src,url.checksum | sed-hash $ARCH1_MD5 arch1-md5 | sed-hash $ARCH1_SHA256 arch1-sha256 | sed-hash $ARCH1_SHA512 arch1-sha512
 url.src:      file://${BASEDIR}/arch1.tgz
-url.checksum: md5=HASH sha256=HASH sha512=HASH
-### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | "=[0-9a-f]\+\(,\|$\)" -> =HASH
+url.checksum: md5=+arch1-md5+, sha256=+arch1-sha256+, sha512=+arch1-sha512+
+### opam show --just-file ./packages/sit/sit.1/opam --field url.src,url.checksum | sed-hash $ARCH2_MD5 arch2-md5 | sed-hash $ARCH2_SHA256 arch2-sha256 | sed-hash $ARCH2_SHA512 arch2-sha512
 url.src:      file://${BASEDIR}/arch2.tgz
-url.checksum: md5=HASH sha256=HASH sha512=HASH
+url.checksum: md5=+arch2-md5+, sha256=+arch2-sha256+, sha512=+arch2-sha512+
 ### opam lint --check-upstream ./packages/dolor/dolor.1/opam ./packages/sit/sit.1/opam
 ${BASEDIR}/packages/dolor/dolor.1/opam: Passed.
 ${BASEDIR}/packages/sit/sit.1/opam: Passed.
@@ -691,8 +697,8 @@ sed -i.bak "s/xf-md5/$XF_MD5/" packages/with-xf/with-xf.1/opam
 sed -i.bak "s/xf-sha/$XF_SHA256/" packages/with-xf/with-xf.1/opam
 ### sh hash-xf.sh
 ### opam admin update-extrafiles
-### opam-cat packages/with-xf/with-xf.1/opam | "${XF_MD5}" -> "good-md5" | "${XF_SHA256}" -> "good-sha"
-extra-files: [["bad-md5" "md5=good-md5"] ["bad-sha" "sha256=good-sha"] ["good-md5" "md5=good-md5"] ["good-sha" "sha256=good-sha"] ["missing-hash" "md5=good-md5"]]
+### opam-cat packages/with-xf/with-xf.1/opam | sed-hash $XF_MD5 xf-md5 | sed-hash $XF_SHA256 xf-sha256
+extra-files: [["bad-md5" "md5=+xf-md5+"] ["bad-sha" "sha256=+xf-sha256+"] ["good-md5" "md5=+xf-md5+"] ["good-sha" "sha256=+xf-sha256+"] ["missing-hash" "md5=+xf-md5+"]]
 opam-version: "2.0"
 ### <packages/with-xf/with-xf.1/opam>
 opam-version: "2.0"
@@ -704,16 +710,16 @@ extra-files: [
 ]
 ### sh hash-xf.sh
 ### opam admin update-extrafiles --hash sha256
-### opam-cat packages/with-xf/with-xf.1/opam | "${XF_MD5}" -> "good-md5" | "${XF_SHA256}" -> "good-sha"
-extra-files: [["bad-md5" "sha256=good-sha"] ["bad-sha" "sha256=good-sha"] ["good-md5" "sha256=good-sha"] ["good-sha" "sha256=good-sha"] ["missing-hash" "sha256=good-sha"]]
+### opam-cat packages/with-xf/with-xf.1/opam | sed-hash $XF_MD5 xf-md5 | sed-hash $XF_SHA256 xf-sha256
+extra-files: [["bad-md5" "sha256=+xf-sha256+"] ["bad-sha" "sha256=+xf-sha256+"] ["good-md5" "sha256=+xf-sha256+"] ["good-sha" "sha256=+xf-sha256+"] ["missing-hash" "sha256=+xf-sha256+"]]
 opam-version: "2.0"
 ### <packages/with-xf/with-xf.2/opam>
 opam-version: "2.0"
 ### mkdir -p packages/with-xf/with-xf.2/files
 ### cp packages/with-xf/with-xf.1/files/good-md5 packages/with-xf/with-xf.2/files/missing-hash
 ### opam admin update-extrafiles
-### opam-cat packages/with-xf/with-xf.2/opam | "${XF_MD5}" -> "good-md5" | "${XF_SHA256}" -> "good-sha"
-extra-files: ["missing-hash" "md5=good-md5"]
+### opam-cat packages/with-xf/with-xf.2/opam | sed-hash $XF_MD5 xf-md5
+extra-files: ["missing-hash" "md5=+xf-md5+"]
 opam-version: "2.0"
 ### ::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ### :: Cache is tested in admin-cache.test ::

--- a/tests/reftests/archive.test
+++ b/tests/reftests/archive.test
@@ -497,26 +497,26 @@ Successfully extracted to ${BASEDIR}/no-checksum.1
 ### opam clean --download-cache
 Clearing cache of downloaded files
 ### :I:6: multiple md5
-### opam lint --package multiple-md5
+### opam lint --package multiple-md5 | sed-hash $ARCHIVE_MD5 archive-md5
 <default>/multiple-md5.1: Errors.
              error 71: Field 'url.checksum' contains duplicated checksums: "md5: 2 occurences"
 # Return code 1 #
-### opam lint --package multiple-md5 --check-upstream | '[0-9a-z]{32}' -> 'hash'
+### opam lint --package multiple-md5 --check-upstream | sed-hash $ARCHIVE_MD5 archive-md5
 <default>/multiple-md5.1: Errors.
              error 60: Upstream check failed: "The archive doesn't match checksum:
-                - archive: md5=hash, in opam file: md5=hash
+                - archive: md5=+archive-md5+, in opam file: md5=00000000000000000000000000000000
               ."
              error 71: Field 'url.checksum' contains duplicated checksums: "md5: 2 occurences"
 # Return code 1 #
-### opam install multiple-md5 | '[0-9a-z]{32}' -> 'hash'
+### opam install multiple-md5 | sed-hash $ARCHIVE_MD5 archive-md5
 The following actions will be performed:
 === install 1 package
   - install multiple-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] multiple-md5.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Failed to get sources of multiple-md5.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -528,15 +528,15 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam install multiple-md5 --require-checksums | '[0-9a-z]{32}' -> 'hash'
+### opam install multiple-md5 --require-checksums | sed-hash $ARCHIVE_MD5 archive-md5
 The following actions will be performed:
 === install 1 package
   - install multiple-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] multiple-md5.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Failed to get sources of multiple-md5.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -548,18 +548,18 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam source multiple-md5 | '[0-9a-z]{32}' -> 'hash'
+### opam source multiple-md5 | sed-hash $ARCHIVE_MD5 archive-md5
 [ERROR] multiple-md5.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f multiple-md5.1/hello
 # Return code 1 #
-### opam source multiple-md5 --require-checksums | '[0-9a-z]{32}' -> 'hash'
+### opam source multiple-md5 --require-checksums | sed-hash $ARCHIVE_MD5 archive-md5
 [ERROR] multiple-md5.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f multiple-md5.1/hello
@@ -569,21 +569,21 @@ Clearing cache of downloaded files
 ### :I:7: bad md5
 ### opam lint --package bad-md5
 <default>/bad-md5.1: Passed.
-### opam lint --package bad-md5 --check-upstream | '[0-9a-z]{32}' -> 'hash'
+### opam lint --package bad-md5 --check-upstream | sed-hash $ARCHIVE_MD5 archive-md5
 <default>/bad-md5.1: Errors.
              error 60: Upstream check failed: "The archive doesn't match checksum:
-                - archive: md5=hash, in opam file: md5=hash
+                - archive: md5=+archive-md5+, in opam file: md5=00000000000000000000000000000000
               ."
 # Return code 1 #
-### opam install bad-md5 | '[0-9a-z]{32}' -> 'hash'
+### opam install bad-md5 | sed-hash $ARCHIVE_MD5 archive-md5
 The following actions will be performed:
 === install 1 package
   - install bad-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] bad-md5.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Failed to get sources of bad-md5.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -595,15 +595,15 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam install bad-md5 --require-checksums | '[0-9a-z]{32}' -> 'hash'
+### opam install bad-md5 --require-checksums | sed-hash $ARCHIVE_MD5 archive-md5
 The following actions will be performed:
 === install 1 package
   - install bad-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] bad-md5.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Failed to get sources of bad-md5.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -615,18 +615,18 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam source bad-md5 | '[0-9a-z]{32}' -> 'hash'
+### opam source bad-md5 | sed-hash $ARCHIVE_MD5 archive-md5
 [ERROR] bad-md5.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f bad-md5.1/hello
 # Return code 1 #
-### opam source bad-md5 --require-checksums | '[0-9a-z]{32}' -> 'hash'
+### opam source bad-md5 --require-checksums | sed-hash $ARCHIVE_MD5 archive-md5
 [ERROR] bad-md5.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f bad-md5.1/hello
@@ -636,10 +636,10 @@ Clearing cache of downloaded files
 ### :I:8: good md5 & bad sha256
 ### opam lint --package good-md5-bad-sha256
 <default>/good-md5-bad-sha256.1: Passed.
-### opam lint --package good-md5-bad-sha256 --check-upstream | '[0-9a-z]{64}' -> 'hash'
+### opam lint --package good-md5-bad-sha256 --check-upstream | sed-hash $ARCHIVE_SHA256 archive-sha256
 <default>/good-md5-bad-sha256.1: Errors.
              error 60: Upstream check failed: "The archive doesn't match checksum:
-                - archive: sha256=hash, in opam file: sha256=hash
+                - archive: sha256=+archive-sha256+, in opam file: sha256=0000000000000000000000000000000000000000000000000000000000000000
               ."
 # Return code 1 #
 ### opam reinstall good-md5
@@ -655,19 +655,19 @@ Done.
 ### sh check-cache.sh
 MD5: archive, with matching checksum
 SHA256: not found
-### opam install good-md5-bad-sha256 | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-md5-bad-sha256 | sed-hash $ARCHIVE_MD5 archive-md5 | sed-hash $ARCHIVE_SHA256 archive-sha256
 The following actions will be performed:
 === install 1 package
   - install good-md5-bad-sha256 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] Conflicting file hashes, or broken or compromised cache!
-          - md5=hash (match)
-          - sha256=hash (MISMATCH)
+          - md5=+archive-md5+ (match)
+          - sha256=0000000000000000000000000000000000000000000000000000000000000000 (MISMATCH)
 
 [ERROR] good-md5-bad-sha256.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected sha256=hash
-          got      sha256=hash
+          expected sha256=0000000000000000000000000000000000000000000000000000000000000000
+          got      sha256=+archive-sha256+
 [ERROR] Failed to get sources of good-md5-bad-sha256.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -705,19 +705,19 @@ Done.
 ### sh check-cache.sh
 MD5: archive, with matching checksum
 SHA256: archive, with matching checksum
-### opam install good-md5-bad-sha256 | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-md5-bad-sha256 | sed-hash $ARCHIVE_MD5 archive-md5 | sed-hash $ARCHIVE_SHA256 archive-sha256
 The following actions will be performed:
 === install 1 package
   - install good-md5-bad-sha256 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] Conflicting file hashes, or broken or compromised cache!
-          - md5=hash (match)
-          - sha256=hash (MISMATCH)
+          - md5=+archive-md5+ (match)
+          - sha256=0000000000000000000000000000000000000000000000000000000000000000 (MISMATCH)
 
 [ERROR] good-md5-bad-sha256.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected sha256=hash
-          got      sha256=hash
+          expected sha256=0000000000000000000000000000000000000000000000000000000000000000
+          got      sha256=+archive-sha256+
 [ERROR] Failed to get sources of good-md5-bad-sha256.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -732,15 +732,15 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 ### sh check-cache.sh
 MD5: not found
 SHA256: archive, with matching checksum
-### opam install good-md5-bad-sha256 --require-checksums | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-md5-bad-sha256 --require-checksum | sed-hash $ARCHIVE_SHA256 archive-sha256
 The following actions will be performed:
 === install 1 package
   - install good-md5-bad-sha256 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] good-md5-bad-sha256.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected sha256=hash
-          got      sha256=hash
+          expected sha256=0000000000000000000000000000000000000000000000000000000000000000
+          got      sha256=+archive-sha256+
 [ERROR] Failed to get sources of good-md5-bad-sha256.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -752,18 +752,18 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam source good-md5-bad-sha256 | '[0-9a-z]{64}' -> 'md5'
+### opam source good-md5-bad-sha256 | sed-hash $ARCHIVE_SHA256 archive-sha256 | sed-hash $ARCHIVE_SHA256 archive-sha256
 [ERROR] good-md5-bad-sha256.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected sha256=md5
-          got      sha256=md5
+          expected sha256=0000000000000000000000000000000000000000000000000000000000000000
+          got      sha256=+archive-sha256+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f good-md5-bad-sha256.1/hello
 # Return code 1 #
-### opam source good-md5-bad-sha256 --require-checksums | '[0-9a-z]{64}' -> 'md5'
+### opam source good-md5-bad-sha256 --require-checksums | sed-hash $ARCHIVE_SHA256 archive-sha256
 [ERROR] good-md5-bad-sha256.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected sha256=md5
-          got      sha256=md5
+          expected sha256=0000000000000000000000000000000000000000000000000000000000000000
+          got      sha256=+archive-sha256+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f good-md5-bad-sha256.1/hello
@@ -773,21 +773,21 @@ Clearing cache of downloaded files
 ### :I:9: good sha256 & bad md5
 ### opam lint --package good-sha256-bad-md5
 <default>/good-sha256-bad-md5.1: Passed.
-### opam lint --package good-sha256-bad-md5 --check-upstream | '[0-9a-z]{32}' -> 'hash'
+### opam lint --package good-sha256-bad-md5 --check-upstream | sed-hash $ARCHIVE_MD5 archive-md5
 <default>/good-sha256-bad-md5.1: Errors.
              error 60: Upstream check failed: "The archive doesn't match checksum:
-                - archive: md5=hash, in opam file: md5=hash
+                - archive: md5=+archive-md5+, in opam file: md5=00000000000000000000000000000000
               ."
 # Return code 1 #
-### opam install good-sha256-bad-md5 | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-sha256-bad-md5 | sed-hash $ARCHIVE_MD5 archive-md5
 The following actions will be performed:
 === install 1 package
   - install good-sha256-bad-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] good-sha256-bad-md5.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Failed to get sources of good-sha256-bad-md5.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -799,15 +799,15 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam install good-sha256-bad-md5 --require-checksums | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-sha256-bad-md5 --require-checksums | sed-hash $ARCHIVE_MD5 archive-md5
 The following actions will be performed:
 === install 1 package
   - install good-sha256-bad-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] good-sha256-bad-md5.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Failed to get sources of good-sha256-bad-md5.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -819,18 +819,18 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam source good-sha256-bad-md5 | '[0-9a-z]{32}' -> 'hash'
+### opam source good-sha256-bad-md5 | sed-hash $ARCHIVE_MD5 archive-md5
 [ERROR] good-sha256-bad-md5.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f good-sha256-bad-md5.1/hello
 # Return code 1 #
-### opam source good-sha256-bad-md5 --require-checksums | '[0-9a-z]{32}' -> 'hash'
+### opam source good-sha256-bad-md5 --require-checksums | sed-hash $ARCHIVE_MD5 archive-md5
 [ERROR] good-sha256-bad-md5.1: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f good-sha256-bad-md5.1/hello
@@ -842,38 +842,38 @@ Clearing cache of downloaded files
 <default>/clash-with-all-md5s.666: Errors.
              error 71: Field 'url.checksum' contains duplicated checksums: "md5: 17 occurences"
 # Return code 1 #
-### opam lint --package clash-with-all-md5s --check-upstream | '[0-9a-z]{32,64}' -> 'hash'
+### opam lint --package clash-with-all-md5s --check-upstream | sed-hash $ARCHIVE_MD5 archive-md5 | sed-hash $ARCHIVE_SHA256 archive-sha256
 <default>/clash-with-all-md5s.666: Errors.
              error 60: Upstream check failed: "The archive doesn't match checksums:
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: md5=hash, in opam file: md5=hash
-                - archive: sha256=hash, in opam file: sha256=hash
+                - archive: md5=+archive-md5+, in opam file: md5=00000000000000000000000000000000
+                - archive: md5=+archive-md5+, in opam file: md5=11111111111111111111111111111111
+                - archive: md5=+archive-md5+, in opam file: md5=22222222222222222222222222222222
+                - archive: md5=+archive-md5+, in opam file: md5=33333333333333333333333333333333
+                - archive: md5=+archive-md5+, in opam file: md5=44444444444444444444444444444444
+                - archive: md5=+archive-md5+, in opam file: md5=55555555555555555555555555555555
+                - archive: md5=+archive-md5+, in opam file: md5=66666666666666666666666666666666
+                - archive: md5=+archive-md5+, in opam file: md5=77777777777777777777777777777777
+                - archive: md5=+archive-md5+, in opam file: md5=88888888888888888888888888888888
+                - archive: md5=+archive-md5+, in opam file: md5=99999999999999999999999999999999
+                - archive: md5=+archive-md5+, in opam file: md5=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+                - archive: md5=+archive-md5+, in opam file: md5=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+                - archive: md5=+archive-md5+, in opam file: md5=cccccccccccccccccccccccccccccccc
+                - archive: md5=+archive-md5+, in opam file: md5=dddddddddddddddddddddddddddddddd
+                - archive: md5=+archive-md5+, in opam file: md5=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                - archive: md5=+archive-md5+, in opam file: md5=ffffffffffffffffffffffffffffffff
+                - archive: sha256=+archive-sha256+, in opam file: sha256=0123456789abcdeffedcba98765432100123456789abcdeffedbca9876543210
               ."
              error 71: Field 'url.checksum' contains duplicated checksums: "md5: 17 occurences"
 # Return code 1 #
-### opam install clash-with-all-md5s | '[0-9a-z]{32}' -> 'hash'
+### opam install clash-with-all-md5s | sed-hash $ARCHIVE_MD5 archive-md5
 The following actions will be performed:
 === install 1 package
   - install clash-with-all-md5s 666
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] clash-with-all-md5s.666: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Failed to get sources of clash-with-all-md5s.666: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -911,35 +911,35 @@ Done.
 ### sh check-cache.sh
 MD5: archive, with matching checksum
 SHA256: archive, with matching checksum
-### opam install clash-with-all-md5s | '[0-9a-z]{32,64}' -> 'hash'
+### opam install clash-with-all-md5s | sed-hash $ARCHIVE_MD5 archive-md5
 The following actions will be performed:
 === install 1 package
   - install clash-with-all-md5s 666
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] Conflicting file hashes, or broken or compromised cache!
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (match)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - sha256=hash (MISMATCH)
+          - md5=00000000000000000000000000000000 (MISMATCH)
+          - md5=11111111111111111111111111111111 (MISMATCH)
+          - md5=22222222222222222222222222222222 (MISMATCH)
+          - md5=33333333333333333333333333333333 (MISMATCH)
+          - md5=44444444444444444444444444444444 (MISMATCH)
+          - md5=+archive-md5+ (match)
+          - md5=55555555555555555555555555555555 (MISMATCH)
+          - md5=66666666666666666666666666666666 (MISMATCH)
+          - md5=77777777777777777777777777777777 (MISMATCH)
+          - md5=88888888888888888888888888888888 (MISMATCH)
+          - md5=99999999999999999999999999999999 (MISMATCH)
+          - md5=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (MISMATCH)
+          - md5=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb (MISMATCH)
+          - md5=cccccccccccccccccccccccccccccccc (MISMATCH)
+          - md5=dddddddddddddddddddddddddddddddd (MISMATCH)
+          - md5=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee (MISMATCH)
+          - md5=ffffffffffffffffffffffffffffffff (MISMATCH)
+          - sha256=0123456789abcdeffedcba98765432100123456789abcdeffedbca9876543210 (MISMATCH)
 
 [ERROR] clash-with-all-md5s.666: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Failed to get sources of clash-with-all-md5s.666: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -954,15 +954,15 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 ### sh check-cache.sh
 MD5: not found
 SHA256: archive, with matching checksum
-### opam install clash-with-all-md5s --require-checksums | '[0-9a-z]{32}' -> 'hash'
+### opam install clash-with-all-md5s --require-checksums | sed-hash $ARCHIVE_MD5 archive-md5
 The following actions will be performed:
 === install 1 package
   - install clash-with-all-md5s 666
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] clash-with-all-md5s.666: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Failed to get sources of clash-with-all-md5s.666: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -974,18 +974,18 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam source clash-with-all-md5s | '[0-9a-z]{32}' -> 'hash'
+### opam source clash-with-all-md5s | sed-hash $ARCHIVE_MD5 archive-md5
 [ERROR] clash-with-all-md5s.666: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f clash-with-all-md5s.666/hello
 # Return code 1 #
-### opam source clash-with-all-md5s --require-checksums | '[0-9a-z]{32}' -> 'hash'
+### opam source clash-with-all-md5s --require-checksums | sed-hash $ARCHIVE_MD5 archive-md5
 [ERROR] clash-with-all-md5s.666: Checksum mismatch for file://${BASEDIR}/archive.tgz:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+archive-md5+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f clash-with-all-md5s.666/hello
@@ -1122,15 +1122,15 @@ Done.
 MD5: archive, with matching checksum
 SHA256: archive, with mismatching checksum
 ### # what happens here is that sha256 is checked first, there is a mismatch on sha256 archive (checking its sha256 & md5), so it is remove, returns file not available, and then it downloads the archive from url
-### opam install good-sha256-good-md5 | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-sha256-good-md5 | sed-hash $ARCHIVE_MD5 archive-md5 | sed-hash $ARCHIVE_SHA256 archive-sha256
 The following actions will be performed:
 === install 1 package
   - install good-sha256-good-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] Conflicting file hashes, or broken or compromised cache!
-          - sha256=hash (MISMATCH)
-          - md5=hash (MISMATCH)
+          - sha256=+archive-sha256+ (MISMATCH)
+          - md5=+archive-md5+ (MISMATCH)
 
 -> retrieved good-sha256-good-md5.1  (file://${BASEDIR}/archive.tgz)
 -> installed good-sha256-good-md5.1
@@ -1154,15 +1154,15 @@ Done.
 ### sh check-cache.sh
 MD5: archive, with mismatching checksum
 SHA256: archive, with mismatching checksum
-### opam install good-sha256-good-md5 | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-sha256-good-md5 | sed-hash $ARCHIVE_MD5 archive-md | sed-hash $ARCHIVE_SHA256 archive-sha2565
 The following actions will be performed:
 === install 1 package
   - install good-sha256-good-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] Conflicting file hashes, or broken or compromised cache!
-          - sha256=hash (MISMATCH)
-          - md5=hash (MISMATCH)
+          - sha256=+archive-sha2565+ (MISMATCH)
+          - md5=+archive-md+ (MISMATCH)
 
 -> retrieved good-sha256-good-md5.1  (file://${BASEDIR}/archive.tgz)
 -> installed good-sha256-good-md5.1
@@ -1220,14 +1220,14 @@ Done.
 ### sh check-cache.sh
 MD5: link, to sha256 archive
 SHA256: archive, with mismatching checksum
-### opam install good-sha256.1 | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-sha256.1 | sed-hash $ARCHIVE_SHA256 archive-sha256
 The following actions will be performed:
 === install 1 package
   - install good-sha256 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] Conflicting file hashes, or broken or compromised cache!
-          - sha256=hash (MISMATCH)
+          - sha256=+archive-sha256+ (MISMATCH)
 
 -> retrieved good-sha256.1  (file://${BASEDIR}/archive.tgz)
 -> installed good-sha256.1

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -161,13 +161,13 @@ Clearing cache of downloaded files
 ### :II:1: local
 ### :II:1:a: archive
 ### tar czf arch.tgz REPO/repo
+### openssl md5 arch.tgz | '.*= ' -> '' >$ MD5
 ### <pkg:foo.1>
 opam-version: "2.0"
 ### <mkurl.sh>
 file="REPO/packages/foo/foo.1/opam"
 basedir=$(printf '%s' "$BASEDIR" | sed 's/\\/\\\\/g')
 arch=arch.tgz
-MD5=$(openssl md5 "$arch" | cut -d' ' -f2)
 cat >> "$file" << EOF
 url {
   src:"$arch"
@@ -182,7 +182,7 @@ EOF
 Now run 'opam upgrade' to apply any package updates.
 ### opam clean -c
 Clearing cache of downloaded files
-### opam install foo --download-only -vv --debug-level=-1 | grep -v "^+-" | sed-cmd rsync tar | grep -v "state-.*.export" | "md5[/\\].*" -> "md5-dir/"
+### opam install foo --download-only -vv --debug-level=-1 | grep -v "^+-" | sed-cmd rsync tar | grep -v "state-.*.export" | sed-hash $MD5 arch-md5
 The following actions will be performed:
 === install 1 package
   - install foo 1
@@ -192,8 +192,8 @@ SYSTEM                          rmdir ${BASEDIR}/OPAM/download/.opam-switch/sour
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [foo.1: rsync]
 + rsync "-rLptgoDvc" "--exclude" ".git" "--exclude" "_darcs" "--exclude" ".hg" "--exclude" ".#*" "--exclude" "_opam*" "--exclude" "_build" "--delete" "--delete-excluded" "${BASEDIR}/arch.tgz" "${OPAMTMP}"
-SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5-dir/
-SYSTEM                          copy ${OPAMTMP}/arch.tgz -> ${BASEDIR}/OPAM/download-cache/md5-dir/
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5/pre
+SYSTEM                          copy ${OPAMTMP}/arch.tgz -> ${BASEDIR}/OPAM/download-cache/md5/pre/+arch-md5+
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [foo.1: extract]
 + tar "xfz" "${OPAMTMP}/arch.tgz" "-C" "${OPAMTMP}"
@@ -259,7 +259,7 @@ url {
 }
 ### opam clean -c
 Clearing cache of downloaded files
-### opam install baz --download-only -vv --debug-level=-1 | grep -v "^+-" | sed-cmd wget tar | "${OPAMVERSION}" -> "current" | grep -v "state-.*.export" | "md5[/\\].*" -> "md5-dir/" | grep -v "OPAM[/\\]log"
+### opam install baz --download-only -vv --debug-level=-1 | grep -v "^+-" | sed-cmd wget tar | "${OPAMVERSION}" -> "current" | grep -v "state-.*.export"  | grep -v "OPAM[/\\]log"
 The following actions will be performed:
 === install 1 package
   - install baz 1
@@ -270,8 +270,8 @@ SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [baz.1: http]
 + wget "--header=Accept: */*" "-t" "3" "-O" "${OPAMTMP}/v1.0.0.tar.gz.part" "-U" "opam/current" "--" "https://github.com/UnixJunkie/get_line/archive/v1.0.0.tar.gz"
 SYSTEM                          mv ${OPAMTMP}/v1.0.0.tar.gz.part -> ${OPAMTMP}/v1.0.0.tar.gz
-SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5-dir/
-SYSTEM                          copy ${OPAMTMP}/v1.0.0.tar.gz -> ${BASEDIR}/OPAM/download-cache/md5-dir/
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5/c9
+SYSTEM                          copy ${OPAMTMP}/v1.0.0.tar.gz -> ${BASEDIR}/OPAM/download-cache/md5/c9/c9c157af4229fbb45d3f59f0d6d75dbe
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [baz.1: extract]
 + tar "xfz" "${OPAMTMP}/v1.0.0.tar.gz" "-C" "${OPAMTMP}"

--- a/tests/reftests/extrasource.test
+++ b/tests/reftests/extrasource.test
@@ -575,15 +575,15 @@ Clearing cache of downloaded files
 <default>/multiple-md5.1: Errors.
              error 72: Field 'extra-sources' contains duplicated checksums: "i-am-a-patch have md5: 2 occurences"
 # Return code 1 #
-### opam install multiple-md5 | '[0-9a-z]{32}' -> 'hash'
+### opam install multiple-md5 | sed-hash $PATCH_MD5 patch-md5
 The following actions will be performed:
 === install 1 package
   - install multiple-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] multiple-md5.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+patch-md5+
 [ERROR] Failed to get extra source "i-am-a-patch" of multiple-md5.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -595,15 +595,15 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam install multiple-md5 --require-checksums | '[0-9a-z]{32}' -> 'hash'
+### opam install multiple-md5 --require-checksums | sed-hash $PATCH_MD5 patch-md5
 The following actions will be performed:
 === install 1 package
   - install multiple-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] multiple-md5.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+patch-md5+
 [ERROR] Failed to get extra source "i-am-a-patch" of multiple-md5.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -615,18 +615,18 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam source multiple-md5 | '[0-9a-z]{32}' -> 'hash'
+### opam source multiple-md5 | sed-hash $PATCH_MD5 patch-md5
 [ERROR] multiple-md5.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+patch-md5+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f multiple-md5.1/i-am-a-patch
 # Return code 1 #
-### opam source multiple-md5 --require-checksums | '[0-9a-z]{32}' -> 'hash'
+### opam source multiple-md5 --require-checksums | sed-hash $PATCH_MD5 patch-md5
 [ERROR] multiple-md5.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+patch-md5+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f multiple-md5.1/i-am-a-patch
@@ -638,15 +638,15 @@ Clearing cache of downloaded files
 <default>/bad-md5.1: Passed.
 ### opam lint --package bad-md5 --check-upstream
 <default>/bad-md5.1: Passed.
-### opam install bad-md5 | '[0-9a-z]{32}' -> 'hash'
+### opam install bad-md5 | sed-hash $PATCH_MD5 patch-md5
 The following actions will be performed:
 === install 1 package
   - install bad-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] bad-md5.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+patch-md5+
 [ERROR] Failed to get extra source "i-am-a-patch" of bad-md5.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -658,15 +658,15 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam install bad-md5 --require-checksums | '[0-9a-z]{32}' -> 'hash'
+### opam install bad-md5 --require-checksums
 The following actions will be performed:
 === install 1 package
   - install bad-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] bad-md5.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=cf8c4c20658f6c3efea4eb2c6b1b34d7
 [ERROR] Failed to get extra source "i-am-a-patch" of bad-md5.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -678,18 +678,18 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam source bad-md5 | '[0-9a-z]{32}' -> 'hash'
+### opam source bad-md5 | sed-hash $PATCH_MD5 patch-md5
 [ERROR] bad-md5.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+patch-md5+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f bad-md5.1/i-am-a-patch
 # Return code 1 #
-### opam source bad-md5 --require-checksums | '[0-9a-z]{32}' -> 'hash'
+### opam source bad-md5 --require-checksums | sed-hash $PATCH_MD5 patch-md5 | sed-hash $PATCH_SHA256 patch-sha256
 [ERROR] bad-md5.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+patch-md5+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f bad-md5.1/i-am-a-patch
@@ -714,19 +714,19 @@ Done.
 ### sh check-cache.sh
 MD5: patch, with matching checksum
 SHA256: not found
-### opam install good-md5-bad-sha256 | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-md5-bad-sha256 | sed-hash $PATCH_MD5 patch-md5 | sed-hash $PATCH_SHA256 patch-sha256
 The following actions will be performed:
 === install 1 package
   - install good-md5-bad-sha256 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] Conflicting file hashes, or broken or compromised cache!
-          - md5=hash (match)
-          - sha256=hash (MISMATCH)
+          - md5=+patch-md5+ (match)
+          - sha256=0000000000000000000000000000000000000000000000000000000000000000 (MISMATCH)
 
 [ERROR] good-md5-bad-sha256.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected sha256=hash
-          got      sha256=hash
+          expected sha256=0000000000000000000000000000000000000000000000000000000000000000
+          got      sha256=+patch-sha256+
 [ERROR] Failed to get extra source "i-am-a-patch" of good-md5-bad-sha256.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -764,19 +764,19 @@ Done.
 ### sh check-cache.sh
 MD5: patch, with matching checksum
 SHA256: patch, with matching checksum
-### opam install good-md5-bad-sha256 | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-md5-bad-sha256 | sed-hash $PATCH_MD5 patch-md5 | sed-hash $PATCH_SHA256 patch-sha256
 The following actions will be performed:
 === install 1 package
   - install good-md5-bad-sha256 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] Conflicting file hashes, or broken or compromised cache!
-          - md5=hash (match)
-          - sha256=hash (MISMATCH)
+          - md5=+patch-md5+ (match)
+          - sha256=0000000000000000000000000000000000000000000000000000000000000000 (MISMATCH)
 
 [ERROR] good-md5-bad-sha256.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected sha256=hash
-          got      sha256=hash
+          expected sha256=0000000000000000000000000000000000000000000000000000000000000000
+          got      sha256=+patch-sha256+
 [ERROR] Failed to get extra source "i-am-a-patch" of good-md5-bad-sha256.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -791,15 +791,15 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 ### sh check-cache.sh
 MD5: not found
 SHA256: patch, with matching checksum
-### opam install good-md5-bad-sha256 --require-checksums | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-md5-bad-sha256 --require-checksums | sed-hash $PATCH_SHA256 patch-sha256
 The following actions will be performed:
 === install 1 package
   - install good-md5-bad-sha256 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] good-md5-bad-sha256.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected sha256=hash
-          got      sha256=hash
+          expected sha256=0000000000000000000000000000000000000000000000000000000000000000
+          got      sha256=+patch-sha256+
 [ERROR] Failed to get extra source "i-am-a-patch" of good-md5-bad-sha256.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -811,18 +811,18 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam source good-md5-bad-sha256 | '[0-9a-z]{64}' -> 'md5'
+### opam source good-md5-bad-sha256
 [ERROR] good-md5-bad-sha256.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected sha256=md5
-          got      sha256=md5
+          expected sha256=0000000000000000000000000000000000000000000000000000000000000000
+          got      sha256=c00eac22da21925d2077b66a29dc911cddc739b1b0d0909a6cb192344fba55ab
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f good-md5-bad-sha256.1/i-am-a-patch
 # Return code 1 #
-### opam source good-md5-bad-sha256 --require-checksums | '[0-9a-z]{64}' -> 'md5'
+### opam source good-md5-bad-sha256 --require-checksums
 [ERROR] good-md5-bad-sha256.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected sha256=md5
-          got      sha256=md5
+          expected sha256=0000000000000000000000000000000000000000000000000000000000000000
+          got      sha256=c00eac22da21925d2077b66a29dc911cddc739b1b0d0909a6cb192344fba55ab
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f good-md5-bad-sha256.1/i-am-a-patch
@@ -834,15 +834,15 @@ Clearing cache of downloaded files
 <default>/good-sha256-bad-md5.1: Passed.
 ### opam lint --package good-sha256-bad-md5 --check-upstream
 <default>/good-sha256-bad-md5.1: Passed.
-### opam install good-sha256-bad-md5 | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-sha256-bad-md5 | sed-hash $PATCH_MD5 patch-md5
 The following actions will be performed:
 === install 1 package
   - install good-sha256-bad-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] good-sha256-bad-md5.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+patch-md5+
 [ERROR] Failed to get extra source "i-am-a-patch" of good-sha256-bad-md5.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -854,15 +854,15 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam install good-sha256-bad-md5 --require-checksums | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-sha256-bad-md5 --require-checksums
 The following actions will be performed:
 === install 1 package
   - install good-sha256-bad-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] good-sha256-bad-md5.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=cf8c4c20658f6c3efea4eb2c6b1b34d7
 [ERROR] Failed to get extra source "i-am-a-patch" of good-sha256-bad-md5.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -874,18 +874,18 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam source good-sha256-bad-md5 | '[0-9a-z]{32}' -> 'hash'
+### opam source good-sha256-bad-md5
 [ERROR] good-sha256-bad-md5.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=cf8c4c20658f6c3efea4eb2c6b1b34d7
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f good-sha256-bad-md5.1/i-am-a-patch
 # Return code 1 #
-### opam source good-sha256-bad-md5 --require-checksums | '[0-9a-z]{32}' -> 'hash'
+### opam source good-sha256-bad-md5 --require-checksums
 [ERROR] good-sha256-bad-md5.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=cf8c4c20658f6c3efea4eb2c6b1b34d7
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f good-sha256-bad-md5.1/i-am-a-patch
@@ -901,15 +901,15 @@ Clearing cache of downloaded files
 <default>/clash-with-all-md5s.666: Errors.
              error 72: Field 'extra-sources' contains duplicated checksums: "i-am-a-patch have md5: 17 occurences"
 # Return code 1 #
-### opam install clash-with-all-md5s | '[0-9a-z]{32}' -> 'hash'
+### opam install clash-with-all-md5s | sed-hash $PATCH_MD5 patch-md5
 The following actions will be performed:
 === install 1 package
   - install clash-with-all-md5s 666
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] clash-with-all-md5s.666/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+patch-md5+
 [ERROR] Failed to get extra source "i-am-a-patch" of clash-with-all-md5s.666: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -947,35 +947,35 @@ Done.
 ### sh check-cache.sh
 MD5: patch, with matching checksum
 SHA256: patch, with matching checksum
-### opam install clash-with-all-md5s | '[0-9a-z]{32}' -> 'hash'
+### opam install clash-with-all-md5s | sed-hash $PATCH_MD5 patch-md5
 The following actions will be performed:
 === install 1 package
   - install clash-with-all-md5s 666
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] Conflicting file hashes, or broken or compromised cache!
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (match)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - md5=hash (MISMATCH)
-          - sha256=hash0123456789abcdeffedbca9876543210 (MISMATCH)
+          - md5=00000000000000000000000000000000 (MISMATCH)
+          - md5=11111111111111111111111111111111 (MISMATCH)
+          - md5=22222222222222222222222222222222 (MISMATCH)
+          - md5=33333333333333333333333333333333 (MISMATCH)
+          - md5=44444444444444444444444444444444 (MISMATCH)
+          - md5=+patch-md5+ (match)
+          - md5=55555555555555555555555555555555 (MISMATCH)
+          - md5=66666666666666666666666666666666 (MISMATCH)
+          - md5=77777777777777777777777777777777 (MISMATCH)
+          - md5=88888888888888888888888888888888 (MISMATCH)
+          - md5=99999999999999999999999999999999 (MISMATCH)
+          - md5=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (MISMATCH)
+          - md5=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb (MISMATCH)
+          - md5=cccccccccccccccccccccccccccccccc (MISMATCH)
+          - md5=dddddddddddddddddddddddddddddddd (MISMATCH)
+          - md5=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee (MISMATCH)
+          - md5=ffffffffffffffffffffffffffffffff (MISMATCH)
+          - sha256=0123456789abcdeffedcba98765432100123456789abcdeffedbca9876543210 (MISMATCH)
 
 [ERROR] clash-with-all-md5s.666/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+patch-md5+
 [ERROR] Failed to get extra source "i-am-a-patch" of clash-with-all-md5s.666: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -990,15 +990,15 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 ### sh check-cache.sh
 MD5: not found
 SHA256: patch, with matching checksum
-### opam install clash-with-all-md5s --require-checksums | '[0-9a-z]{32}' -> 'hash'
+### opam install clash-with-all-md5s --require-checksum | sed-hash $PATCH_MD5 patch-md5s
 The following actions will be performed:
 === install 1 package
   - install clash-with-all-md5s 666
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] clash-with-all-md5s.666/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+patch-md5s+
 [ERROR] Failed to get extra source "i-am-a-patch" of clash-with-all-md5s.666: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -1010,18 +1010,18 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam source clash-with-all-md5s | '[0-9a-z]{32}' -> 'hash'
+### opam source clash-with-all-md5s | sed-hash $PATCH_MD5 patch-md5
 [ERROR] clash-with-all-md5s.666/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+patch-md5+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f clash-with-all-md5s.666/i-am-a-patch
 # Return code 1 #
-### opam source clash-with-all-md5s --require-checksums | '[0-9a-z]{32}' -> 'hash'
+### opam source clash-with-all-md5s --require-checksum | sed-hash $PATCH_MD5 patch-md5s
 [ERROR] clash-with-all-md5s.666/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
-          expected md5=hash
-          got      md5=hash
+          expected md5=00000000000000000000000000000000
+          got      md5=+patch-md5s+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f clash-with-all-md5s.666/i-am-a-patch
@@ -1213,15 +1213,15 @@ Done.
 ### sh check-cache.sh
 MD5: patch, with mismatching checksum
 SHA256: link, to md5 patch
-### opam install good-sha256-good-md5 | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-sha256-good-md5 | sed-hash $PATCH_MD5 patch-md5 | sed-hash $PATCH_SHA256 patch-sha256
 The following actions will be performed:
 === install 1 package
   - install good-sha256-good-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] Conflicting file hashes, or broken or compromised cache!
-          - sha256=hash (MISMATCH)
-          - md5=hash (MISMATCH)
+          - sha256=+patch-sha256+ (MISMATCH)
+          - md5=+patch-md5+ (MISMATCH)
 
 -> retrieved good-sha256-good-md5.1  (file://${BASEDIR}/p.patch)
 -> installed good-sha256-good-md5.1
@@ -1247,15 +1247,15 @@ Done.
 ### sh check-cache.sh
 MD5: patch, with matching checksum
 SHA256: patch, with mismatching checksum
-### opam install good-sha256-good-md5 | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-sha256-good-md5 | sed-hash $PATCH_MD5 patch-md5 | sed-hash $PATCH_SHA256 patch-sha256
 The following actions will be performed:
 === install 1 package
   - install good-sha256-good-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] Conflicting file hashes, or broken or compromised cache!
-          - sha256=hash (MISMATCH)
-          - md5=hash (MISMATCH)
+          - sha256=+patch-sha256+ (MISMATCH)
+          - md5=+patch-md5+ (MISMATCH)
 
 -> retrieved good-sha256-good-md5.1  (file://${BASEDIR}/p.patch)
 -> installed good-sha256-good-md5.1
@@ -1278,15 +1278,15 @@ Done.
 ### sh check-cache.sh
 MD5: patch, with mismatching checksum
 SHA256: patch, with mismatching checksum
-### opam install good-sha256-good-md5 | '[0-9a-z]{32,64}' -> 'hash'
+### opam install good-sha256-good-md5 | sed-hash $PATCH_MD5 patch-md5 | sed-hash $PATCH_SHA256 patch-sha256
 The following actions will be performed:
 === install 1 package
   - install good-sha256-good-md5 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] Conflicting file hashes, or broken or compromised cache!
-          - sha256=hash (MISMATCH)
-          - md5=hash (MISMATCH)
+          - sha256=+patch-sha256+ (MISMATCH)
+          - md5=+patch-md5+ (MISMATCH)
 
 -> retrieved good-sha256-good-md5.1  (file://${BASEDIR}/p.patch)
 -> installed good-sha256-good-md5.1

--- a/tests/reftests/hooks-variables.test
+++ b/tests/reftests/hooks-variables.test
@@ -59,7 +59,6 @@ etc: [
 ]
 ### tar czf archive.tgz printer.sh i-am-a-repo-pkg.install
 ### openssl md5 archive.tgz | '.*= ' -> '' >$ MD5
-### sh -c "echo '$MD5' | cut -c 1-2" >$ PRE_MD5
 ### <add-url.sh>
 basedir=$(printf '%s' "$BASEDIR" | sed 's/\\/\\\\/g')
 cat << EOF >> REPO/packages/i-am-a-repo-pkg/i-am-a-repo-pkg.1/opam
@@ -107,7 +106,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed dep.1
 Done.
-### opam install i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | $MD5 -> +archive-hash+ | sed-cmd bash tar rsync | etc -> etc
+### opam install i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | sed-hash $MD5 archive-hash | sed-cmd bash tar rsync | etc -> etc
 The following actions will be performed:
 === install 1 package
   - install i-am-a-repo-pkg 1
@@ -287,7 +286,7 @@ Processing  3/3: [i-am-a-repo-pkg: bash ...post-installing...]
 - installed-files:etc etc/i-am-a-repo-pkg etc/i-am-a-repo-pkg/printer
 -> installed i-am-a-repo-pkg.1
 Done.
-### opam remove i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | $MD5 -> +archive-hash+ | sed-cmd bash tar
+### opam remove i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | sed-hash $MD5 archive-hash | sed-cmd bash tar
 The following actions will be performed:
 === remove 1 package
   - remove i-am-a-repo-pkg 1
@@ -411,7 +410,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed dep.1
 Done.
-### opam install i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | $MD5 -> +archive-hash+ | sed-cmd bash tar | etc -> etc
+### opam install i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | sed-hash $MD5 archive-hash | sed-cmd bash tar | etc -> etc
 The following actions will be performed:
 === install 1 package
   - install i-am-a-repo-pkg 1
@@ -588,7 +587,7 @@ Processing  3/3: [i-am-a-repo-pkg: bash ...post-installing...]
 - installed-files:etc etc/i-am-a-repo-pkg etc/i-am-a-repo-pkg/printer
 -> installed i-am-a-repo-pkg.1
 Done.
-### opam remove i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | $MD5 -> +archive-hash+ | sed-cmd bash tar
+### opam remove i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | sed-hash $MD5 archive-hash | sed-cmd bash tar
 The following actions will be performed:
 === remove 1 package
   - remove i-am-a-repo-pkg 1
@@ -744,7 +743,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed dep.1
 Done.
-### opam install i-am-a-repo-pkg | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | $MD5 -> +archive-hash+ | sed-cmd bash tar | etc -> etc
+### opam install i-am-a-repo-pkg | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | sed-hash $MD5 archive-hash | sed-cmd bash tar | etc -> etc
 The following actions will be performed:
 === install 1 package
   - install i-am-a-repo-pkg 1
@@ -783,7 +782,7 @@ Done.
    success:true
    failure:false
    installed-files:
-### opam remove i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | $MD5 -> +archive-hash+ | sed-cmd bash tar
+### opam remove i-am-a-repo-pkg -vv | "${OPAMVERSION}" -> "++current++" | '[0-9a-z]{64}' -> '+hash+' | sed-hash $MD5 archive-hash | sed-cmd bash tar
 The following actions will be performed:
 === remove 1 package
   - remove i-am-a-repo-pkg 1

--- a/tests/reftests/hooks-variables.unix.test
+++ b/tests/reftests/hooks-variables.unix.test
@@ -16,7 +16,6 @@ install: [ "a-install-command" ]
 remove: [ "a-remove-command" ]
 ### tar czf archive.tgz printer.sh
 ### openssl md5 archive.tgz | '.*= ' -> '' >$ MD5
-### sh -c "echo '$MD5' | cut -c 1-2" >$ PRE_MD5
 ### <add-url.sh>
 basedir=$(printf '%s' "$BASEDIR" | sed 's/\\/\\\\/g')
 cat << EOF >> REPO/packages/i-am-a-repo-pkg/i-am-a-repo-pkg.1/opam
@@ -57,7 +56,7 @@ Set to '[ "bash" "%{hooks}%/printer.sh" "...post-installing..." "exe:%{exe}%" ]'
 ### opam option --global 'post-remove-commands=[ "bash" "%{hooks}%/printer.sh" "...post-removing..." "exe:%{exe}%" ]'
 Set to '[ "bash" "%{hooks}%/printer.sh" "...post-removing..." "exe:%{exe}%" ]' the field post-remove-commands in global configuration
 ### opam switch create global-wrappers --empty
-### opam install i-am-a-repo-pkg | $MD5 -> +archive-hash+ | sed-cmd bash tar rsync
+### opam install i-am-a-repo-pkg | sed-hash $MD5 archive-hash | sed-cmd bash tar rsync
 The following actions will be performed:
 === install 1 package
   - install i-am-a-repo-pkg 1
@@ -99,7 +98,7 @@ Processing  3/3: [i-am-a-repo-pkg: bash ...post-installing...]
 - exe:
 -> installed i-am-a-repo-pkg.1
 Done.
-### opam remove i-am-a-repo-pkg | $MD5 -> +archive-hash+ | '/md5/$PRE_MD5/' -> '/md5/pre/' | sed-cmd bash tar
+### opam remove i-am-a-repo-pkg | sed-hash $MD5 archive-hash | sed-cmd bash tar
 The following actions will be performed:
 === remove 1 package
   - remove i-am-a-repo-pkg 1
@@ -146,7 +145,7 @@ Set to '[ "bash" "%{hooks}%/printer.sh" "...post-building..." "exe:%{exe}%" ]' t
 Set to '[ "bash" "%{hooks}%/printer.sh" "...post-installing..." "exe:%{exe}%" ]' the field post-install-commands in switch switch-wrappers
 ### opam option --switch switch-wrappers 'post-remove-commands=[ "bash" "%{hooks}%/printer.sh" "...post-removing..." "exe:%{exe}%" ]'
 Set to '[ "bash" "%{hooks}%/printer.sh" "...post-removing..." "exe:%{exe}%" ]' the field post-remove-commands in switch switch-wrappers
-### opam install i-am-a-repo-pkg | $MD5 -> +archive-hash+ | '/md5/$PRE_MD5/' -> '/md5/pre/' | sed-cmd bash tar
+### opam install i-am-a-repo-pkg | sed-hash $MD5 archive-hash | sed-cmd bash tar
 The following actions will be performed:
 === install 1 package
   - install i-am-a-repo-pkg 1
@@ -184,7 +183,7 @@ Processing  3/3: [i-am-a-repo-pkg: bash ...post-installing...]
 - exe:
 -> installed i-am-a-repo-pkg.1
 Done.
-### opam remove i-am-a-repo-pkg | $MD5 -> +archive-hash+ | '/md5/$PRE_MD5/' -> '/md5/pre/' | sed-cmd bash tar
+### opam remove i-am-a-repo-pkg | sed-hash $MD5 archive-hash | sed-cmd bash tar
 The following actions will be performed:
 === remove 1 package
   - remove i-am-a-repo-pkg 1
@@ -237,7 +236,7 @@ EOF
 Processing: [default: loading data]
 Now run 'opam upgrade' to apply any package updates.
 ### opam switch create pkg-from-repo --empty
-### opam install i-am-a-repo-pkg | $MD5 -> +archive-hash+ | '/md5/$PRE_MD5/' -> '/md5/pre/' | sed-cmd bash tar
+### opam install i-am-a-repo-pkg | sed-hash $MD5 archive-hash | sed-cmd bash tar
 The following actions will be performed:
 === install 1 package
   - install i-am-a-repo-pkg 1
@@ -261,7 +260,7 @@ Done.
 <><> i-am-a-repo-pkg.1 installed successfully <><><><><><><><><><><><><><><><><>
 => ...A last message...
    exe:
-### opam remove i-am-a-repo-pkg | $MD5 -> +archive-hash+ | '/md5/$PRE_MD5/' -> '/md5/pre/' | sed-cmd bash tar
+### opam remove i-am-a-repo-pkg | sed-hash $MD5 archive-hash | sed-cmd bash tar
 The following actions will be performed:
 === remove 1 package
   - remove i-am-a-repo-pkg 1

--- a/tests/reftests/hooks-variables.win32.test
+++ b/tests/reftests/hooks-variables.win32.test
@@ -16,7 +16,6 @@ install: [ "a-install-command" ]
 remove: [ "a-remove-command" ]
 ### tar czf archive.tgz printer.sh
 ### openssl md5 archive.tgz | '.*= ' -> '' >$ MD5
-### sh -c "echo '$MD5' | cut -c 1-2" >$ PRE_MD5
 ### <add-url.sh>
 basedir=$(printf '%s' "$BASEDIR" | sed 's/\\/\\\\/g')
 cat << EOF >> REPO/packages/i-am-a-repo-pkg/i-am-a-repo-pkg.1/opam
@@ -57,7 +56,7 @@ Set to '[ "bash" "%{hooks}%/printer.sh" "...post-installing..." "exe:%{exe}%" ]'
 ### opam option --global 'post-remove-commands=[ "bash" "%{hooks}%/printer.sh" "...post-removing..." "exe:%{exe}%" ]'
 Set to '[ "bash" "%{hooks}%/printer.sh" "...post-removing..." "exe:%{exe}%" ]' the field post-remove-commands in global configuration
 ### opam switch create global-wrappers --empty
-### opam install i-am-a-repo-pkg | sed-cmd bash tar rsync
+### opam install i-am-a-repo-pkg | sed-hash $MD5 archive-hash | sed-cmd bash tar rsync
 The following actions will be performed:
 === install 1 package
   - install i-am-a-repo-pkg 1
@@ -99,7 +98,7 @@ Processing  3/3: [i-am-a-repo-pkg: bash ...post-installing...]
 - exe:.exe
 -> installed i-am-a-repo-pkg.1
 Done.
-### opam remove i-am-a-repo-pkg | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | sed-cmd bash tar
+### opam remove i-am-a-repo-pkg | sed-hash $MD5 archive-hash | sed-cmd bash tar
 The following actions will be performed:
 === remove 1 package
   - remove i-am-a-repo-pkg 1
@@ -146,7 +145,7 @@ Set to '[ "bash" "%{hooks}%/printer.sh" "...post-building..." "exe:%{exe}%" ]' t
 Set to '[ "bash" "%{hooks}%/printer.sh" "...post-installing..." "exe:%{exe}%" ]' the field post-install-commands in switch switch-wrappers
 ### opam option --switch switch-wrappers 'post-remove-commands=[ "bash" "%{hooks}%/printer.sh" "...post-removing..." "exe:%{exe}%" ]'
 Set to '[ "bash" "%{hooks}%/printer.sh" "...post-removing..." "exe:%{exe}%" ]' the field post-remove-commands in switch switch-wrappers
-### opam install i-am-a-repo-pkg | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | sed-cmd bash tar
+### opam install i-am-a-repo-pkg | sed-hash $MD5 archive-hash | sed-cmd bash tar
 The following actions will be performed:
 === install 1 package
   - install i-am-a-repo-pkg 1
@@ -184,7 +183,7 @@ Processing  3/3: [i-am-a-repo-pkg: bash ...post-installing...]
 - exe:.exe
 -> installed i-am-a-repo-pkg.1
 Done.
-### opam remove i-am-a-repo-pkg | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | sed-cmd bash tar
+### opam remove i-am-a-repo-pkg | sed-hash $MD5 archive-hash | sed-cmd bash tar
 The following actions will be performed:
 === remove 1 package
   - remove i-am-a-repo-pkg 1
@@ -237,7 +236,7 @@ EOF
 Processing: [default: loading data]
 Now run 'opam upgrade' to apply any package updates.
 ### opam switch create pkg-from-repo --empty
-### opam install i-am-a-repo-pkg | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | sed-cmd bash tar
+### opam install i-am-a-repo-pkg | sed-hash $MD5 archive-hash | sed-cmd bash tar
 The following actions will be performed:
 === install 1 package
   - install i-am-a-repo-pkg 1
@@ -261,7 +260,7 @@ Done.
 <><> i-am-a-repo-pkg.1 installed successfully <><><><><><><><><><><><><><><><><>
 => ...A last message...
    exe:.exe
-### opam remove i-am-a-repo-pkg | '${PRE_MD5}[^[:alnum:]].?${MD5}' -> pre/+archive-hash+ | sed-cmd bash tar
+### opam remove i-am-a-repo-pkg | sed-hash $MD5 archive-hash | sed-cmd bash tar
 The following actions will be performed:
 === remove 1 package
   - remove i-am-a-repo-pkg 1

--- a/tests/reftests/opam-repo-ci.test
+++ b/tests/reftests/opam-repo-ci.test
@@ -52,7 +52,7 @@ main is now pinned to version 1
 ### # emulate '(cache (opam-archives (target /home/opam/.opam/download-cache)))'
 ### mkdir -p OPAM/download-cache/md5/$PRE_MD5
 ### cp archive.tgz OPAM/download-cache/md5/$PRE_MD5/$MD5
-### opam reinstall main.1 | sed-cmd tar | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash
+### opam reinstall main.1 | sed-cmd tar | sed-hash $MD5 arch-md5
 main.1 is not installed. Install it? [Y/n] y
 The following actions will be performed:
 === install 2 packages
@@ -64,7 +64,7 @@ Processing  2/6: [main.1: extract]
 Processing  3/6: [main.1: extract]
 -> installed dep.1
 Processing  4/6: [main.1: extract]
-+ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/hash" "-C" "${OPAMTMP}"
++ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/+arch-md5+" "-C" "${OPAMTMP}"
 -> retrieved main.1  (cached)
 -> installed main.1
 Done.
@@ -85,7 +85,7 @@ The following actions will be performed:
 Done.
 ### # Third reinstall
 ### # no change in source on cache archive
-### opam reinstall main.1 --with-test -vv | sed-cmd rsync tar | "${PRE_MD5}[^[:alnum:]].?${MD5}" -> pre/hash
+### opam reinstall main.1 --with-test -vv | sed-cmd rsync tar
 The following actions will be performed:
 === recompile 1 package
   - recompile main 1 (pinned)

--- a/tests/reftests/readme.md
+++ b/tests/reftests/readme.md
@@ -64,6 +64,7 @@ output...
     * `| unordered` compares lines without considering their ordering
     * `| sort` sorts output
     * `| sed-cmd command` replaces full path resolved command by `command`
+    * `| sed-hash <HASH|$VAR> [name]` replaces HASH (or hash contained in $VAR) by `+name+` or `+hash+` if unspecified
   * variables from command outputs: `cmd args >$ VAR`
 - additional commands
   * `opam-cat file`: prints a normalised opam file

--- a/tests/reftests/reftests.test
+++ b/tests/reftests/reftests.test
@@ -707,6 +707,108 @@ Something smtg else
 Something smtg else
 Something smtg else
 Something smtg else
+### :IV:7: sed-hash
+### <hashes>
+                - archive: md5=f75b8179e4bbe7e2b4a074dcef62de95, in opam file: md5=f75b8179e4bbe7e2b4a074dcef62de95
+                - archive: sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c, in opam file: sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c
+                - archive: sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c, in opam file: sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c
++ bash "${BASEDIR}/OPAM/opam-init/hooks/printer.sh" "...building..." "opam-version:++current++" "switch:global-wrappers" "jobs:2" "root:${BASEDIR}/OPAM" "make:make" "name:i-am-a-repo-pkg" "version:1" "depends:dep.1" "installed:false" "enable:" "pinned:false" "bin:${BASEDIR}/OPAM/global-wrappers/bin" "sbin:${BASEDIR}/OPAM/global-wrappers/sbin" "lib:${BASEDIR}/OPAM/global-wrappers/lib" "man:${BASEDIR}/OPAM/global-wrappers/man" "doc:${BASEDIR}/OPAM/global-wrappers/doc" "share:${BASEDIR}/OPAM/global-wrappers/share" "etc:${BASEDIR}/OPAM/global-wrappers/etc" "build:${BASEDIR}/OPAM/global-wrappers/.opam-switch/build/i-am-a-repo-pkg.1" "hash:md5=f75b8179e4bbe7e2b4a074dcef62de95" "dev:false" "build-id:+hash+" "opamfile:${OPAMTMP}/opam" "installed-files:" "a-build-command" (CWD=${BASEDIR}/OPAM/global-wrappers/.opam-switch/build/i-am-a-repo-pkg.1)
+"eta.installl" "md5=f75b8179e4bbe7e2b4a074dcef62de95"
+          expected md5=f75b8179e4bbe7e2b4a074dcef62de95
+          expected sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c
+extra-files: [["bad-md5" "md5=f75b8179e4bbe7e2b4a074dcef62de95"] ["bad-sha" "sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c"] ["good-md5" "md5=f75b8179e4bbe7e2b4a074dcef62de95"] ["good-sha" "sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c"] ["missing-hash" "md5=f75b8179e4bbe7e2b4a074dcef62de95"]]
+extra-files: [["bad-md5" "sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c"] ["bad-sha" "sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c"] ["good-md5" "sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c"] ["good-sha" "sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c"] ["missing-hash" "sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c"]]
+extra-files: ["missing-hash" "md5=f75b8179e4bbe7e2b4a074dcef62de95"]
+          got      md5=f75b8179e4bbe7e2b4a074dcef62de95
+          got      sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c
+   hash:md5=f75b8179e4bbe7e2b4a074dcef62de95
+- hash:md5=f75b8179e4bbe7e2b4a074dcef62de95
+          - md5=f75b8179e4bbe7e2b4a074dcef62de95 (match)
+          - md5=11111111111111111111111111111111 (MISMATCH)
+"qux.installl" "md5=f75b8179e4bbe7e2b4a074dcef62de95"
+          - sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c (MISMATCH)
+          - sha512=a31cffeeaf410435d5b802e87c7f4b17ec8f1ac433f0ed2366989cc7e26f75f1ec76e0f9a031aa8622e2e27e7b1773d2fa63c387191fa3ed6658e652fb15e645 (MISMATCH)
+SYSTEM                          copy ${OPAMTMP}/archive.tgz -> ${BASEDIR}/OPAM/download-cache/md5/f7/f75b8179e4bbe7e2b4a074dcef62de95
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5/f7
++ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/f7/f75b8179e4bbe7e2b4a074dcef62de95" "-C" "${OPAMTMP}"
+url.checksum: md5=f75b8179e4bbe7e2b4a074dcef62de95
+url.checksum: md5=f75b8179e4bbe7e2b4a074dcef62de95, sha512=a31cffeeaf410435d5b802e87c7f4b17ec8f1ac433f0ed2366989cc7e26f75f1ec76e0f9a031aa8622e2e27e7b1773d2fa63c387191fa3ed6658e652fb15e645
+url.checksum: md5=f75b8179e4bbe7e2b4a074dcef62de95, sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c
+url.checksum: md5=f75b8179e4bbe7e2b4a074dcef62de95, sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c, sha512=a31cffeeaf410435d5b802e87c7f4b17ec8f1ac433f0ed2366989cc7e26f75f1ec76e0f9a031aa8622e2e27e7b1773d2fa63c387191fa3ed6658e652fb15e645
+url.checksum: sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c
+url.checksum: sha256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c, md5=f75b8179e4bbe7e2b4a074dcef62de95, sha512=a31cffeeaf410435d5b802e87c7f4b17ec8f1ac433f0ed2366989cc7e26f75f1ec76e0f9a031aa8622e2e27e7b1773d2fa63c387191fa3ed6658e652fb15e645
+### MD5=f75b8179e4bbe7e2b4a074dcef62de95
+### SHA256=3b0a6bcd854adc9a1a590f527751bec278a058b2152ac50b26f4276a1c49e67c
+### SHA512=a31cffeeaf410435d5b802e87c7f4b17ec8f1ac433f0ed2366989cc7e26f75f1ec76e0f9a031aa8622e2e27e7b1773d2fa63c387191fa3ed6658e652fb15e645
+### cat hashes | sed-hash $MD5 md5-hash | sed-hash $SHA256 sha256-hash | sed-hash $SHA512
+                - archive: md5=+md5-hash+, in opam file: md5=+md5-hash+
+                - archive: sha256=+sha256-hash+, in opam file: sha256=+sha256-hash+
+                - archive: sha256=+sha256-hash+, in opam file: sha256=+sha256-hash+
++ bash "${BASEDIR}/OPAM/opam-init/hooks/printer.sh" "...building..." "opam-version:++current++" "switch:global-wrappers" "jobs:2" "root:${BASEDIR}/OPAM" "make:make" "name:i-am-a-repo-pkg" "version:1" "depends:dep.1" "installed:false" "enable:" "pinned:false" "bin:${BASEDIR}/OPAM/global-wrappers/bin" "sbin:${BASEDIR}/OPAM/global-wrappers/sbin" "lib:${BASEDIR}/OPAM/global-wrappers/lib" "man:${BASEDIR}/OPAM/global-wrappers/man" "doc:${BASEDIR}/OPAM/global-wrappers/doc" "share:${BASEDIR}/OPAM/global-wrappers/share" "etc:${BASEDIR}/OPAM/global-wrappers/etc" "build:${BASEDIR}/OPAM/global-wrappers/.opam-switch/build/i-am-a-repo-pkg.1" "hash:md5=+md5-hash+" "dev:false" "build-id:+hash+" "opamfile:${OPAMTMP}/opam" "installed-files:" "a-build-command" (CWD=${BASEDIR}/OPAM/global-wrappers/.opam-switch/build/i-am-a-repo-pkg.1)
+"eta.installl" "md5=+md5-hash+"
+          expected md5=+md5-hash+
+          expected sha256=+sha256-hash+
+extra-files: [["bad-md5" "md5=+md5-hash+"] ["bad-sha" "sha256=+sha256-hash+"] ["good-md5" "md5=+md5-hash+"] ["good-sha" "sha256=+sha256-hash+"] ["missing-hash" "md5=+md5-hash+"]]
+extra-files: [["bad-md5" "sha256=+sha256-hash+"] ["bad-sha" "sha256=+sha256-hash+"] ["good-md5" "sha256=+sha256-hash+"] ["good-sha" "sha256=+sha256-hash+"] ["missing-hash" "sha256=+sha256-hash+"]]
+extra-files: ["missing-hash" "md5=+md5-hash+"]
+          got      md5=+md5-hash+
+          got      sha256=+sha256-hash+
+   hash:md5=+md5-hash+
+- hash:md5=+md5-hash+
+          - md5=+md5-hash+ (match)
+          - md5=11111111111111111111111111111111 (MISMATCH)
+"qux.installl" "md5=+md5-hash+"
+          - sha256=+sha256-hash+ (MISMATCH)
+          - sha512=+hash+ (MISMATCH)
+SYSTEM                          copy ${OPAMTMP}/archive.tgz -> ${BASEDIR}/OPAM/download-cache/md5/pre/+md5-hash+
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5/pre
++ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/+md5-hash+" "-C" "${OPAMTMP}"
+url.checksum: md5=+md5-hash+
+url.checksum: md5=+md5-hash+, sha512=+hash+
+url.checksum: md5=+md5-hash+, sha256=+sha256-hash+
+url.checksum: md5=+md5-hash+, sha256=+sha256-hash+, sha512=+hash+
+url.checksum: sha256=+sha256-hash+
+url.checksum: sha256=+sha256-hash+, md5=+md5-hash+, sha512=+hash+
+### <hashes-d5>
+SYSTEM                          copy ${OPAMTMP}/archive.tgz -> ${BASEDIR}/OPAM/download-cache/md5/d5/d55b8179e4bbe7e2b4a074dcef62de95
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5/d5
++ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/d5/d55b8179e4bbe7e2b4a074dcef62de95" "-C" "${OPAMTMP}"
+### MD5=d55b8179e4bbe7e2b4a074dcef62de95
+### cat hashes-d5 | sed-hash $MD5 md5-hash
+SYSTEM                          copy ${OPAMTMP}/archive.tgz -> ${BASEDIR}/OPAM/download-cache/md5/pre/+md5-hash+
+SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/md5/pre
++ tar "xfz" "${BASEDIR}/OPAM/download-cache/md5/pre/+md5-hash+" "-C" "${OPAMTMP}"
+### <hashes-basic>
+0123456789abcdef0123456789abcdef
+0a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f6789
+### cat hashes-basic | sed-hash $MD5
+0123456789abcdef0123456789abcdef
+0a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f6789
+### cat hashes-basic | sed-hash 0123456789abcdef0123456789abcdef
++hash+
+0a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f6789
+### cat hashes-basic | sed-hash 0a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f6789
+0123456789abcdef0123456789abcdef
++hash+
+### cat hashes-basic | sed-hash 0123456789abcdef0123456789
+Bad 'sed-hash' argument (0123456789abcdef0123456789), expecting a environment variable beginning with '$' or a hash of 32, 64, or 128 characters0123456789abcdef0123456789abcdef
+0a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f6789
+### cat hashes-basic | sed-hash 0a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67
+Bad 'sed-hash' argument (0a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67), expecting a environment variable beginning with '$' or a hash of 32, 64, or 128 characters0123456789abcdef0123456789abcdef
+0a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f6789
+### cat hashes-basic | sed-hash 0a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f678999999
+Bad 'sed-hash' argument (0a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f678999999), expecting a environment variable beginning with '$' or a hash of 32, 64, or 128 characters0123456789abcdef0123456789abcdef
+0a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f6789
+### cat hashes-basic | sed-hash FOO
+Bad 'sed-hash' argument (FOO), expecting a environment variable beginning with '$' or a hash of 32, 64, or 128 characters0123456789abcdef0123456789abcdef
+0a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f6789
+### cat hashes-basic | sed-hash $FOO
+0123456789abcdef0123456789abcdef
+0a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f6789
+### cat hashes-basic | sed-hash
+Bad rewrite "| sed-hash", expecting '| RE -> STR' or '>$ VAR'
+0123456789abcdef0123456789abcdef
+0a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f6789
 ### ###################
 ### :V: Additional commands
 ### ###################

--- a/tests/reftests/update.test
+++ b/tests/reftests/update.test
@@ -155,8 +155,8 @@ opam-version: "2.0"
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 Now run 'opam upgrade' to apply any package updates.
-### opam show qux --field extra-files: | $INSTALL_MD5 -> hash
-"qux.installl" "md5=hash"
+### opam show qux --field extra-files: | sed-hash $INSTALL_MD5 install-md5
+"qux.installl" "md5=+install-md5+"
 ### :I:6:b: change extra-file with opam file
 ### <REPO/packages/qux/qux.1/opam>
 opam-version: "2.0"
@@ -166,8 +166,8 @@ opam-version: "2.0"
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 Now run 'opam upgrade' to apply any package updates.
-### opam show qux --field extra-files: | $AINSTALL_MD5 -> hash
-"qux.installl" "md5=hash"
+### opam show qux --field extra-files: | sed-hash $AINSTALL_MD5 ainstall-md5
+"qux.installl" "md5=+ainstall-md5+"
 ### :I:6:c: remove extra-file with opam file
 ### <REPO/packages/qux/qux.1/opam>
 opam-version: "2.0"
@@ -203,8 +203,8 @@ opam-version: "2.0"
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/qux/qux.1: wrong checksum (1)
 Now run 'opam upgrade' to apply any package updates.
-### opam show qux --field extra-files: | $INSTALL_MD5 -> hash
-"qux.installl" "md5=hash"
+### opam show qux --field extra-files: | sed-hash $INSTALL_MD5 install-md5
+"qux.installl" "md5=+install-md5+"
 ### :I:6:e: remove extra-file without opam file
 ### <REPO/packages/qux/qux.1/opam>
 opam-version: "2.0"
@@ -216,8 +216,8 @@ opam-version: "2.0"
 [default] synchronised from file://${BASEDIR}/REPO
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 opam-file                       Missing expected extra files qux.installl at ${BASEDIR}/OPAM/repo/default/packages/qux/qux.1/files
-### opam show qux --field extra-files: | $INSTALL_MD5 -> hash
-"qux.installl" "md5=hash"
+### opam show qux --field extra-files: | sed-hash $INSTALL_MD5 install-md5
+"qux.installl" "md5=+install-md5+"
 ### :II: Git repo
 ### opam switch create repo-git-update --empty
 ### git init -q --initial-branch=master GITREPO
@@ -291,8 +291,8 @@ opam-version: "2.0"
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [git-test] synchronised from git+file://${BASEDIR}/GITREPO
 Now run 'opam upgrade' to apply any package updates.
-### opam show qux --field extra-files: | $INSTALL_MD5 -> hash
-"qux.installl" "md5=hash"
+### opam show qux --field extra-files: | sed-hash $INSTALL_MD5 install-md5
+"qux.installl" "md5=+install-md5+"
 ### :II:5:b: change extra-file with opam file
 ### <GITREPO/packages/qux/qux.1/opam>
 opam-version: "2.0"
@@ -304,8 +304,8 @@ opam-version: "2.0"
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [git-test] synchronised from git+file://${BASEDIR}/GITREPO
 Now run 'opam upgrade' to apply any package updates.
-### opam show qux --field extra-files: | $AINSTALL_MD5 -> hash
-"qux.installl" "md5=hash"
+### opam show qux --field extra-files: | sed-hash $AINSTALL_MD5 ainstall-md5
+"qux.installl" "md5=+ainstall-md5+"
 ### :II:5:c: remove extra-file with opam file
 ### <GITREPO/packages/qux/qux.1/opam>
 opam-version: "2.0"
@@ -346,8 +346,8 @@ opam-version: "2.0"
 [git-test] synchronised from git+file://${BASEDIR}/GITREPO
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/git-test/packages/qux/qux.1: wrong checksum (1)
 Now run 'opam upgrade' to apply any package updates.
-### opam show qux --field extra-files: | $INSTALL_MD5 -> hash
-"qux.installl" "md5=hash"
+### opam show qux --field extra-files | sed-hash $INSTALL_MD5 install-md5
+"qux.installl" "md5=+install-md5+"
 ### :II:5:e: remove extra-file without opam file
 ### <GITREPO/packages/qux/qux.1/opam>
 opam-version: "2.0"
@@ -360,8 +360,8 @@ opam-version: "2.0"
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [git-test] synchronised from git+file://${BASEDIR}/GITREPO
 opam-file                       Missing expected extra files qux.installl at ${BASEDIR}/OPAM/repo/git-test/packages/qux/qux.1/files
-### opam show qux --field extra-files: | $INSTALL_MD5 -> hash
-"qux.installl" "md5=hash"
+### opam show qux --field extra-files: | sed-hash $INSTALL_MD5 install-md5
+"qux.installl" "md5=+install-md5+"
 ### :II:6: Package removal with prefix directories
 ### <add-pkg.sh>
 set -ue
@@ -607,8 +607,8 @@ REPO_BACKEND                    Internal diff (non-empty, 2 changed files) done 
 [incremental] synchronised from file://${BASEDIR}/INCR_REPO
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/incremental/packages/eta/eta.1/opam in 0.000s
 Now run 'opam upgrade' to apply any package updates.
-### opam show eta --field extra-files: | $INSTALL_MD5 -> hash
-"eta.installl" "md5=hash"
+### opam show eta --field extra-files:
+"eta.installl" "md5=d9b673248d119b87a2e1f9766e543aa3"
 ### opam install eta
 The following actions will be performed:
 === install 1 package
@@ -632,8 +632,8 @@ REPO_BACKEND                    Internal diff (non-empty, 2 changed files) done 
 [incremental] synchronised from file://${BASEDIR}/INCR_REPO
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/incremental/packages/eta/eta.1/opam in 0.000s
 Now run 'opam upgrade' to apply any package updates.
-### opam show eta --field extra-files: | $AINSTALL_MD5 -> hash
-"eta.installl" "md5=hash"
+### opam show eta --field extra-files: | sed-hash $AINSTALL_MD5 ainstall-md5
+"eta.installl" "md5=+ainstall-md5+"
 ### opam install eta
 The following actions will be performed:
 === install 1 package
@@ -727,8 +727,8 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/incremental/packages/eta/eta.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/incremental/packages/eta/eta.1: wrong checksum (1)
 Now run 'opam upgrade' to apply any package updates.
-### opam show eta --field extra-files: | $INSTALL_MD5 -> hash
-"eta.installl" "md5=hash"
+### opam show eta --field extra-files:
+"eta.installl" "md5=d9b673248d119b87a2e1f9766e543aa3"
 ### opam install eta
 The following actions will be performed:
 === install 1 package
@@ -763,8 +763,8 @@ REPO_BACKEND                    Internal diff (non-empty, 1 changed files) done 
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/incremental/packages/eta/eta.1/opam in 0.000s
 opam-file                       Missing expected extra files eta.installl at ${BASEDIR}/OPAM/repo/incremental/packages/eta/eta.1/files
-### opam show eta --field extra-files: | $INSTALL_MD5 -> hash
-"eta.installl" "md5=hash"
+### opam show eta --field extra-files:
+"eta.installl" "md5=d9b673248d119b87a2e1f9766e543aa3"
 ### opam install eta
 The following actions will be performed:
 === install 1 package


### PR DESCRIPTION
It avoids the several hash seds and path separator handling that it contains.
todo : check that it works on windows 