### PR TITLE
[2.5 backport] Allow the macOS sandbox to write in the /var/folders/ and /var/db/mds/ directories

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -67,6 +67,7 @@ users)
 ## Format upgrade
 
 ## Sandbox
+  * Allow the macOS sandbox to write in the `/var/folders/` and `/var/db/mds/` directories as it is required by some of macOS core tools [#4797 @kit-ty-kate - fix #4389 #6460]
 
 ## VCS
 

--- a/src/state/shellscripts/sandbox_exec.sh
+++ b/src/state/shellscripts/sandbox_exec.sh
@@ -8,6 +8,8 @@ POL='(version 1)(allow default)(deny network*)(deny file-write*)'
 POL="$POL"'(allow network* (remote unix))'
 POL="$POL"'(allow file-write* (literal "/dev/null") (literal "/dev/dtracehelper"))'
 POL="$POL"'(allow file-write* (regex #"^(/private)?(/var)?/tmp/"))'
+POL="$POL"'(allow file-write* (regex #"^(/private)?/var/folders/"))'
+POL="$POL"'(allow file-write* (regex #"^(/private)?/var/db/mds/"))'
 
 add_mounts() {
     if [ -d "$2" ]; then


### PR DESCRIPTION
Backport of https://github.com/ocaml/opam/pull/4797 to the 2.5 branch