### PR TITLE
GHA: Disable testing conf-clang-format in favour of conf-fts on Alpine

### DIFF
--- a/.github/scripts/depexts/generate-actions.sh
+++ b/.github/scripts/depexts/generate-actions.sh
@@ -238,7 +238,8 @@ if [ "$target" = debian ] || [ "$target" = ubuntu ]; then
 fi
 
 if [ "$target" = alpine ]; then
- test_depext conf-clang-format.1
+ test_depext conf-fts.1
+ # conf-clang-format.1
  # conf-pandoc.0.1
 fi
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -166,6 +166,7 @@ users)
   * Regenerate the cache when `OPAM_TEST_REPO_SHA` is changed [#6832 #6821 @kit-ty-kate]
   * Trigger the depexts CI when OpamSysPoll is modified [#6886 @kit-ty-kate]
   * Speedup macOS builds by stopping testing alternative solvers on macOS [#6889 @kit-ty-kate]
+  * Disable testing conf-clang-format in favour of conf-fts on Alpine [#6888 @kit-ty-kate]
 
 ## Doc
   * Add spacing between two words in `--locked` man section [#6806 @yosefAlsuhaibani]


### PR DESCRIPTION
The package is too brittle and the prefix of the command called in the build section can change from a version to another
Example of failure:
```
 + ./opam install conf-clang-format.1
The following actions will be performed:
=== install 1 package
  - install conf-clang-format 1

The following system packages will first need to be installed:
    clang20-extra-tools

<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><><><>

opam believes some required external dependencies are missing. opam can:
> 1. Run apk to install them (may need root/sudo access)
  2. Display the recommended apk command and wait while you run it manually (e.g. in another terminal)
  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
  4. Abort the installation

[1/2/3/4] 1

+ /sbin/apk "add" "clang20-extra-tools"
- (1/7) Installing libffi (3.5.2-r0)
- (2/7) Installing libxml2 (2.13.9-r0)
- (3/7) Installing llvm20-libs (20.1.8-r0)
- (4/7) Installing clang20-libs (20.1.8-r1)
- (5/7) Installing clang20-headers (20.1.8-r1)
- (6/7) Installing clang20-libclang (20.1.8-r1)
- (7/7) Installing clang20-extra-tools (20.1.8-r1)
- OK: 947.5 MiB in 78 packages

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>

#=== ERROR while compiling conf-clang-format.1 ================================#
"clang-format": command not found.
```