### PR TITLE
Fix a GC corruption on Windows in enumRegistry

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -134,6 +134,7 @@ users)
   * Make OpamStd.String.compare_case allocation free [#6515 @dra27]
   * Add a helper script to help generate the configure file on platforms without autoconf 2.71 [#6878 @kit-ty-kate]
   * Fix a rare potential GC corruption in `OpamStubs.uname` [#6880 @avsm @kit-ty-kate @andrew]
+  * Fix a rare potential GC corruption in `OpamStubs.enumRegistry` on Windows [#6882 @kit-ty-kate]
 
 ## Internal: Unix
 

--- a/src/core/opamWindows.c
+++ b/src/core/opamWindows.c
@@ -431,11 +431,6 @@ CAMLprim value OPAMW_RegEnumValue(value hKey, value sub_key, value value_type)
 
   LPWSTR lpEnvironment;
 
-  result = caml_alloc_small(2, 0);
-  Field(result, 0) = Val_int(0);    /* Unused */
-  Field(result, 1) = Val_emptylist; /* The actual result */
-  tail = result;
-
   HKEY key;
   DWORD type;
   LSTATUS ret;
@@ -452,6 +447,11 @@ CAMLprim value OPAMW_RegEnumValue(value hKey, value sub_key, value value_type)
   if (!(lpSubKey = caml_stat_strdup_to_utf16(String_val(sub_key)))) {
     caml_raise_out_of_memory();
   }
+
+  result = caml_alloc_small(2, 0);
+  Field(result, 0) = Val_int(0);    /* Unused */
+  Field(result, 1) = Val_emptylist; /* The actual result */
+  tail = result;
 
   ret = RegOpenKey(roots[Int_val(hKey)], lpSubKey, &key);
   if (ret == ERROR_SUCCESS)


### PR DESCRIPTION
sub_key was used after the allocation, thus sub_key can in rare cases be moved elsewhere and its value becomes invalid. Simply moving the allocation after the last use of any non-immediate values fixes this problem.

Backported to 2.5 in https://github.com/ocaml/opam/pull/6892