### PR TITLE
Allow moving a file to a directory with the same name (and vice-versa) in opam repositories

### DIFF
--- a/tests/reftests/update.test
+++ b/tests/reftests/update.test
@@ -783,3 +783,24 @@ eta.1: Missing extra-file for
 +- 
 - No changes have been performed
 # Return code 31 #
+### :V:1: Check that a file can become a directory
+### <CORNER_CASE_REPO/repo>
+opam-version: "2.0"
+### <CORNER_CASE_REPO/packages/pkg/pkg.1>
+opam-version: "2.0"
+### opam repo add --dont-select corner-case ./CORNER_CASE_REPO
+[corner-case] Initialised
+### opam list --repos=corner-case -A
+# Packages matching: from-repository(corner-case) & any
+# No matches found
+### mv CORNER_CASE_REPO/packages/pkg/pkg.1 CORNER_CASE_REPO/tmp
+### mkdir CORNER_CASE_REPO/packages/pkg/pkg.1
+### mv CORNER_CASE_REPO/tmp CORNER_CASE_REPO/packages/pkg/pkg.1/opam
+### opam update corner-case
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[ERROR] Could not update repository "corner-case": Change from a regular file to a directory is unsupported
+# Return code 40 #
+### opam list --repos=corner-case -A
+# Packages matching: from-repository(corner-case) & any
+# No matches found


### PR DESCRIPTION
Fixes #3830 

https://github.com/ocaml/opam/pull/5892 allows us to implement this, however it is a corner-case that wasn't supported before so i chose to not implement it at the time. It instead now at least show a proper error message.

It might be interesting to implement it in the future to avoid breaking users if issues such as the one described in #3830 happened again.

TODO:
- [ ] Implement file -> dir (see `OpamRepositoryBackend`)
- [ ] Implement dir -> file (see `OpamRepositoryBackend`, this one is a quite a bit more complicated as it involves checking that the directory doesn't contain other files that aren't moved too and moving them at the same time if so)
- [ ] Add more tests (e.g. git repository, patchDiff.ml, etc...)