### PR TITLE
Harden the Makefile's inline shell scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.SHELLFLAGS := -eu$(if $(shell (set -o pipefail 2>/dev/null > /dev/null && echo yes)),o pipefail) $(.SHELLFLAGS)
+
 ifeq ($(filter distclean clean,$(MAKECMDGOALS)),)
 -include Makefile.config
 endif

--- a/admin-scripts/Makefile
+++ b/admin-scripts/Makefile
@@ -1,3 +1,5 @@
+.SHELLFLAGS := -eu$(if $(shell (set -o pipefail 2>/dev/null > /dev/null && echo yes)),o pipefail) $(.SHELLFLAGS)
+
 DEPS = core format repository
 
 INCLUDE = $(patsubst %,-I ../src/%,$(DEPS)) -I ../src/tools

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,3 +1,5 @@
+.SHELLFLAGS := -eu$(if $(shell (set -o pipefail 2>/dev/null > /dev/null && echo yes)),o pipefail) $(.SHELLFLAGS)
+
 -include ../Makefile.config
 
 ifeq ($(DUNE),)

--- a/master_changes.md
+++ b/master_changes.md
@@ -78,12 +78,14 @@ users)
   * Clean variables before calling make on different projects to avoid clashes [#6769 @kit-ty-kate]
   * Add the upcoming OCaml 5.5 (trunk) support when using dune's dev profile [#6670 @kit-ty-kate]
   * Update the download-if-missing patch to 3.1.0 [#6772 @kit-ty-kate]
+  * Harden the Makefile's inline shell scripts [#6751 @kit-ty-kate]
 
 ## Infrastructure
 
 ## Release scripts
   * Fix the placement of the vendored archives in the release tarball [#6765 @kit-ty-kate - fix #6762]
   * Fix the Windows build [#6769 @kit-ty-kate]
+  * Harden the Makefile's inline shell scripts [#6751 @kit-ty-kate]
 
 ## Install script
   * Add `2.5.0~alpha1` to the installers [#6748 @kit-ty-kate]

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,3 +1,5 @@
+.SHELLFLAGS := -eu$(if $(shell (set -o pipefail 2>/dev/null > /dev/null && echo yes)),o pipefail) $(.SHELLFLAGS)
+
 TAG = master
 VERSION = $(shell git describe $(TAG))
 OPAM_VERSION = $(subst -,~,$(VERSION))
@@ -31,8 +33,7 @@ $(OUTDIR)/opam-full-$(VERSION).tar.gz:
 	git clone $(GIT_URL) -b $(TAG) "$(OUTDIR)/opam-full-$(VERSION)"
 	unset MAKEFLAGS MAKEOVERRIDES && \
 	  $(MAKE) -C "$(OUTDIR)/opam-full-$(VERSION)" OCAML=$(call pathsearch,ocaml) download-ext
-	( set -euo pipefail && \
-	  cd "$(OUTDIR)/opam-full-$(VERSION)" && \
+	( cd "$(OUTDIR)/opam-full-$(VERSION)" && \
 	  git archive "$(TAG)" \
 		--mtime "$$(git show -s --format=%ct "$(TAG)" | tail -1)" \
 		-o "$(abspath $(OUTDIR)/opam-full-$(VERSION).tar)" \

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -1,3 +1,5 @@
+.SHELLFLAGS := -eu$(if $(shell (set -o pipefail 2>/dev/null > /dev/null && echo yes)),o pipefail) $(.SHELLFLAGS)
+
 ifneq ($(wildcard ../Makefile.config)$(filter-out archives cache-archives,$(MAKECMDGOALS)),)
 -include ../Makefile.config
 endif


### PR DESCRIPTION
Some of the `src_ext` Makefile in particular, broke during the release of 2.5.0~alpha1 for whatever temporary reason but only showed the error well after the error had past