### PR TITLE
Update PATH in place in env hook

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -151,6 +151,7 @@ users)
 
 ## Shell
   * added return 0 for zsh/bash/sh/fish to prevent leaking error codes [#6930 @ta2005]
+  * Update PATH in place in env hook [#6859 @gridbugs fix #6815]
 
 ## Internal
   * Improve cache-loading performance when using OCaml >= 5.4 by using `Gc.ramp_up` [#6515 @dra27]

--- a/src/state/shellscripts/env_hook.csh
+++ b/src/state/shellscripts/env_hook.csh
@@ -1,1 +1,1 @@
-alias precmd 'eval `opam env --shell=csh --readonly`'
+alias precmd 'eval `opam env --shell=csh --readonly --inplace-path`'

--- a/src/state/shellscripts/env_hook.fish
+++ b/src/state/shellscripts/env_hook.fish
@@ -1,3 +1,3 @@
 function __opam_env_export_eval --on-event fish_prompt
-    eval (opam env --shell=fish --readonly 2> /dev/null)
+    eval (opam env --shell=fish --readonly --inplace-path 2> /dev/null)
 end

--- a/src/state/shellscripts/env_hook.sh
+++ b/src/state/shellscripts/env_hook.sh
@@ -1,6 +1,6 @@
 _opam_env_hook() {
  local previous_exit_status=$?;
- eval $(opam env --shell=bash --readonly 2> /dev/null <&- );
+ eval $(opam env --shell=bash --readonly --inplace-path 2> /dev/null <&- );
  return $previous_exit_status;
 };
 if ! [[ "$PROMPT_COMMAND" =~ _opam_env_hook ]]; then

--- a/src/state/shellscripts/env_hook.zsh
+++ b/src/state/shellscripts/env_hook.zsh
@@ -1,5 +1,5 @@
 _opam_env_hook() {
-    eval $(opam env --shell=zsh --readonly 2> /dev/null <&-);
+    eval $(opam env --shell=zsh --readonly --inplace-path 2> /dev/null <&-);
 }
 typeset -ag precmd_functions;
 if [[ -z ${precmd_functions[(r)_opam_env_hook]} ]]; then

--- a/tests/reftests/init-scripts.unix.test
+++ b/tests/reftests/init-scripts.unix.test
@@ -100,7 +100,7 @@ $env:PATH='${BASEDIR}/root/fake/bin:' + "$env:PATH"
 OPAMNOENVNOTICE=true; export OPAMNOENVNOTICE;
 _opam_env_hook() {
  local previous_exit_status=$?;
- eval $(opam env --shell=bash --readonly 2> /dev/null <&- );
+ eval $(opam env --shell=bash --readonly --inplace-path 2> /dev/null <&- );
  return $previous_exit_status;
 };
 if ! [[ "$PROMPT_COMMAND" =~ _opam_env_hook ]]; then
@@ -109,7 +109,7 @@ fi
 ### cat root/opam-init/env_hook.zsh
 OPAMNOENVNOTICE=true; export OPAMNOENVNOTICE;
 _opam_env_hook() {
-    eval $(opam env --shell=zsh --readonly 2> /dev/null <&-);
+    eval $(opam env --shell=zsh --readonly --inplace-path 2> /dev/null <&-);
 }
 typeset -ag precmd_functions;
 if [[ -z ${precmd_functions[(r)_opam_env_hook]} ]]; then
@@ -118,11 +118,11 @@ fi
 ### cat root/opam-init/env_hook.fish
 set -gx OPAMNOENVNOTICE true;
 function __opam_env_export_eval --on-event fish_prompt
-    eval (opam env --shell=fish --readonly 2> /dev/null)
+    eval (opam env --shell=fish --readonly --inplace-path 2> /dev/null)
 end
 ### cat root/opam-init/env_hook.csh
 setenv OPAMNOENVNOTICE true
-alias precmd 'eval `opam env --shell=csh --readonly`'
+alias precmd 'eval `opam env --shell=csh --readonly --inplace-path`'
 ### test -f root/opam-init/env_hook.cmd
 # Return code 1 #
 ### test -f root/opam-init/env_hook.ps1

--- a/tests/reftests/init-scripts.win32.test
+++ b/tests/reftests/init-scripts.win32.test
@@ -95,7 +95,7 @@ $env:PATH='${BASEDIR}/root/fake/bin;' + "$env:PATH"
 OPAMNOENVNOTICE=true; export OPAMNOENVNOTICE;
 _opam_env_hook() {
  local previous_exit_status=$?;
- eval $(opam env --shell=bash --readonly 2> /dev/null <&- );
+ eval $(opam env --shell=bash --readonly --inplace-path 2> /dev/null <&- );
  return $previous_exit_status;
 };
 if ! [[ "$PROMPT_COMMAND" =~ _opam_env_hook ]]; then
@@ -104,7 +104,7 @@ fi
 ### cat root/opam-init/env_hook.zsh
 OPAMNOENVNOTICE=true; export OPAMNOENVNOTICE;
 _opam_env_hook() {
-    eval $(opam env --shell=zsh --readonly 2> /dev/null <&-);
+    eval $(opam env --shell=zsh --readonly --inplace-path 2> /dev/null <&-);
 }
 typeset -ag precmd_functions;
 if [[ -z ${precmd_functions[(r)_opam_env_hook]} ]]; then
@@ -113,11 +113,11 @@ fi
 ### cat root/opam-init/env_hook.fish
 set -gx OPAMNOENVNOTICE true;
 function __opam_env_export_eval --on-event fish_prompt
-    eval (opam env --shell=fish --readonly 2> /dev/null)
+    eval (opam env --shell=fish --readonly --inplace-path 2> /dev/null)
 end
 ### cat root/opam-init/env_hook.csh
 setenv OPAMNOENVNOTICE true
-alias precmd 'eval `opam env --shell=csh --readonly`'
+alias precmd 'eval `opam env --shell=csh --readonly --inplace-path`'
 ### test -f root/opam-init/env_hook.cmd
 # Return code 1 #
 ### test -f root/opam-init/env_hook.ps1


### PR DESCRIPTION
Prior to this change, the default behaviour of `opam init` was to register a shell hook which ran before each command, and added/moved the bin dir from the current opam switch to the beginning of the PATH variable. If a user has a custom bin directory at the beginning of their PATH containing an executable with the same name as an executable in their current opam switch, the executable in the opam switch will take precedence.

This commit changes the behaviour of the shell hook to update the existing opam switch in PATH in place rather than prepending it, so the precedence of the opam switch relative to other dirs in PATH is preserved.

This change doesn't affect the behaviour of running `eval $(opam env)`.

Fixes https://github.com/ocaml/opam/issues/6815