### PR TITLE
chore: add spacing between two words in `--locked` man section

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -132,6 +132,7 @@ users)
   * Remove the unconditional Windows binary uploads on PRs [#6771 @kit-ty-kate]
 
 ## Doc
+  * Add spacing between two words in `--locked` man section [#6806 @yosefAlsuhaibani]
 
 ## Security fixes
 

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1418,7 +1418,7 @@ let locked ?section cli =
      of the file with an added .$(i,locked) extension is found (e.g. \
      $(b,foo.opam.locked) besides $(b,foo.opam)), that will be used instead. \
      This is typically useful to offer a more specific set of dependencies \
-     and reproduce similar build contexts, hence the name. The $(i, lock)\
+     and reproduce similar build contexts, hence the name. The $(i, lock) \
      option can be used to generate such files, based on the versions \
      of the dependencies currently installed on the host. This is equivalent \
      to setting the $(b,\\$OPAMLOCKED) environment variable. Note that this \


### PR DESCRIPTION
Please update `master_changes.md` file with your changes.


I noticed while reading the `--locked` man page that `lock` and `option` were conjoined; this PR just adds space between them in the doc string :)