### PR TITLE
OpamDarcs: remove Num patches fallback

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -82,6 +82,7 @@ users)
   * Allow the macOS sandbox to write in the `/var/folders/` and `/var/db/mds/` directories as it is required by some of macOS core tools [#4797 @kit-ty-kate - fix #4389 #6460]
 
 ## VCS
+  * Darcs no longer fall back to “Num Patches” as “Weak Hash” has been supported since 2016 [#6866 @toastal]
 
 ## Build
   * opam no longer depends on `cmdliner` [#6755 @kit-ty-kate - fix #6425]

--- a/src/repository/opamDarcs.ml
+++ b/src/repository/opamDarcs.ml
@@ -98,7 +98,6 @@ module VCS = struct
   let patch_applied _ _ = Done ()
 
   let revision repo_root =
-    (* 'Weak hash' is only supported from 2.10.3, so provide a fallback *)
     darcs repo_root [ "show"; "repo" ] @@> fun r ->
     OpamSystem.raise_on_process_error r;
     try
@@ -108,16 +107,6 @@ module VCS = struct
            | Some (label, value)
              when OpamStd.String.contains ~sub:"Weak Hash" label ->
              Some (Done (Some value))
-           | _ -> None)
-        r.OpamProcess.r_stdout
-    with Not_found ->
-    try
-      OpamStd.List.find_map
-        (fun s ->
-           match OpamStd.String.rcut_at s ' ' with
-           | Some (label, value)
-             when OpamStd.String.contains ~sub:"Num Patches" label ->
-             Some (Done (Some (Printf.sprintf "darcs-%s" value)))
            | _ -> None)
         r.OpamProcess.r_stdout
     with Not_found ->


### PR DESCRIPTION
2.10.3 was released in 2016. It’s probably safe to remove the code after a decade of maturity.

There is a lot of room for improvement for Darcs tho—there is a big comment talking about Darcs deficiencies, but I don’t think a lot of it is true with my understanding of Darcs. Context files should be used more broadly, but this merge request is specifically a low-hanging change that purely eliminates code. I would like to look at bigger fixes in the nearer future.

Yes, Darcs is still used & is still an active project.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.