### PR TITLE
uname: register roots for intermediate strings to avoid GC corruption

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -133,6 +133,7 @@ users)
   * Improve cache-loading performance when using OCaml >= 5.4 by using `Gc.ramp_up` [#6515 @dra27]
   * Make OpamStd.String.compare_case allocation free [#6515 @dra27]
   * Add a helper script to help generate the configure file on platforms without autoconf 2.71 [#6878 @kit-ty-kate]
+  * Fix a rare potential GC corruption in `OpamStubs.uname` [#6880 @avsm @kit-ty-kate @andrew]
 
 ## Internal: Unix
 

--- a/src/core/opamUnix.c
+++ b/src/core/opamUnix.c
@@ -22,8 +22,9 @@ CAMLprim value opam_stdout_ws_col(value _unit) {
 #include <sys/utsname.h>
 
 CAMLprim value opam_uname(value _unit) {
+  CAMLparam0();
+  CAMLlocal1(ret);
   struct utsname buf;
-  value ret;
 
   if (-1 == uname(&buf)) {
     caml_uerror("uname", Nothing);
@@ -33,5 +34,5 @@ CAMLprim value opam_uname(value _unit) {
   Store_field(ret, 1, caml_copy_string(buf.release));
   Store_field(ret, 2, caml_copy_string(buf.machine));
 
-  return ret;
+  CAMLreturn(ret);
 }


### PR DESCRIPTION
uname: register roots for intermediate strings to avoid GC corruption

Reported by @andrew
Backported to 2.5 in https://github.com/ocaml/opam/pull/6893
