### PR TITLE
Set environment variables needed for bash, zsh completion in opam env

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -59,6 +59,7 @@ users)
 ## Clean
 
 ## Env
+  * Env now sets `XDG_DATA_DIRS` to include the opam share directory and `FPATH` to include share/zsh/site-functions. Tools which install shell autocomplete scripts in these directories will now be picked up automatically. [#6427 @WardBrian - fix #6812]
 
 ## Opamfile
 

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -613,7 +613,7 @@ let env_update_resolved_with_default ?comment var =
   let rewrite = Some (SPF_Resolved (Some (default_sep_fmt_str var))) in
   env_update_resolved ?comment ~rewrite var
 
-let compute_updates ?(force_path=false) st =
+let compute_updates ?(force_path=false) ?(shell=None) st =
   (* Todo: put these back into their packages!
   let perl5 = OpamPackage.Name.of_string "perl5" in
   let add_to_perl5lib =  OpamPath.Switch.lib t.root t.switch t.switch_config perl5 in
@@ -640,14 +640,34 @@ let compute_updates ?(force_path=false) st =
                 st.switch st.switch_config))
           ~comment:"Current opam switch man dir"
       ]
- in
- let switch_env =
-   (env_update_resolved_with_default "OPAM_SWITCH_PREFIX" Eq
-      (OpamFilename.Dir.to_string
-         (OpamPath.Switch.root st.switch_global.root st.switch))
-      ~comment:"Prefix of the current opam switch")
-   ::
-   List.map (env_expansion st) (OpamFile.Switch_config.env st.switch_config)
+  in
+  let share_dir = OpamFilename.Dir.to_string (OpamPath.Switch.share_dir st.switch_global.root st.switch st.switch_config) in
+  let shell = match shell with
+    | Some s -> s
+    | None -> OpamStd.Sys.guess_shell_compat () in
+  let zsh_fpath =
+    match shell with
+    | SH_zsh ->
+      (* add share/zsh/site-functions to FPATH for function lookup *)
+      [ env_update_resolved_with_default "FPATH"
+          EqPlusEq (Filename.concat share_dir (Filename.concat "zsh" "site-functions"))
+          ~comment:"Current opam switch zsh site-functions"
+      ]
+    | _ -> []
+  in
+  let xdg_data_dirs =
+    (* in particular, this is used by bash-completion, but it is not specific to it *)
+    [ env_update_resolved_with_default "XDG_DATA_DIRS"
+        EqPlusEq share_dir
+        ~comment:"Current opam switch share dir" ]
+  in
+  let switch_env =
+    (env_update_resolved_with_default "OPAM_SWITCH_PREFIX" Eq
+       (OpamFilename.Dir.to_string
+          (OpamPath.Switch.root st.switch_global.root st.switch))
+       ~comment:"Prefix of the current opam switch")
+    ::
+    List.map (env_expansion st) (OpamFile.Switch_config.env st.switch_config)
   in
   let pkg_env = (* XXX: Does this need a (costly) topological sort? *)
     let updates =
@@ -660,7 +680,8 @@ let compute_updates ?(force_path=false) st =
     in
     List.map resolve_separator_and_format updates
   in
-  switch_env @ pkg_env @ man_path @ [path]
+  switch_env @ pkg_env @ man_path @ xdg_data_dirs @ zsh_fpath @ [path]
+
 
 let updates_common ~set_opamroot ~set_opamswitch root switch =
   let root =
@@ -688,11 +709,11 @@ let updates_nix st =
      | Some env -> List.map resolve_separator_and_format env)
   | _ -> []
 
-let updates ~set_opamroot ~set_opamswitch ?force_path st =
+let updates ~set_opamroot ~set_opamswitch ?force_path ?shell st =
   let common =
     updates_common ~set_opamroot ~set_opamswitch st.switch_global.root st.switch
   in
-  common @ compute_updates ?force_path st @ updates_nix st
+  common @ compute_updates ?force_path ?shell st @ updates_nix st
 
 let get_pure ?(updates=[]) () =
   let env = List.map (fun (v,va) -> v,va,None) (OpamStd.Env.list ()) in
@@ -943,7 +964,8 @@ let env_hook_file = function
   | SH_pwsh _ | SH_cmd -> None
 
 let variables_file = function
-  | SH_sh | SH_bash | SH_zsh -> "variables.sh"
+  | SH_sh | SH_bash -> "variables.sh"
+  | SH_zsh -> "variables.zsh"
   | SH_csh -> "variables.csh"
   | SH_fish -> "variables.fish"
   | SH_pwsh _ -> "variables.ps1"
@@ -1226,10 +1248,6 @@ let write_dynamic_init_scripts st =
     end
   | _ -> true
   in
-  let updates =
-    updates ~set_opamroot:false ~set_opamswitch:false st
-    |> List.filter is_not_empty_update
-  in
   try
     if OpamStateConfig.is_newer_than_self
         ~lock_kind:`Lock_write st.switch_global then
@@ -1239,11 +1257,15 @@ let write_dynamic_init_scripts st =
     @@ fun _ ->
     List.iter
       (fun shell ->
+         let updates =
+           updates ~set_opamroot:false ~set_opamswitch:false ~shell:(Some shell) st
+           |> List.filter is_not_empty_update
+         in
          write_script (OpamPath.init st.switch_global.root)
            (variables_file shell,
             abort_if_set "OPAM_SWITCH_PREFIX" shell
             ^ string_of_update st shell updates))
-      [SH_sh; SH_csh; SH_fish; SH_pwsh Powershell; SH_cmd]
+      [SH_sh; SH_zsh; SH_csh; SH_fish; SH_pwsh Powershell; SH_cmd]
   with OpamSystem.Locked ->
     OpamConsole.warning
       "Global shell init scripts not installed (could not acquire lock)"

--- a/src/state/opamEnv.mli
+++ b/src/state/opamEnv.mli
@@ -75,7 +75,7 @@ val add: env -> (spf_resolved, euok_internal) env_update list -> env
 (** Like {!get_opam} computes environment modification by OPAM , but returns
     these [updates] instead of the new environment. *)
 val updates:
-  set_opamroot:bool -> set_opamswitch:bool -> ?force_path:bool ->
+  set_opamroot:bool -> set_opamswitch:bool -> ?force_path:bool -> ?shell:shell option ->
   'a switch_state -> (spf_resolved, [> euok_writeable ]) env_update list
 
 (** Check if the shell environment is in sync with the current OPAM switch,
@@ -89,7 +89,9 @@ val is_up_to_date_switch: dirname -> switch -> bool
 
 (** Returns the current environment updates to configure the current switch with
     its set of installed packages *)
-val compute_updates: ?force_path:bool -> 'a switch_state -> (spf_resolved, [> euok_writeable ]) env_update list
+val compute_updates:
+  ?force_path:bool -> ?shell:shell option -> 'a switch_state ->
+  (spf_resolved, [> euok_writeable ]) env_update list
 
 (** Returns shell-appropriate statement to evaluate [cmd]. *)
 val shell_eval_invocation:

--- a/tests/reftests/action-disk.test
+++ b/tests/reftests/action-disk.test
@@ -172,6 +172,7 @@ FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-sw
 FILE(environment)               Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-switch/environment atomically in 0.000s
 FILE(config)                    Wrote ${BASEDIR}/OPAM/config atomically in 0.000s
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.sh
+SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.zsh
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.csh
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.fish
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.ps1
@@ -585,6 +586,7 @@ FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/
 FILE(environment)               Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/environment atomically in 0.000s
 FILE(config)                    Wrote ${BASEDIR}/OPAM/config atomically in 0.000s
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.sh
+SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.zsh
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.csh
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.fish
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.ps1
@@ -1238,6 +1240,7 @@ FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.
 FILE(environment)               Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/environment atomically in 0.000s
 FILE(config)                    Wrote ${BASEDIR}/OPAM/config atomically in 0.000s
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.sh
+SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.zsh
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.csh
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.fish
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.ps1
@@ -1943,6 +1946,7 @@ FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-version-pin/.
 FILE(environment)               Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/environment atomically in 0.000s
 FILE(config)                    Wrote ${BASEDIR}/OPAM/config atomically in 0.000s
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.sh
+SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.zsh
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.csh
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.fish
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.ps1
@@ -2342,6 +2346,7 @@ FILE(switch-state)              Wrote ${BASEDIR}/OPAM/package-switch/.opam-switc
 FILE(environment)               Wrote ${BASEDIR}/OPAM/package-switch/.opam-switch/environment atomically in 0.000s
 FILE(config)                    Wrote ${BASEDIR}/OPAM/config atomically in 0.000s
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.sh
+SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.zsh
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.csh
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.fish
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.ps1

--- a/tests/reftests/env-idempotent.test
+++ b/tests/reftests/env-idempotent.test
@@ -32,5 +32,5 @@ User configuration:
 ### # Simulate nuking a root entirely
 ### opam switch create fake2 --empty --root root
 ### rm -rf root/fake2
-### bash bash-lc.sh "'$OPAMBIN' exec --root root --switch=fake -- env" | grep -v MANPATH | grep /root/fake2/ | '=.*' -> ''
+### bash bash-lc.sh "'$OPAMBIN' exec --root root --switch=fake -- env" | grep -v MANPATH | grep -v XDG_DATA_DIRS | grep /root/fake2/ | '=.*' -> ''
 PATH

--- a/tests/reftests/env.test
+++ b/tests/reftests/env.test
@@ -609,6 +609,7 @@ OPAMSWITCH=bd
 OPAM_PACKAGE_NAME=to-build
 OPAM_PACKAGE_VERSION=2
 OPAM_SWITCH_PREFIX=${BASEDIR}/OPAM/bd
+XDG_DATA_DIRS=${BASEDIR}/OPAM/bd/share
 PATH=${BASEDIR}/OPAM/bd/bin
 ### opam remove to-build
 The following actions will be performed:
@@ -650,4 +651,5 @@ OPAMSWITCH=bd
 OPAM_PACKAGE_NAME=another-package
 OPAM_PACKAGE_VERSION=another-version
 OPAM_SWITCH_PREFIX=${BASEDIR}/OPAM/bd
+XDG_DATA_DIRS=${BASEDIR}/OPAM/bd/share
 PATH=${BASEDIR}/OPAM/bd/bin:another-path

--- a/tests/reftests/env.unix.test
+++ b/tests/reftests/env.unix.test
@@ -764,7 +764,17 @@ Processing  2/3: [all-formulae: sh env | grep RAF_ENV | sort]
 [ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ("host" true | "target-quoted" true). Using default ':' 'target'.
 [ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ":" true | ";" true. Using default ':' 'target'.
 [ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ("host" true | "target-quoted" true). Using default ':' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ":" true | ";" true. Using default ':' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ("host" true | "target-quoted" true). Using default ':' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ":" true | ";" true. Using default ':' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ("host" true | "target-quoted" true). Using default ':' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ":" true | ";" true. Using default ':' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ("host" true | "target-quoted" true). Using default ':' 'target'.
 Done.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ":" true | ";" true. Using default ':' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ("host" true | "target-quoted" true). Using default ':' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ":" true | ";" true. Using default ':' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ("host" true | "target-quoted" true). Using default ':' 'target'.
 ### opam env | sort | grep "RAF_ENV"
 RAF_ENVSET_ATOM='/is/atom'; export RAF_ENVSET_ATOM;
 RAF_ENVSET_DBL='sec/ond:fir/st'; export RAF_ENVSET_DBL;

--- a/tests/reftests/env.win32.test
+++ b/tests/reftests/env.win32.test
@@ -811,7 +811,17 @@ Processing  2/3: [all-formulae: sh env | grep RAF_ENV | sort]
 [ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ("host" true | "target-quoted" true). Using default ';' 'target'.
 [ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ":" true | ";" true. Using default ';' 'target'.
 [ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ("host" true | "target-quoted" true). Using default ';' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ":" true | ";" true. Using default ';' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ("host" true | "target-quoted" true). Using default ';' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ":" true | ";" true. Using default ';' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ("host" true | "target-quoted" true). Using default ';' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ":" true | ";" true. Using default ';' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ("host" true | "target-quoted" true). Using default ';' 'target'.
 Done.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ":" true | ";" true. Using default ';' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ("host" true | "target-quoted" true). Using default ';' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ":" true | ";" true. Using default ';' 'target'.
+[ERROR] Formula can't be completely resolved : RAF_ENVSET_UNRES ("host" true | "target-quoted" true). Using default ';' 'target'.
 ### opam env | sort | grep "RAF_ENV"
 RAF_ENVSET_ATOM='\is\atom'; export RAF_ENVSET_ATOM;
 RAF_ENVSET_DBL='sec/ond;fir/st'; export RAF_ENVSET_DBL;

--- a/tests/reftests/init-scripts.unix.test
+++ b/tests/reftests/init-scripts.unix.test
@@ -26,6 +26,7 @@ variables.csh
 variables.fish
 variables.ps1
 variables.sh
+variables.zsh
 ### : Init scripts :
 ### cat root/opam-init/init.sh
 if [ -t 0 ]; then
@@ -42,7 +43,7 @@ if [[ -o interactive ]]; then
   [[ ! -r '${BASEDIR}/root/opam-init/env_hook.zsh' ]] || source '${BASEDIR}/root/opam-init/env_hook.zsh' > /dev/null 2> /dev/null; true
 fi
 
-[[ ! -r '${BASEDIR}/root/opam-init/variables.sh' ]] || source '${BASEDIR}/root/opam-init/variables.sh' > /dev/null 2> /dev/null; true
+[[ ! -r '${BASEDIR}/root/opam-init/variables.zsh' ]] || source '${BASEDIR}/root/opam-init/variables.zsh' > /dev/null 2> /dev/null; true
 ### cat root/opam-init/init.fish
 if status is-interactive
   test -r '${BASEDIR}/root/opam-init/env_hook.fish' && source '${BASEDIR}/root/opam-init/env_hook.fish' > /dev/null 2> /dev/null; or true
@@ -64,14 +65,26 @@ if Test-Path "${BASEDIR}/root/opam-init/variables.ps1" { . "${BASEDIR}/root/opam
 test -z "${OPAM_SWITCH_PREFIX:+x}" || return 0
 # Prefix of the current opam switch
 OPAM_SWITCH_PREFIX='${BASEDIR}/root/fake'; export OPAM_SWITCH_PREFIX;
+# Current opam switch share dir
+XDG_DATA_DIRS='${BASEDIR}/root/fake/share':"$XDG_DATA_DIRS"; export XDG_DATA_DIRS;
 # Binary dir for opam switch fake
 PATH='${BASEDIR}/root/fake/bin':"$PATH"; export PATH;
-### test -f root/opam-init/variables.zsh
-# Return code 1 #
+### cat root/opam-init/variables.zsh | grep -v man | grep -v MANPATH
+test -z "${OPAM_SWITCH_PREFIX:+x}" || return 0
+# Prefix of the current opam switch
+OPAM_SWITCH_PREFIX='${BASEDIR}/root/fake'; export OPAM_SWITCH_PREFIX;
+# Current opam switch share dir
+XDG_DATA_DIRS='${BASEDIR}/root/fake/share':"$XDG_DATA_DIRS"; export XDG_DATA_DIRS;
+# Current opam switch zsh site-functions
+FPATH='${BASEDIR}/root/fake/share/zsh/site-functions':"$FPATH"; export FPATH;
+# Binary dir for opam switch fake
+PATH='${BASEDIR}/root/fake/bin':"$PATH"; export PATH;
 ### cat root/opam-init/variables.fish | grep -v man | grep -v MANPATH
 test -z "$OPAM_SWITCH_PREFIX"; or return 0
 # Prefix of the current opam switch
 set -gx OPAM_SWITCH_PREFIX '${BASEDIR}/root/fake';
+# Current opam switch share dir
+set -gx XDG_DATA_DIRS '${BASEDIR}/root/fake/share':"$XDG_DATA_DIRS";
 # Binary dir for opam switch fake
 set -gx PATH '${BASEDIR}/root/fake/bin' $PATH;
 ### cat root/opam-init/variables.csh | grep -v man | grep -v MANPATH
@@ -80,6 +93,9 @@ if ( ${?OPAM_SWITCH_PREFIX} ) then
 endif
 # Prefix of the current opam switch
 setenv OPAM_SWITCH_PREFIX '${BASEDIR}/root/fake'
+# Current opam switch share dir
+if ( ! ${?XDG_DATA_DIRS} ) setenv XDG_DATA_DIRS ""
+setenv XDG_DATA_DIRS '${BASEDIR}/root/fake/share':"$XDG_DATA_DIRS"
 # Binary dir for opam switch fake
 if ( ! ${?PATH} ) setenv PATH ""
 setenv PATH '${BASEDIR}/root/fake/bin':"$PATH"
@@ -87,12 +103,16 @@ setenv PATH '${BASEDIR}/root/fake/bin':"$PATH"
 if defined OPAM_SWITCH_PREFIX if "%OPAM_SWITCH_PREFIX%" neq "" goto :EOF
 :: Prefix of the current opam switch
 set "OPAM_SWITCH_PREFIX=${BASEDIR}/root/fake"
+:: Current opam switch share dir
+set "XDG_DATA_DIRS=${BASEDIR}/root/fake/share:%XDG_DATA_DIRS%"
 :: Binary dir for opam switch fake
 set "PATH=${BASEDIR}/root/fake/bin:%PATH%"
 ### cat root/opam-init/variables.ps1 | grep -v man | grep -v MANPATH
 if ($env:OPAM_SWITCH_PREFIX -ne $null -and $env:OPAM_SWITCH_PREFIX -ne '') { return }
 # Prefix of the current opam switch
 $env:OPAM_SWITCH_PREFIX='${BASEDIR}/root/fake'
+# Current opam switch share dir
+$env:XDG_DATA_DIRS='${BASEDIR}/root/fake/share:' + "$env:XDG_DATA_DIRS"
 # Binary dir for opam switch fake
 $env:PATH='${BASEDIR}/root/fake/bin:' + "$env:PATH"
 ### : Env hook scripts :

--- a/tests/reftests/init-scripts.win32.test
+++ b/tests/reftests/init-scripts.win32.test
@@ -25,6 +25,7 @@ variables.csh
 variables.fish
 variables.ps1
 variables.sh
+variables.zsh
 ### : Init scripts :
 ### cat root/opam-init/init.sh
 if [ -t 0 ]; then
@@ -41,7 +42,7 @@ if [[ -o interactive ]]; then
   [[ ! -r '${BASEDIR}/root/opam-init/env_hook.zsh' ]] || source '${BASEDIR}/root/opam-init/env_hook.zsh' > /dev/null 2> /dev/null; true
 fi
 
-[[ ! -r '${BASEDIR}/root/opam-init/variables.sh' ]] || source '${BASEDIR}/root/opam-init/variables.sh' > /dev/null 2> /dev/null; true
+[[ ! -r '${BASEDIR}/root/opam-init/variables.zsh' ]] || source '${BASEDIR}/root/opam-init/variables.zsh' > /dev/null 2> /dev/null; true
 ### cat root/opam-init/init.fish
 if status is-interactive
   test -r '${BASEDIR}/root/opam-init/env_hook.fish' && source '${BASEDIR}/root/opam-init/env_hook.fish' > /dev/null 2> /dev/null; or true
@@ -63,10 +64,11 @@ if Test-Path "${BASEDIR}/root/opam-init/variables.ps1" { . "${BASEDIR}/root/opam
 test -z "${OPAM_SWITCH_PREFIX:+x}" || return 0
 # Prefix of the current opam switch
 OPAM_SWITCH_PREFIX='${BASEDIR}/root/fake'; export OPAM_SWITCH_PREFIX;
+# Current opam switch share dir
+XDG_DATA_DIRS='${BASEDIR}/root/fake/share':"$XDG_DATA_DIRS"; export XDG_DATA_DIRS;
 # Binary dir for opam switch fake
 PATH='${BASEDIR}/root/fake/bin':"$PATH"; export PATH;
 ### test -f root/opam-init/variables.zsh
-# Return code 1 #
 ### # ERROR, broken, see opam#5854 testing only its existence
 ### test -f root/opam-init/variables.fish
 ### cat root/opam-init/variables.csh | grep -v man | grep -v MANPATH
@@ -75,6 +77,9 @@ if ( ${?OPAM_SWITCH_PREFIX} ) then
 endif
 # Prefix of the current opam switch
 setenv OPAM_SWITCH_PREFIX '${BASEDIR}/root/fake'
+# Current opam switch share dir
+if ( ! ${?XDG_DATA_DIRS} ) setenv XDG_DATA_DIRS ""
+setenv XDG_DATA_DIRS '${BASEDIR}/root/fake/share':"$XDG_DATA_DIRS"
 # Binary dir for opam switch fake
 if ( ! ${?PATH} ) setenv PATH ""
 setenv PATH '${BASEDIR}/root/fake/bin':"$PATH"
@@ -82,12 +87,16 @@ setenv PATH '${BASEDIR}/root/fake/bin':"$PATH"
 if defined OPAM_SWITCH_PREFIX if "%OPAM_SWITCH_PREFIX%" neq "" goto :EOF
 :: Prefix of the current opam switch
 set "OPAM_SWITCH_PREFIX=${BASEDIR}/root/fake"
+:: Current opam switch share dir
+set "XDG_DATA_DIRS=${BASEDIR}/root/fake/share;%XDG_DATA_DIRS%"
 :: Binary dir for opam switch fake
 set "PATH=${BASEDIR}/root/fake/bin;%PATH%"
 ### cat root/opam-init/variables.ps1 | grep -v man | grep -v MANPATH
 if ($env:OPAM_SWITCH_PREFIX -ne $null -and $env:OPAM_SWITCH_PREFIX -ne '') { return }
 # Prefix of the current opam switch
 $env:OPAM_SWITCH_PREFIX='${BASEDIR}/root/fake'
+# Current opam switch share dir
+$env:XDG_DATA_DIRS='${BASEDIR}/root/fake/share;' + "$env:XDG_DATA_DIRS"
 # Binary dir for opam switch fake
 $env:PATH='${BASEDIR}/root/fake/bin;' + "$env:PATH"
 ### : Env hook scripts :


### PR DESCRIPTION
Would close #6427 

This updates  `opam env` to set `XDG_DATA_DIRS` (from the [XDG base directory specification](https://specifications.freedesktop.org/basedir/latest/)) to include the current switch's share root, and `FPATH` to include `%{share}%/zsh/site-functions` when the shell is zsh

The former works with [`bash-completion`](https://github.com/scop/bash-completion), which looks in the XDG_DATA_DIRS entries for `bash-completion/completions` sub-directories, while the later sets up zsh's built-in completion mechanisms to look in this location.

Questions for reviewers --

1. I currently only modify FPATH on zsh, but I think it would be safe to do it generically (the only other shell that seems to assign meaning to the FPATH variable is ksh, which opam doesn't support)
2. Assuming we want to keep FPATH zsh-specific, is it worth threading through a shell variable all the way from the CLI to where we compute these updates, or is it fine to keep the `guess_shell_compat` call?