### PR TITLE
Remove unnecessary use of chdir

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -15,6 +15,7 @@ users)
 
 ## Global CLI
   * Update Kate's email address [#6808 @kit-ty-kate]
+  * Remove unnecessary uses of `chdir` [#6910 @NathanReb]
 
 ## Plugins
 
@@ -247,6 +248,7 @@ users)
   * `OpamPathName` was added [#6917 @rjbou]
   * `OpamRepositoryPathName` was added [#6917 @rjbou]
   * `OpamRepositoryPath` was moved from `opam-repository` [#6917 @rjbou]
+  * `OpamFilter.expand_interpolations_in_file`: changed argument type from `basename` to `filename` [#6910 @NathanReb]
 
 ## opam-core
   * `OpamCmdliner` was added. It is accessible through a new `opam-core.cmdliner` sub-library [#6755 @kit-ty-kate]
@@ -263,3 +265,8 @@ users)
   * `OpamFilename`: add `is_dir_read_only` [#6489 @rjbou]
   * `OpamFilename.might_escape`: ensure / is detected as a file separator when called with `~sep:Unspecified` on Windows [#6897 @kit-ty-kate]
   * `OpamFilename.Unix` was added abstracting over `/` separated paths regardless of the current system [#6914 @rjbou @kit-ty-kate]
+  * `OpamFilename.in_dir`: removed [#6910 @NathanReb]
+  * `OpamSystem.in_tmp_dir`: removed [#6910 @NathanReb]
+  * `OpamSystem.in_dir`: removed [#6910 @NathanReb]
+  * `OpamSystem.chdir`: removed [#6910 @NathanReb]
+  * `OpamSystem.{command,commands,read_command_output}`: add a `?dir: dirname` optional arg to launch the command in a specific directory [#6910 @NathanReb]

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -168,7 +168,7 @@ let preprocess_dot_install_t st nv build_dir =
     List.map (fun (src, dst) ->
         let file = file_wo_prefix dst in
         let inst warning =
-          let src_file = OpamFilename.create (OpamFilename.cwd ()) src.c in
+          let src_file = OpamFilename.create build_dir src.c in
           if OpamFilename.exists dst
           && OpamConsole.confirm "Overwriting %s?" (OpamFilename.to_string dst) then
             OpamFilename.install ~warning ~src:src_file ~dst ()
@@ -211,7 +211,6 @@ let preprocess_dot_install st nv build_dir =
         else
           (OpamSystem.default_install_warning, (fun () -> false))
       in
-      OpamFilename.in_dir build_dir @@ fun () ->
       log "Installing %s.\n" (OpamPackage.to_string nv);
       let warnings =
         List.filter_map (fun install -> install warning) installs
@@ -396,26 +395,22 @@ let prepare_package_build env opam nv dir =
      None)
   else
     let subst_errs =
-      OpamFilename.in_dir dir  @@ fun () ->
       List.fold_left (fun errs f ->
           try
             print_subst f;
-            OpamFilter.expand_interpolations_in_file env f;
+            let file = OpamFilename.create dir f in
+            OpamFilter.expand_interpolations_in_file env file;
             errs
           with e -> (f, e)::errs)
         [] subst_patches
     in
     let patching_errors = apply_patches () in
-    (* Substitute the configuration files. We should be in the right
-       directory to get the correct absolute path for the
-       substitution files (see [OpamFilter.expand_interpolations_in_file] and
-       [OpamFilename.of_basename]. *)
     let subst_errs =
-      OpamFilename.in_dir dir @@ fun () ->
       List.fold_left (fun errs f ->
           try
             print_subst f;
-            OpamFilter.expand_interpolations_in_file env f;
+            let file = OpamFilename.create dir f in
+            OpamFilter.expand_interpolations_in_file env file;
             errs
           with e -> (f, e)::errs)
         subst_errs subst_others

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -588,9 +588,8 @@ let check_and_revert_sandboxing root config =
         Array.append [| "OPAM_SWITCH_PREFIX=/dev/null" |] (Unix.environment ())
       in
       try
-        (* Don't assume that we can mount the CWD *)
-        OpamSystem.in_tmp_dir @@ fun () ->
-          OpamSystem.read_command_output ~env ~allow_stdin:false (cmd @ test_cmd)
+        OpamSystem.with_tmp_dir @@ fun dir ->
+          OpamSystem.read_command_output ~env ~dir ~allow_stdin:false (cmd @ test_cmd)
         = ["SUCCESS"]
       with e ->
         (OpamConsole.error "Sandboxing is not working on your platform%s:\n%s"

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -377,8 +377,11 @@ let env gt switch ?(set_opamroot=false) ?(set_opamswitch=false)
 let subst gt fs =
   log "config-substitute";
   OpamSwitchState.with_ `Lock_none gt @@ fun st ->
+  let env = OpamPackageVar.resolve st in
   List.iter
-    (OpamFilter.expand_interpolations_in_file (OpamPackageVar.resolve st))
+    (fun b ->
+       let file = OpamFilename.of_basename b in
+       OpamFilter.expand_interpolations_in_file env file)
     fs
 
 let expand gt str =

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -106,19 +106,16 @@ let dirs d =
 let dir_is_empty d =
   OpamSystem.dir_is_empty (Dir.to_string d)
 
-let in_dir dirname fn = OpamSystem.in_dir dirname fn
-
 let is_dir_read_only dirname =
   OpamSystem.is_dir_read_only (Dir.to_string dirname)
 
 let env_of_list l = Array.of_list (List.rev_map (fun (k,v) -> k^"="^v) l)
 
-let exec dirname ?env ?name ?metadata ?keep_going cmds =
+let exec dir ?env ?name ?metadata ?keep_going cmds =
   let env = match env with
     | None   -> None
     | Some l -> Some (env_of_list l) in
-  in_dir dirname
-    (fun () -> OpamSystem.commands ?env ?name ?metadata ?keep_going cmds)
+  OpamSystem.commands ~dir ?env ?name ?metadata ?keep_going cmds
 
 let move_dir ~src ~dst =
   OpamSystem.mv (Dir.to_string src) (Dir.to_string dst)

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -60,9 +60,6 @@ val is_dir_read_only: Dir.t -> bool
 (** List the sub-directory (do not recurse) *)
 val dirs: Dir.t -> Dir.t list
 
-(** Evaluate a function in a given directory *)
-val in_dir: Dir.t -> (unit -> 'a) -> 'a
-
 (** Turns an assoc list into an array suitable to be provided as environment *)
 val env_of_list: (string * string) list -> string array
 

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -337,36 +337,17 @@ let copy_file_aux ?chmod ~src ~dst () =
     (try Unix.unlink dst with Unix.Unix_error _ -> ());
     internal_error "Cannot copy %s to %s (%s)." src dst (Printexc.to_string e)
 
-let chdir dir =
-  try Unix.chdir dir
-  with Unix.Unix_error _ -> raise (File_not_found dir)
-
-let in_dir dir fn =
-  let reset_cwd =
-    let cwd =
-      try Some (Sys.getcwd ())
-      with Sys_error _ -> None in
-    fun () ->
-      match cwd with
-      | None     -> ()
-      | Some cwd -> try chdir cwd with File_not_found _ -> () in
-  chdir dir;
-  try
-    let r = fn () in
-    reset_cwd ();
-    r
-  with e ->
-    OpamStd.Exn.finalise e reset_cwd
-
 let list kind dir =
-  try
-    in_dir dir (fun () ->
-      let d = Sys.readdir (Sys.getcwd ()) in
-      let d = Array.to_list d in
-      let l = List.filter kind d in
-      List.map (Filename.concat dir) (List.sort compare l)
-    )
-  with File_not_found _ -> []
+  let d = try Sys.readdir dir with Sys_error _ -> [||] in
+  let filtered =
+    Array.fold_left
+      (fun acc base ->
+         let path = Filename.concat dir base in
+         if kind path then path::acc else acc)
+      []
+      d
+  in
+  List.sort String.compare filtered
 
 let ls dir = list (fun _ -> true) dir
 
@@ -432,10 +413,6 @@ let with_tmp_dir fn =
   with e ->
     OpamStd.Exn.finalise e @@ fun () ->
     remove_dir dir
-
-let in_tmp_dir fn =
-  with_tmp_dir @@ fun dir ->
-    in_dir dir fn
 
 let with_tmp_dir_job fjob =
   let dir = mk_temp_dir () in
@@ -573,7 +550,7 @@ let make_command
   | `Denied -> permission_denied cmd
 
 let run_process
-    ?verbose ?env ~name ?metadata ?stdout ?allow_stdin command =
+    ?verbose ?env ~name ?metadata ?dir ?stdout ?allow_stdin command =
   let env = match env with None -> OpamProcess.default_env () | Some e -> e in
   let chrono = OpamConsole.timer () in
   match command with
@@ -588,7 +565,7 @@ let run_process
       let r =
         OpamProcess.run
           (OpamProcess.command
-             ~env ~name ~verbose ?metadata ?allow_stdin ?stdout
+             ~env ~name ~verbose ?metadata ?dir ?allow_stdin ?stdout
              full_cmd args)
       in
       let str = String.concat " " (cmd :: args) in
@@ -599,15 +576,15 @@ let run_process
     | `Not_found -> command_not_found cmd
     | `Denied -> permission_denied cmd
 
-let command ?verbose ?env ?name ?metadata ?allow_stdin cmd =
+let command ?verbose ?env ?name ?metadata ?dir ?allow_stdin cmd =
   let name = log_file name in
-  let r = run_process ?verbose ?env ~name ?metadata ?allow_stdin cmd in
+  let r = run_process ?verbose ?env ~name ?metadata ?dir ?allow_stdin cmd in
   OpamProcess.cleanup r;
   raise_on_process_error r
 
-let commands ?verbose ?env ?name ?metadata ?(keep_going=false) commands =
+let commands ?verbose ?env ?name ?metadata ?dir ?(keep_going=false) commands =
   let name = log_file name in
-  let run = run_process ?verbose ?env ~name ?metadata in
+  let run = run_process ?verbose ?env ~name ?metadata ?dir in
   let command r0 c =
     match r0, keep_going with
     | (`Error _ | `Exception _), false -> r0
@@ -625,12 +602,12 @@ let commands ?verbose ?env ?name ?metadata ?(keep_going=false) commands =
   | `Error e -> process_error e
   | `Exception e -> raise e
 
-let read_command_output ?verbose ?env ?metadata ?allow_stdin
+let read_command_output ?verbose ?env ?metadata ?dir ?allow_stdin
     ?(ignore_stderr=false) cmd =
   let name = log_file None in
   let stdout = name ^ (if ignore_stderr then ".stdout" else ".out") in
   let r =
-    run_process ?verbose ?env ~name ?metadata ?allow_stdin
+    run_process ?verbose ?env ~name ?metadata ?dir ?allow_stdin
       ~stdout
       cmd
   in

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -36,9 +36,6 @@ val internal_error: ('a, unit, string, 'b) format4 -> 'a
     passes its name to [fn]. The directory is always removed on completion. *)
 val with_tmp_dir: (string -> 'a) -> 'a
 
-(** [in_tmp_dir fn] executes [fn] in a temporary directory. *)
-val in_tmp_dir: (unit -> 'a) -> 'a
-
 (** Runs a job with a temp dir that is cleaned up afterwards *)
 val with_tmp_dir_job: (string -> 'a OpamProcess.job) -> 'a OpamProcess.job
 
@@ -164,12 +161,6 @@ val rmdir_cleanup : string -> unit
     exists and is not a symlink. Returns [false] otherwise. *)
 val is_reg_dir: string -> bool
 
-(** Change the current working directory *)
-val chdir: string -> unit
-
-(** [in_dir dir fn] evaluates [fn] in the directory [dir] *)
-val in_dir: string -> (unit -> 'a) -> 'a
-
 (** Returns the list of files and directories in the given directory (full
     names) *)
 val ls: string -> string list
@@ -251,14 +242,15 @@ val apply_cygpath: string -> string
 (** [command cmd] executes the command [cmd] in the correct OPAM
     environment. *)
 val command: ?verbose:bool -> ?env:string array -> ?name:string ->
-  ?metadata:(string * string) list -> ?allow_stdin:bool ->
+  ?metadata:(string * string) list -> ?dir: string -> ?allow_stdin:bool ->
   command -> unit
 
 (** [commands cmds] executes the commands [cmds] in the correct OPAM
     environment. It stops whenever one command fails unless [keep_going] is set
     to [true]. In this case, the first error is re-raised at the end. *)
 val commands: ?verbose:bool -> ?env:string array -> ?name:string ->
-  ?metadata:(string * string) list -> ?keep_going:bool -> command list -> unit
+  ?metadata:(string * string) list -> ?dir: string -> ?keep_going:bool ->
+  command list -> unit
 
 (** [read_command_output cmd] executes the command [cmd] in the
     correct OPAM environment and return the lines from output if the command
@@ -267,7 +259,7 @@ val commands: ?verbose:bool -> ?env:string array -> ?name:string ->
     It returns stdout and stder combiend, unless [ignore_stderr] is st to true.
     *)
 val read_command_output: ?verbose:bool -> ?env:string array ->
-  ?metadata:(string * string) list ->  ?allow_stdin:bool ->
+  ?metadata:(string * string) list -> ?dir: string -> ?allow_stdin:bool ->
   ?ignore_stderr:bool -> command -> string list
 
 (** END *)

--- a/src/format/opamFilter.ml
+++ b/src/format/opamFilter.ml
@@ -461,10 +461,9 @@ let expand_interpolations_in_file_full env ~src ~dst =
   close_out oc
 
 (* Substitute the file contents *)
-let expand_interpolations_in_file env file =
-  let file = OpamFilename.of_basename file in
-  let src = OpamFilename.add_extension file OpamPathName.subst_ext in
-  expand_interpolations_in_file_full env ~src ~dst:file
+let expand_interpolations_in_file env dst =
+  let src = OpamFilename.add_extension dst OpamPathName.subst_ext in
+  expand_interpolations_in_file_full env ~src ~dst
 
 (* Apply filters and interpolations to package commands *)
 

--- a/src/format/opamFilter.mli
+++ b/src/format/opamFilter.mli
@@ -143,12 +143,12 @@ val expand_interpolations_in_file_full: env -> src:filename -> dst:filename -> u
 (** Same as {!expand_interpolations_in_file} but allows to set the source [src] and
     destination [dst] files independently instead of implying [src] = [dst].in *)
 
-(** Rewrites [basename.in] to [basename], expanding interpolations.
+(** Rewrites [filename.in] to [filename], expanding interpolations.
     If the first line begins ["opam-version:"], assumes that expansion of
     variables within strings should be properly escaped. In particular, this
     means that Windows paths should expand correctly when generating .config
     files. *)
-val expand_interpolations_in_file: env -> basename -> unit
+val expand_interpolations_in_file: env -> filename -> unit
 
 
 (** Processes filters evaluation in a command list: parameter expansion and

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -30,7 +30,7 @@ module VCS : OpamVCS.VCS = struct
        of git will need to change, as altering PATH could select a different
        Git *)
     fun ?verbose ?stdout args ->
-      OpamSystem.make_command ~dir ?verbose ?stdout "git" args
+      OpamSystem.make_command ?verbose ?stdout "git" ("-C"::dir::args)
 
   let init repo_root repo_url =
     OpamFilename.mkdir repo_root;

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -94,13 +94,24 @@ end
 (* Helper functions used by opam-admin *)
 
 let make_index_tar_gz repo_root =
-  OpamFilename.in_dir repo_root (fun () ->
-    let to_include = [
-      "version";
-      OpamRepositoryPathName.packages_d;
-      OpamRepositoryPathName.repo_f;
+  let open OpamFilename.Op in
+  let files_to_include = [
+    "version";
+    OpamRepositoryPathName.repo_f;
+  ] in
+  let dirs_to_include = [
+    OpamRepositoryPathName.packages_d;
     ] in
-    match List.filter Sys.file_exists to_include with
-    | [] -> ()
-    | d  -> OpamSystem.command ("tar" :: "czhf" :: "index.tar.gz" :: "--exclude=.git*" :: d)
-  )
+  let filtered =
+    List.filter (fun i -> OpamFilename.exists (repo_root // i))
+      files_to_include
+    @ List.filter (fun i -> OpamFilename.exists_dir (repo_root / i))
+      dirs_to_include
+  in
+  match filtered with
+  | [] -> ()
+  | d  ->
+    OpamSystem.command
+      ("tar" :: "czhf" :: "index.tar.gz" ::
+       "-C" :: OpamFilename.Dir.to_string repo_root :: "--exclude=.git*" ::
+       d)

--- a/tests/lib/patcher.ml
+++ b/tests/lib/patcher.ml
@@ -26,7 +26,7 @@ let touch ~dir name =
 let setup_directory ~dir =
   OpamSystem.remove dir;
   OpamSystem.mkdir dir;
-  OpamSystem.chdir dir;
+  Unix.chdir dir;
   List.iter OpamSystem.mkdir ["a"; "b"; "c"]
 
 let pattern1 ?(test1 = false) ?(test2 = false) ?(test3 = false) ?(test4 = false) ?(eoleof_cr = false) dir =
@@ -78,7 +78,7 @@ let generate_patch () =
   set_debug_level (-3) ["PATCH"];
   OpamSystem.translate_patch ~dir:"c" "input.patch" "output.patch";
   set_debug_level 0 [];
-  OpamSystem.chdir "c";
+  Unix.chdir "c";
   Printf.eprintf "Before patch state of c:\n";
   print_directory ".";
   flush stdout;
@@ -91,7 +91,7 @@ let generate_patch () =
   if Sys.command (gpatch^" -p1 -i ../output.patch") <> 0 then (Printf.eprintf "patch application failed\n%!"; exit 2);
   Printf.eprintf "After patch state of c:\n";
   print_directory ".";
-  OpamSystem.chdir Filename.parent_dir_name
+  Unix.chdir Filename.parent_dir_name
 
 let tests () =
   set_debug_level 0 [];
@@ -103,7 +103,7 @@ let tests () =
   generate_patch ();
   pattern1 ~test2:true ~test4:true ~eoleof_cr:true "c";
   generate_patch ();
-  OpamSystem.chdir cwd;
+  Unix.chdir cwd;
   OpamSystem.remove test_dir
 
 let () =

--- a/tests/reftests/action-disk.test
+++ b/tests/reftests/action-disk.test
@@ -1255,7 +1255,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.o
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
 ### opam pin ./main-gpin -n | sed-cmd git | grep -v "HEAD is now"
-+ git "symbolic-ref" "--quiet" "--short" "HEAD" (CWD=${BASEDIR}/main-gpin)
++ git "-C" "${BASEDIR}/main-gpin" "symbolic-ref" "--quiet" "--short" "HEAD"
 - master
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(opam)                      Read ${BASEDIR}/main-gpin/main-gpin.opam in 0.000s
@@ -1277,18 +1277,18 @@ SYSTEM                          mkdir ${OPAMTMP}
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin
 Processing  1/1: [main-gpin: git]
-+ git "init" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "init"
 - Initialized empty Git repository in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/.git/
-+ git "config" "--local" "fetch.prune" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "config" "--local" "diff.noprefix" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "config" "--local" "core.autocrlf" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "config" "--local" "core.eol" "lf" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "config" "--local" "color.ui" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "remote" "add" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "reset" "--hard" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "config" "--local" "fetch.prune" "false"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "config" "--local" "diff.noprefix" "false"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "config" "--local" "core.autocrlf" "false"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "config" "--local" "core.eol" "lf"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "config" "--local" "color.ui" "false"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "remote" "add" "origin" "file://${BASEDIR}/main-gpin"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "reset" "--hard" "refs/remotes/opam-ref-master" "--"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "clean" "-fdx"
 SYSTEM                          rmdir ${OPAMTMP}
 [NOTE] Package main-gpin does not exist in opam repositories registered in the current switch.
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
@@ -1326,17 +1326,22 @@ FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/main-gpin.opam in 0.000s
 Processing  1/1:
-+ git "symbolic-ref" "--quiet" "--short" "HEAD" (CWD=${BASEDIR}/main-gpin)
++ git "-C" "${BASEDIR}/main-gpin" "symbolic-ref" "--quiet" "--short" "HEAD"
++ git "-C" "${BASEDIR}/main-gpin" "diff" "--no-ext-diff" "--quiet" "HEAD"
++ git "-C" "${BASEDIR}/main-gpin" "ls-files" "--others" "--exclude-standard"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "clean" "-fdx"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "submodule" "status" "--recursive"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "clean" "-fdx"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "submodule" "status" "--recursive"
 - master
-+ git "diff" "--no-ext-diff" "--quiet" "HEAD" (CWD=${BASEDIR}/main-gpin)
-+ git "ls-files" "--others" "--exclude-standard" (CWD=${BASEDIR}/main-gpin)
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [main-gpin.dev: git]
-+ git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "submodule" "status" "--recursive" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
 [main-gpin.dev] synchronised (no changes)
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/reinstall
@@ -1350,11 +1355,6 @@ The following actions will be performed:
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/main-gpin.opam in 0.000s
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/3: [main-gpin.dev: git]
-+ git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "submodule" "status" "--recursive" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
 -> retrieved main-gpin.dev  (no changes)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/build/main-gpin.dev
@@ -1410,17 +1410,22 @@ FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/main-gpin.opam in 0.000s
 Processing  1/1:
-+ git "symbolic-ref" "--quiet" "--short" "HEAD" (CWD=${BASEDIR}/main-gpin)
++ git "-C" "${BASEDIR}/main-gpin" "symbolic-ref" "--quiet" "--short" "HEAD"
++ git "-C" "${BASEDIR}/main-gpin" "diff" "--no-ext-diff" "--quiet" "HEAD"
++ git "-C" "${BASEDIR}/main-gpin" "ls-files" "--others" "--exclude-standard"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "clean" "-fdx"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "submodule" "status" "--recursive"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "clean" "-fdx"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "submodule" "status" "--recursive"
 - master
-+ git "diff" "--no-ext-diff" "--quiet" "HEAD" (CWD=${BASEDIR}/main-gpin)
-+ git "ls-files" "--others" "--exclude-standard" (CWD=${BASEDIR}/main-gpin)
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [main-gpin.dev: git]
-+ git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "submodule" "status" "--recursive" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
 [main-gpin.dev] synchronised (no changes)
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/reinstall
@@ -1434,11 +1439,6 @@ The following actions will be performed:
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/main-gpin.opam in 0.000s
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/4: [main-gpin.dev: git]
-+ git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "submodule" "status" "--recursive" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
 -> retrieved main-gpin.dev  (no changes)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/build/main-gpin.dev
@@ -1525,11 +1525,11 @@ The following actions will be performed:
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/main-gpin.opam in 0.000s
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/2: [main-gpin.dev: git]
-+ git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "submodule" "status" "--recursive" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "clean" "-fdx"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "submodule" "status" "--recursive"
 SYSTEM                          rmdir ${OPAMTMP}
 -> retrieved main-gpin.dev  (no changes)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/remove/main-gpin.dev
@@ -1630,7 +1630,18 @@ CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-git-pin-all/
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config atomically in 0.000s
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
-+ git "symbolic-ref" "--quiet" "--short" "HEAD" (CWD=${BASEDIR}/main-gpin)
++ git "-C" "${BASEDIR}/main-gpin" "symbolic-ref" "--quiet" "--short" "HEAD"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "init"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "config" "--local" "fetch.prune" "false"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "config" "--local" "diff.noprefix" "false"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "config" "--local" "core.autocrlf" "false"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "config" "--local" "core.eol" "lf"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "config" "--local" "color.ui" "false"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "remote" "add" "origin" "file://${BASEDIR}/main-gpin"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "reset" "--hard" "refs/remotes/opam-ref-master" "--"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "clean" "-fdx"
 - master
 FILE(opam)                      Read ${BASEDIR}/main-gpin/main-gpin.opam in 0.000s
 [NOTE] Package main-gpin does not exist in opam repositories registered in the current switch.
@@ -1651,18 +1662,7 @@ The following actions will be performed:
 SYSTEM                          mkdir ${OPAMTMP}
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin
 Processing  1/3: [main-gpin.dev: git]
-+ git "init" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 - Initialized empty Git repository in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/.git/
-+ git "config" "--local" "fetch.prune" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "config" "--local" "diff.noprefix" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "config" "--local" "core.autocrlf" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "config" "--local" "core.eol" "lf" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "config" "--local" "color.ui" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "remote" "add" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "reset" "--hard" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
 -> retrieved main-gpin.dev  (git+file://${BASEDIR}/main-gpin#master)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/build/main-gpin.dev
@@ -1721,17 +1721,22 @@ FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/main-gpin.opam in 0.000s
 Processing  1/1:
-+ git "symbolic-ref" "--quiet" "--short" "HEAD" (CWD=${BASEDIR}/main-gpin)
++ git "-C" "${BASEDIR}/main-gpin" "symbolic-ref" "--quiet" "--short" "HEAD"
++ git "-C" "${BASEDIR}/main-gpin" "diff" "--no-ext-diff" "--quiet" "HEAD"
++ git "-C" "${BASEDIR}/main-gpin" "ls-files" "--others" "--exclude-standard"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "clean" "-fdx"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "submodule" "status" "--recursive"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "clean" "-fdx"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "submodule" "status" "--recursive"
 - master
-+ git "diff" "--no-ext-diff" "--quiet" "HEAD" (CWD=${BASEDIR}/main-gpin)
-+ git "ls-files" "--others" "--exclude-standard" (CWD=${BASEDIR}/main-gpin)
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/1: [main-gpin.dev: git]
-+ git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "submodule" "status" "--recursive" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
 [main-gpin.dev] synchronised (no changes)
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/reinstall
@@ -1745,11 +1750,6 @@ The following actions will be performed:
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/main-gpin.opam in 0.000s
 SYSTEM                          mkdir ${OPAMTMP}
 Processing  1/4: [main-gpin.dev: git]
-+ git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "diff" "--no-ext-diff" "--quiet" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
-+ git "submodule" "status" "--recursive" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin)
 SYSTEM                          rmdir ${OPAMTMP}
 -> retrieved main-gpin.dev  (no changes)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/build/main-gpin.dev
@@ -1843,18 +1843,18 @@ The following actions will be performed:
 SYSTEM                          mkdir ${OPAMTMP}
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev
 Processing  1/2: [main-gpin.dev: git]
-+ git "init" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "init"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "config" "--local" "fetch.prune" "false"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "config" "--local" "diff.noprefix" "false"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "config" "--local" "core.autocrlf" "false"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "config" "--local" "core.eol" "lf"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "config" "--local" "color.ui" "false"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "remote" "add" "origin" "file://${BASEDIR}/main-gpin"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "reset" "--hard" "refs/remotes/opam-ref-master" "--"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "clean" "-fdx"
 - Initialized empty Git repository in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev/.git/
-+ git "config" "--local" "fetch.prune" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
-+ git "config" "--local" "diff.noprefix" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
-+ git "config" "--local" "core.autocrlf" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
-+ git "config" "--local" "core.eol" "lf" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
-+ git "config" "--local" "color.ui" "false" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
-+ git "remote" "add" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
-+ git "remote" "set-url" "origin" "file://${BASEDIR}/main-gpin" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
-+ git "fetch" "-q" "file://${BASEDIR}/main-gpin" "--update-shallow" "+master:refs/remotes/opam-ref-master" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
-+ git "reset" "--hard" "refs/remotes/opam-ref-master" "--" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
-+ git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev)
 SYSTEM                          rmdir ${OPAMTMP}
 -> retrieved main-gpin.dev  (git+file://${BASEDIR}/main-gpin#master)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/remove/main-gpin.dev

--- a/tests/reftests/autopin.test
+++ b/tests/reftests/autopin.test
@@ -459,6 +459,4 @@ The following actions will be performed:
 Proceed with 2 installations? [Y/n] n
 # Return code 10 #
 ### opam pin list
-Fatal error:
-${OPAM}: "chdir" failed on ${BASEDIR}/OPAM/abort-install-local/.opam-switch/sources/abort-install: No such file or directory
-# Return code 99 #
+abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at error while fetching current revision)

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -236,17 +236,17 @@ The following actions will be performed:
 SYSTEM                          mkdir ${OPAMTMP}
 SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1
 Processing  1/1: [bar.1: git]
-+ git "init" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
-+ git "config" "--local" "fetch.prune" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
-+ git "config" "--local" "diff.noprefix" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
-+ git "config" "--local" "core.autocrlf" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
-+ git "config" "--local" "core.eol" "lf" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
-+ git "config" "--local" "color.ui" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
-+ git "remote" "add" "origin" "file://${BASEDIR}/bar" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
-+ git "remote" "set-url" "origin" "file://${BASEDIR}/bar" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
-+ git "fetch" "-q" "file://${BASEDIR}/bar" "--update-shallow" "+HEAD:refs/remotes/opam-ref" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
-+ git "reset" "--hard" "refs/remotes/opam-ref" "--" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
-+ git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1)
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "init"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "config" "--local" "fetch.prune" "false"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "config" "--local" "diff.noprefix" "false"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "config" "--local" "core.autocrlf" "false"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "config" "--local" "core.eol" "lf"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "config" "--local" "color.ui" "false"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "remote" "add" "origin" "file://${BASEDIR}/bar"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "remote" "set-url" "origin" "file://${BASEDIR}/bar"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "fetch" "-q" "file://${BASEDIR}/bar" "--update-shallow" "+HEAD:refs/remotes/opam-ref"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "reset" "--hard" "refs/remotes/opam-ref" "--"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "clean" "-fdx"
 SYSTEM                          rmdir ${OPAMTMP}
 Done.
 ### :II:2: distant
@@ -295,20 +295,20 @@ The following actions will be performed:
 SYSTEM                          mkdir ${OPAMTMP}
 SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1
 Processing  1/1: [qux.1: git]
-+ git "init" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
-+ git "config" "--local" "fetch.prune" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
-+ git "config" "--local" "diff.noprefix" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
-+ git "config" "--local" "core.autocrlf" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
-+ git "config" "--local" "core.eol" "lf" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
-+ git "config" "--local" "color.ui" "false" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
-+ git "remote" "add" "origin" "https://github.com/ocaml-opam/opam-depext" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "init"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "config" "--local" "fetch.prune" "false"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "config" "--local" "diff.noprefix" "false"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "config" "--local" "core.autocrlf" "false"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "config" "--local" "core.eol" "lf"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "config" "--local" "color.ui" "false"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "remote" "add" "origin" "https://github.com/ocaml-opam/opam-depext"
 SYSTEM                          mkdir ${BASEDIR}/OPAM/download-cache/git
-+ git "init" "--bare" (CWD=${BASEDIR}/OPAM/download-cache/git)
-+ git "remote" "set-url" "origin" "https://github.com/ocaml-opam/opam-depext" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
-+ git "fetch" "-q" "https://github.com/ocaml-opam/opam-depext" "--update-shallow" "+HEAD:refs/remotes/opam-ref" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
-+ git "push" git "+refs/remotes/opam-ref:refs/remotes/cd8336413a06dcd0c48d3f48df5d1940" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
-+ git "reset" "--hard" "refs/remotes/opam-ref" "--" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
-+ git "clean" "-fdx" (CWD=${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1)
++ git "-C" git "init" "--bare"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "remote" "set-url" "origin" "https://github.com/ocaml-opam/opam-depext"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "fetch" "-q" "https://github.com/ocaml-opam/opam-depext" "--update-shallow" "+HEAD:refs/remotes/opam-ref"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "push" git "+refs/remotes/opam-ref:refs/remotes/cd8336413a06dcd0c48d3f48df5d1940"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "reset" "--hard" "refs/remotes/opam-ref" "--"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "clean" "-fdx"
 SYSTEM                          rmdir ${OPAMTMP}
 Done.
 ### :::::::::::::::

--- a/tests/reftests/git.test
+++ b/tests/reftests/git.test
@@ -59,7 +59,7 @@ The following actions will be performed:
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] Could not synchronize ${BASEDIR}/OPAM/submodule/.opam-switch/sources/submodule.1 from "git+file://${BASEDIR}/use-submodule":
-        "git submodule update --init --recursive" exited with code 1
+        "git -C ${BASEDIR}/OPAM/submodule/.opam-switch/sources/submodule.1 submodule update --init --recursive" exited with code 1
 [ERROR] Failed to get sources of submodule.1: git+file://${BASEDIR}/use-submodule
 
 OpamSolution.Fetch_fail("git+file://${BASEDIR}/use-submodule")

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -241,8 +241,8 @@ The following actions will be performed:
 -> installed nip-git2.ved
 Done.
 ### opam pin add ./nip-path2 --kind git | sed-cmd git | "128.*" -> "128"
-[ERROR] Command "git ls-files" failed:
-"git ls-files" exited with code 128
+[ERROR] Command "git -C ${BASEDIR}/nip-path2 ls-files" failed:
+"git -C ${BASEDIR}/nip-path2 ls-files" exited with code 128
 # Return code 99 #
 ### : auto
 ### opam pin add ./nip-git3 --kind auto

--- a/tests/reftests/pin.test
+++ b/tests/reftests/pin.test
@@ -240,7 +240,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed nip-git2.ved
 Done.
-### opam pin add ./nip-path2 --kind git | sed-cmd git | "128.*" -> "128"
+### opam pin add ./nip-path2 --kind git | sed-cmd git | " 128.*" -> " 128"
 [ERROR] Command "git -C ${BASEDIR}/nip-path2 ls-files" failed:
 "git -C ${BASEDIR}/nip-path2 ls-files" exited with code 128
 # Return code 99 #

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -296,7 +296,7 @@ opam-version: "2.0"
 first  --
 ### ::: rsync - git :::
 ### opam repository set-url oper git+file://$BASEDIR/OPER4 | sed-cmd git
-[ERROR] Could not update repository "oper": "git fetch -q" exited with code 128
+[ERROR] Could not update repository "oper": "git -C ${BASEDIR}/OPAM/repo/oper fetch -q" exited with code 128
 [ERROR] Fetching repository oper with git+file://${BASEDIR}/OPER4 fails, reverting to file://${BASEDIR}/OPER
 # Return code 40 #
 ### opam list --available --repo=oper
@@ -304,7 +304,7 @@ first  --
 # Name # Installed # Synopsis
 first  --
 ### opam repository set-url oper git+file://./OPER3#unknownbranch | sed-cmd git
-[ERROR] Could not update repository "oper": "git fetch -q" exited with code 128
+[ERROR] Could not update repository "oper": "git -C ${BASEDIR}/OPAM/repo/oper fetch -q" exited with code 128
 [ERROR] Fetching repository oper with git+file://./OPER3#unknownbranch fails, reverting to file://${BASEDIR}/OPER
 # Return code 40 #
 ### opam list --available --repo=oper
@@ -335,7 +335,7 @@ first  --
 first  --
 ### ::: git - git :::
 ### opam repository set-url oper git+file://$BASEDIR/OPER4 | sed-cmd git
-[ERROR] Could not update repository "oper": "git fetch -q" exited with code 128
+[ERROR] Could not update repository "oper": "git -C ${BASEDIR}/OPAM/repo/oper fetch -q" exited with code 128
 [ERROR] Fetching repository oper with git+file://${BASEDIR}/OPER4 fails, reverting to git+file://${BASEDIR}/OPER
 # Return code 40 #
 ### opam list --available --repo=oper
@@ -343,7 +343,7 @@ first  --
 # Name # Installed # Synopsis
 first  --
 ### opam repository set-url oper git+file://./OPER3#unknownbranch | sed-cmd git
-[ERROR] Could not update repository "oper": "git fetch -q" exited with code 128
+[ERROR] Could not update repository "oper": "git -C ${BASEDIR}/OPAM/repo/oper fetch -q" exited with code 128
 [ERROR] Fetching repository oper with git+file://./OPER3#unknownbranch fails, reverting to git+file://${BASEDIR}/OPER
 # Return code 40 #
 ### opam list --available --repo=oper
@@ -462,7 +462,7 @@ opam-version: "2.0"
 first  --
 ### :::: rsync - git ::::
 ### opam repository set-url oper git+file://$BASEDIR/OPER4 | sed-cmd git
-[ERROR] Could not update repository "oper": "git fetch -q" exited with code 128
+[ERROR] Could not update repository "oper": "git -C ${BASEDIR}/OPAM/repo/oper fetch -q" exited with code 128
 [ERROR] Fetching repository oper with git+file://${BASEDIR}/OPER4 fails, reverting to file://${BASEDIR}/OPER
 # Return code 40 #
 ### opam list --available --repo=oper
@@ -470,7 +470,7 @@ first  --
 # Name # Installed # Synopsis
 first  --
 ### opam repository set-url oper git+file://./OPER3#unknownbranch | sed-cmd git
-[ERROR] Could not update repository "oper": "git fetch -q" exited with code 128
+[ERROR] Could not update repository "oper": "git -C ${BASEDIR}/OPAM/repo/oper fetch -q" exited with code 128
 [ERROR] Fetching repository oper with git+file://./OPER3#unknownbranch fails, reverting to file://${BASEDIR}/OPER
 # Return code 40 #
 ### opam list --available --repo=oper
@@ -501,7 +501,7 @@ first  --
 first  --
 ### :::: git - git ::::
 ### opam repository set-url oper git+file://$BASEDIR/OPER4 | sed-cmd git
-[ERROR] Could not update repository "oper": "git fetch -q" exited with code 128
+[ERROR] Could not update repository "oper": "git -C ${BASEDIR}/OPAM/repo/oper fetch -q" exited with code 128
 [ERROR] Fetching repository oper with git+file://${BASEDIR}/OPER4 fails, reverting to git+file://${BASEDIR}/OPER
 # Return code 40 #
 ### opam list --available --repo=oper
@@ -509,7 +509,7 @@ first  --
 # Name # Installed # Synopsis
 first  --
 ### opam repository set-url oper git+file://./OPER3#unknownbranch | sed-cmd git
-[ERROR] Could not update repository "oper": "git fetch -q" exited with code 128
+[ERROR] Could not update repository "oper": "git -C ${BASEDIR}/OPAM/repo/oper fetch -q" exited with code 128
 [ERROR] Fetching repository oper with git+file://./OPER3#unknownbranch fails, reverting to git+file://${BASEDIR}/OPER
 # Return code 40 #
 ### opam list --available --repo=oper


### PR DESCRIPTION
This ports the `chdir` removal from https://github.com/ocaml/opam/pull/5966 as asked for in https://github.com/ocaml/opam/issues/6600.

