### PR TITLE
Clean variables before calling make on different projects to avoid clashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,10 +282,10 @@ endif
 
 .PHONY: compiler cold
 compiler:
-	env MAKE=$(MAKE) BOOTSTRAP_EXTRA_OPTS= BOOTSTRAP_TARGETS=world.opt BOOTSTRAP_ROOT=.. BOOTSTRAP_DIR=bootstrap ./shell/bootstrap-ocaml.sh $(OCAML_PORT)
+	env MAKE=$(MAKE) BOOTSTRAP_EXTRA_OPTS= BOOTSTRAP_TARGETS=world.opt BOOTSTRAP_ROOT=.. BOOTSTRAP_DIR=bootstrap MAKEFLAGS= MAKEOVERRIDES= ./shell/bootstrap-ocaml.sh $(OCAML_PORT)
 
 src_ext/secondary/ocaml/bin/ocaml:
-	env MAKE=$(MAKE) BOOTSTRAP_EXTRA_OPTS="--disable-ocamldoc --disable-debug-runtime --disable-debugger" BOOTSTRAP_TARGETS="world opt" BOOTSTRAP_ROOT=../.. BOOTSTRAP_DIR=src_ext/secondary ./shell/bootstrap-ocaml.sh $(OCAML_PORT)
+	env MAKE=$(MAKE) BOOTSTRAP_EXTRA_OPTS="--disable-ocamldoc --disable-debug-runtime --disable-debugger" BOOTSTRAP_TARGETS="world opt" BOOTSTRAP_ROOT=../.. BOOTSTRAP_DIR=src_ext/secondary MAKEFLAGS= MAKEOVERRIDES= ./shell/bootstrap-ocaml.sh $(OCAML_PORT)
 
 cold: compiler
 	env PATH="`pwd`/bootstrap/ocaml/bin:$$PATH" CAML_LD_LIBRARY_PATH= OPAM_SWITCH_PREFIX= ./configure --with-vendored-deps --without-dune --enable-cold-check $(CONFIGURE_ARGS)

--- a/master_changes.md
+++ b/master_changes.md
@@ -75,11 +75,13 @@ users)
 
 ## Build
   * opam no longer depends on `cmdliner` [#6755 @kit-ty-kate - fix #6425]
+  * Clean variables before calling make on different projects to avoid clashes [#6769 @kit-ty-kate]
 
 ## Infrastructure
 
 ## Release scripts
   * Fix the placement of the vendored archives in the release tarball [#6765 @kit-ty-kate - fix #6762]
+  * Fix the Windows build [#6769 @kit-ty-kate]
 
 ## Install script
   * Add `2.5.0~alpha1` to the installers [#6748 @kit-ty-kate]

--- a/release/Makefile
+++ b/release/Makefile
@@ -29,7 +29,8 @@ riscv64-linux: $(OUTDIR)/opam-$(VERSION)-riscv64-linux
 $(OUTDIR)/opam-full-$(VERSION).tar.gz:
 	mkdir -p "$(OUTDIR)"
 	git clone $(GIT_URL) -b $(TAG) "$(OUTDIR)/opam-full-$(VERSION)"
-	$(MAKE) -C "$(OUTDIR)/opam-full-$(VERSION)" OCAML=$(call pathsearch,ocaml) download-ext
+	unset MAKEFLAGS MAKEOVERRIDES && \
+	  $(MAKE) -C "$(OUTDIR)/opam-full-$(VERSION)" OCAML=$(call pathsearch,ocaml) download-ext
 	( set -euo pipefail && \
 	  cd "$(OUTDIR)/opam-full-$(VERSION)" && \
 	  git archive "$(TAG)" \
@@ -119,7 +120,8 @@ build/$(HOST).env:
 	cd build/$(HOST)/ocaml-$(OCAMLV) && curl -OL $(FLEXDLL_URL)
 	cd build/$(HOST)/ocaml-$(OCAMLV) && tar xzf $(shell basename "$(FLEXDLL_URL)")
 	cd build/$(HOST)/ocaml-$(OCAMLV) && rmdir flexdll && mv "flexdll-$(FLEXDLLV)" flexdll
-	cd build/$(HOST)/ocaml-$(OCAMLV) && \
+	unset MAKEFLAGS MAKEOVERRIDES && \
+	  cd build/$(HOST)/ocaml-$(OCAMLV) && \
 	  ./configure --prefix "$(shell pwd)/build/$(HOST)" \
 	    --disable-debug-runtime --disable-debugger --disable-instrumented-runtime \
 	    --disable-ocamldoc --disable-stdlib-manpages --disable-ocamltest \
@@ -139,6 +141,7 @@ host: $(OUTDIR)/opam-full-$(VERSION).tar.gz build/$(HOST).env
 	    MAKE=$(MAKE) \
 	    $(EXPORTS_$(HOST_OS)); \
 	  cd build/opam-full-$(VERSION) && \
+	  unset MAKEFLAGS MAKEOVERRIDES && \
 	  ./configure --with-vendored-deps --with-mccs \
 	    $(EXTRA_OPAM_CONFIGURE_ARGS_$(HOST_OS)) && \
 	  echo "$(call LINKING,$(HOST_OS))" >src/client/linking.sexp && \


### PR DESCRIPTION
This fixes the compilation of the OCaml compiler on Windows during the release process

Backported to 2.5 in https://github.com/ocaml/opam/pull/6770