### PR TITLE
Follow symlinks transparently in get_diff

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -63,6 +63,7 @@ users)
 ## Lint
 
 ## Repository
+  * Fix `opam update` failure with `file://` repositories containing symlinks by following symlinks transparently in the internal diff computation [#6874 @smorimoto - fix #6410]
 
 ## Lock
 
@@ -133,6 +134,8 @@ users)
 ## Internal: Windows
 
 ## Test
+  * Add dangling symlink test cases for the internal diff computation [#6874 @smorimoto]
+  * Fix test isolation issue where symlink target file was shared across patchDiff tests [#6874 @smorimoto]
 
 ## Benchmarks
   * Add an even larger real-world diff to benchmark `opam update` [#6567 @kit-ty-kate]

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -138,11 +138,12 @@ let get_diff parent_dir dir1 dir2 =
     in
     (file, OpamSystem.read real_file)
   in
-  let lstat_opt parent_dir = function
+  let stat_opt parent_dir = function
     | None -> None
     | Some file ->
       let file = Filename.concat (OpamFilename.Dir.to_string parent_dir) file in
-      Some (Unix.lstat file)
+      try Some (Unix.stat file)
+      with Unix.Unix_error ((Unix.ENOENT | Unix.ELOOP), _, _) -> None
   in
   let rec aux diffs dir1 dir2 =
     let files = get_files_for_diff parent_dir dir1 dir2 in
@@ -153,7 +154,13 @@ let get_diff parent_dir dir1 dir2 =
             | None -> diffs
             | Some diff -> diff :: diffs
           in
-          match lstat_opt parent_dir file1, lstat_opt parent_dir file2 with
+          let stat1 = stat_opt parent_dir file1 in
+          let stat2 = stat_opt parent_dir file2 in
+          (* When stat fails (e.g. dangling symlink), treat the file
+             as absent for reading and recursion too. *)
+          let file1 = if Option.is_none stat1 then None else file1 in
+          let file2 = if Option.is_none stat2 then None else file2 in
+          match stat1, stat2 with
           | Some {st_kind = S_REG; _}, None
           | None, Some {st_kind = S_REG; _}
           | Some {st_kind = S_REG; _}, Some {st_kind = S_REG; _} ->
@@ -168,7 +175,8 @@ let get_diff parent_dir dir1 dir2 =
           | Some {st_kind = S_REG; _}, Some {st_kind = S_DIR; _} ->
             failwith "Change from a regular file to a directory is unsupported"
           | Some {st_kind = S_LNK; _}, _ | _, Some {st_kind = S_LNK; _} ->
-            failwith "Symlinks are unsupported"
+            (* Unreachable: Unix.stat resolves symlinks *)
+            assert false
           | Some {st_kind = S_CHR; _}, _ | _, Some {st_kind = S_CHR; _} ->
             failwith "Character devices are unsupported"
           | Some {st_kind = S_BLK; _}, _ | _, Some {st_kind = S_BLK; _} ->
@@ -177,7 +185,7 @@ let get_diff parent_dir dir1 dir2 =
             failwith "Named pipes are unsupported"
           | Some {st_kind = S_SOCK; _}, _ | _, Some {st_kind = S_SOCK; _} ->
             failwith "Sockets are unsupported"
-          | None, None -> assert false)
+          | None, None -> diffs)
         diffs files
     in
     diffs

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -112,9 +112,13 @@ val job_text:
     subdirs of [parent_dir], returns None if they are equal, and the
     corresponding patch and the list of file-changes otherwise.
 
+    Symlinks are resolved transparently: they are followed to their targets.
+    Dangling symlinks (whose targets do not exist) and circular symlinks
+    are silently skipped.
+
     @raise Stdlib.Failure if an unsupported file type or comparison is
     detected in any of [subdir1] or [subdir2].
-    Unsupported file types: symlinks, character devices, block devices,
-    named pipes, sockets.
+    Unsupported file types: character devices, block devices, named pipes,
+    sockets.
     Unsupported comparison: comparison between regular files and directories. *)
 val get_diff: dirname -> basename -> basename -> (filename * Patch.t list) option

--- a/tests/lib/patchDiff.expected
+++ b/tests/lib/patchDiff.expected
@@ -273,7 +273,24 @@ ERROR: Change from a directory to a regular file is unsupported
   > foo
 
 *** DIFF ***
-ERROR: Symlinks are unsupported
+--- first/linked-file-fst
++++ second/linked-file-fst
+@@ -1,1 +1,1 @@
+-bar
++foo
+
+*** PATCHED ***
++ first/
++ first/linked-file-fst
+  > foo
++ first/same-file
+  > foo
++ second/
++ second/linked-file-fst
+  > foo
++ second/same-file
+  > foo
+
 
 ----------------------
  Test 5: symlink snd
@@ -292,10 +309,94 @@ ERROR: Symlinks are unsupported
   > foo
 
 *** DIFF ***
-ERROR: Symlinks are unsupported
+--- first/linked-file-snd
++++ second/linked-file-snd
+@@ -1,1 +1,1 @@
+-foo
++bar
+
+*** PATCHED ***
++ first/
++ first/linked-file-snd
+  > bar
++ first/same-file
+  > foo
++ second/
++ second/linked-file-snd
+  > bar
++ second/same-file
+  > foo
+
 
 ----------------------
- Test 6: hardlink fst
+ Test 6: dangling symlink fst
+----------------------
+
+*** SETUP ***
++ first/
++ first/same-file
+  > foo
++ second/
++ second/dangling-fst
+  > foo
++ second/same-file
+  > foo
+
+*** DIFF ***
+--- /dev/null
++++ second/dangling-fst
+@@ -0,0 +1,1 @@
++foo
+
+*** PATCH ERROR ***
+ERROR: OpamSystem.File_not_found("$TMPDIR/first/dangling-fst")
+
+----------------------
+ Test 7: dangling symlink snd
+----------------------
+
+*** SETUP ***
++ first/
++ first/dangling-snd
+  > foo
++ first/same-file
+  > foo
++ second/
++ second/same-file
+  > foo
+
+*** DIFF ***
+--- first/dangling-snd
++++ /dev/null
+@@ -1,1 +0,0 @@
+-foo
+
+*** PATCHED ***
++ first/
++ first/same-file
+  > foo
++ second/
++ second/same-file
+  > foo
+
+
+----------------------
+ Test 8: dangling symlink both
+----------------------
+
+*** SETUP ***
++ first/
++ first/same-file
+  > foo
++ second/
++ second/same-file
+  > foo
+
+*** DIFF ***
+No diff
+
+----------------------
+ Test 9: hardlink fst
 ----------------------
 
 *** SETUP ***
@@ -331,7 +432,7 @@ ERROR: Symlinks are unsupported
 
 
 ----------------------
- Test 7: hardlink snd
+ Test 10: hardlink snd
 ----------------------
 
 *** SETUP ***
@@ -342,15 +443,32 @@ ERROR: Symlinks are unsupported
   > foo
 + second/
 + second/hardlinked-file-snd
-  > foo
+  > bar
 + second/same-file
   > foo
 
 *** DIFF ***
-No diff
+--- first/hardlinked-file-snd
++++ second/hardlinked-file-snd
+@@ -1,1 +1,1 @@
+-foo
++bar
+
+*** PATCHED ***
++ first/
++ first/hardlinked-file-snd
+  > bar
++ first/same-file
+  > foo
++ second/
++ second/hardlinked-file-snd
+  > bar
++ second/same-file
+  > foo
+
 
 ----------------------
- Test 8: patch error garbage
+ Test 11: patch error garbage
 ----------------------
 
 *** SETUP ***
@@ -385,7 +503,7 @@ patch format
 
 
 ----------------------
- Test 9: patch truncated
+ Test 12: patch truncated
 ----------------------
 
 *** SETUP ***
@@ -432,7 +550,7 @@ patch format
 
 
 ----------------------
- Test 10: add empty file
+ Test 13: add empty file
 ----------------------
 
 *** SETUP ***
@@ -475,7 +593,7 @@ index c0ffee..c0ffee
 
 
 ----------------------
- Test 11: remove empty file
+ Test 14: remove empty file
 ----------------------
 
 *** SETUP ***
@@ -514,7 +632,7 @@ index c0ffee..c0ffee
 
 
 ----------------------
- Test 12: move file into a new directory
+ Test 15: move file into a new directory
 ----------------------
 
 *** SETUP ***
@@ -576,7 +694,7 @@ rename to inner/move-me
 
 
 ----------------------
- Test 13: delete file that deletes the directory
+ Test 16: delete file that deletes the directory
 ----------------------
 
 *** SETUP ***

--- a/tests/lib/patchDiff.ml
+++ b/tests/lib/patchDiff.ml
@@ -3,6 +3,7 @@ type content =
   | Dir of (string * string) list (* directory with list filename * content *)
   | NamedDir of string * (string * string) list (* directory with list filename * content *)
   | Symlink (* Soft Link *)
+  | DanglingSymlink (* Symlink to nonexistent target *)
   | Hardlink (* Hard link *)
   | V (* void *)
 
@@ -110,6 +111,30 @@ let content_symlink_snd = [
   { name = "linked-file-snd";
     first = File foo;
     second = Symlink;
+  };
+]
+
+let content_dangling_symlink_fst = [
+  same_file;
+  { name = "dangling-fst";
+    first = DanglingSymlink;
+    second = File foo;
+  };
+]
+
+let content_dangling_symlink_snd = [
+  same_file;
+  { name = "dangling-snd";
+    first = File foo;
+    second = DanglingSymlink;
+  };
+]
+
+let content_dangling_symlink_both = [
+  same_file;
+  { name = "dangling-both";
+    first = DanglingSymlink;
+    second = DanglingSymlink;
   };
 ]
 
@@ -257,8 +282,7 @@ let write_setup ?(only_fst=false) dir content =
   let link_f =
     let link = lazy (
       let f = dir // "linked_file" in
-      if not (OpamFilename.exists f) then
-        OpamFilename.write f bar;
+      OpamFilename.write f bar;
       f
     ) in
     fun () -> Lazy.force link
@@ -279,6 +303,9 @@ let write_setup ?(only_fst=false) dir content =
     | Symlink ->
       OpamFilename.link ~relative:false ~target:(link_f ())
         ~link:(inner_dir // name)
+    | DanglingSymlink ->
+      let link = OpamFilename.to_string (inner_dir // name) in
+      Unix.symlink "/nonexistent/target" link
     | Hardlink ->
       let target = OpamFilename.to_string (link_f ()) in
       let link = OpamFilename.to_string (inner_dir // name) in
@@ -349,6 +376,10 @@ let print_dirs dir =
   print "%s\n" (read_dir dir [ first; second ])
 
 let diff_patch dir setup =
+  let rm_tmpdir =
+    let re = Str.regexp_string (OpamFilename.Dir.to_string dir) in
+    fun s -> Str.global_replace re "$TMPDIR" s
+  in
   let { content; kind; git; _ } = setup in
   write_setup dir content;
   print "*** SETUP ***\n";
@@ -367,9 +398,9 @@ let diff_patch dir setup =
           (OpamFilename.Base.of_string first)
           (OpamFilename.Base.of_string second)
       with
-      | exception Failure s -> print "ERROR: %s\n" (rm_hex s); None
+      | exception Failure s -> print "ERROR: %s\n" (rm_hex @@ rm_tmpdir s); None
       | exception e ->
-        print "ERROR: %s\n" (rm_hex @@ Printexc.to_string e);
+        print "ERROR: %s\n" (rm_hex @@ rm_tmpdir @@ Printexc.to_string e);
         None
       | None -> print "No diff\n"; None
       | Some (f,_) -> Some f
@@ -392,7 +423,7 @@ let diff_patch dir setup =
         true
       | Error exn ->
         print "*** %sPATCH ERROR ***\n" git;
-        print "ERROR: %s\n" (rm_hex @@ Printexc.to_string exn);
+        print "ERROR: %s\n" (rm_hex @@ rm_tmpdir @@ Printexc.to_string exn);
         false
     in
     let patched = apply ~git:false diff in
@@ -426,6 +457,21 @@ let tests = [
   };
   { label = "symlink snd";
     content = content_symlink_snd;
+    kind = DiffPatch;
+    git = false;
+  };
+  { label = "dangling symlink fst";
+    content = content_dangling_symlink_fst;
+    kind = DiffPatch;
+    git = false;
+  };
+  { label = "dangling symlink snd";
+    content = content_dangling_symlink_snd;
+    kind = DiffPatch;
+    git = false;
+  };
+  { label = "dangling symlink both";
+    content = content_dangling_symlink_both;
     kind = DiffPatch;
     git = false;
   };


### PR DESCRIPTION
## Problem

When a repository is configured with a `file://` URL pointing to a local directory containing symlinks, `opam update` fails with:

```
[ERROR] Could not update repository "default": Symlinks are unsupported
```

This occurs because `get_diff` in `opamRepositoryBackend.ml` uses `Unix.lstat` to determine file types. `lstat` does not follow symlinks, so any symlink is reported as `S_LNK` and immediately rejected with `failwith "Symlinks are unsupported"`.

The issue was encountered in the opam-repository CI on Windows/Cygwin (ocaml/opam-repository#29613), where the workflow uses `file://${{ github.workspace }}` as the repository URL. The opam-repository checkout contains symlinks (used for package version aliases), and the `file://` backend's local copy handler (`OpamLocal.fetch_repo_update`) preserves them in the quarantine directory. When `get_diff` then compares the quarantine against the existing repository state, it encounters these symlinks and fails.

This is related to #6410, which reports a similar `opam update` failure after a GitHub Actions cache restore with `file://` pinned packages.

### Why `git+file://` works but `file://` does not

Switching the repository URL from `file://` to `git+file://` avoids the problem entirely. The `git+file://` URL uses the git backend (`OpamVCS`), which computes diffs via `git diff` — this never calls `get_diff`. The `file://` URL uses the rsync/local backend (`OpamLocal`), which copies the directory to a quarantine and then calls `get_diff` to compare old and new states. Only this latter code path encounters the `S_LNK` rejection. Users should not need to work around this by changing URL schemes; the `file://` backend ought to handle symlinks properly.

### Why this affects more than just Windows

Although the original report was on Windows, the `"Symlinks are unsupported"` error comes from `get_diff` in `opamRepositoryBackend.ml`, which is platform-independent code. Any `file://` repository containing symlinks triggers the same failure on Linux and macOS. The `git+file://` workaround happens to bypass `get_diff` entirely, which is why it appears to be a Windows-only issue.

## Solution

Replace `Unix.lstat` with `Unix.stat` in the `get_diff` function. `Unix.stat` follows symlinks transparently: a symlink to a regular file is seen as `S_REG`, and a symlink to a directory is seen as `S_DIR`. The diff then operates on the logical content of the repository rather than its filesystem metadata.

### Edge cases handled

**Dangling symlinks** (`ENOENT`): When `Unix.stat` follows a symlink whose target does not exist, it raises `Unix_error(ENOENT, ...)`. This is caught in `stat_opt` and mapped to `None`, treating the entry as absent. The corresponding file path is also set to `None` so that `readfile` is not called on the dangling symlink (which would raise `File_not_found` from `OpamSystem.read`).

**Circular symlinks** (`ELOOP`): When `Unix.stat` encounters a symlink loop, it raises `Unix_error(ELOOP, ...)`. This is caught alongside `ENOENT` for the same treatment.

**Other errors** (e.g. `EACCES`): These are intentionally *not* caught — they represent genuine failures that should propagate as exceptions. This is consistent with the existing behaviour of the old `lstat_opt`, which also did not catch any `Unix_error`.

### Match arm changes

- The `S_LNK` arm is retained for pattern exhaustiveness but changed from `failwith` to `assert false`. `Unix.stat` never returns `S_LNK`, so this arm is unreachable. Using `assert false` (rather than silently skipping) ensures a clear, debuggable failure if this invariant is ever violated.

- The `None, None` arm is changed from `assert false` to `diffs` (skip). Previously, `get_files_for_diff` always produced pairs with at least one `Some` side, and `lstat` never returned `None` for an existing directory entry, so `None, None` was genuinely unreachable. With `stat`, both sides can become `None` when both entries are dangling symlinks. Skipping is correct: there is nothing to diff when neither side has accessible content.

### Test changes

- **Symlink tests** (tests 4–5): Now produce proper diffs instead of `ERROR: Symlinks are unsupported`.
- **Dangling symlink tests** (tests 6–8): Three new test cases exercise the `ENOENT` code path — dangling on first side (treated as file creation), dangling on second side (treated as file deletion), and dangling on both sides (no diff).
- **Test isolation fix**: The shared `linked_file` target is now unconditionally rewritten in `write_setup`. Previously, the existence check (`if not (OpamFilename.exists f)`) meant the file was only written once; when test 4's patch application modified it through the symlink, subsequent tests inherited the corrupted content. This was masked before because symlink tests always errored out before reaching the patch step.
- **Path normalisation**: Added `rm_tmpdir` to replace the platform-specific temporary directory path with `$TMPDIR` in error messages, ensuring the expected output is stable across operating systems.

Fixes #6410
