### PR TITLE
`opam show`: Reduce I/O when multiple versions of a package exist

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -168,3 +168,4 @@ users)
   * `OpamCompat.Int.min`: was added [#6515 @kit-ty-kate]
   * `OpamStd.String.compare_case`: is now allocation free [#6515 @dra27]
   * `OpamVersionCompare.{compare,equal}`: are now allocation free [#6515 @dra27]
+  * `OpamCompat.Map.add_to_list`: was added [#6818 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -42,6 +42,7 @@ users)
 ## List
 
 ## Show
+  * Improve performance of `opam show` by reading switch selection only once instead of once per package-version [#6818 @dra27]
 
 ## Var/Option
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -156,6 +156,7 @@ users)
 
 ## opam-state
   * `OpamRepositoryState.load_opams_from_diff` track added packages to avoid removing version-equivalent packages [#6774 @arozovyk fix #6754]
+  * `OpamGlobalState.all_installed_versions`: was added [#6818 @dra27]
 
 ## opam-solver
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -158,6 +158,7 @@ users)
 ## opam-state
   * `OpamRepositoryState.load_opams_from_diff` track added packages to avoid removing version-equivalent packages [#6774 @arozovyk fix #6754]
   * `OpamGlobalState.all_installed_versions`: was added [#6818 @dra27]
+  * `OpamGlobalState.installed_versions`: was removed [#6818 @dra27]
 
 ## opam-solver
 

--- a/src/core/opamCompat.ml
+++ b/src/core/opamCompat.ml
@@ -238,6 +238,9 @@ module type MAP = sig
 
   (** NOTE: OCaml >= 4.11 *)
   val filter_map: (key -> 'a -> 'b option) -> 'a t -> 'b t
+
+  (** NOTE: OCaml >= 5.1 *)
+  val add_to_list: key -> 'a -> 'a list t -> 'a list t
 end
 
 module Map(Ord : Stdlib.Map.OrderedType) = struct
@@ -252,6 +255,11 @@ module Map(Ord : Stdlib.Map.OrderedType) = struct
         | Some value -> M.add key value map
         | None -> map
       ) map M.empty
+
+  (** NOTE: OCaml >= 5.1 *)
+  let add_to_list x data m =
+    let add = function None -> Some [data] | Some l -> Some (data :: l) in
+    M.update x add m
 
   include M
 end

--- a/src/core/opamCompat.mli
+++ b/src/core/opamCompat.mli
@@ -78,6 +78,9 @@ module type MAP = sig
 
   (** NOTE: OCaml >= 4.11 *)
   val filter_map: (key -> 'a -> 'b option) -> 'a t -> 'b t
+
+  (** NOTE: OCaml >= 5.1 *)
+  val add_to_list: key -> 'a -> 'a list t -> 'a list t
 end
 
 module Map(Ord : Stdlib.Map.OrderedType) : MAP with type key = Ord.t

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -179,6 +179,12 @@ let installed_versions gt name =
       with Not_found -> acc)
     gt OpamPackage.Map.empty
 
+let all_installed_versions gt =
+  fold_switches (fun switch sel acc ->
+      OpamPackage.Set.fold (fun nv acc ->
+        OpamPackage.Map.add_to_list nv switch acc) sel.sel_installed acc)
+    gt OpamPackage.Map.empty
+
 let repos_list gt = OpamFile.Config.repositories gt.config
 
 let unlock gt =

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -167,18 +167,6 @@ let all_installed gt =
       OpamPackage.Set.union acc sel.sel_installed)
     gt  OpamPackage.Set.empty
 
-let installed_versions gt name =
-  fold_switches (fun switch sel acc ->
-      let installed =
-        OpamPackage.packages_of_name sel.sel_installed name
-      in
-      try
-        let nv = OpamPackage.Set.choose installed in
-        try OpamPackage.Map.add nv (switch::OpamPackage.Map.find nv acc) acc
-        with Not_found -> OpamPackage.Map.add nv [switch] acc
-      with Not_found -> acc)
-    gt OpamPackage.Map.empty
-
 let all_installed_versions gt =
   fold_switches (fun switch sel acc ->
       OpamPackage.Set.fold (fun nv acc ->

--- a/src/state/opamGlobalState.mli
+++ b/src/state/opamGlobalState.mli
@@ -41,6 +41,10 @@ val switch_exists: 'a global_state -> switch -> bool
     of switches they are installed in *)
 val installed_versions: 'a global_state -> name -> switch list package_map
 
+(** Returns the map of all installed packages to the list of switch(es) they're
+    installed in. *)
+val all_installed_versions: 'a global_state -> switch list package_map
+
 (** Default list of repositories to get packages from, ordered by decreasing
     priority. This can be overridden by switch-specific selections, and does not
     have to include all configured repositories. *)

--- a/src/state/opamGlobalState.mli
+++ b/src/state/opamGlobalState.mli
@@ -37,10 +37,6 @@ val fold_switches:
     local switch with a configuration file pointing to the current root *)
 val switch_exists: 'a global_state -> switch -> bool
 
-(** Returns the map of installed instances of the package name towards the list
-    of switches they are installed in *)
-val installed_versions: 'a global_state -> name -> switch list package_map
-
 (** Returns the map of all installed packages to the list of switch(es) they're
     installed in. *)
 val all_installed_versions: 'a global_state -> switch list package_map


### PR DESCRIPTION
Extracted from #6515, authored by @dra27
_I noticed with `opam show dune` that the switch selections of the switches are read in proportion to the number of versions being displayed. That creates both unnecessary I/O and GC pressure. [...] I'd countenance against hyping the performance improvement on `opam show` because it won't always show up that way!_