### PR TITLE
`install.sh`: update and fix apparmor section

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -95,6 +95,7 @@ users)
   * Use `install` instead of `mv`+`chmod`+`chown` [#6760 @rjbou]
   * Clean apparmor temporary file [#6760 @rjbou]
   * Use variables instead of plain paths [#6760 @rjbou]
+  * Reword apparmor message when user need to check the profile [#6760 @rjbou]
 
 ## Admin
 

--- a/shell/install.sh
+++ b/shell/install.sh
@@ -835,7 +835,9 @@ EOF
     rm "$TMP_APPARMOR_PROFILE"
     echo "AppArmor profile successfully added."
   else
-    echo "Warning: Please make sure an AppArmor profile exists for opam. See $TMP_APPARMOR_PROFILE"
+    echo "Warning: Please make sure an AppArmor profile exists for locally installed opam."
+    echo "  You can find our proposed profile in $TMP_APPARMOR_PROFILE,"
+    echo "  and see if there is any difference with the one installed in $APPARMOR_PROFILE."
   fi
 fi
 


### PR DESCRIPTION
* Fix apparmor profile remplacement option
* Use `install` instead of `mv`+`chmod`+`chown`
* Clean apparmor temporary file
* Use variables instead of plain paths
* Reword apparmor message when user need to check the profile

* [x] Queued on https://github.com/ocaml/opam/pull/6767 