### PR TITLE
Call man2html only on actual man pages

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -38,7 +38,7 @@ man-html:
 	echo '</head><body>' >>$@/index.html
 	echo '<h1>Opam $(version) man-pages index</h1>' >>$@/index.html
 	echo '<ul>' >>$@/index.html
-	for f in ${MANDIR}/*; do\
+	for f in ${MANDIR}/*.1; do\
 	  man2html -r $$f | sed 1,2d > $@/$$(basename $$f .1).html;\
 	  echo "  <li><a href=\"$$(basename $$f .1).html\">$$(basename $$f .1)</a></li>" >>$@/index.html;\
 	done

--- a/master_changes.md
+++ b/master_changes.md
@@ -193,6 +193,7 @@ users)
   * Mention more explicitely that raw fields are an option [@raphael-proust]
   * Correct configure instruction in README [#6858 @gridbugs @kit-ty-kate]
   * Improve visibility of `depopts` filter note [#6920 @ccoulombel - fix #5367]
+  * Call man2html only on actual man pages [#6807 @kit-ty-kate]
 
 ## Security fixes
   * Invalidate .install fields containing destination filepath trying to escape their scope [#6897 @kit-ty-kate]


### PR DESCRIPTION
While this doesn't really matter as `man2html` ignores errors, the output of `opam2web` is filled with error messages from unrelated files and fills the `/doc/man` directory with empty files such as `dune_man.exe` (see https://staging.opam.ocaml.org/doc/man/, disregard the non-working links for now, see https://github.com/ocaml/opam/issues/6637)

Detected while working on fixing https://github.com/ocaml-opam/opam2web/pull/249
Related to https://github.com/ocaml-opam/opam2web/pull/250
* [x] Queued on https://github.com/ocaml/opam/issues/6810