### PR TITLE
Add argument --ignore-available-on to ignore availibility of specific packages

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -16,6 +16,7 @@ users)
 ## Global CLI
   * Update Kate's email address [#6808 @kit-ty-kate]
   * Remove unnecessary uses of `chdir` [#6910 @NathanReb]
+  * Added `--ignore-available-on` option to allow ignoring the `available:` section of certain packages. [#6836 @WardBrian - fix #5283]
 
 ## Plugins
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -224,6 +224,7 @@ users)
   * Add a test showing the order of install actions for each relevant commands [#6864 @kit-ty-kate]
   * Add a test showing some of the internal steps of `opam init` [#6957 @kit-ty-kate]
   * Add tests for `.install` `root` and `rootexec` fields [#6938 @rjbou]
+  * Test the new `--ignore-available-on` argument and `OPAMIGNOREAVAILABLE` environment variable [#6836 @WardBrian @kit-ty-kate]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -248,6 +248,9 @@ let environment_variables =
       "sets the maximum number of simultaneous downloads.";
       "DRYRUN", cli_original, (fun v -> DRYRUN (env_bool v)),
       "see option `--dry-run'.";
+      "IGNOREAVAILABLE", cli_from cli2_6,
+      (fun v -> IGNOREAVAILABLE (env_string v)),
+      "see install option `--ignore-available-on'.";
       "IGNORECONSTRAINTS", cli_original,
       (fun v -> IGNORECONSTRAINTS (env_string v)),
       "see install option `--ignore-constraints-on'.";
@@ -656,6 +659,7 @@ type build_options = {
   skip_update   : bool;
   jobs          : int option;
   ignore_constraints_on: name list option;
+  ignore_available_on: name list option;
   unlock_base   : bool;
   locked        : bool;
   lock_suffix   : string;
@@ -667,14 +671,14 @@ type build_options = {
 let create_build_options
     keep_build_dir reuse_build_dir inplace_build make no_checksums
     req_checksums build_test build_doc dev_setup show dryrun skip_update
-    fake jobs ignore_constraints_on unlock_base locked lock_suffix
+    fake jobs ignore_constraints_on ignore_available_on unlock_base locked lock_suffix
     assume_depexts no_depexts verbose_on
     =
   {
     keep_build_dir; reuse_build_dir; inplace_build; make; no_checksums;
     req_checksums; build_test; build_doc; dev_setup; show; dryrun; skip_update;
-    fake; jobs; ignore_constraints_on; unlock_base; locked; lock_suffix;
-    assume_depexts; no_depexts; verbose_on;
+    fake; jobs; ignore_constraints_on; ignore_available_on; unlock_base;
+    locked; lock_suffix; assume_depexts; no_depexts; verbose_on;
   }
 
 let apply_build_options cli b =
@@ -700,6 +704,9 @@ let apply_build_options cli b =
     ?ignore_constraints_on:
       (b.ignore_constraints_on >>|
        OpamPackage.Name.Set.of_list)
+    ?ignore_available_on:
+      (b.ignore_available_on >>|
+        OpamPackage.Name.Set.of_list)
     ?unlock_base:(flag b.unlock_base)
     ?locked:(if b.locked then Some (Some b.lock_suffix) else None)
     ?depexts:
@@ -1539,6 +1546,14 @@ let build_options cli =
        are unaffected. This is equivalent to setting $(b,\\$OPAMIGNORECONSTRAINTS)."
       Arg.(some (list package_name)) None ~vopt:(Some [])
   in
+  let ignore_available_on =
+    mk_opt ~cli (cli_from cli2_6) ~section ["ignore-available-on"] "PACKAGES"
+      "Forces opam to mark the listed packages as available. This can be \
+       used to test compatibility, but expect builds to break when using \
+       this. Note that version constraints of the packages' dependencies \
+       are unaffected."
+      Arg.(some (list package_name)) None ~vopt:(Some [])
+  in
   let unlock_base =
     mk_flag_replaced ~cli ~section [
       cli_between cli2_0 cli2_1 ~replaced:"--update-invariant", ["unlock-base"];
@@ -1573,8 +1588,8 @@ let build_options cli =
         $keep_build_dir $reuse_build_dir $inplace_build $make
         $no_checksums $req_checksums $build_test $build_doc $dev_setup $show
         $dryrun $skip_update $fake $jobs_flag ~section cli cli_original
-        $ignore_constraints_on $unlock_base $locked $lock_suffix
-        $assume_depexts $no_depexts $verbose_on)
+        $ignore_constraints_on $ignore_available_on $unlock_base $locked
+        $lock_suffix $assume_depexts $no_depexts $verbose_on)
 
 (* Option common to install commands *)
 let assume_built ?section cli =

--- a/src/client/opamClientConfig.mli
+++ b/src/client/opamClientConfig.mli
@@ -131,6 +131,7 @@ val opam_init:
   ?dryrun:bool ->
   ?makecmd:string Lazy.t ->
   ?ignore_constraints_on:OpamPackage.Name.Set.t ->
+  ?ignore_available_on:OpamPackage.Name.Set.t ->
   ?unlock_base:bool ->
   ?no_env_notice:bool ->
   ?locked:string option ->

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -18,6 +18,7 @@ module E = struct
     | BUILDTEST of bool option
     | DOWNLOADJOBS of int option
     | DRYRUN of bool option
+    | IGNOREAVAILABLE of string option
     | IGNORECONSTRAINTS of string option
     | JOBS of int option
     | LOCKED of string option
@@ -36,6 +37,7 @@ module E = struct
   let buildtest = value (function BUILDTEST b -> b | _ -> None)
   let downloadjobs = value (function DOWNLOADJOBS i -> i | _ -> None)
   let dryrun = value (function DRYRUN b -> b | _ -> None)
+  let ignoreavailable = value (function IGNOREAVAILABLE s -> s | _ -> None)
   let ignoreconstraints = value (function IGNORECONSTRAINTS s -> s | _ -> None)
   let jobs = value (function JOBS i -> i | _ -> None)
   let locked = value (function LOCKED s -> s | _ -> None)
@@ -65,6 +67,7 @@ type t = {
   dryrun: bool;
   makecmd: string Lazy.t;
   ignore_constraints_on: name_set;
+  ignore_available_on: name_set;
   unlock_base: bool;
   no_env_notice: bool;
   locked: string option;
@@ -111,6 +114,7 @@ let default = {
       | _ -> "make"
     );
   ignore_constraints_on = OpamPackage.Name.Set.empty;
+  ignore_available_on = OpamPackage.Name.Set.empty;
   unlock_base = false;
   no_env_notice = false;
   locked = None;
@@ -131,6 +135,7 @@ type 'a options_fun =
   ?dryrun:bool ->
   ?makecmd:string Lazy.t ->
   ?ignore_constraints_on:name_set ->
+  ?ignore_available_on:name_set ->
   ?unlock_base:bool ->
   ?no_env_notice:bool ->
   ?locked:string option ->
@@ -151,6 +156,7 @@ let[@ocaml.warning "-unerasable-optional-argument"] setk k t
     ?dryrun
     ?makecmd
     ?ignore_constraints_on
+    ?ignore_available_on
     ?unlock_base
     ?no_env_notice
     ?locked
@@ -172,6 +178,7 @@ let[@ocaml.warning "-unerasable-optional-argument"] setk k t
     dryrun = t.dryrun + dryrun;
     makecmd = t.makecmd + makecmd;
     ignore_constraints_on = t.ignore_constraints_on + ignore_constraints_on;
+    ignore_available_on = t.ignore_available_on + ignore_available_on;
     unlock_base = t.unlock_base + unlock_base;
     no_env_notice = t.no_env_notice + no_env_notice;
     locked = t.locked + locked;
@@ -198,6 +205,12 @@ let initk k =
     | Some "" | None -> None, None
     | Some s -> Some (OpamSwitch.of_string s), Some `Env
   in
+  let pkgname_list f =
+    f () >>| fun s ->
+    OpamStd.String.split s ',' |>
+    List.map OpamPackage.Name.of_string |>
+    OpamPackage.Name.Set.of_list
+  in
   setk (setk (fun c -> r := c; k)) !r
     ?root_dir
     ?original_root_dir
@@ -211,11 +224,8 @@ let initk k =
     ?dev_setup:(E.withdevsetup())
     ?dryrun:(E.dryrun ())
     ?makecmd:(E.makecmd () >>| fun s -> lazy s)
-    ?ignore_constraints_on:
-      (E.ignoreconstraints () >>| fun s ->
-       OpamStd.String.split s ',' |>
-       List.map OpamPackage.Name.of_string |>
-       OpamPackage.Name.Set.of_list)
+    ?ignore_constraints_on:(pkgname_list E.ignoreconstraints)
+    ?ignore_available_on:(pkgname_list E.ignoreavailable)
     ?unlock_base:(E.unlockbase ())
     ?no_env_notice:(E.noenvnotice ())
     ?locked:(E.locked () >>| function "" -> None | s -> Some s)

--- a/src/state/opamStateConfig.mli
+++ b/src/state/opamStateConfig.mli
@@ -20,6 +20,7 @@ module E : sig
     | BUILDTEST of bool option
     | DOWNLOADJOBS of int option
     | DRYRUN of bool option
+    | IGNOREAVAILABLE of string option
     | IGNORECONSTRAINTS of string option
     | JOBS of int option
     | LOCKED of string option
@@ -50,6 +51,7 @@ type t = private {
   dryrun: bool;
   makecmd: string Lazy.t;
   ignore_constraints_on: name_set;
+  ignore_available_on: name_set;
   unlock_base: bool;
   no_env_notice: bool;
   locked: string option;
@@ -70,6 +72,7 @@ type 'a options_fun =
   ?dryrun:bool ->
   ?makecmd:string Lazy.t ->
   ?ignore_constraints_on:name_set ->
+  ?ignore_available_on:name_set ->
   ?unlock_base:bool ->
   ?no_env_notice:bool ->
   ?locked:string option ->

--- a/src/state/opamSwitchState.ml
+++ b/src/state/opamSwitchState.ml
@@ -572,6 +572,13 @@ let load lock_kind gt rt switch =
         (Lazy.force available_packages)
     )
   in
+  let available_packages = lazy (
+    OpamPackage.Set.union
+      (OpamPackage.packages_of_names
+        packages OpamStateConfig.(!r.ignore_available_on))
+      (Lazy.force available_packages)
+    )
+  in
   let sys_packages_changed = lazy (
     let sys_packages =
       OpamPackage.Map.filter (fun pkg spkg ->

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1113,6 +1113,27 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:hooks-variables.win32.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-ignore-available-on)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (action
+  (diff ignore-available-on.test ignore-available-on.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (deps (alias reftest-ignore-available-on)))
+
+(rule
+ (targets ignore-available-on.out)
+ (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:ignore-available-on.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-init-ocaml-eval-variables.unix)
  (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action

--- a/tests/reftests/ignore-available-on.test
+++ b/tests/reftests/ignore-available-on.test
@@ -1,0 +1,179 @@
+N0REP0
+### OPAMYES=1
+### <pkg:unavail.1>
+opam-version: "2.0"
+available: false
+### :I: Unavailable package
+### :I:1: Install
+### :I:1:a: - without ignore-available-on
+### opam switch create direct --empty
+### opam install unavail
+[ERROR] unavail: unmet availability conditions: 'false'
+# Return code 5 #
+### :I:1:b: - with ignore-available-on
+### opam install unavail --ignore-available-on unavail
+The following actions will be performed:
+=== install 1 package
+  - install unavail 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed unavail.1
+Done.
+### :I:2: Upgrade
+### <pkg:unavail.2>
+opam-version: "2.0"
+available: false
+### :I:2:a: - upgrade all without ignore-available-on
+### opam upgrade --show
+The following actions would be performed:
+=== remove 1 package
+  - remove unavail 1 [no longer available]
+### :I:2:b: - upgrade pkg without ignore-available-on
+### opam upgrade unavail
+[ERROR] unavail: unmet availability conditions, e.g. 'false'
+# Return code 5 #
+### :I:2:c: - upgrade all with ignore-available-on
+### opam upgrade --show --ignore-available-on unavail
+The following actions would be performed:
+=== upgrade 1 package
+  - upgrade unavail 1 to 2
+### :I:2:d: - upgrade pkg with ignore-available-on via environment
+### OPAMIGNOREAVAILABLE=unavail opam upgrade --show unavail
+The following actions would be performed:
+=== upgrade 1 package
+  - upgrade unavail 1 to 2
+### :I:2:e: - upgrade pkg with ignore-available-on
+### opam upgrade unavail --show --ignore-available-on unavail
+The following actions would be performed:
+=== upgrade 1 package
+  - upgrade unavail 1 to 2
+### :I:3: Reinstall
+### :I:3:a: - without ignore-available-on
+### opam reinstall unavail
+[ERROR] unavail: unmet availability conditions, e.g. 'false'
+# Return code 5 #
+### :I:2:d: - upgrade pkg with ignore-available-on via environment
+### OPAMIGNOREAVAILABLE=unavail opam reinstall --show unavail
+The following actions would be performed:
+=== recompile 1 package
+  - recompile unavail 1
+### :I:3:b: - with ignore-available-on
+### opam reinstall unavail --ignore-available-on unavail
+The following actions will be performed:
+=== recompile 1 package
+  - recompile unavail 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   unavail.1
+-> installed unavail.1
+Done.
+### :I:4: Remove (flag is unnecessary)
+### opam remove unavail
+The following actions will be performed:
+=== remove 1 package
+  - remove unavail 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   unavail.1
+Done.
+### :II: Available package with unavailable dependency
+### <pkg:avail.1>
+opam-version: "2.0"
+depends: "unavail"
+### :II:1: Install
+### :II:1:a: - without ignore-available-on
+### opam install avail
+[ERROR] Package conflict!
+  * Missing dependency:
+    - avail -> unavail
+    unmet availability conditions, e.g. 'false'
+
+No solution found, exiting
+# Return code 20 #
+### :II:1:b: - with ignore-available-on via environment
+### OPAMIGNOREAVAILABLE=unavail opam install --show avail
+The following actions would be performed:
+=== install 2 packages
+  - install avail   1
+  - install unavail 2 [required by avail]
+### :II:1:c: - with ignore-available-on
+### opam install avail --ignore-available-on unavail
+The following actions will be performed:
+=== install 2 packages
+  - install avail   1
+  - install unavail 2 [required by avail]
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed unavail.2
+-> installed avail.1
+Done.
+### :II:2: Upgrade
+### <pkg:avail.2>
+opam-version: "2.0"
+depends: "unavail"
+### :II:2:a: - without ignore-available-on
+### opam upgrade avail
+[ERROR] Package conflict!
+  * Missing dependency:
+    - avail >= 2 -> unavail -> unavail.2: no longer available
+
+# Return code 20 #
+### :II:2:b: - with ignore-available-on via environment
+### OPAMIGNOREAVAILABLE=unavail opam upgrade --show avail
+The following actions would be performed:
+=== upgrade 1 package
+  - upgrade avail 1 to 2
+### :II:2:c: - with ignore-available-on
+### opam upgrade avail --ignore-available-on unavail
+The following actions will be performed:
+=== upgrade 1 package
+  - upgrade avail 1 to 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   avail.1
+-> installed avail.2
+Done.
+### :II:3: Reinstall
+### :II:3:a: - without ignore-available-on
+### opam reinstall avail
+  * Missing dependency:
+    - avail >= 2 -> unavail -> unavail.2: no longer available
+
+No solution found, exiting
+# Return code 20 #
+### :II:3:b: - - with ignore-available-on via environment
+### OPAMIGNOREAVAILABLE=unavail opam reinstall --show avail
+The following actions would be performed:
+=== recompile 1 package
+  - recompile avail 2
+### :II:3:c: - with ignore-available-on
+### opam reinstall avail --ignore-available-on unavail
+The following actions will be performed:
+=== recompile 1 package
+  - recompile avail 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   avail.2
+-> installed avail.2
+Done.
+### :II:4: Remove
+### :II:4:a: - without ignore-available-on (also removes dependency)
+### opam remove --show avail
+The following actions would be performed:
+=== remove 2 packages
+  - remove avail   2
+  - remove unavail 2 [no longer available]
+### :II:4:b: - with ignore-available-on via environment
+### OPAMIGNOREAVAILABLE=unavail opam remove --show avail
+The following actions would be performed:
+=== remove 1 package
+  - remove avail 2
+### :II:4:c: - with ignore-available-on (leaves unavail installed)
+### opam remove avail --ignore-available-on unavail
+The following actions will be performed:
+=== remove 1 package
+  - remove avail 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   avail.2
+Done.


### PR DESCRIPTION
This is a proposed new argument to resolve the feature request in #5283. 

I've decided to make it a separate argument from the `--ignore-constraints-on` argument mentioned there, but it's an easy modification if we'd prefer that argument to do double duty. 

As a minimum demonstration, here is me trying to install the `osx-plutil` opam package, which is marked as only available on macos, on my ubuntu machine:

```shell
$ ./opam install osx-plutil 
[ERROR] osx-plutil: unmet availability conditions: 'os = "macos"'
$ ./opam install --force-available osx-plutil osx-plutil 
The following actions will be performed:
=== install 3 packages
  ∗ osx-plutil 0.5.0
  ∗ process    0.2.1 [required by osx-plutil]
  ∗ result     1.5   [required by osx-plutil]

Proceed with ∗ 3 installations? [Y/n] n
```

I have thus far made exactly the set of modifications that seemed necessary to get this working and no more. 
I suspect that there is at least a couple more places this information would need to be propagated to be 'feature complete', but I decided to pause here to kindly ask for feedback on the general approach before continuing.

Fixes #5283