### PR TITLE
Add regression test for aborted local install leaving half-pinned pkgs

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -159,6 +159,8 @@ users)
   * Add disabled depexts tests [#6489 @rjbou]
   * Add depexts tests with debug section that demostrate system availability polling [#6489 @arozovyk]
   * Add a test showing the behaviour of .install files containing destination filepath trying to escape their scope [#6897 @rjbou @kit-ty-kate]
+  * Add a test showing that `opam install ./` will leave packages pinned if
+    aborted or failed [#6922 @NathanReb]
 
 ### Engine
 

--- a/tests/reftests/autopin.test
+++ b/tests/reftests/autopin.test
@@ -428,3 +428,37 @@ Switch invariant: ["ocaml" {>= "4.05.0"}]
 
 Switch initialisation failed: clean up? ('n' will leave the switch partially installed) [Y/n] y
 # Return code 20 #
+### :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+### : Aborting install . should not leave half-pinned packages around
+### :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+### opam switch create abort-install-local --empty
+### <abort-install/abort-install.opam>
+opam-version: "2.0"
+name: "abort-install"
+maintainer: "me"
+authors: "me"
+homepage: "foo.com"
+bug-reports: "foo.com/bugs"
+license: "MIT"
+synopsis: "Test pkg please ignore"
+depends: [ "dep-lib" ]
+### <pkg:dep-lib.1>
+opam-version: "2.0"
+### git -C abort-install init -q --initial-branch=master
+### git -C abort-install config core.autocrlf false
+### git -C abort-install add abort-install.opam
+### git -C abort-install commit -qm 'init'
+### opam install ./abort-install --no
+[NOTE] Package abort-install does not exist in opam repositories registered in the current switch.
+abort-install is now pinned to git+file://${BASEDIR}/abort-install#master (version dev)
+The following actions will be performed:
+=== install 2 packages
+  - install abort-install dev (pinned)
+  - install dep-lib       1            [required by abort-install]
+
+Proceed with 2 installations? [Y/n] n
+# Return code 10 #
+### opam pin list
+Fatal error:
+${OPAM}: "chdir" failed on ${BASEDIR}/OPAM/abort-install-local/.opam-switch/sources/abort-install: No such file or directory
+# Return code 99 #


### PR DESCRIPTION
This adds a test to show what happens when an install containing local packages is aborted or fails mid run and what packages are still pinned afterwards.

At the moment it only shows that it leaves the switch in a state that `opam pin list` cannot handle and it crashes with a terrible `chdir` error.

After #6910, `opam pin list` should work and it will show that packages pinned during the aborted install are left as such, which is something that we'd like to change and that I'll fix in a separate PR.
