### PR TITLE
Fix the AppArmor support in the install script

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -99,6 +99,7 @@ users)
   * Use variables instead of plain paths [#6760 @rjbou]
   * Reword apparmor message when user need to check the profile [#6760 @rjbou]
   * Add `2.5.0` to the installers [#6817 @kit-ty-kate]
+  * Fix the AppArmor support when installing in `/usr/bin` [#6823 @kit-ty-kate - fix #6820]
 
 ## Admin
 

--- a/shell/install.sh
+++ b/shell/install.sh
@@ -808,6 +808,7 @@ echo "## opam $VERSION installed to $BINDIR"
 if [ -f /etc/apparmor.d/abi/4.0 ] && [ "$(aa-enabled 2> /dev/null)" = Yes ]; then
   TMP_APPARMOR_PROFILE=/tmp/opam-local.aa.tmp
   APPARMOR_PROFILE=/etc/apparmor.d/opam-local
+  UPSTREAM_APPARMOR_PROFILE=/etc/apparmor.d/opam
   cat << EOF > "$TMP_APPARMOR_PROFILE"
 # This profile allows everything and only exists to give the
 # application a name instead of having the label "unconfined"
@@ -826,7 +827,10 @@ EOF
   SKIP_APPARMOR=0
   APPARMOR_CREATION_OPTION="-a"
   if [ -e "$APPARMOR_PROFILE" ]; then
-    if diff -q "$TMP_APPARMOR_PROFILE" "$APPARMOR_PROFILE"; then
+    if [ -f "$UPSTREAM_APPARMOR_PROFILE" ] && [ "$(realpath "$BINDIR")" = /usr/bin ]; then
+      APPARMOR_PROFILE=$UPSTREAM_APPARMOR_PROFILE
+      SKIP_APPARMOR=1
+    elif diff -q "$TMP_APPARMOR_PROFILE" "$APPARMOR_PROFILE"; then
       SKIP_APPARMOR=1
     else
       echo "## The opam-local AppArmor profile already exists and differs from the expected content."


### PR DESCRIPTION
AppArmor currently doesn't support having multiple profiles targetting the same path. AppArmor currently ships with a builtin opam profile targetting /usr/bin/opam so we have to avoid installing our opam-local profile if BINDIR=/usr/bin

Fixes #6820 

---
*Special thanks to the AppArmor maintainer who replied to my questions on IRC.*