### PR TITLE
GHA depexts improvements

### DIFF
--- a/.github/scripts/depexts/generate-actions.sh
+++ b/.github/scripts/depexts/generate-actions.sh
@@ -49,8 +49,8 @@ EOF
 FROM almalinux
 RUN dnf install 'dnf-command(config-manager)' -y
 RUN dnf config-manager --set-enabled crb
-RUN yum install -y $mainlibs $ocaml
-RUN yum install -y gcc-c++ diffutils
+RUN dnf install -y $mainlibs $ocaml
+RUN dnf install -y gcc-c++ diffutils
 RUN sed -i 's/ID="almalinux"/ID="centos"/' /etc/os-release
 EOF
     ;;
@@ -97,8 +97,8 @@ EOF
     cat > "$dir/Dockerfile" << EOF
 FROM oraclelinux:10
 RUN dnf config-manager --set-enabled ol10_codeready_builder
-RUN yum install -y $mainlibs $ocaml
-RUN yum install -y gcc-c++
+RUN dnf install -y $mainlibs $ocaml
+RUN dnf install -y gcc-c++
 EOF
   ;;
   nix)

--- a/.github/scripts/depexts/generate-actions.sh
+++ b/.github/scripts/depexts/generate-actions.sh
@@ -21,8 +21,6 @@ EOF
 mainlibs="m4 git rsync tar unzip bzip2 make wget"
 ocaml="ocaml ocaml-compiler-libs"
 
-OCAML_CONSTRAINT=''
-
 case "$target" in
   alpine)
     cat > "$dir/Dockerfile" << EOF
@@ -47,8 +45,6 @@ RUN pacman -Syu --noconfirm $mainlibs $ocaml gcc diffutils
 EOF
     ;;
  centos)
-   # CentOS 7 doesn't support OCaml 5 (GCC is too old)
-   OCAML_CONSTRAINT=' & < "5.0"'
     cat > "$dir/Dockerfile" << EOF
 FROM almalinux
 RUN dnf install 'dnf-command(config-manager)' -y
@@ -86,21 +82,22 @@ FROM gentoo/stage3
 COPY --from=portage /var/db/repos/gentoo /var/db/repos/gentoo
 RUN getuto
 RUN echo 'FEATURES="getbinpkg"' >> /etc/portage/make.conf
-RUN emerge -qv $mainlibs
+RUN emerge -qv $mainlibs dev-lang/ocaml
 EOF
     ;;
   opensuse)
   # glpk-dev is installed manually because os-family doesn't handle tumbleweed
     cat > "$dir/Dockerfile" << EOF
 FROM opensuse/leap
-RUN zypper --non-interactive install $mainlibs $ocaml diffutils gzip glpk-devel
+RUN zypper --non-interactive install $mainlibs ocaml ocaml-compiler-libs-devel diffutils gzip glpk-devel
 RUN zypper --non-interactive install gcc-c++
 EOF
     ;;
   oraclelinux)
     cat > "$dir/Dockerfile" << EOF
 FROM oraclelinux:10
-RUN yum install -y $mainlibs
+RUN dnf config-manager --set-enabled ol10_codeready_builder
+RUN yum install -y $mainlibs $ocaml
 RUN yum install -y gcc-c++
 EOF
   ;;
@@ -129,7 +126,7 @@ EOF
     ;;
 esac
 
-OCAML_INVARIANT="\"ocaml\" {>= \"4.11.0\"$OCAML_CONSTRAINT}"
+OCAML_INVARIANT='"ocaml-system"'
 
 # Copy released opam binary from cache
 cp binary/opam "$dir/opam"

--- a/.github/scripts/depexts/generate-actions.sh
+++ b/.github/scripts/depexts/generate-actions.sh
@@ -50,7 +50,7 @@ EOF
    # CentOS 7 doesn't support OCaml 5 (GCC is too old)
    OCAML_CONSTRAINT=' & < "5.0"'
     cat > "$dir/Dockerfile" << EOF
-FROM almalinux:9.4
+FROM almalinux
 RUN dnf install 'dnf-command(config-manager)' -y
 RUN dnf config-manager --set-enabled crb
 RUN yum install -y $mainlibs $ocaml
@@ -68,7 +68,7 @@ EOF
     ;;
   fedora)
   cat > "$dir/Dockerfile" << EOF
-FROM fedora:43
+FROM fedora
 RUN dnf install -y $mainlibs $ocaml diffutils
 RUN dnf install -y gcc-c++
 EOF
@@ -92,14 +92,14 @@ EOF
   opensuse)
   # glpk-dev is installed manually because os-family doesn't handle tumbleweed
     cat > "$dir/Dockerfile" << EOF
-FROM opensuse/leap:15.3
+FROM opensuse/leap
 RUN zypper --non-interactive install $mainlibs $ocaml diffutils gzip glpk-devel
 RUN zypper --non-interactive install gcc-c++
 EOF
     ;;
   oraclelinux)
     cat > "$dir/Dockerfile" << EOF
-FROM oraclelinux:8
+FROM oraclelinux:10
 RUN yum install -y $mainlibs
 RUN yum install -y gcc-c++
 EOF
@@ -121,7 +121,7 @@ EOF
     ;;
   ubuntu)
   cat > "$dir/Dockerfile" << EOF
-FROM ubuntu:20.04
+FROM ubuntu
 RUN apt update
 RUN apt install -y $mainlibs $ocaml
 RUN apt install -y g++

--- a/.github/workflows/depexts.yml
+++ b/.github/workflows/depexts.yml
@@ -20,7 +20,7 @@ defaults:
 env:
   OPAMVERSION: 2.5.1
   OPAM_REPO: https://github.com/ocaml/opam-repository.git
-  OPAM_REPO_SHA: eb45f7ec868b0ffc828b9d59cccc72cfec100333
+  OPAM_REPO_SHA: ea549f9f2496d9b1454d1cb4817bba7be9013985
 
 jobs:
   opam-cache:

--- a/master_changes.md
+++ b/master_changes.md
@@ -176,6 +176,7 @@ users)
   * Disable testing conf-clang-format in favour of conf-fts on Alpine [#6888 @kit-ty-kate]
   * Upgrade to use opam 2.5.1 [#6904 @kit-ty-kate]
   * depexts: Always use the latest 'stable' version of each distribution [#6905 @kit-ty-kate]
+  * depexts: Always use the already installed ocaml package via ocaml-system [#6905 @kit-ty-kate]
 
 ## Doc
   * Add spacing between two words in `--locked` man section [#6806 @yosefAlsuhaibani]

--- a/master_changes.md
+++ b/master_changes.md
@@ -175,6 +175,7 @@ users)
   * Speedup macOS builds by stopping testing alternative solvers on macOS [#6889 @kit-ty-kate]
   * Disable testing conf-clang-format in favour of conf-fts on Alpine [#6888 @kit-ty-kate]
   * Upgrade to use opam 2.5.1 [#6904 @kit-ty-kate]
+  * depexts: Always use the latest 'stable' version of each distribution [#6905 @kit-ty-kate]
 
 ## Doc
   * Add spacing between two words in `--locked` man section [#6806 @yosefAlsuhaibani]


### PR DESCRIPTION
This speeds up the depexts CI by quite a bit (it doesn't need to compile ocaml everytime), allows us to stay up-to-date with whatever the distributions do and puts on the same level rolling-releases and version-based distributions.

The only distribution that does not have a `latest` docker tag is oraclelinux because they have purposefully removed it (i guess their main user-base want stability)