### PR TITLE
Allow opam update to update repositories that changed a file to a directory of the same name and vice versa

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -161,6 +161,7 @@ users)
   * Add a test showing the behaviour of .install files containing destination filepath trying to escape their scope [#6897 @rjbou @kit-ty-kate]
   * Add a test showing that `opam install ./` will leave packages pinned if
     aborted or failed [#6922 @NathanReb]
+  * Add test for update in repository that changes directories to files and vice versa [#6915 @rjbou]
 
 ### Engine
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -147,6 +147,7 @@ users)
 ## Test
   * lib/patchDiff: no longer print unecessary information after patch [#6915 @rjbou]
   * lib/patchDiff: Ensure a more consistent output accross Unix and Windows platforms [#6915 @kit-ty-kate]
+  * lib/patchdiff: add dir-file transformations tests [#6915 @rjbou]
 
 ## Benchmarks
   * Add an even larger real-world diff to benchmark `opam update` [#6567 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -146,6 +146,7 @@ users)
 
 ## Test
   * lib/patchDiff: no longer print unecessary information after patch [#6915 @rjbou]
+  * lib/patchDiff: Ensure a more consistent output accross Unix and Windows platforms [#6915 @kit-ty-kate]
 
 ## Benchmarks
   * Add an even larger real-world diff to benchmark `opam update` [#6567 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -145,6 +145,7 @@ users)
 ## Internal: Windows
 
 ## Test
+  * lib/patchDiff: no longer print unecessary information after patch [#6915 @rjbou]
 
 ## Benchmarks
   * Add an even larger real-world diff to benchmark `opam update` [#6567 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -53,6 +53,7 @@ users)
   * Compute the list of available depexts on `opam update` [#6489 @arozovyk - fix #6461]
   * Update depexts availability repository state cache when running `opam update --depexts` [#6489 @arozovyk - fix #6461]
   * Display status message while loading system package availability during `opam update` [#6489 @arozovyk - fix #6461]
+  * `opam update` now supports updating a repository that changed a file to a directory of the same name and vice versa [#6915 @rjbou @arozovyk - fix #3830]
 
 ## Tree
 

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -55,10 +55,7 @@ module B = struct
       Done (OpamRepositoryBackend.Update_full quarantine)
     else
       OpamStd.Exn.finally finalise @@ fun () ->
-      OpamRepositoryBackend.get_diff
-        (OpamFilename.dirname_dir repo_root)
-        (OpamFilename.basename_dir repo_root)
-        (OpamFilename.basename_dir quarantine)
+      OpamRepositoryBackend.get_diff repo_root quarantine
       |> function
       | None -> Done OpamRepositoryBackend.Update_empty
       | Some patch -> Done (OpamRepositoryBackend.Update_patch patch)

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -178,10 +178,7 @@ module B = struct
         Done (OpamRepositoryBackend.Update_full quarantine)
       else
         OpamStd.Exn.finally finalise @@ fun () ->
-        OpamRepositoryBackend.get_diff
-          (OpamFilename.dirname_dir repo_root)
-          (OpamFilename.basename_dir repo_root)
-          (OpamFilename.basename_dir quarantine)
+        OpamRepositoryBackend.get_diff repo_root quarantine
         |> function
         | None -> Done OpamRepositoryBackend.Update_empty
         | Some p -> Done (OpamRepositoryBackend.Update_patch p)

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -71,122 +71,112 @@ let job_text name label =
        (OpamConsole.colorise `green (OpamRepositoryName.to_string name))
        label)
 
-let get_files_for_diff parent_dir dir1 dir2 =
-  let getfiles parent_dir dir =
-    let dir = Filename.concat (OpamFilename.Dir.to_string parent_dir) dir in
-    OpamSystem.get_files_except_vcs dir
+(**  DIFF *)
+
+(* We put back the prefix for patch -p1 harmonisation *)
+let add_prefix repo1 repo2 =
+  let prefix repo =
+    OpamFilename.basename_dir repo
+    |> OpamFilename.Base.to_string
   in
-  match dir1, dir2 with
-  | None, None -> assert false
-  | Some dir, None ->
-    List.map (fun file -> (Some (dir^"/"^file), None))
-      (getfiles parent_dir dir)
-  | None, Some dir ->
-    List.map (fun file -> (None, Some (dir^"/"^file)))
-      (getfiles parent_dir dir)
-  | Some dir1, Some dir2 ->
-    let files1 = List.fast_sort String.compare (getfiles parent_dir dir1) in
-    let files2 = List.fast_sort String.compare (getfiles parent_dir dir2) in
-    let rec aux acc files1 files2 = match files1, files2 with
-      | (file1::files1 as orig1), (file2::files2 as orig2) ->
-        let cmp = String.compare file1 file2 in
-        if cmp = 0 then
-          aux ((Some (dir1^"/"^file1), Some (dir2^"/"^file2)) :: acc)
-            files1 files2
-        else if cmp < 0 then
-          aux ((Some (dir1^"/"^file1), None) :: acc) files1 orig2
-        else
-          aux ((None, Some (dir2^"/"^file2)) :: acc) orig1 files2
-      | file1::files1, [] ->
-        aux ((Some (dir1^"/"^file1), None) :: acc) files1 []
-      | [], file2::files2 ->
-        aux ((None, Some (dir2^"/"^file2)) :: acc) [] files2
-      | [], [] ->
-        acc
+  let p1 x = prefix repo1 ^ "/" ^ x in
+  let p2 x = prefix repo2 ^ "/" ^ x in
+  fun patch ->
+    let operation =
+      match patch.Patch.operation with
+      | Patch.Create f -> Patch.Create (p2 f)
+      | Patch.Delete f -> Patch.Delete (p1 f)
+      | Patch.Edit (f1, f2) -> Patch.Edit (p1 f1, p2 f2)
+      | Patch.Git_ext (f1, f2, ext) -> Patch.Git_ext (p1 f1, p2 f2, ext)
     in
-    aux [] files1 files2
+    {patch with operation}
 
-(* Serves to remove the repository suffix since the quarantine mechanism in
-   local and http patches causes incoherencies with vcs patches *)
-let strip_repo_suffix patch =
-  let rm_prefix f =
-    match OpamStd.String.cut_at f '/' with
-    | None ->
-      log "Internal diff: failed to remove prefix of %s" f;
-      f
-    | Some (_, r) -> r
-  in
-  let operation =
-    match patch.Patch.operation with
-    | Patch.Create f -> Patch.Create (rm_prefix f)
-    | Patch.Delete f -> Patch.Delete (rm_prefix f)
-    | Patch.Edit (f1, f2) -> Patch.Edit (rm_prefix f1, rm_prefix f2)
-    | Patch.Git_ext (f1, f2, ext) ->
-      Patch.Git_ext (rm_prefix f1, rm_prefix f2, ext)
-  in
-  {patch with operation}
-
-let get_diff parent_dir dir1 dir2 =
+let get_diff repo1 repo2 =
   let chrono = OpamConsole.timer () in
-  log "diff: %a/{%a,%a}"
-    (slog OpamFilename.Dir.to_string) parent_dir
-    (slog OpamFilename.Base.to_string) dir1
-    (slog OpamFilename.Base.to_string) dir2;
-  let readfile parent_dir file =
-    let real_file =
-      Filename.concat (OpamFilename.Dir.to_string parent_dir) file
+  log "diff: %a"
+    (fun fmt () ->
+       if OpamFilename.Dir.equal
+           (OpamFilename.dirname_dir repo1)
+           (OpamFilename.dirname_dir repo2) then
+         Format.fprintf fmt "%s/{%s,%s}"
+           (OpamFilename.Dir.to_string (OpamFilename.dirname_dir repo1))
+           (OpamFilename.Base.to_string (OpamFilename.basename_dir repo1))
+           (OpamFilename.Base.to_string (OpamFilename.basename_dir repo2))
+       else
+         Format.fprintf fmt "%s vs %s"
+           (OpamFilename.Dir.to_string repo1)
+           (OpamFilename.Dir.to_string repo2))
+    ();
+  let get_contents =
+    let read_dir_contents dir =
+      let fail s = failwith (s ^ " are unsupported") in
+      (* Recursively read directory contents into a string map.
+         Returns a map from relative file paths to their contents. *)
+      let rec aux acc prefix current_dir =
+        let entries = OpamSystem.get_files_except_vcs current_dir in
+        List.fold_left (fun acc entry ->
+            let full_path = Filename.concat current_dir entry in
+            let relative_path =
+              match prefix with
+              | None -> entry
+              | Some prefix -> prefix ^ "/" ^ entry
+            in
+            let stat = Unix.lstat full_path in
+            match stat.Unix.st_kind with
+            | Unix.S_REG ->
+              let content = OpamSystem.read full_path in
+              OpamStd.String.Map.add relative_path content acc
+            | Unix.S_DIR ->
+              aux acc (Some relative_path) full_path
+            | Unix.S_LNK -> fail "Symlinks"
+            | Unix.S_CHR -> fail "Character devices"
+            | Unix.S_BLK -> fail "Block devices"
+            | Unix.S_FIFO -> fail "Named pipes"
+            | Unix.S_SOCK -> fail "Sockets")
+          acc entries
+      in
+      aux OpamStd.String.Map.empty None dir
     in
-    (file, OpamSystem.read real_file)
+    fun dir ->
+      read_dir_contents (OpamFilename.Dir.to_string dir)
   in
-  let lstat_opt parent_dir = function
-    | None -> None
-    | Some file ->
-      let file = Filename.concat (OpamFilename.Dir.to_string parent_dir) file in
-      Some (Unix.lstat file)
+  let contents1 = get_contents repo1 in
+  let contents2 = get_contents repo2 in
+  let get_content_diffs filename contents1 content2 diffs seen =
+    (* Compute content diffs for a single file.
+       Compares [content2] (new) against [contents1] (old state map).
+       Adds [filename] to [seen] set and generates a diff if contents differ.
+       Returns updated (diffs, seen) accumulator pair *)
+    let seen = OpamStd.String.Set.add filename seen in
+    match OpamStd.String.Map.find_opt filename contents1 with
+    | Some content1 when String.equal content1 content2 ->
+      (diffs, seen)
+    | content1_opt ->
+      let content1 = Option.map (fun c -> (filename, c)) content1_opt in
+      let content2 = Some (filename, content2) in
+      match Patch.diff content1 content2 with
+      | None -> (diffs, seen)
+      | Some diff -> (diff :: diffs, seen)
   in
-  let rec aux diffs dir1 dir2 =
-    let files = get_files_for_diff parent_dir dir1 dir2 in
-    let diffs =
-      List.fold_left (fun diffs (file1, file2) ->
-          let add_to_diffs content1 content2 diffs =
-            match Patch.diff content1 content2 with
-            | None -> diffs
-            | Some diff -> diff :: diffs
-          in
-          match lstat_opt parent_dir file1, lstat_opt parent_dir file2 with
-          | Some {st_kind = S_REG; _}, None
-          | None, Some {st_kind = S_REG; _}
-          | Some {st_kind = S_REG; _}, Some {st_kind = S_REG; _} ->
-            let content1 = Option.map (readfile parent_dir) file1 in
-            let content2 = Option.map (readfile parent_dir) file2 in
-            add_to_diffs content1 content2 diffs
-          | Some {st_kind = S_DIR; _}, None | None, Some {st_kind = S_DIR; _}
-          | Some {st_kind = S_DIR; _}, Some {st_kind = S_DIR; _} ->
-            aux diffs file1 file2
-          | Some {st_kind = S_DIR; _}, Some {st_kind = S_REG; _} ->
-            failwith "Change from a directory to a regular file is unsupported"
-          | Some {st_kind = S_REG; _}, Some {st_kind = S_DIR; _} ->
-            failwith "Change from a regular file to a directory is unsupported"
-          | Some {st_kind = S_LNK; _}, _ | _, Some {st_kind = S_LNK; _} ->
-            failwith "Symlinks are unsupported"
-          | Some {st_kind = S_CHR; _}, _ | _, Some {st_kind = S_CHR; _} ->
-            failwith "Character devices are unsupported"
-          | Some {st_kind = S_BLK; _}, _ | _, Some {st_kind = S_BLK; _} ->
-            failwith "Block devices are unsupported"
-          | Some {st_kind = S_FIFO; _}, _ | _, Some {st_kind = S_FIFO; _} ->
-            failwith "Named pipes are unsupported"
-          | Some {st_kind = S_SOCK; _}, _ | _, Some {st_kind = S_SOCK; _} ->
-            failwith "Sockets are unsupported"
-          | None, None -> assert false)
-        diffs files
-    in
-    diffs
+  let diffs, seen =
+    OpamStd.String.Map.fold
+      (fun filename content2 (diffs, seen) ->
+         get_content_diffs filename contents1 content2 diffs seen)
+      contents2 ([], OpamStd.String.Set.empty)
   in
-  match
-    aux []
-      (Some (OpamFilename.Base.to_string dir1))
-      (Some (OpamFilename.Base.to_string dir2))
-  with
+  let diffs =
+    (* NOTE: putting the deletions first in the list allows us to have
+       a simpler implementation of OpamPatch. This might not be needed
+       in the future if OpamPatch supports git apply style reordering. *)
+    OpamStd.String.Map.fold (fun filename content diffs ->
+        if OpamStd.String.Set.mem filename seen then diffs
+        else
+          match Patch.diff (Some (filename, content)) None with
+          | None -> diffs
+          | Some diff -> diff :: diffs)
+      contents1 diffs
+  in
+  match diffs with
   | [] ->
     log "Internal diff (empty) done in %.2fs." (chrono ());
     None
@@ -195,5 +185,6 @@ let get_diff parent_dir dir1 dir2 =
       (slog (fun l -> string_of_int (List.length l))) diffs (chrono ());
     let patch = OpamSystem.temp_file ~auto_clean:false "patch" in
     let patch_file = OpamFilename.of_string patch in
-    OpamFilename.write patch_file (Format.asprintf "%a" Patch.pp_list diffs);
-    Some (patch_file, List.map strip_repo_suffix diffs)
+    let file_diffs = List.map (add_prefix repo1 repo2) diffs in
+    OpamFilename.write patch_file (Format.asprintf "%a" Patch.pp_list file_diffs);
+    Some (patch_file, diffs)

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -108,13 +108,13 @@ val check_digest: filename -> OpamHash.t option -> bool
 val job_text:
   repository_name -> string -> 'a OpamProcess.job -> 'a OpamProcess.job
 
-(** [get_diff parent_dir subdir1 subdir2] computes the diff between the two
-    subdirs of [parent_dir], returns None if they are equal, and the
-    corresponding patch and the list of file-changes otherwise.
+(** [get_diff dir1 dir2] computes the diff between the two directories,
+    returns None if they are equal, and the corresponding patch and the list of
+    file-changes otherwise.
 
     @raise Stdlib.Failure if an unsupported file type or comparison is
     detected in any of [subdir1] or [subdir2].
     Unsupported file types: symlinks, character devices, block devices,
     named pipes, sockets.
     Unsupported comparison: comparison between regular files and directories. *)
-val get_diff: dirname -> basename -> basename -> (filename * Patch.t list) option
+val get_diff: dirname -> dirname -> (filename * Patch.t list) option

--- a/tests/lib/patchDiff.expected
+++ b/tests/lib/patchDiff.expected
@@ -549,3 +549,62 @@ index c0ffee..c0ffee
 + first/same-file
   > foo
 
+
+----------------------
+ Test 14: diff dir/file error, with content in the dir that is removed
+----------------------
+
+*** SETUP ***
++ first/
++ first/dir-fst-file-snd
++ first/dir-fst-file-snd/fst
+  > foo
++ first/dir-fst-file-snd/remove-me
+  > bar
++ first/same-file
+  > foo
++ second/
++ second/dir-fst-file-snd
+  > foo
++ second/same-file
+  > foo
+
+*** DIFF ***
+ERROR: Change from a directory to a regular file is unsupported
+
+----------------------
+ Test 15: diff dir/file error, with content in the dir that is not removed
+----------------------
+
+*** SETUP ***
++ first/
++ first/dir-fst-file-snd
++ first/dir-fst-file-snd/fst
+  > foo
++ first/dir-fst-file-snd/i-wont-be-removed
+  > baz
++ first/dir-fst-file-snd/remove-me
+  > bar
++ first/same-file
+  > foo
++ second/
++ second/dir-fst-file-snd
+  > foo
++ second/same-file
+  > foo
+
+*** GIVEN DIFF ***
+diff --git b/dir-fst-file-snd/fst a/dir-fst-file-snd
+similarity index 100%
+rename from dir-fst-file-snd/fst
+rename to dir-fst-file-snd
+diff --git b/dir-fst-file-snd/remove-me a/dir-fst-file-snd/remove-me
+deleted file mode c0ffee
+index c0ffee..c0ffee
+--- b/dir-fst-file-snd/remove-me
++++ /dev/null
+@@ -1 +0,0 @@
+-bar
+
+*** PATCH ERROR ***
+ERROR: OpamSystem.Internal_error("Cannot remove ${BASEDIR}/first/dir-fst-file-snd (Unix.Unix_error(Unix.EISDIR, \"unlink\", \"${BASEDIR}/first/dir-fst-file-snd\")).")

--- a/tests/lib/patchDiff.expected
+++ b/tests/lib/patchDiff.expected
@@ -104,26 +104,6 @@
 + first/same-dir
 + first/same-file
   > foo
-+ second/
-+ second/diff-dir-plus-fst
-+ second/diff-dir-plus-fst/fst
-  > foo
-  > bar
-+ second/diff-dir-plus-snd
-+ second/diff-dir-plus-snd/fst
-  > foo
-+ second/diff-file
-  > bar
-+ second/diff-file-plus-fst
-  > foo
-+ second/diff-file-plus-snd
-  > foo
-  > bar
-+ second/file-only-snd
-  > foo
-+ second/same-dir
-+ second/same-file
-  > foo
 
 *** GIT DIFF ***
 diff --git b/diff-dir-plus-fst/fst a/diff-dir-plus-fst/fst
@@ -193,26 +173,6 @@ rename to file-only-snd
   > foo
 + first/same-dir
 + first/same-file
-  > foo
-+ second/
-+ second/diff-dir-plus-fst
-+ second/diff-dir-plus-fst/fst
-  > foo
-  > bar
-+ second/diff-dir-plus-snd
-+ second/diff-dir-plus-snd/fst
-  > foo
-+ second/diff-file
-  > bar
-+ second/diff-file-plus-fst
-  > foo
-+ second/diff-file-plus-snd
-  > foo
-  > bar
-+ second/file-only-snd
-  > foo
-+ second/same-dir
-+ second/same-file
   > foo
 
 
@@ -323,11 +283,6 @@ ERROR: Symlinks are unsupported
   > foo
 + first/same-file
   > foo
-+ second/
-+ second/hardlinked-file-fst
-  > foo
-+ second/same-file
-  > foo
 
 
 ----------------------
@@ -377,11 +332,6 @@ patch format
   > foo
 + first/same-file
   > foo
-+ second/
-+ second/diff-file
-  > bar
-+ second/same-file
-  > foo
 
 
 ----------------------
@@ -422,13 +372,6 @@ patch format
   > bar
 + first/same-file
   > foo
-+ second/
-+ second/diff-file
-  > bar
-+ second/diff-file-plus-fst
-  > foo
-+ second/same-file
-  > foo
 
 
 ----------------------
@@ -453,10 +396,6 @@ new file mode 100644
 + first/im-empty
 + first/same-file
   > foo
-+ second/
-+ second/im-empty
-+ second/same-file
-  > foo
 
 *** GIT DIFF ***
 diff --git b/im-empty a/im-empty
@@ -467,10 +406,6 @@ index c0ffee..c0ffee
 + first/
 + first/im-empty
 + first/same-file
-  > foo
-+ second/
-+ second/im-empty
-+ second/same-file
   > foo
 
 
@@ -495,9 +430,6 @@ deleted file mode 100644
 + first/
 + first/same-file
   > foo
-+ second/
-+ second/same-file
-  > foo
 
 *** GIT DIFF ***
 diff --git b/im-empty a/im-empty
@@ -507,9 +439,6 @@ index c0ffee..c0ffee
 *** GIT PATCHED ***
 + first/
 + first/same-file
-  > foo
-+ second/
-+ second/same-file
   > foo
 
 
@@ -547,12 +476,6 @@ index c0ffee..c0ffee
   > bar
 + first/same-file
   > foo
-+ second/
-+ second/inner
-+ second/inner/move-me
-  > bar
-+ second/same-file
-  > foo
 
 *** GIT DIFF ***
 diff --git b/move-me a/inner/move-me
@@ -566,12 +489,6 @@ rename to inner/move-me
 + first/inner/move-me
   > bar
 + first/same-file
-  > foo
-+ second/
-+ second/inner
-+ second/inner/move-me
-  > bar
-+ second/same-file
   > foo
 
 
@@ -609,10 +526,6 @@ rename to inner/move-me
 + first/
 + first/same-file
   > foo
-+ second/
-+ second/im-here
-+ second/same-file
-  > foo
 
 *** GIT DIFF ***
 diff --git b/im-here/delete-me a/im-here/delete-me
@@ -634,9 +547,5 @@ index c0ffee..c0ffee
 *** GIT PATCHED ***
 + first/
 + first/same-file
-  > foo
-+ second/
-+ second/im-here
-+ second/same-file
   > foo
 

--- a/tests/lib/patchDiff.expected
+++ b/tests/lib/patchDiff.expected
@@ -49,32 +49,11 @@
   > foo
 
 *** DIFF ***
---- first/diff-dir-plus-fst/fst
-+++ second/diff-dir-plus-fst/fst
-@@ -2,0 +2,1 @@
-+bar
---- first/diff-dir-plus-snd/fst
-+++ second/diff-dir-plus-snd/fst
-@@ -2,1 +2,0 @@
--bar
---- first/diff-file
-+++ second/diff-file
-@@ -1,1 +1,1 @@
--foo
-+bar
---- first/diff-file-plus-fst
-+++ second/diff-file-plus-fst
-@@ -2,1 +2,0 @@
--bar
---- first/diff-file-plus-snd
-+++ second/diff-file-plus-snd
-@@ -2,0 +2,1 @@
-+bar
---- first/dir-only-fst/fst
+--- first/file-only-fst
 +++ /dev/null
 @@ -1,1 +0,0 @@
 -foo
---- first/file-only-fst
+--- first/dir-only-fst/fst
 +++ /dev/null
 @@ -1,1 +0,0 @@
 -foo
@@ -82,6 +61,27 @@
 +++ second/file-only-snd
 @@ -0,0 +1,1 @@
 +foo
+--- first/diff-file-plus-snd
++++ second/diff-file-plus-snd
+@@ -2,0 +2,1 @@
++bar
+--- first/diff-file-plus-fst
++++ second/diff-file-plus-fst
+@@ -2,1 +2,0 @@
+-bar
+--- first/diff-file
++++ second/diff-file
+@@ -1,1 +1,1 @@
+-foo
++bar
+--- first/diff-dir-plus-snd/fst
++++ second/diff-dir-plus-snd/fst
+@@ -2,1 +2,0 @@
+-bar
+--- first/diff-dir-plus-fst/fst
++++ second/diff-dir-plus-fst/fst
+@@ -2,0 +2,1 @@
++bar
 
 *** PATCHED ***
 + first/
@@ -194,7 +194,31 @@ rename to file-only-snd
   > foo
 
 *** DIFF ***
-ERROR: Change from a regular file to a directory is unsupported
+--- first/file-fst-dir-snd
++++ /dev/null
+@@ -1,1 +0,0 @@
+-foo
+--- /dev/null
++++ second/file-fst-dir-snd/fst
+@@ -0,0 +1,1 @@
++foo
+
+*** PATCHED ***
++ first/
++ first/file-fst-dir-snd
++ first/file-fst-dir-snd/fst
+  > foo
++ first/same-file
+  > foo
+
+*** GIT DIFF ***
+diff --git b/file-fst-dir-snd a/file-fst-dir-snd/fst
+similarity index 100%
+rename from file-fst-dir-snd
+rename to file-fst-dir-snd/fst
+
+*** GIT PATCH ERROR ***
+ERROR: Unix.Unix_error(Unix.ENOTDIR, "lstat", "${BASEDIR}/first/file-fst-dir-snd/fst")
 
 ----------------------
  Test 3: diff dir/file error
@@ -214,7 +238,30 @@ ERROR: Change from a regular file to a directory is unsupported
   > foo
 
 *** DIFF ***
-ERROR: Change from a directory to a regular file is unsupported
+--- first/dir-fst-file-snd/fst
++++ /dev/null
+@@ -1,1 +0,0 @@
+-foo
+--- /dev/null
++++ second/dir-fst-file-snd
+@@ -0,0 +1,1 @@
++foo
+
+*** PATCHED ***
++ first/
++ first/dir-fst-file-snd
+  > foo
++ first/same-file
+  > foo
+
+*** GIT DIFF ***
+diff --git b/dir-fst-file-snd/fst a/dir-fst-file-snd
+similarity index 100%
+rename from dir-fst-file-snd/fst
+rename to dir-fst-file-snd
+
+*** GIT PATCH ERROR ***
+ERROR: OpamSystem.Internal_error("Cannot remove ${BASEDIR}/first/dir-fst-file-snd (Unix.Unix_error(Unix.EISDIR, \"unlink\", \"${BASEDIR}/first/dir-fst-file-snd\")).")
 
 ----------------------
  Test 4: symlink fst
@@ -388,7 +435,7 @@ patch format
   > foo
 
 *** DIFF ***
-diff --git second/im-empty second/im-empty
+diff --git first/im-empty second/im-empty
 new file mode 100644
 
 *** PATCHED ***
@@ -423,7 +470,7 @@ index c0ffee..c0ffee
   > foo
 
 *** DIFF ***
-diff --git first/im-empty first/im-empty
+diff --git first/im-empty second/im-empty
 deleted file mode 100644
 
 *** PATCHED ***
@@ -460,14 +507,14 @@ index c0ffee..c0ffee
   > foo
 
 *** DIFF ***
---- /dev/null
-+++ second/inner/move-me
-@@ -0,0 +1,1 @@
-+bar
 --- first/move-me
 +++ /dev/null
 @@ -1,1 +0,0 @@
 -bar
+--- /dev/null
++++ second/inner/move-me
+@@ -0,0 +1,1 @@
++bar
 
 *** PATCHED ***
 + first/
@@ -512,15 +559,15 @@ rename to inner/move-me
   > foo
 
 *** DIFF ***
---- first/im-here/delete-me
-+++ /dev/null
-@@ -1,1 +0,0 @@
--bar
 --- first/im-not-here/delete-me
 +++ /dev/null
 @@ -1,1 +0,0 @@
 -baz
 \ No newline at end of file
+--- first/im-here/delete-me
++++ /dev/null
+@@ -1,1 +0,0 @@
+-bar
 
 *** PATCHED ***
 + first/
@@ -570,7 +617,41 @@ index c0ffee..c0ffee
   > foo
 
 *** DIFF ***
-ERROR: Change from a directory to a regular file is unsupported
+--- first/dir-fst-file-snd/remove-me
++++ /dev/null
+@@ -1,1 +0,0 @@
+-bar
+--- first/dir-fst-file-snd/fst
++++ /dev/null
+@@ -1,1 +0,0 @@
+-foo
+--- /dev/null
++++ second/dir-fst-file-snd
+@@ -0,0 +1,1 @@
++foo
+
+*** PATCHED ***
++ first/
++ first/dir-fst-file-snd
+  > foo
++ first/same-file
+  > foo
+
+*** GIT DIFF ***
+diff --git b/dir-fst-file-snd/fst a/dir-fst-file-snd
+similarity index 100%
+rename from dir-fst-file-snd/fst
+rename to dir-fst-file-snd
+diff --git b/dir-fst-file-snd/remove-me a/dir-fst-file-snd/remove-me
+deleted file mode c0ffee
+index c0ffee..c0ffee
+--- b/dir-fst-file-snd/remove-me
++++ /dev/null
+@@ -1 +0,0 @@
+-bar
+
+*** GIT PATCH ERROR ***
+ERROR: OpamSystem.Internal_error("Cannot remove ${BASEDIR}/first/dir-fst-file-snd (Unix.Unix_error(Unix.EISDIR, \"unlink\", \"${BASEDIR}/first/dir-fst-file-snd\")).")
 
 ----------------------
  Test 15: diff dir/file error, with content in the dir that is not removed

--- a/tests/lib/patchDiff.ml
+++ b/tests/lib/patchDiff.ml
@@ -205,12 +205,19 @@ let content_single_file_in_dir_snd = [
 (** Utils *)
 
 let print = Printf.printf
-let rm_hex =
-  let re =
-    Str.regexp {|[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]?|}
-  in
-  let by = "c0ffee" in
-  fun s -> Str.global_replace re by s
+let rewrite ~dir s =
+  let l = [
+    Str.regexp_string {|\\\\|}, "/";
+    Str.regexp_string {|\\|}, "/";
+    Str.regexp_string (OpamSystem.back_to_forward (OpamFilename.Dir.to_string OpamFilename.Op.(dir / ""))), "${BASEDIR}/";
+    Str.regexp_string "Unix.EPERM", "Unix.EISDIR"; (* macOS *)
+    Str.regexp {|[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]?|}, "c0ffee";
+    Str.regexp_string (* Windows *)
+      {|Unix.Unix_error(Unix.EACCES, "rename", "${BASEDIR}/first/file-fst-dir-snd")|},
+    {|Unix.Unix_error(Unix.ENOTDIR, "lstat", "${BASEDIR}/first/file-fst-dir-snd/fst")|};
+    Str.regexp_string "Unix.EACCES", "Unix.EISDIR"; (* Windows *)
+  ] in
+  List.fold_left (fun s (re, by) -> Str.global_replace re by s) s l
 
 open OpamFilename.Op
 let read_dir root names =
@@ -291,7 +298,7 @@ let write_setup ?(only_fst=false) dir content =
     content
 
 (* --Git-- *)
-let git_cmds repo_root commands error_msg =
+let git_cmds ~dir repo_root commands error_msg =
   let commands =
     List.map (fun args ->
         OpamSystem.make_command "git"
@@ -305,7 +312,7 @@ let git_cmds repo_root commands error_msg =
         | _ -> failwith (OpamProcess.string_of_command command))
       commands
   with Failure e ->
-    print "ERROR:%s: %s\n" error_msg (rm_hex e)
+    print "ERROR:%s: %s\n" error_msg (rewrite ~dir e)
 
 let make_git_repo dir =
   let first_root = dir / first in
@@ -314,7 +321,7 @@ let make_git_repo dir =
     [ "add"; "--all" ];
     [ "commit"; "-qm"; "first" ];
   ] in
-  git_cmds first_root commands "Git init"
+  git_cmds ~dir first_root commands "Git init"
 
 let generate_git_diff dir =
   let first_root = dir / first in
@@ -328,9 +335,9 @@ let generate_git_diff dir =
     [ "-c"; "diff.noprefix=false"; "diff"; "--text"; "--no-ext-diff"; "-R"; "-p";
       "HEAD..HEAD^"; "--output="^(OpamFilename.to_string name) ]
   ] in
-  git_cmds first_root commands "Git generate diff";
+  git_cmds ~dir first_root commands "Git generate diff";
   print "*** GIT DIFF ***\n";
-  print "%s\n" (rm_hex @@ OpamFilename.read name);
+  print "%s\n" (rewrite ~dir (OpamFilename.read name));
   name
 (* --Git-- *)
 
@@ -367,9 +374,9 @@ let diff_patch dir setup =
           (OpamFilename.Base.of_string first)
           (OpamFilename.Base.of_string second)
       with
-      | exception Failure s -> print "ERROR: %s\n" (rm_hex s); None
+      | exception Failure s -> print "ERROR: %s\n" (rewrite ~dir s); None
       | exception e ->
-        print "ERROR: %s\n" (rm_hex @@ Printexc.to_string e);
+        print "ERROR: %s\n" (rewrite ~dir (Printexc.to_string e));
         None
       | None -> print "No diff\n"; None
       | Some (f,_) -> Some f
@@ -392,7 +399,7 @@ let diff_patch dir setup =
         true
       | Error exn ->
         print "*** %sPATCH ERROR ***\n" git;
-        print "ERROR: %s\n" (rm_hex @@ Printexc.to_string exn);
+        print "ERROR: %s\n" (rewrite ~dir (Printexc.to_string exn));
         false
     in
     let patched = apply ~git:false diff in

--- a/tests/lib/patchDiff.ml
+++ b/tests/lib/patchDiff.ml
@@ -345,14 +345,14 @@ type setup = {
   git: bool; (* add a test where the first directory is a git directory or not *)
 }
 
-let print_dirs dir =
-  print "%s\n" (read_dir dir [ first; second ])
+let print_dirs dir dirs =
+  print "%s\n" (read_dir dir dirs)
 
 let diff_patch dir setup =
   let { content; kind; git; _ } = setup in
   write_setup dir content;
   print "*** SETUP ***\n";
-  print_dirs dir;
+  print_dirs dir [first; second];
   let diff =
     match kind with
     | Patch patch ->
@@ -388,7 +388,7 @@ let diff_patch dir setup =
       match result with
       | Ok _ ->
         print "*** %sPATCHED ***\n" git;
-        print_dirs dir;
+        print_dirs dir [first];
         true
       | Error exn ->
         print "*** %sPATCH ERROR ***\n" git;

--- a/tests/lib/patchDiff.ml
+++ b/tests/lib/patchDiff.ml
@@ -399,9 +399,9 @@ let diff_patch dir setup =
     | DiffPatch ->
       print "*** DIFF ***\n";
       match
-        OpamRepositoryBackend.get_diff dir
-          (OpamFilename.Base.of_string first)
-          (OpamFilename.Base.of_string second)
+        OpamRepositoryBackend.get_diff
+          (dir / first)
+          (dir / second)
       with
       | exception Failure s -> print "ERROR: %s\n" (rewrite ~dir s); None
       | exception e ->

--- a/tests/lib/patchDiff.ml
+++ b/tests/lib/patchDiff.ml
@@ -97,6 +97,35 @@ let content_file_dir = [
   };
 ]
 
+let content_file_dir_with_content = [
+  same_file;
+  { name = "dir-fst-file-snd";
+    first = Dir [ "fst", foo; "remove-me", bar ];
+    second = File foo;
+  };
+]
+
+let content_file_dir_with_content_error = [
+  same_file;
+  { name = "dir-fst-file-snd";
+    first = Dir [ "fst", foo; "remove-me", bar; "i-wont-be-removed", "baz"];
+    second = File foo;
+  };
+]
+
+let gitdiff_patch_failure_dir_non_empty =
+  "diff --git b/dir-fst-file-snd/fst a/dir-fst-file-snd\n" ^
+  "similarity index 100%\n" ^
+  "rename from dir-fst-file-snd/fst\n" ^
+  "rename to dir-fst-file-snd\n" ^
+  "diff --git b/dir-fst-file-snd/remove-me a/dir-fst-file-snd/remove-me\n" ^
+  "deleted file mode c0ffee\n" ^
+  "index c0ffee..c0ffee\n" ^
+  "--- b/dir-fst-file-snd/remove-me\n" ^
+  "+++ /dev/null\n" ^
+  "@@ -1 +0,0 @@\n" ^
+  "-bar\n"
+
 let content_symlink_fst = [
   same_file;
   { name = "linked-file-fst";
@@ -475,6 +504,16 @@ let tests = [
     content = content_single_file_in_dir_snd;
     kind = DiffPatch;
     git = true;
+  };
+  { label = "diff dir/file error, with content in the dir that is removed";
+    content = content_file_dir_with_content;
+    kind = DiffPatch;
+    git = true;
+  };
+  { label = "diff dir/file error, with content in the dir that is not removed";
+    content = content_file_dir_with_content_error;
+    kind = Patch gitdiff_patch_failure_dir_non_empty;
+    git = false;
   };
 ]
 

--- a/tests/reftests/update.test
+++ b/tests/reftests/update.test
@@ -971,16 +971,16 @@ Am I a file ?
 ### opam update diff-repo
 
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
-[ERROR] Could not update repository "diff-repo": Change from a regular file to a directory is unsupported
-# Return code 40 #
+[diff-repo] synchronised from file://${BASEDIR}/DREPO
+Now run 'opam upgrade' to apply any package updates.
 ### opam install due -vv | sed-cmd test
 The following actions will be performed:
 === install 1 package
   - install due 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-Processing  2/3: [due: test archivio]
-+ test "-f" "archivio" (CWD=${BASEDIR}/OPAM/update-file-dir/.opam-switch/build/due.1)
+Processing  2/3: [due: test]
++ test "-f" "archivio/interno" (CWD=${BASEDIR}/OPAM/update-file-dir/.opam-switch/build/due.1)
 -> compiled  due.1
 -> installed due.1
 Done.
@@ -1000,16 +1000,16 @@ Am I a file ?
 ### opam update diff-repo
 
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
-[ERROR] Could not update repository "diff-repo": Change from a directory to a regular file is unsupported
-# Return code 40 #
+[diff-repo] synchronised from file://${BASEDIR}/DREPO
+Now run 'opam upgrade' to apply any package updates.
 ### opam install due -vv | sed-cmd test
 The following actions will be performed:
 === install 1 package
   - install due 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-Processing  2/3: [due: test]
-+ test "-f" "archivio/interno" (CWD=${BASEDIR}/OPAM/update-dir-file/.opam-switch/build/due.1)
+Processing  2/3: [due: test archivio]
++ test "-f" "archivio" (CWD=${BASEDIR}/OPAM/update-dir-file/.opam-switch/build/due.1)
 -> compiled  due.1
 -> installed due.1
 Done.

--- a/tests/reftests/update.test
+++ b/tests/reftests/update.test
@@ -905,3 +905,111 @@ The following actions would be performed:
   - upgrade pkg-foo 1.0.0~alpha1 to 1.0.0~alpha2~pre0
 === install 1 package
   - install lib-foo 1.0.0~alpha1                      [required by pkg-foo]
+### :V: Changes that move a file into a directory and vice versa
+### <DREPO/repo>
+opam-version: "2.0"
+### <DREPO/packages/uno/uno.1>
+opam-version: "2.0"
+### <DREPO/packages/due/due.1/opam>
+opam-version: "2.0"
+### <DREPO/packages/due/due.1/files/archivio>
+Am I a file ?
+### <add-xf.sh>
+set -eu
+nv=$1
+file=$2
+n=${nv%.*}
+path="DREPO/packages/$n/$nv"
+md5=$(openssl md5 "$path/files/$file" | cut -d' ' -f2)
+cat >> "$path/opam" << EOF
+build: [ "test" "-f" "$file" ]
+extra-files: [
+  [ "$file" "md5=$md5" ]
+]
+EOF
+### sh add-xf.sh due.1 archivio
+### opam repo remove git-ver git-test incremental --all
+### opam repo -a
+# Repository # Url # Switches(rank)
+### opam show pkg-foo.1.0.0~alpha1
+
+<><> pkg-foo: information on all versions <><><><><><><><><><><><><><><><><><><>
+name                   pkg-foo
+all-installed-versions 1.0.0~alpha1 [git-version-switch]
+all-versions           1.0.0~alpha1
+
+<><> Version-specific details <><><><><><><><><><><><><><><><><><><><><><><><><>
+version 1.0.0~alpha1
+### opam repo add diff-repo ./DREPO --set-default
+[diff-repo] Initialised
+### opam switch create update-init --empty
+### opam list -A
+# Packages matching: any
+# Name # Installed # Synopsis
+due    --
+### opam install due -vv | sed-cmd test
+The following actions will be performed:
+=== install 1 package
+  - install due 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/3: [due: test archivio]
++ test "-f" "archivio" (CWD=${BASEDIR}/OPAM/update-init/.opam-switch/build/due.1)
+-> compiled  due.1
+-> installed due.1
+Done.
+### :V:1: Update repository with changes File -> Dir
+### rm DREPO/packages/uno/uno.1 DREPO/packages/due/due.1/files/archivio
+### <DREPO/packages/uno/uno.1/opam>
+opam-version: "2.0"
+### <DREPO/packages/due/due.1/opam>
+opam-version: "2.0"
+### <DREPO/packages/due/due.1/files/archivio/interno>
+Am I a file ?
+### sh add-xf.sh due.1 archivio/interno
+### opam switch create update-file-dir --empty
+### opam update diff-repo
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[ERROR] Could not update repository "diff-repo": Change from a regular file to a directory is unsupported
+# Return code 40 #
+### opam install due -vv | sed-cmd test
+The following actions will be performed:
+=== install 1 package
+  - install due 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/3: [due: test archivio]
++ test "-f" "archivio" (CWD=${BASEDIR}/OPAM/update-file-dir/.opam-switch/build/due.1)
+-> compiled  due.1
+-> installed due.1
+Done.
+### :V:2: Update repository with changes Dir -> File
+### opam repo remove diff-repo --all
+### opam repo add diff-repo ./DREPO --set-default
+[diff-repo] Initialised
+### rm -r DREPO/packages/uno/uno.1 DREPO/packages/due/due.1/files/archivio
+### <DREPO/packages/uno/uno.1>
+opam-version: "2.0"
+### <DREPO/packages/due/due.1/opam>
+opam-version: "2.0"
+### <DREPO/packages/due/due.1/files/archivio>
+Am I a file ?
+### sh add-xf.sh due.1 archivio
+### opam switch create update-dir-file --empty
+### opam update diff-repo
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[ERROR] Could not update repository "diff-repo": Change from a directory to a regular file is unsupported
+# Return code 40 #
+### opam install due -vv | sed-cmd test
+The following actions will be performed:
+=== install 1 package
+  - install due 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/3: [due: test]
++ test "-f" "archivio/interno" (CWD=${BASEDIR}/OPAM/update-dir-file/.opam-switch/build/due.1)
+-> compiled  due.1
+-> installed due.1
+Done.


### PR DESCRIPTION
With the addition of tar.gz archives as an internal representation of a repository (#6625), we want to be able to diff between directories (as now), but also between archives and directory and archive.
`OpamRepositoryBackend.get_diff` was rewritten to support those several types. As tar.gz implementation only list existing files (no directories), it has a side effect to no longer easily detect directory-file renames automatically (see #3830) to error on them. The new implementation allow them and generates a diff accordingly.
~Our patch function didn't support application of this kind of operation, it is then updated to handle it properly.~

~In this PR, there is also the creation of `OpamPatch` module that contains patch related functions. As we have other things that will be added for patch function in #6625, it is moved to its own module in advance.~ extracted as no longer needed here.

The `patchDiff` test is also updated with new tests for this new supported diff operation and better rewrites for consistent output.

TODO:
  * [x] add changelog
  * [x] check documentation

fix #3830
In the story of #6625