### PR TITLE
GHA: Lighten macos jobs

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -451,17 +451,24 @@ let solvers_job ~analyse_job ~build_linux_job ~build_windows_job ~build_macOS_jo
   let matrix =
     (fail_fast, ("solver", ["z3"; "0install"])::matrix, [])
   in
+  let withs = [ "filter", Literal [ "src/solver/**"] ] in
+  let cond =
+    match runner with
+    | MacOS ->  Some (Predicate(false, Compare("steps.files.outputs.all", "")))
+    | _ -> None
+  in
   let ocamlv = "${{ matrix.ocamlv }}" in
   job ~oc ~workflow ?section ~runs_on:(Runner [runner]) ~env ~needs ~matrix ("Solvers-" ^ name_of_platform platform)
     ++ only_on Linux (run "Install bubblewrap" ["sudo apt install bubblewrap"])
     ++ only_on Linux (run "Disable AppArmor" ["echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns"])
     ++ checkout ()
-    ++ cache Archives
-    ++ cache OCaml platform ocamlv host
-    ++ build_cache OCaml platform ocamlv host
-    ++ cache OpamBS ocamlv "-${{ matrix.solver }}"
-    ++ build_cache OpamBS ocamlv "-${{ matrix.solver }}"
-    ++ run "Compile" ["bash -exu .github/scripts/main/solvers.sh"]
+    ++ only_on MacOS (changed_files ~withs ())
+    ++ cache ?cond Archives
+    ++ cache ?cond OCaml platform ocamlv host
+    ++ build_cache ?cond OCaml platform ocamlv host
+    ++ cache ?cond OpamBS ocamlv "-${{ matrix.solver }}"
+    ++ build_cache ?cond OpamBS ocamlv "-${{ matrix.solver }}"
+    ++ run ?cond "Compile" ["bash -exu .github/scripts/main/solvers.sh"]
     ++ end_job f
 
 let upgrade_job ~analyse_job ~build_linux_job ~build_windows_job ~build_macOS_job ?section runner ~oc ~workflow f =

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -549,8 +549,15 @@ jobs:
     steps:
     - name: Checkout tree
       uses: actions/checkout@v5
+    - name: Get changed files
+      id: files
+      if: github.event_name == 'pull_request'
+      uses: Ana06/get-changed-files@v2.3.0
+      with:
+        filter: src/solver/**
     - name: src_ext/archives and opam-repository Cache
       id: archives
+      if: steps.files.outputs.all != ''
       uses: actions/cache@v4
       with:
         path: |
@@ -560,15 +567,17 @@ jobs:
         enableCrossOsArchive: true
     - name: OCaml ${{ matrix.ocamlv }} Cache
       id: ocaml-cache
+      if: steps.files.outputs.all != ''
       uses: actions/cache@v4
       with:
         path: ~/.cache/ocaml-local/**
         key: ${{ runner.os }}-ocaml-${{ matrix.ocamlv }}-${{ needs.Analyse.outputs.ocaml-cache }}
     - name: Create OCaml ${{ matrix.ocamlv }} cache
-      if: steps.ocaml-cache.outputs.cache-hit != 'true'
+      if: steps.files.outputs.all != '' && steps.ocaml-cache.outputs.cache-hit != 'true'
       run: bash -exu .github/scripts/main/ocaml-cache.sh ${{ runner.os }} ${{ matrix.ocamlv }}
     - name: opam bootstrap Cache
       id: opam-bootstrap
+      if: steps.files.outputs.all != ''
       uses: actions/cache@v4
       with:
         path: |
@@ -576,9 +585,10 @@ jobs:
           ~/.cache/opam-local/bin/**
         key: opam-${{ matrix.solver }}-${{ runner.os }}-${{ env.OPAMBSVERSION }}-${{ matrix.ocamlv }}-${{ env.OPAM_REPO_SHA }}-${{ needs.Analyse.outputs.opam-bs-cache }}
     - name: Create opam bootstrap cache
-      if: steps.opam-bootstrap.outputs.cache-hit != 'true'
+      if: steps.files.outputs.all != '' && steps.opam-bootstrap.outputs.cache-hit != 'true'
       run: bash -exu .github/scripts/main/opam-bs-cache.sh
     - name: Compile
+      if: steps.files.outputs.all != ''
       run: bash -exu .github/scripts/main/solvers.sh
 
 ####

--- a/master_changes.md
+++ b/master_changes.md
@@ -205,6 +205,7 @@ users)
   * Bump opam binary used in depexts actions to 2.4.1 [#6676 @rjbou]
   * Check `src_ext/update-sources.sh` using shellcheck [#6701 @kit-ty-kate]
   * Remove upgrade from 1.2 to current root macos job [#6745 @rjbou]
+  * Enable macOS solver job only if `src/solver` has changed [#6745 @rjbou]
 
 ## Doc
   * Update the installation documentation with the release of opam 2.4.1 [#6620 @kit-ty-kate]


### PR DESCRIPTION
* remove upgrade from 1.2 to current version macos job
* enable solvers jobs on macos only if `src/solver` is modified
