### PR TITLE
nix depexts: load from json instead of inlining package names

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -76,6 +76,7 @@ users)
 ## External dependencies
   * Restore the distribution detection on Gentoo [#6886 @kit-ty-kate - fix #6887]
   * Add support for single-quoted values of the /etc/os-release file [#6886 @kit-ty-kate - fix #6887]
+  * Fix a string injection from the depexts field to nix-build, when `os-family=nixos` [#6894 @RyanGibb]
 
 ## Format upgrade
   * Fix switch and repo format upgrade on Windows. A block occurred because the global lock fd was reopened instead of using the one already opened.  [#6839 @rjbou]

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -1474,11 +1474,22 @@ let install_packages_commands_t ?(env=OpamVariable.Map.empty) ~to_show st
          OpamFilename.create dir
            (OpamFilename.Base.of_string "env.nix")
        in
-       let packages =
-         String.concat " "
-           (OpamSysPkg.Set.fold (fun p l -> OpamSysPkg.to_string p :: l)
-              OpamSysPkg.Set.Op.(sys_packages.ti_new ++ sys_packages.ti_required) [])
+       let packageFile =
+         OpamFilename.create dir
+           (OpamFilename.Base.of_string "nix-depexts.json")
        in
+       (* We create a JSON object to avoid passing this kind of depexts
+          depexts: [
+            ["gmp ]; <arbitrary nix expression>"] {os-distribution = "nixos"}
+       *)
+       let packages =
+         "[" ^
+         String.concat ", "
+           (OpamSysPkg.Set.fold (fun p l -> ("\"" ^ OpamSysPkg.to_string p ^ "\"") :: l)
+              OpamSysPkg.Set.Op.(sys_packages.ti_new ++ sys_packages.ti_required) [])
+         ^ "]"
+       in
+       OpamFilename.write packageFile packages;
        (* We exclude variables from
             https://github.com/NixOS/nix/blob/e4bda20918ad2af690c2e938211a7d362548e403/src/nix/develop.cc#L308-L325
           append to variables from
@@ -1489,7 +1500,7 @@ let install_packages_commands_t ?(env=OpamVariable.Map.empty) ~to_show st
 with pkgs;
 stdenv.mkDerivation {
   name = "opam-nix-env";
-  nativeBuildInputs = with buildPackages; [ |} ^ packages ^ {| ];
+  nativeBuildInputs = map (name: buildPackages.${name}) (builtins.fromJSON (builtins.readFile ./nix-depexts.json));
 
   phases = [ "buildPhase" ];
 


### PR DESCRIPTION
Fixed and tested by @RyanGibb 

The following pattern was allowed:
```
depexts: [
  ["gmp ]; <arbitrary nix expression>"] {os-distribution = "nixos"}
```

The json values can include strings trying to escape the json, but the `map (name: buildPackages.${name})` ensures any value will either be correct or make nix-build fail which is a reasonable behaviour. Nix syntax does not work like bash and thus ensure that nothing can escape the `${name}`.

Backported to 2.5 in https://github.com/ocaml/opam/pull/6895