### PR TITLE
Mitigate DNF explosion for depends field with disjoint disjunctions

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -163,6 +163,7 @@ users)
   * Fix a rare potential GC corruption in `OpamStubs.uname` [#6880 @avsm @kit-ty-kate @andrew]
   * Fix a rare potential GC corruption in `OpamStubs.enumRegistry` on Windows [#6882 @kit-ty-kate]
   * Remove uses of `Stdlib.ignore` [#6481 @rjbou @kit-ty-kate]
+  * Mitigate potential exponential blow-up converting dependency formulae to DNF [#6831 @dra27]
 
 ## Internal: Unix
 

--- a/src/format/opamFormula.ml
+++ b/src/format/opamFormula.ml
@@ -396,15 +396,47 @@ let dnf_of_formula t =
     | And (x,y) -> mk_right (mk x) (mk y) in
   mk t
 
-let verifies f nv =
-  let name_formula =
-    map (fun ((n, _) as a) -> if n = OpamPackage.name nv then Atom a else Empty)
-      (dnf_of_formula f)
+let name_formula name f =
+  let is_name (n, _cstr) = OpamPackage.Name.equal n name in
+  let formula_or_empty cond f = if cond then f else Empty in
+  (* Determine if nv could possibly part of the solution for [f]. This
+     means checking that either [v] satisfies the constraints on name.
+     This is done by converting [f] to DNF, which allows us to transform
+     the formula into a union of intervals, where ignoring atoms for
+     different package names works. We can then ignore conjunctions
+     where [name] doesn't appear. However, this function is typically
+     used on a dependency formula, which is most normally a large
+     conjunction. We capitalise on this with a peephole simplification,
+     observing that if we're testing for package name A in the formula
+     [X & Y], then we can ignore X if it doesn't contain A (and likewise
+     Y). This eliminates unrelated sub-formula from the top-level
+     conjunction, in particular it means that
+     [Dep1 & Dep2 & (Dep3 | Dep4) & (Dep5 | Dep6)] does not cause
+     trigger worst-case expansion for DNF. *)
+  let rec simplify_formula f =
+    match f with
+    | Empty -> Empty
+    | Atom atom ->
+      formula_or_empty (is_name atom) f
+    | Block b ->
+      formula_or_empty (exists is_name b) f
+    | Or(a, b) ->
+      formula_or_empty (exists is_name a || exists is_name b) f
+    | And(a, b) ->
+      let a = simplify_formula a in
+      let b = simplify_formula b in
+      make_and a b
   in
-  name_formula <> Empty &&
+  simplify_formula f
+  |> dnf_of_formula
+  |> map (fun a -> formula_or_empty (is_name a) (Atom a))
+
+let verifies f nv =
+  let f = name_formula (OpamPackage.name nv) f in
+  f <> Empty &&
   eval (fun (_name, cstr) ->
       check_version_formula cstr (OpamPackage.version nv))
-    name_formula
+    f
 
 let all_names f =
   fold_left (fun acc (name, _) ->
@@ -413,42 +445,7 @@ let all_names f =
 
 let packages pkgset f =
   OpamPackage.Name.Set.fold (fun name acc ->
-      let is_name (n, _cstr) = OpamPackage.Name.equal n name in
-      let formula_or_empty cond f = if cond then f else Empty in
-      (* Determine if nv could possibly part of the solution for [f]. This
-         means checking that either [v] satisfies the constraints on name.
-         This is done by converting [f] to DNF, which allows us to transform
-         the formula into a union of intervals, where ignoring atoms for
-         different package names works. We can then ignore conjunctions
-         where [name] doesn't appear. However, this function is typically
-         used on a dependency formula, which is most normally a large
-         conjunction. We capitalise on this with a peephole simplification,
-         observing that if we're testing for package name A in the formula
-         [X & Y], then we can ignore X if it doesn't contain A (and likewise
-         Y). This eliminates unrelated sub-formula from the top-level
-         conjunction, in particular it means that
-         [Dep1 & Dep2 & (Dep3 | Dep4) & (Dep5 | Dep6)] does not cause
-         trigger worst-case expansion for DNF. *)
-      let rec simplify_formula f =
-        match f with
-        | Empty -> Empty
-        | Atom atom ->
-            formula_or_empty (is_name atom) f
-        | Block b ->
-            formula_or_empty (exists is_name b) f
-        | Or(a, b) ->
-            formula_or_empty (exists is_name a || exists is_name b) f
-        | And(a, b) ->
-            let a = simplify_formula a in
-            let b = simplify_formula b in
-            make_and a b
-      in
-      let f =
-        f
-        |> simplify_formula
-        |> dnf_of_formula
-        |> map (fun a -> formula_or_empty (is_name a) (Atom a))
-      in
+      let f = name_formula name f in
       OpamPackage.Set.union acc @@
       OpamPackage.Set.filter (fun nv ->
           let v = OpamPackage.version nv in

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -1054,13 +1054,15 @@ let universe st
                             OpamPackage.Map.find nv u_depopts ])
       |> OpamFormula.packages st.packages
     in
-    let requested_deps =
-      OpamPackage.Set.fixpoint resolve_deps requested_allpkgs
-    in
-    requested_deps %% Lazy.force st.reinstall ++
-    match reinstall with
-    | Some set -> set
-    | None -> OpamPackage.Set.empty
+    let reinstall = Option.value ~default:OpamPackage.Set.empty reinstall in
+    let lazy switch_reinstall = st.reinstall in
+    if OpamPackage.Set.is_empty switch_reinstall then
+      reinstall
+    else
+      let requested_deps =
+        OpamPackage.Set.fixpoint resolve_deps requested_allpkgs
+      in
+      requested_deps %% Lazy.force st.reinstall ++ reinstall
   in
   let missing_depexts =
     lazy (


### PR DESCRIPTION
I had a `depends` field enforcing an invariant for an little-known experimental branch of OCaml:

```
depends: [
  "conf-autoconf"         {build}
  "conf-which"            {build}
  "ocaml"                 {= "5.2.0" & post}
  "base-unix"             {post}
  "base-bigarray"         {post}
  "base-threads"          {post}
  "base-domains"          {post}
  "base-nnp"              {post}
  "ocaml-options-vanilla" {post}
  ("oxcaml-no-alcotest" {tpost} | "oxcaml-alcotest" {post})
  ("oxcaml-no-backoff" {post} | "oxcaml-backoff" {post})
  ("oxcaml-no-ctypes" {post} | "oxcaml-ctypes" {post})
  ("oxcaml-no-ctypes-foreign" {post} | "oxcaml-ctypes-foreign" {post})
  ("oxcaml-no-dot-merlin-reader" {post} | "oxcaml-dot-merlin-reader" {post})
  ("oxcaml-no-dune" {post} | "oxcaml-dune" {post})
  ("oxcaml-no-gen_js_api" {post} | "oxcaml-gen_js_api" {post})
  ("oxcaml-no-js_of_ocaml" {post} | "oxcaml-js_of_ocaml" {post})
  ("oxcaml-no-js_of_ocaml-compiler" {post} | "oxcaml-js_of_ocaml-compiler" {post})
  ("oxcaml-no-js_of_ocaml-ppx" {post} | "oxcaml-js_of_ocaml-ppx" {post})
  ("oxcaml-no-js_of_ocaml-toplevel" {post} | "oxcaml-js_of_ocaml-toplevel" {post})
  ("oxcaml-no-jsonrpc" {post} | "oxcaml-jsonrpc" {post})
  ("oxcaml-no-lsp" {post} | "oxcaml-lsp" {post})
  ("oxcaml-no-lwt_ppx" {post} | "oxcaml-lwt_ppx" {post})
  ("oxcaml-no-mdx" {post} | "oxcaml-mdx" {post})
  ("oxcaml-no-merlin" {post} | "oxcaml-merlin" {post})
  ("oxcaml-no-merlin-lib" {post} | "oxcaml-merlin-lib" {post})
  ("oxcaml-no-notty-community" {post} | "oxcaml-notty-community" {post})
  ("oxcaml-no-ocaml-compiler-libs" {post} | "oxcaml-ocaml-compiler-libs" {post})
  ("oxcaml-no-ocaml-index" {post} | "oxcaml-ocaml-index" {post})
  ("oxcaml-no-ocaml-lsp-server" {post} | "oxcaml-ocaml-lsp-server" {post})
  ("oxcaml-no-ocamlbuild" {post} | "oxcaml-ocamlbuild" {post})
  ("oxcaml-no-ocamlformat" {post} | "oxcaml-ocamlformat" {post})
  ("oxcaml-no-ocamlformat-lib" {post} | "oxcaml-ocamlformat-lib" {post})
  ("oxcaml-no-ojs" {post} | "oxcaml-ojs" {post})
  ("oxcaml-no-ppxlib" {post} | "oxcaml-ppxlib" {post})
  ("oxcaml-no-ppxlib_ast" {post} | "oxcaml-ppxlib_ast" {post})
  ("oxcaml-no-re" {post} | "oxcaml-re" {post})
  ("oxcaml-no-sedlex" {post} | "oxcaml-sedlex" {post})
  ("oxcaml-no-spawn" {post} | "oxcaml-spawn" {post})
  ("oxcaml-no-topkg" {post} | "oxcaml-topkg" {post})
  ("oxcaml-no-utop" {post} | "oxcaml-utop" {post})
  ("oxcaml-no-uutf" {post} | "oxcaml-uutf" {post})
  ("oxcaml-no-wasm_of_ocaml-compiler" {post} | "oxcaml-wasm_of_ocaml-compiler" {post})
  ("oxcaml-no-zarith" {post} | "oxcaml-zarith" {post})
]
```

`opam switch create oxcaml ocaml-variants.5.2.0+ox` completely falls over with this. The problem is the conversion to DNF which takes place in `OpamFormula.packages`.

While it's possible to re-encode this formula across more packages (which is the workaround I'm using), the conversion to DNF followed by filtering is sub-optimal.

The observation here is that in `(X1 | X2) & (Y1 | Y2)`, there's no need to consider `Y1 | Y2` if the atoms of `Y1 | Y2` are distinct from the atoms of `X1 | X2` combined (hopefully correctly) with the observation that if _the entire sub-formula_ `Y1 | Y2` doesn't refer to the specific package being filtered, then we don't need consider it when converting to DNF.

In example above, that means, say, that when considering which versions of the `ocaml` package to consider, all the disjunctions are eliminated, because the conversion to DNF cannot introduce formula of interest.