### PR TITLE
specify Windows version for windows.h

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -84,6 +84,7 @@ users)
 ## VCS
 
 ## Build
+  * Fix Windows build on MSYS2 [#6862 @Firobe]
   * opam no longer depends on `cmdliner` [#6755 @kit-ty-kate - fix #6425]
   * Clean variables before calling make on different projects to avoid clashes [#6769 @kit-ty-kate]
   * Add the upcoming OCaml 5.5 (trunk) support when using dune's dev profile [#6670 @kit-ty-kate]

--- a/src/core/dune
+++ b/src/core/dune
@@ -13,6 +13,7 @@
     (names opam_stubs)
     (flags :standard
            -DUNICODE -D_UNICODE -DCAML_NAME_SPACE
+           -D_WIN32_WINNT=0x602 ; Require Windows 8 / Server 2012 or later
            (:include c-flags.sexp)))
   (c_library_flags (:standard
                    (:include c-libraries.sexp)))


### PR DESCRIPTION
As initially reported by @hannesm in https://github.com/tarides/opam-monorepo/issues/421, opam-monorepo fails to build in a MSYS2 environment because it vendors opam (in this case opam 2.3.0, but there has been no relevant change since).

Full logs at: https://github.com/ocaml/opam-repository/actions/runs/22346082152/job/64660957616?pr=29454

It seems `GetCurrentProcessToken` is [only available since Windows 8.1](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocesstoken), but MSYS2 defaults to Windows 7.

This PR sets `_WIN32_WINNT` to the [constant for Windows 8.1](https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170).

My Windows knowledge is limited and I don't really have ways to test this easily, so don't hesitate to tell me I'm wrong :)
