### PR TITLE
Fix the placement of the vendored archives in the release tarball

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -77,6 +77,7 @@ users)
 ## Infrastructure
 
 ## Release scripts
+  * Fix the placement of the vendored archives in the release tarball [#6765 @kit-ty-kate - fix #6762]
 
 ## Install script
   * Add `2.5.0~alpha1` to the installers [#6748 @kit-ty-kate]

--- a/release/Makefile
+++ b/release/Makefile
@@ -33,10 +33,10 @@ $(OUTDIR)/opam-full-$(VERSION).tar.gz:
 	( set -euo pipefail && \
 	  cd "$(OUTDIR)/opam-full-$(VERSION)" && \
 	  git archive "$(TAG)" \
-		--prefix "opam-full-$(VERSION)/" \
 		--mtime "$$(git show -s --format=%ct "$(TAG)" | tail -1)" \
 		-o "$(abspath $(OUTDIR)/opam-full-$(VERSION).tar)" \
-		$$(for f in $$(git ls-files -i -o -x '*'); do echo "--add-file=$$f" || exit 1; done) && \
+		$$(for f in $$(git ls-files -i -o -x '*'); do echo "--prefix=opam-full-$(VERSION)/$$(dirname -- $$f)/ --add-file=$$f" || exit 1; done) \
+		--prefix "opam-full-$(VERSION)/" && \
 	  gzip --no-name --best "$(abspath $(OUTDIR)/opam-full-$(VERSION).tar)" )
 	rm -rf "$(OUTDIR)/opam-full-$(VERSION)"
 


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/6762

I messed up in #6706 and forgot to check that the archives were at the correct place (and to read the man page correctly).
In 2.5.0\~alpha1 the archives are in the tarball (which i did check) but they were in the toplevel directory instead of `src_ext/archives`.

Per `git-archive(1)`:
```
--prefix=<prefix>/
    Prepend <prefix>/ to paths in the archive. Can be repeated; its rightmost value is used for all
    tracked files. See below which value gets used by --add-file.

--add-file=<file>
    Add a non-tracked file to the archive. Can be repeated to add multiple files. The path of the
    file in the archive is built by concatenating the value of the last --prefix option (if any)
    before this --add-file and the basename of <file>.
```

So a `--prefix` needs to be inserted before each `--add-file` and the "main" prefix needs to be moved to be the last argument as it will be used for all the other files.

Backported to the 2.5 branch in https://github.com/ocaml/opam/pull/6766