### PR TITLE
Speedup pinning local git packages by avoiding the git transport protocol

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -39,6 +39,7 @@ users)
 ## Config
 
 ## Pin
+  * Speedup pinning local git packages by avoiding the git transport protocol [#6838 @kit-ty-kate - fix #6837]
 
 ## List
 

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -102,6 +102,9 @@ let dirs d =
 let dir_is_empty d =
   OpamSystem.dir_is_empty (Dir.to_string d)
 
+let rec_dir_is_empty d =
+  OpamSystem.rec_dir_is_empty (Dir.to_string d)
+
 let in_dir dirname fn = OpamSystem.in_dir dirname fn
 
 let env_of_list l = Array.of_list (List.rev_map (fun (k,v) -> k^"="^v) l)

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -54,6 +54,8 @@ val rec_dirs: Dir.t -> Dir.t list
     Returns [None] if the directory could not be found. *)
 val dir_is_empty: Dir.t -> bool option
 
+val rec_dir_is_empty: Dir.t -> bool option
+
 (** List the sub-directory (do not recurse) *)
 val dirs: Dir.t -> Dir.t list
 

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -195,6 +195,8 @@ val dirs: string -> string list
     Returns [None] if the directory could not be found. *)
 val dir_is_empty: string -> bool option
 
+val rec_dir_is_empty: string -> bool option
+
 (** [directories_with_links dir] returns the directories in the directory [dir].
     Links pointing to directory are also returned. *)
 val directories_with_links: string -> string list


### PR DESCRIPTION
Fixes #6837 

I've checked the possible presence of hardlinks and no files in .git are hardlinked to the source repository (unlike with `git clone`), so i believe it is good to go as-is.