### PR TITLE
Improve visibility of depopts filter note in documentation

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -1083,7 +1083,7 @@ files.
     [`depends:`](#opamfield-depends), with the same specific variables
     available (except for `post`, which wouldn't make sense).
 
-    Note that `depopts: [ "foo" { = "3" } ]` means that the optional dependency
+    **Note:** `depopts: [ "foo" { = "3" } ]` means that the optional dependency
     only applies for `foo` version `3`, not that your package can't be installed
     with other versions of `foo`: for that, use the
     [`conflicts:`](#opamfield-conflicts) field.

--- a/master_changes.md
+++ b/master_changes.md
@@ -183,6 +183,7 @@ users)
   * Update the Install page with the new opam 2.5.0 release [#6821 @kit-ty-kate]
   * Mention more explicitely that raw fields are an option [@raphael-proust]
   * Correct configure instruction in README [#6858 @gridbugs @kit-ty-kate]
+  * Improve visibility of `depopts` filter note [#6920 @ccoulombel - fix #5367]
 
 ## Security fixes
   * Invalidate .install fields containing destination filepath trying to escape their scope [#6897 @kit-ty-kate]


### PR DESCRIPTION
This change makes the existing note more visible by using bold formatting.

Fixes #5367 
