### PR TITLE
depexts: Harden the parsing of 'apk policy' on Alpine

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -77,6 +77,7 @@ users)
 ## Opamfile
 
 ## External dependencies
+  * Harden the parsing of `apk policy` on Alpine [#6742 @kit-ty-kate]
 
 ## Format upgrade
   * Complete upgrade mechanism to permit on the fly upgrade and write upgrade from repo and switch level [#6416 @rjbou]

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -693,7 +693,8 @@ let packages_status ?(env=OpamVariable.Map.empty) config packages =
           try (* package name *)
             Re.(Group.get (exec pkg_name l) 1), false, instavail
           with Not_found ->
-            if l.[2] <> ' ' then (* only version field is after two spaces *)
+            if not (OpamCompat.String.starts_with ~prefix:"  " l) then
+              (* only version field is after two spaces *)
               pkg, false, instavail
             else if l = "    lib/apk/db/installed" then
               (* from https://git.alpinelinux.org/apk-tools/tree/src/database.c#n58 *)


### PR DESCRIPTION
Extracted from https://github.com/ocaml/opam/pull/6489