### PR TITLE
document raw-field syntax more prominently

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -153,6 +153,7 @@ users)
 ## Doc
   * Add spacing between two words in `--locked` man section [#6806 @yosefAlsuhaibani]
   * Update the Install page with the new opam 2.5.0 release [#6821 @kit-ty-kate]
+  * Mention more explicitely that raw fields are an option [@raphael-proust]
 
 ## Security fixes
 

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1761,6 +1761,8 @@ let package_listing cli =
   let columns =
     mk_opt ~cli cli_original ["columns"] "COLUMNS" ~section
       (Printf.sprintf "Select the columns to display among: %s.\n\
+                       The special form $(b,<field>:) (field name followed by \
+                       colon, e.g., $(b,license:)) selects an arbitrary field. \
                        The default is $(b,name) when $(i,--short) is present \
                        and %s otherwise."
          (OpamStd.List.concat_map ", " (fun (_,f) -> Printf.sprintf "$(b,%s)" f)


### PR DESCRIPTION
split from #6841 as recommended in https://github.com/ocaml/opam/pull/6841#issuecomment-3729238438

