### PR TITLE
Add support for single-quoted values of the /etc/os-release file

### DIFF
--- a/.github/workflows/depexts.yml
+++ b/.github/workflows/depexts.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '*.opam'
       - 'src/state/opamSysInteract.ml'
+      - 'src/state/opamSysPoll.ml'
       - '.github/workflows/depexts.yml'
       - '.github/scripts/depexts/**'
   push:

--- a/master_changes.md
+++ b/master_changes.md
@@ -160,6 +160,7 @@ users)
   * Bump the `actions/checkout` to version 6 [#6811 @kit-ty-kate]
   * Bump `actions/cache` to version 5 [#6835 @kit-ty-kate]
   * Regenerate the cache when `OPAM_TEST_REPO_SHA` is changed [#6832 #6821 @kit-ty-kate]
+  * Trigger the depexts CI when OpamSysPoll is modified [#6886 @kit-ty-kate]
 
 ## Doc
   * Add spacing between two words in `--locked` man section [#6806 @yosefAlsuhaibani]

--- a/master_changes.md
+++ b/master_changes.md
@@ -74,6 +74,8 @@ users)
   * The `url` file now only supports the legacy opam 1.2 fields [#6827 @kit-ty-kate]
 
 ## External dependencies
+  * Restore the distribution detection on Gentoo [#6886 @kit-ty-kate - fix #6887]
+  * Add support for single-quoted values of the /etc/os-release file [#6886 @kit-ty-kate - fix #6887]
 
 ## Format upgrade
   * Fix switch and repo format upgrade on Windows. A block occurred because the global lock fd was reopened instead of using the one already opened.  [#6839 @rjbou]

--- a/src/state/opamSysPoll.ml
+++ b/src/state/opamSysPoll.ml
@@ -93,6 +93,8 @@ let os_release_field =
           Scanf.sscanf s "%s@= %s" (fun x v ->
               let contents =
                 try Scanf.sscanf v "\"%s@\"" (fun s -> s)
+                with Scanf.Scan_failure _ | End_of_file ->
+                try Scanf.sscanf v "'%s@'" (fun s -> s)
                 with Scanf.Scan_failure _ | End_of_file -> v
               in
               Some (x, contents))


### PR DESCRIPTION
Gentoo changed its format to use single quotes everywhere and thus broke our distribution name detection

Fixes https://github.com/ocaml/opam/issues/6887
Backported to 2.5 in https://github.com/ocaml/opam/pull/6891