### PR TITLE
OpamFile: fix comparison between two dummy files

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -227,6 +227,7 @@ users)
   * `OpamFile.URL` was moved to `OpamFile.URL_legacy` and a simpler `OpamFile.URL` module was created only containing non-IO functions removing the outdated `url` file support [#6827 @kit-ty-kate]
   * `OpamFile.Descr.of_legacy`: was added [#6827 @kit-ty-kate]
   * `OpamFile.URL.of_legacy`: was added [#6827 @kit-ty-kate]
+  * `OpamFile`: allow dummy filenames to be added a prefix and still be detected as a dummy filename [#6913 @rjbou]
   * `OpamSysPkg`: add `availability_mode` type to indicate the availability of system packages on a given system [#6489 @arozovyk]
   * `OpamSysPkg`: add `equal_availability_mode` function [#6489 @arozovyk]
   * `OpamTypes`: change `result` type name to `solver_result` to avoid conflicts with Stdlib [#6885 @rjbou]

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3464,8 +3464,11 @@ module OPAMSyntax = struct
       (fun ~pos:_ (filename, t) ->
          filename,
          let metadata_dir =
-           if filename <> dummy_file
-           then Some (None, OpamFilename.(Dir.to_string (dirname filename)))
+           if not (OpamFilename.Base.equal
+                     (OpamFilename.basename filename)
+                     (OpamFilename.basename dummy_file))
+           then
+             Some (None, OpamFilename.(Dir.to_string (dirname filename)))
            else None
          in
          let t = { t with metadata_dir } in


### PR DESCRIPTION
Otherwise, it tries to compare `path/to/<none>` and `./<none>` and fail

TODO:
  * [x] add changelog
  * [x] check documentation

In the story of #6625