### PR TITLE
[2.5] Add support for single-quoted values of the /etc/os-release file

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -63,6 +63,8 @@ users)
 ## Opamfile
 
 ## External dependencies
+  * Restore the distribution detection on Gentoo [#6886 @kit-ty-kate - fix #6887]
+  * Add support for single-quoted values of the /etc/os-release file [#6886 @kit-ty-kate - fix #6887]
 
 ## Format upgrade
 

--- a/src/state/opamSysPoll.ml
+++ b/src/state/opamSysPoll.ml
@@ -93,6 +93,8 @@ let os_release_field =
           Scanf.sscanf s "%s@= %s" (fun x v ->
               let contents =
                 try Scanf.sscanf v "\"%s@\"" (fun s -> s)
+                with Scanf.Scan_failure _ | End_of_file ->
+                try Scanf.sscanf v "'%s@'" (fun s -> s)
                 with Scanf.Scan_failure _ | End_of_file -> v
               in
               Some (x, contents))


### PR DESCRIPTION
Backport of https://github.com/ocaml/opam/pull/6886 to 2.5