### PR TITLE
[2.5] nix depexts: load from json instead of inlining package names

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -65,6 +65,7 @@ users)
 ## External dependencies
   * Restore the distribution detection on Gentoo [#6886 @kit-ty-kate - fix #6887]
   * Add support for single-quoted values of the /etc/os-release file [#6886 @kit-ty-kate - fix #6887]
+  * Fix a string injection from the depexts field to nix-build, when `os-family=nixos` [#6894 @RyanGibb]
 
 ## Format upgrade
 

--- a/src/state/opamSysInteract.ml
+++ b/src/state/opamSysInteract.ml
@@ -1141,11 +1141,18 @@ let install_packages_commands_t ?(env=OpamVariable.Map.empty) ~to_show st
          OpamFilename.create dir
            (OpamFilename.Base.of_string "env.nix")
        in
-       let packages =
-         String.concat " "
-           (OpamSysPkg.Set.fold (fun p l -> OpamSysPkg.to_string p :: l)
-              OpamSysPkg.Set.Op.(sys_packages.ti_new ++ sys_packages.ti_required) [])
+       let packageFile =
+         OpamFilename.create dir
+           (OpamFilename.Base.of_string "nix-depexts.json")
        in
+       let packages =
+         "[" ^
+         String.concat ", "
+           (OpamSysPkg.Set.fold (fun p l -> ("\"" ^ OpamSysPkg.to_string p ^ "\"") :: l)
+           OpamSysPkg.Set.Op.(sys_packages.ti_new ++ sys_packages.ti_required) [])
+           ^ "]"
+       in
+       OpamFilename.write packageFile packages;
        (* We exclude variables from
             https://github.com/NixOS/nix/blob/e4bda20918ad2af690c2e938211a7d362548e403/src/nix/develop.cc#L308-L325
           append to variables from
@@ -1156,7 +1163,7 @@ let install_packages_commands_t ?(env=OpamVariable.Map.empty) ~to_show st
 with pkgs;
 stdenv.mkDerivation {
   name = "opam-nix-env";
-  nativeBuildInputs = with buildPackages; [ |} ^ packages ^ {| ];
+  nativeBuildInputs = map (name: buildPackages.${name}) (builtins.fromJSON (builtins.readFile ./nix-depexts.json));
 
   phases = [ "buildPhase" ];
 


### PR DESCRIPTION
Backport of https://github.com/ocaml/opam/pull/6894 to the 2.5 branch