### PR TITLE
[API] Split the deprecated url and descr files implementations to their own submodules

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -1211,10 +1211,11 @@ files.
   defines a long description (one or more paragraphs) for the package. This can
   also be defined as the body of an external [`descr`](#descr) file.
 
-- <a id="opamsection-url">`url "{" <url-file> "}"`</a>:
-  defines the URL where the package source can be obtained. This section has
-  contents in the same format as the [`url`](#url) file, and has the same effect
-  as using a separate `url` file.
+- <a id="opamsection-url">`url "{" <url-section> "}"`</a>:
+  defines the URL where the package source can be obtained. Before opam 2.6,
+  this section' content was the same format as the [`url`](#url) file,
+  and had the same effect as using a separate `url` file.
+  As of opam 2.6, the `url` file now only supports the legacy opam 1.2 fields.
 
 - <a id="opamfield-setenv">`setenv: [ <environment-update> ... ]`</a>: defines
   environment variables updates that will be applied upon installing the
@@ -1249,7 +1250,7 @@ files.
   See [`x-env-path-rewrite:`](#opamfield-x-env-path-rewrite)
   for path portability of environment variables on Windows.
 
-- <a id="opamsection-extra-sources">`extra-source <string> "{" <url-file> "}"`</a>:
+- <a id="opamsection-extra-sources">`extra-source <string> "{" <url-section> "}"`</a>:
   allows the definition of extra files that need downloading into the source
   tree before the package can be patched (if necessary) and built. The format is
   similar to that of the `url` section, but here it is expected to point to a

--- a/master_changes.md
+++ b/master_changes.md
@@ -67,6 +67,7 @@ users)
 ## Env
 
 ## Opamfile
+  * The `url` file now only supports the legacy opam 1.2 fields [#6827 @kit-ty-kate]
 
 ## External dependencies
 
@@ -164,6 +165,10 @@ users)
 ## opam-solver
 
 ## opam-format
+  * `OpamFile.Descr` was moved to `OpamFile.Descr_legacy` and a simpler `OpamFile.Descr` module was created only containing non-IO functions removing the outdated `descr` file support [#6827 @kit-ty-kate]
+  * `OpamFile.URL` was moved to `OpamFile.URL_legacy` and a simpler `OpamFile.URL` module was created only containing non-IO functions removing the outdated `url` file support [#6827 @kit-ty-kate]
+  * `OpamFile.Descr.of_legacy`: was added [#6827 @kit-ty-kate]
+  * `OpamFile.URL.of_legacy`: was added [#6827 @kit-ty-kate]
 
 ## opam-core
   * `OpamCmdliner` was added. It is accessible through a new `opam-core.cmdliner` sub-library [#6755 @kit-ty-kate]

--- a/src/client/opamAdminRepoUpgrade.ml
+++ b/src/client/opamAdminRepoUpgrade.ml
@@ -219,7 +219,7 @@ let do_upgrade repo_root =
       let descr_file =
         OpamFilename.(opt_file (add_extension (chop_extension comp_file) "descr"))
       in
-      let descr = descr_file >>| fun f -> OpamFile.Descr.read (OpamFile.make f) in
+      let descr = descr_file >>| fun f -> OpamFile.Descr_legacy.read (OpamFile.make f) in
       let nv, ocaml_version, variant =
         match OpamStd.String.cut_at c '+' with
         | None ->

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -297,7 +297,7 @@ module InitConfig: sig
 end
 
 (** Package descriptions: [$opam/descr/] *)
-module Descr: sig
+module Descr_legacy: sig
 
   include IO_FILE
 
@@ -317,10 +317,52 @@ module Descr: sig
 
 end
 
+module Descr: sig
+
+  type t
+
+  val empty: t
+  val create: string -> t
+
+  (** Return the first line *)
+  val synopsis: t -> string
+
+  (** Return the body *)
+  val body: t -> string
+
+  val of_legacy: Descr_legacy.t -> t
+
+end
+
 (** {2 Urls for OPAM repositories} *)
-module URL: sig
+module URL_legacy: sig
 
   include IO_FILE
+
+  val create:
+    ?mirrors:url list -> ?checksum:OpamHash.t list ->
+    url -> t
+
+  (** URL address *)
+  val url: t -> url
+
+  val mirrors: t -> url list
+
+  (** Archive checksum *)
+  val checksum: t -> OpamHash.t list
+
+  (** Constructor *)
+  val with_url: url -> t -> t
+  val with_checksum: OpamHash.t list -> t -> t
+  val with_mirrors: OpamUrl.t list -> t -> t
+
+end
+
+module URL: sig
+
+  type t
+
+  val empty: t
 
   val create:
     ?mirrors:url list -> ?checksum:OpamHash.t list ->
@@ -347,6 +389,7 @@ module URL: sig
 
   val subpath: t -> subpath option
 
+  val of_legacy: URL_legacy.t -> t
 end
 
 (** OPAM files *)
@@ -872,7 +915,7 @@ module Comp: sig
       created with "VARIANT" the part of the compiler name on the right of the
       "+". In both case, the version corresponds to the OCaml version and is
       [version comp]. *)
-  val to_package: ?package:package -> t -> Descr.t option -> OPAM.t
+  val to_package: ?package:package -> t -> Descr_legacy.t option -> OPAM.t
 
 end
 

--- a/src/repository/opamRepositoryPath.mli
+++ b/src/repository/opamRepositoryPath.mli
@@ -43,10 +43,10 @@ val opam: dirname -> string option -> package -> OpamFile.OPAM.t OpamFile.t
 
 (** Return the description file for a given package:
     {i $repo/packages/XXX/$NAME.VERSION/descr} *)
-val descr: dirname -> string option -> package -> OpamFile.Descr.t OpamFile.t
+val descr: dirname -> string option -> package -> OpamFile.Descr_legacy.t OpamFile.t
 
 (** urls {i $repo/package/XXX/$NAME.$VERSION/url} *)
-val url: dirname -> string option -> package -> OpamFile.URL.t OpamFile.t
+val url: dirname -> string option -> package -> OpamFile.URL_legacy.t OpamFile.t
 
 (** files {i $repo/packages/XXX/$NAME.$VERSION/files} *)
 val files: dirname -> string option -> package -> dirname

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -1321,20 +1321,21 @@ let add_aux_files ?dir ?(files_subdir_hashes=false) opam =
   match dir with
   | None -> opam
   | Some dir ->
-    let (url_file: OpamFile.URL.t OpamFile.t) =
+    let (url_file: OpamFile.URL_legacy.t OpamFile.t) =
       OpamFile.make (dir // "url")
     in
-    let (descr_file: OpamFile.Descr.t OpamFile.t)  =
+    let (descr_file: OpamFile.Descr_legacy.t OpamFile.t)  =
       OpamFile.make (dir // "descr")
     in
     let files_dir =
       OpamFilename.Op.(dir / "files")
     in
     let opam =
-      match OpamFile.OPAM.url opam, try_read OpamFile.URL.read_opt url_file with
-      | None, (Some url, None) -> OpamFile.OPAM.with_url url opam
+      match OpamFile.OPAM.url opam, try_read OpamFile.URL_legacy.read_opt url_file with
+      | None, (Some url, None) ->
+        OpamFile.OPAM.with_url (OpamFile.URL.of_legacy url) opam
       | Some opam_url, (Some url, errs) ->
-        if url = opam_url && errs = None then
+        if (OpamFile.URL.of_legacy url) = opam_url && errs = None then
           log "Duplicate definition of url in '%s' and opam file"
             (OpamFile.to_string url_file)
         else
@@ -1349,8 +1350,9 @@ let add_aux_files ?dir ?(files_subdir_hashes=false) opam =
     in
     let opam =
       match OpamFile.OPAM.descr opam,
-            try_read OpamFile.Descr.read_opt descr_file with
-      | None, (Some descr, None) -> OpamFile.OPAM.with_descr descr opam
+            try_read OpamFile.Descr_legacy.read_opt descr_file with
+      | None, (Some descr, None) ->
+        OpamFile.OPAM.with_descr (OpamFile.Descr.of_legacy descr) opam
       | Some _, (Some _, _) ->
         log "Duplicate descr in '%s' and opam file"
           (OpamFile.to_string descr_file);

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -561,9 +561,9 @@ let from_1_3_dev2_to_1_3_dev5 ~on_the_fly:_ root conf =
           in
           let descr =
             OpamStd.Option.default
-              (OpamFile.Descr.create
+              (OpamFile.Descr_legacy.create
                  "Switch relying on a system-wide installation of OCaml")
-              (OpamFile.Descr.read_opt descr_f)
+              (OpamFile.Descr_legacy.read_opt descr_f)
           in
           let comp_opam =
             OpamFile.Comp.to_package comp (Some descr)

--- a/src/state/opamFormatUpgrade.mli
+++ b/src/state/opamFormatUpgrade.mli
@@ -79,7 +79,7 @@ val opam_file:
 (** Convert the comp file to an opam one, using {!OpamFile.Comp.to_package} and
     applying filter rewriting *)
 val comp_file:
-  ?package:package -> ?descr:OpamFile.Descr.t -> OpamFile.Comp.t ->
+  ?package:package -> ?descr:OpamFile.Descr_legacy.t -> OpamFile.Comp.t ->
   OpamFile.OPAM.t
 
 (** Runs the opam file format from the file's format to current, and adds data

--- a/src/tools/opam_admin_top.ml
+++ b/src/tools/opam_admin_top.ml
@@ -52,9 +52,9 @@ let iter_packages_gen ?(quiet=false) f =
       let opam_file = OpamRepositoryPath.opam repo prefix package in
       let opam = OpamFile.OPAM.read opam_file in
       let descr_file = OpamRepositoryPath.descr repo prefix package in
-      let descr = OpamFile.Descr.read_opt descr_file in
+      let descr = OpamFile.Descr_legacy.read_opt descr_file in
       let url_file = OpamRepositoryPath.url repo prefix package in
-      let url = OpamFile.URL.read_opt url_file in
+      let url = OpamFile.URL_legacy.read_opt url_file in
       let dot_install_file : OpamFile.Dot_install.t OpamFile.t =
         OpamFile.make
           (OpamRepositoryPath.files repo prefix package
@@ -72,9 +72,9 @@ let iter_packages_gen ?(quiet=false) f =
       if opam <> opam2 then
         (upd (); OpamFile.OPAM.write_with_preserved_format opam_file opam2);
       if descr <> descr2 then
-        (upd (); wopt OpamFile.Descr.write descr_file descr2);
+        (upd (); wopt OpamFile.Descr_legacy.write descr_file descr2);
       if url <> url2 then
-        (upd (); wopt OpamFile.URL.write url_file url2);
+        (upd (); wopt OpamFile.URL_legacy.write url_file url2);
       if dot_install <> dot_install2 then
         (upd (); wopt OpamFile.Dot_install.write dot_install_file dot_install2);
       if !changed then

--- a/src/tools/opam_admin_top.mli
+++ b/src/tools/opam_admin_top.mli
@@ -28,10 +28,10 @@ val iter_packages_gen:
   (OpamPackage.t ->
    prefix:string option ->
    opam:OPAM.t ->
-   descr:Descr.t option ->
-   url:URL.t option ->
+   descr:Descr_legacy.t option ->
+   url:URL_legacy.t option ->
    dot_install:Dot_install.t option ->
-   OPAM.t * Descr.t action * URL.t action * Dot_install.t action)
+   OPAM.t * Descr_legacy.t action * URL_legacy.t action * Dot_install.t action)
   -> unit
 
 (** Turn a list of glob patterns into a proper filtering function on
@@ -44,7 +44,7 @@ val iter_packages:
   ?filter:(OpamPackage.t -> bool) ->
   ?f:(OpamPackage.t -> string option -> OPAM.t -> unit) ->
   ?opam:(OpamPackage.t -> OPAM.t -> OPAM.t) ->
-  ?descr:(OpamPackage.t -> Descr.t -> Descr.t) ->
-  ?url:(OpamPackage.t -> URL.t -> URL.t) ->
+  ?descr:(OpamPackage.t -> Descr_legacy.t -> Descr_legacy.t) ->
+  ?url:(OpamPackage.t -> URL_legacy.t -> URL_legacy.t) ->
   ?dot_install:(OpamPackage.t -> Dot_install.t -> Dot_install.t) ->
   unit -> unit


### PR DESCRIPTION
Per discussion with @rjbou regarding https://github.com/ocaml/opam/pull/6253, we'd like to keep the format upgrade code around if only as a basis for opam 3.0.

The real issue with `url` and `descr` is that they are used even when the opam file being parsed is up-to-date. This is documented but we'd like to move forward and stop doing that and require a manual upgrade to read them.

However currently the code for `url` and `descr` are in their own `URL` and `Descr` submodule, which is used for for the deprecated file formats and as a datatype (including the new features). This PR splits these submodules into two of each to separate the legacy part (dealing with the legacy file formats) and the "normal" submodules which still holds the current datatypes.

~TODO: while doing this change i chose to change the representation of synopsis/description, which probably should be moved to its own PR with its own discussion.~

* Queued on https://github.com/ocaml-opam/opam-publish/pull/194