### PR TITLE
OpamFilename.might_escape ~sep:Unspecified: Fix escape detection on Windows

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -235,3 +235,4 @@ users)
   * `OpamCompat.Map.add_to_list`: was added [#6818 @dra27]
   * `OpamSystem`: add `is_dir_read_only` [#6489 @rjbou]
   * `OpamFilename`: add `is_dir_read_only` [#6489 @rjbou]
+  * `OpamFilename.might_escape`: ensure / is detected as a file separator when called with `~sep:Unspecified` on Windows [#6896 @kit-ty-kate]

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -11,10 +11,14 @@
 
 let might_escape ~sep path =
   let sep =
+    let real_sep = function
+      | `Unix -> Re.char '/'
+      | `Windows -> Re.alt Re.[ char '\\'; char '/' ]
+    in
     match sep with
-    | `Unix -> Re.char '/'
-    | `Windows -> Re.alt Re.[  char '\\'; char '/' ]
-    | `Unspecified -> Re.str Filename.dir_sep
+    | `Unspecified when Sys.win32 -> real_sep `Windows
+    | `Unspecified -> real_sep `Unix
+    | `Unix | `Windows as sep -> real_sep sep
   in
   List.exists (String.equal Filename.parent_dir_name)
     Re.(split (compile sep) path)


### PR DESCRIPTION
This function with this particular parameter is unused in the code currently so this is only an issue for library users at the moment.