### PR TITLE
Source compatibility with newer cmdliner versions

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -163,6 +163,7 @@ users)
   * Fix a rare potential GC corruption in `OpamStubs.uname` [#6880 @avsm @kit-ty-kate @andrew]
   * Fix a rare potential GC corruption in `OpamStubs.enumRegistry` on Windows [#6882 @kit-ty-kate]
   * Remove uses of `Stdlib.ignore` [#6481 @rjbou @kit-ty-kate]
+  * Source compatibility with newer `cmdliner` versions [#6854 @WardBrian]
 
 ## Internal: Unix
 

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -1422,12 +1422,15 @@ let help =
     | None       -> `Help (`Pager, None)
     | Some topic ->
       let topics = "topics" :: cmds in
-      let conv, _ = OpamCmdliner.Arg.enum (List.rev_map (fun s -> (s, s)) topics) in
+      let conv =
+        OpamCmdliner.Arg.conv_parser
+          (OpamCmdliner.Arg.enum (List.rev_map (fun s -> (s, s)) topics))
+      in
       match conv topic with
-      | `Error e -> `Error (false, e)
-      | `Ok t when t = "topics" ->
+      | Error (`Msg e) -> `Error (false, e)
+      | Ok t when t = "topics" ->
           List.iter (OpamConsole.msg "%s\n") cmds; `Ok ()
-      | `Ok t -> `Help (man_format, Some t) in
+      | Ok t -> `Help (man_format, Some t) in
 
   Term.(ret (const help $Arg.man_format $Term.choice_names $topic)),
   Cmd.info "help" ~doc ~man

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -729,51 +729,51 @@ let build_options_no_depexts b = b.no_depexts
 let pr_str = Format.pp_print_string
 
 let repository_name =
-  let parse str = `Ok (OpamRepositoryName.of_string str) in
+  let parse str = Ok (OpamRepositoryName.of_string str) in
   let print ppf name = pr_str ppf (OpamRepositoryName.to_string name) in
-  parse, print
+  Arg.conv' (parse, print)
 
 let url =
   let parse str =
     match OpamUrl.parse_opt ~from_file:false str with
-    | Some url -> `Ok url
-    | None -> `Error ("malformed url "^str)
+    | Some url -> Ok url
+    | None -> Error ("malformed url "^str)
   in
   let print ppf url = pr_str ppf (OpamUrl.to_string url) in
-  parse, print
+  Arg.conv' (parse, print)
 
 let filename =
-  let parse str = `Ok (OpamFilename.of_string str) in
+  let parse str = Ok (OpamFilename.of_string str) in
   let print ppf filename = pr_str ppf (OpamFilename.to_string filename) in
-  parse, print
+  Arg.conv' (parse, print)
 
 let existing_filename_or_dash =
   let parse str =
-    if str = "-" then `Ok None
+    if str = "-" then Ok None
     else
       let f = OpamFilename.of_string str in
-      if OpamFilename.exists f then `Ok (Some f)
+      if OpamFilename.exists f then Ok (Some f)
       else
-        `Error (Printf.sprintf "File %s not found" (OpamFilename.to_string f))
+        Error (Printf.sprintf "File %s not found" (OpamFilename.to_string f))
   in
   let print ppf filename =
     pr_str ppf OpamStd.Option.Op.((filename >>| OpamFilename.to_string) +! "-") in
-  parse, print
+  Arg.conv' (parse, print)
 
 let dirname =
-  let parse str = `Ok (OpamFilename.Dir.of_string str) in
+  let parse str = Ok (OpamFilename.Dir.of_string str) in
   let print ppf dir = pr_str ppf (escape_path (OpamFilename.prettify_dir dir)) in
-  parse, print
+  Arg.conv' (parse, print)
 
 let existing_filename_dirname_or_dash =
   let parse str =
-    if str = "-" then `Ok None else
+    if str = "-" then Ok None else
     match OpamFilename.opt_file (OpamFilename.of_string str) with
-    | Some f -> `Ok (Some (OpamFilename.F f))
+    | Some f -> Ok (Some (OpamFilename.F f))
     | None -> match OpamFilename.opt_dir (OpamFilename.Dir.of_string str) with
-      | Some d -> `Ok (Some (OpamFilename.D d))
+      | Some d -> Ok (Some (OpamFilename.D d))
       | None ->
-        `Error (Printf.sprintf "File or directory %s not found" str)
+        Error (Printf.sprintf "File or directory %s not found" str)
   in
   let print ppf gf =
     pr_str ppf @@ match gf with
@@ -781,40 +781,41 @@ let existing_filename_dirname_or_dash =
     | Some (OpamFilename.D d) -> OpamFilename.Dir.to_string d
     | Some (OpamFilename.F f) -> OpamFilename.to_string f
   in
-  parse, print
+  Arg.conv' (parse, print)
 
 let subpath_conv =
   let parse str =
-    `Ok (OpamFilename.SubPath.of_string str)
+    Ok (OpamFilename.SubPath.of_string str)
   in
   let print ppf sb = pr_str ppf (OpamFilename.SubPath.to_string sb) in
-  parse, print
+  Arg.conv' (parse, print)
 
 let package_name =
   let parse str =
-    try `Ok (OpamPackage.Name.of_string str)
-    with Failure msg -> `Error msg
+    try Ok (OpamPackage.Name.of_string str)
+    with Failure msg -> Error msg
   in
   let print ppf pkg = pr_str ppf (OpamPackage.Name.to_string pkg) in
-  parse, print
+  Arg.conv' (parse, print)
 
 let package_version =
   let parse str =
-    try `Ok (OpamPackage.Version.of_string str)
-    with Failure msg -> `Error msg
+    try Ok (OpamPackage.Version.of_string str)
+    with Failure msg -> Error msg
   in
   let print ppf ver = pr_str ppf (OpamPackage.Version.to_string ver) in
-  parse, print
+  Arg.conv' (parse, print)
 
 let positive_integer : int Arg.conv =
-  let (parser, printer) = Arg.int in
+  let parser = Arg.conv_parser Arg.int in
+  let printer = Arg.conv_printer Arg.int in
   let parser s =
     match parser s with
-    | `Error _ -> `Error "expected a strictly positive integer"
-    | `Ok n as r -> if n <= 0
-      then `Error "expected a positive integer"
+    | Error _ -> Error "expected a strictly positive integer"
+    | Ok n as r -> if n <= 0
+      then Error "expected a positive integer"
       else r in
-  (parser, printer)
+  Arg.conv' (parser, printer)
 
 (* name * version option *)
 let package =
@@ -831,8 +832,8 @@ let package =
       let version_opt =
         try Some (OpamPackage.Version.of_string (Re.Group.get sub 2))
         with Not_found -> None in
-      `Ok (name, version_opt)
-    with Not_found | Failure _ -> `Error "bad package format"
+      Ok (name, version_opt)
+    with Not_found | Failure _ -> Error "bad package format"
   in
   let print ppf (name, version_opt) =
     match version_opt with
@@ -840,27 +841,27 @@ let package =
     | Some v -> pr_str ppf (OpamPackage.Name.to_string name ^"."^
                             OpamPackage.Version.to_string v)
   in
-  parse, print
+  Arg.conv' (parse, print)
 
 let package_with_version =
   let parse str =
-    match fst package str with
-    | `Ok (n, Some v) -> `Ok (OpamPackage.create n v)
-    | `Ok (_, None) -> `Error "missing package version"
-    | `Error e -> `Error e
+    match Arg.conv_parser package str with
+    | Ok (n, Some v) -> Ok (OpamPackage.create n v)
+    | Ok (_, None) -> Error "missing package version"
+    | Error (`Msg e) -> Error e
   in
   let print ppf nv = pr_str ppf (OpamPackage.to_string nv) in
-  parse, print
+  Arg.conv' (parse, print)
 
 (* name * version constraint *)
 let atom =
   let parse str =
-    try `Ok (OpamFormula.atom_of_string str)
-    with Failure msg -> `Error msg
+    try Ok (OpamFormula.atom_of_string str)
+    with Failure msg -> Error msg
   in
   let print ppf atom =
     pr_str ppf (OpamFormula.short_string_of_atom atom) in
-  parse, print
+  Arg.conv' (parse, print)
 
 let atom_or_local =
   let parse str =
@@ -868,35 +869,38 @@ let atom_or_local =
        OpamCompat.String.starts_with ~prefix:"." str
     then
       if OpamFilename.(exists (of_string str)) then
-        `Ok (`Filename (OpamFilename.of_string str))
+        Ok (`Filename (OpamFilename.of_string str))
       else if  OpamFilename.(exists_dir (Dir.of_string str)) then
-        `Ok (`Dirname (OpamFilename.Dir.of_string str))
+        Ok (`Dirname (OpamFilename.Dir.of_string str))
       else
-        `Error (Printf.sprintf
-                  "Not a valid package specification or existing file or \
-                   directory: %s" str)
-    else match fst atom str with
-      | `Ok at -> `Ok (`Atom at)
-      | `Error e -> `Error e
+        Error (Printf.sprintf
+                 "Not a valid package specification or existing file or \
+                  directory: %s" str)
+    else match Arg.conv_parser atom str with
+      | Ok at -> Ok (`Atom at)
+      | Error (`Msg e) -> Error e
   in
   let print ppf = function
     | `Filename f -> pr_str ppf (OpamFilename.to_string f)
     | `Dirname d -> pr_str ppf (OpamFilename.Dir.to_string d)
-    | `Atom a -> snd atom ppf a
+    | `Atom a -> Arg.conv_printer atom ppf a
   in
-  parse, print
+  Arg.conv' (parse, print)
 
 let atom_or_dir =
-  let parse str = match fst atom_or_local str with
-    | `Ok (`Filename _) ->
-      `Error (Printf.sprintf
-                "Not a valid package specification or existing directory: %s"
-                str)
-    | `Ok (`Atom _ | `Dirname _ as atom_or_dir) -> `Ok (atom_or_dir)
-    | `Error e -> `Error e
+  let parse str = match Arg.conv_parser atom_or_local str with
+    | Ok (`Filename _) ->
+      Error (Printf.sprintf
+               "Not a valid package specification or existing directory: %s"
+               str)
+    | Ok (`Atom _ | `Dirname _ as atom_or_dir) -> Ok (atom_or_dir)
+    | Error (`Msg e) -> Error e
   in
-  let print ppf = snd atom_or_local ppf in
-  parse, print
+  let print ppf
+    :> [ `Atom of OpamTypes.atom | `Dirname of OpamTypes.dirname ] -> unit
+    = Arg.conv_printer atom_or_local ppf
+  in
+  Arg.conv' (parse, print)
 
 let dep_formula =
   let module OpamParser = OpamParser.FullPos in
@@ -905,13 +909,13 @@ let dep_formula =
   let parse str =
     try
       let v = OpamParser.value_from_string str "<command-line>" in
-      `Ok (OpamPp.parse pp ~pos:pos_null v)
-    with e -> OpamStd.Exn.fatal e; `Error (Printexc.to_string e)
+      Ok (OpamPp.parse pp ~pos:pos_null v)
+    with e -> OpamStd.Exn.fatal e; Error (Printexc.to_string e)
   in
   let print ppf f =
     pr_str ppf (OpamPrinter.value (OpamPp.print pp f))
   in
-  parse, print
+  Arg.conv' (parse, print)
 
 let variable_bindings =
   let parse str =
@@ -920,8 +924,8 @@ let variable_bindings =
       List.map (fun s -> match OpamStd.String.cut_at s '=' with
           | Some (a, b) -> OpamVariable.of_string a, b
           | None -> Printf.ksprintf failwith "%S is not a binding" s) |>
-      fun bnds -> `Ok bnds
-    with Failure e -> `Error e
+      fun bnds -> Ok bnds
+    with Failure e -> Error e
   in
   let print ppf x =
     List.map
@@ -929,7 +933,7 @@ let variable_bindings =
     String.concat "," |>
     pr_str ppf
   in
-  parse, print
+  Arg.conv' (parse, print)
 
 let warn_selector =
   let parse str =
@@ -962,9 +966,9 @@ let warn_selector =
       | [] -> acc
       | _ -> raise Not_found
     in
-    try `Ok (List.rev (aux [] (Re.split_full sep str)))
+    try Ok (List.rev (aux [] (Re.split_full sep str)))
     with Not_found ->
-      `Error "Expected a warning string, e.g. '--warn=-10..21+12-36'"
+      Error "Expected a warning string, e.g. '--warn=-10..21+12-36'"
   in
   let print ppf warns =
     pr_str ppf @@
@@ -977,7 +981,7 @@ let warn_selector =
         Printf.sprintf "%c%d" state num)
       warns
   in
-  parse, print
+  Arg.conv' (parse, print)
 
 let _selector =
   let parse str =
@@ -991,7 +995,7 @@ let _selector =
           |  _ ->  elem::plus, minus)
         ([],[]) (OpamStd.String.split str ',')
     in
-    `Ok r
+    Ok r
   in
   let print ppf (plus,minus) =
     let concat c =
@@ -999,7 +1003,7 @@ let _selector =
     in
     pr_str ppf @@ Printf.sprintf "%s,%s" (concat "+" plus) (concat "-" minus)
   in
-  parse, print
+  Arg.conv' (parse, print)
 
 (* unused
 let enum_with_default sl: 'a Arg.converter =
@@ -1015,23 +1019,23 @@ let opamlist_column =
   let parse str =
     if OpamCompat.String.ends_with ~suffix:":" str then
       let fld = OpamStd.String.remove_suffix ~suffix:":" str in
-      `Ok (OpamListCommand.Field fld)
+      Ok (OpamListCommand.Field fld)
     else
     try
       List.find (function (OpamListCommand.Field _), _ -> false
                         | _, name -> name = str)
         OpamListCommand.field_names
-      |> fun (f, _) -> `Ok f
+      |> fun (f, _) -> Ok f
     with Not_found ->
-      `Error (Printf.sprintf
-                "No known printer for column %s. If you meant an opam file \
-                 field, use '%s:' instead (with a trailing colon)."
-                str str)
+      Error (Printf.sprintf
+               "No known printer for column %s. If you meant an opam file \
+                field, use '%s:' instead (with a trailing colon)."
+               str str)
   in
   let print ppf field =
     Format.pp_print_string ppf (OpamListCommand.string_of_field field)
   in
-  parse, print
+  Arg.conv' (parse, print)
 
 let opamlist_columns =
   let field_re =
@@ -1054,25 +1058,27 @@ let opamlist_columns =
       in
       let fields = aux 0 in
       List.fold_left (function
-          | `Error _ as e -> fun _ -> e
-          | `Ok acc -> fun str ->
-            match fst opamlist_column str with
-            | `Ok f -> `Ok (acc @ [f])
-            | `Error _ as e -> e)
-        (`Ok []) fields
+          | Error _ as e -> fun _ -> e
+          | Ok acc -> fun str ->
+            match Arg.conv_parser opamlist_column str with
+            | Ok f -> Ok (acc @ [f])
+            | Error (`Msg e) -> Error e)
+        (Ok []) fields
     with Not_found ->
-      `Error (Printf.sprintf "Invalid columns specification: '%s'." str)
+      Error (Printf.sprintf "Invalid columns specification: '%s'." str)
   in
   let print ppf cols =
     let rec aux = function
       | x::(_::_) as r ->
-        snd opamlist_column ppf x; Format.pp_print_char ppf ','; aux r
-      | [x] -> snd opamlist_column ppf x
+        Arg.conv_printer opamlist_column ppf x;
+        Format.pp_print_char ppf ',';
+        aux r
+      | [x] -> Arg.conv_printer opamlist_column ppf x
       | [] -> ()
     in
     aux cols
   in
-  parse, print
+  Arg.conv' (parse, print)
 
 let hash_kinds =
   Arg.enum
@@ -1682,14 +1688,15 @@ let package_selection cli =
        (OpamStd.List.concat_map " "
           (Printf.sprintf "$(b,%s)" @* string_of_pkg_flag)
           all_package_flags))
-      ((fun s -> match pkg_flag_of_string s with
-          | Pkgflag_Unknown s ->
-            `Error ("Invalid package flag "^s^", must be one of "^
-                    OpamStd.List.concat_map " " string_of_pkg_flag
-                      all_package_flags)
-          | f -> `Ok f),
-       fun fmt flag ->
-         Format.pp_print_string fmt (string_of_pkg_flag flag))
+      (Arg.conv'
+         ((fun s -> match pkg_flag_of_string s with
+             | Pkgflag_Unknown s ->
+               Error ("Invalid package flag "^s^", must be one of "^
+                      OpamStd.List.concat_map " " string_of_pkg_flag
+                        all_package_flags)
+             | f -> Ok f),
+          (fun fmt flag ->
+             Format.pp_print_string fmt (string_of_pkg_flag flag))))
   in
   let has_tag =
     mk_opt_all ~cli cli_original ["has-tag"] "TAG" ~section

--- a/src/client/opamArgTools.ml
+++ b/src/client/opamArgTools.ml
@@ -710,12 +710,15 @@ type 'a default = [> `default of string] as 'a
 
 let mk_subcommands_with_default ~cli commands =
   let enum_with_default_valrem sl =
-    let parse, print = Arg.enum sl in
+    let parse, print =
+      let base = Arg.enum sl in
+      (Arg.conv_parser base, Arg.conv_printer base)
+    in
     let parse s =
       match parse s with
-      | `Ok x -> `Ok (x)
-      | _ -> `Ok (Valid (`default s)) in
-    parse, print
+      | Ok x -> Ok (x)
+      | _ -> Ok (Valid (`default s)) in
+    Arg.conv (parse, print)
   in
   mk_subcommands_aux ~cli enum_with_default_valrem commands
 

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1774,11 +1774,12 @@ let env cli =
         (OpamEnv.add [] [])
   in
   let open Common_config_flags in
+  let ( $ ) = OpamCmdliner.Term.( $ ) in
   mk_command  ~cli cli_original "env" ~doc ~man
-  Term.(const env
-        $global_options cli $shell_opt cli cli_original $sexp cli
-        $inplace_path cli $set_opamroot cli $set_opamswitch cli
-        $revert $check)
+    (Term.const env
+     $global_options cli $shell_opt cli cli_original $sexp cli
+     $inplace_path cli $set_opamroot cli $set_opamswitch cli
+     $revert $check)
 
 (* INSTALL *)
 let install_doc = "Install a list of packages."
@@ -3605,16 +3606,16 @@ let pin ?(unpin_only=false) cli =
             match as_url with
             | Some ((_::_) as url) -> err, url @ acc
             | _->
-              match (fst package) arg with
-              | `Ok (name, None) -> err, name::acc
-              | `Ok (name, Some version) ->
+              match (Arg.conv_parser package) arg with
+              | Ok (name, None) -> err, name::acc
+              | Ok (name, Some version) ->
                 (match OpamPinned.version_opt st name with
                  | Some v when not (OpamPackage.Version.equal v version) ->
                    OpamConsole.error "%s is pinned but not to version %s. Skipping."
                      (OpamPackage.Name.to_string name) (OpamPackage.Version.to_string version);
                    true, acc
                  | Some _ | None -> err, name::acc)
-              | `Error _ ->
+              | Error _ ->
                 OpamConsole.error
                   "No package pinned to this target found, or invalid package \
                    name/url: %s" arg;
@@ -3634,15 +3635,15 @@ let pin ?(unpin_only=false) cli =
       OpamSwitchState.drop @@ OpamClient.PIN.unpin st ~action to_unpin;
       `Ok ()
     | `edit nv  ->
-      (match (fst package) nv with
-       | `Ok (name, version) ->
+      (match (Arg.conv_parser package) nv with
+       | Ok (name, version) ->
          OpamGlobalState.with_ `Lock_none @@ fun gt ->
          OpamSwitchState.with_ `Lock_write gt @@ fun st ->
          let version = OpamStd.Option.Op.(with_version ++ version) in
          OpamSwitchState.drop @@
          OpamClient.PIN.edit st ?locked ~action ?version name;
          `Ok ()
-       | `Error e -> `Error (false, e))
+       | Error (`Msg e) -> `Error (false, e))
     | `add_normalised pins ->
       let pins = OpamPinCommand.parse_pins pins in
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -3656,8 +3657,8 @@ let pin ?(unpin_only=false) cli =
             pins);
       `Ok ()
     | `add_dev nv ->
-      (match (fst package) nv with
-       | `Ok (name,version) ->
+      (match (Arg.conv_parser package) nv with
+       | Ok (name,version) ->
          OpamGlobalState.with_ `Lock_none @@ fun gt ->
          OpamSwitchState.with_ `Lock_write gt @@ fun st ->
          let name = OpamSolution.fuzzy_name st name in
@@ -3666,7 +3667,7 @@ let pin ?(unpin_only=false) cli =
          OpamClient.PIN.pin st name ?locked ~edit ?version ~action
            `Dev_upstream;
          `Ok ()
-       | `Error e ->
+       | Error (`Msg e) ->
          if command = Some `add then `Error (false, e)
          else bad_subcommand ~cli commands ("pin", command, params))
     | `add_url arg ->
@@ -3688,9 +3689,9 @@ let pin ?(unpin_only=false) cli =
                names);
          `Ok ())
     | `add_current n ->
-      (match (fst package) n with
-       | `Error e -> `Error (false, e)
-       | `Ok (name,version) ->
+      (match (Arg.conv_parser package) n with
+       | Error (`Msg e) -> `Error (false, e)
+       | Ok (name,version) ->
          OpamGlobalState.with_ `Lock_none @@ fun gt ->
          OpamSwitchState.with_ `Lock_write gt @@ fun st ->
          match OpamPackage.package_of_name_opt st.installed name, version with
@@ -3709,8 +3710,8 @@ let pin ?(unpin_only=false) cli =
            OpamPinCommand.pin_current st nv;
            `Ok ())
     | `add_wtarget (n, target) ->
-      (match (fst package) n with
-       | `Ok (name,version) ->
+      (match (Arg.conv_parser package) n with
+       | Ok (name,version) ->
          let pin =
            match pin_target kind target, with_version with
            | `Version v, Some v' -> `Source_version (v, v')
@@ -3722,7 +3723,7 @@ let pin ?(unpin_only=false) cli =
          OpamSwitchState.drop @@
          OpamClient.PIN.pin st name ?locked ?version ~edit ~action ?subpath pin;
          `Ok ()
-       | `Error e -> `Error (false, e))
+       | Error (`Msg e) -> `Error (false, e))
     | `incorrect -> bad_subcommand ~cli commands ("pin", command, params)
   in
   mk_command_ret  ~cli cli_original "pin" ~doc ~man
@@ -4517,12 +4518,15 @@ let help =
     | None       -> `Help (`Pager, None)
     | Some topic ->
       let topics = "topics" :: cmds in
-      let conv, _ = OpamCmdliner.Arg.enum (List.rev_map (fun s -> (s, s)) topics) in
+      let conv =
+        OpamCmdliner.Arg.conv_parser
+          (OpamCmdliner.Arg.enum (List.rev_map (fun s -> (s, s)) topics))
+      in
       match conv topic with
-      | `Error e -> `Error (false, e)
-      | `Ok t when t = "topics" ->
+      | Error (`Msg e) -> `Error (false, e)
+      | Ok t when t = "topics" ->
           List.iter (OpamConsole.msg "%s\n") cmds; `Ok ()
-      | `Ok t -> `Help (man_format, Some t) in
+      | Ok t -> `Help (man_format, Some t) in
 
   Term.(ret (const help $Arg.man_format $Term.choice_names $topic)),
   Cmd.info "help" ~doc ~man

--- a/src/tools/opam_installer.ml
+++ b/src/tools/opam_installer.ml
@@ -383,17 +383,17 @@ let command =
 let info =
   let doc = "Handles (un)installation of package files following instructions from \
              opam *.install files." in
-  (Term.info [@ocaml.warning "-3"]) "opam-installer" ~version:OpamVersion.(to_string current) ~doc
+  Cmd.info "opam-installer" ~version:OpamVersion.(to_string current) ~doc ~exits:[]
 
 let () =
   OpamSystem.init ();
   OpamCoreConfig.init ();
   try
     match
-      (Term.eval [@ocaml.warning "-3"]) ~catch:false (command,info)
+      Cmd.eval ~catch:false (Cmd.v info command)
     with
-    | `Error _ -> exit 2
-    | _ -> exit 0
+    | 0 -> exit 0
+    | _ -> exit 2
   with
   | Invalid_argument s ->
     OpamConsole.error "%s" s; exit 2


### PR DESCRIPTION
Related to issues #6424, #6849, #6853

This PR makes the necessary code changes to allow compilation under cmdliner 2.0 **while keeping the existing vendored version of 1.3.0**.


These changes are mostly find-and-replace type things, but they would allow (at some future point):

- Updating the vendor to 2.1.0+
- Progressive enhancement from that point (e.g., replacing of the `Arg.conv'` calls this PR ads with 2.0's `Arg.Conv.make`, which would also allow us to specify completion handlers)

---

To verify, change the `vendor_cmdliner.sh` script to 
```sh
#!/bin/sh

set -euo pipefail

cd src/core/cmdliner
rm -rf *.ml *.mli dune

git clone https://github.com/dbuenzli/cmdliner tmp-vendor
git -C tmp-vendor switch --detach v2.1.0

mv tmp-vendor/src/*.{ml,mli} .
rm -rf tmp-vendor

mv cmdliner.ml opamCmdliner.ml
mv cmdliner.mli opamCmdliner.mli

cat > dune << EOF
(library
 (name opamCmdliner)
 (public_name opam-core.cmdliner)
 (flags :standard -w -27-32-35-50))
EOF
```

run it, and re-build.
