### PR TITLE
[2.5] uname: register roots for intermediate strings to avoid potential GC corruption

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -96,6 +96,7 @@ users)
 
 ## Internal
   * Fix a rare potential GC corruption in `OpamStubs.enumRegistry` on Windows [#6882 @kit-ty-kate]
+  * Fix a rare potential GC corruption in `OpamStubs.uname` [#6880 @avsm @kit-ty-kate @andrew]
 
 ## Internal: Unix
 

--- a/src/core/opamUnix.c
+++ b/src/core/opamUnix.c
@@ -22,8 +22,9 @@ CAMLprim value opam_stdout_ws_col(value _unit) {
 #include <sys/utsname.h>
 
 CAMLprim value opam_uname(value _unit) {
+  CAMLparam0();
+  CAMLlocal1(ret);
   struct utsname buf;
-  value ret;
 
   if (-1 == uname(&buf)) {
     caml_uerror("uname", Nothing);
@@ -33,5 +34,5 @@ CAMLprim value opam_uname(value _unit) {
   Store_field(ret, 1, caml_copy_string(buf.release));
   Store_field(ret, 2, caml_copy_string(buf.machine));
 
-  return ret;
+  CAMLreturn(ret);
 }


### PR DESCRIPTION
Backports https://github.com/ocaml/opam/pull/6880