### PR TITLE
Offer to remove autopin pkgs on install failure

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -28,6 +28,8 @@ users)
 
 ## Install
 
+  * Unpin packages pinned by `opam install` when the install is aborted by the user. [#6923, @NathanReb]
+
 ## Build (package)
 
 ## Remove

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1894,10 +1894,28 @@ let install cli =
       else atoms_or_locals
     in
     if formula = OpamFormula.Empty && atoms_or_locals = [] then `Ok () else
+    let already_pinned = st.pinned in
     let st, atoms =
       OpamAuxCommands.autopin
         st ~recurse ?subpath ~quiet:check ~simulate:(deps_only||check||depext_only)
         ?locked:OpamStateConfig.(!r.locked) atoms_or_locals
+    in
+    let newly_pinned = OpamPackage.Set.diff st.pinned already_pinned in
+    let clean_up_pins_on_failure st () =
+      let newly_pinned_l =
+        OpamPackage.Set.elements newly_pinned
+        |> List.map OpamPackage.name
+      in
+      match newly_pinned_l with
+      | [] -> ()
+      | _ ->
+        OpamConsole.msg
+          "Unpinning packages pinned during install:\n%s"
+          (OpamStd.Format.itemize
+             (fun name ->
+                OpamConsole.colorise `bold (OpamPackage.Name.to_string name))
+             newly_pinned_l);
+        ignore (OpamPinCommand.unpin st newly_pinned_l)
     in
     if formula = OpamFormula.Empty && atoms = [] then
       (OpamConsole.msg "Nothing to do\n";
@@ -1920,9 +1938,12 @@ let install cli =
           OpamStd.Sys.exit_because `False)
     else
     let st =
-      OpamClient.install st atoms ~formula
-        ~autoupdate:pure_atoms ?add_to_roots ~deps_only ~ignore_conflicts
-        ~assume_built ~depext_only ~download_only
+      try
+        OpamClient.install st atoms ~formula
+          ~autoupdate:pure_atoms ?add_to_roots ~deps_only ~ignore_conflicts
+          ~assume_built ~depext_only ~download_only
+      with OpamStd.Sys.Exit 10 as exn -> (* [exit_because `Aborted] *)
+        OpamStd.Exn.finalise exn (clean_up_pins_on_failure st)
     in
     match destdir with
     | None -> `Ok ()

--- a/tests/reftests/autopin.test
+++ b/tests/reftests/autopin.test
@@ -431,6 +431,8 @@ Switch initialisation failed: clean up? ('n' will leave the switch partially ins
 ### :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ### : Aborting install . should not leave half-pinned packages around
 ### :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+### : When aborting an install, any packages pinned during the process
+### : is unpinned, including pin-depends.
 ### opam switch create abort-install-local --empty
 ### <abort-install/abort-install.opam>
 opam-version: "2.0"
@@ -458,9 +460,11 @@ The following actions will be performed:
   - install dep-lib       1            [required by abort-install]
 
 Proceed with 2 installations? [Y/n] n
+Unpinning packages pinned during install:
+  - abort-install
+Ok, abort-install is no longer pinned to git+file://${BASEDIR}/abort-install#master (version dev)
 # Return code 10 #
 ### opam pin list
-abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at error while fetching current revision)
 ### opam install ./abort-install --deps-only
 The following actions will be performed:
 === install 1 package
@@ -469,13 +473,11 @@ The following actions will be performed:
 Proceed with 1 installation? [Y/n] n
 # Return code 10 #
 ### opam pin list
-abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at error while fetching current revision)
 ### opam install ./abort-install --check
 Missing dependencies:
 dep-lib
 # Return code 1 #
 ### opam pin list
-abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at error while fetching current revision)
 ### opam install ./abort-install --dry-run
 The following actions will be simulated:
 === install 2 packages
@@ -483,9 +485,11 @@ The following actions will be simulated:
   - install dep-lib       1            [required by abort-install]
 
 Proceed with 2 installations? [Y/n] n
+Unpinning packages pinned during install:
+  - abort-install
+Ok, abort-install is no longer pinned locally (version dev)
 # Return code 10 #
 ### opam pin list
-abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at error while fetching current revision)
 ### :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ### : Autopin removal on aborted install should also correctly handle
 ### : pin-depends
@@ -522,6 +526,7 @@ synopsis: "Test pkg please ignore"
 ### git -C pin-dep-lib add pin-dep-lib.opam
 ### git -C pin-dep-lib commit -qm 'init'
 ### opam install ./abort-install
+[NOTE] Package abort-install does not exist in opam repositories registered in the current switch.
 The following additional pinnings are required by abort-install.dev:
   - pin-dep-lib.dev at git+file://${BASEDIR}/pin-dep-lib
 Pin and install them? [Y/n] y
@@ -529,7 +534,6 @@ Pin and install them? [Y/n] y
 [pin-dep-lib.dev] synchronised (no changes)
 pin-dep-lib is now pinned to git+file://${BASEDIR}/pin-dep-lib (version dev)
 abort-install is now pinned to git+file://${BASEDIR}/abort-install#master (version dev)
-[abort-install.dev] synchronised (git+file://${BASEDIR}/abort-install#master)
 The following actions will be performed:
 === install 3 packages
   - install abort-install dev (pinned)
@@ -537,25 +541,40 @@ The following actions will be performed:
   - install pin-dep-lib   dev (pinned) [required by abort-install]
 
 Proceed with 3 installations? [Y/n] n
+Unpinning packages pinned during install:
+  - abort-install
+  - pin-dep-lib
+Ok, abort-install is no longer pinned to git+file://${BASEDIR}/abort-install#master (version dev)
+Ok, pin-dep-lib is no longer pinned to git+file://${BASEDIR}/pin-dep-lib (version dev)
 # Return code 10 #
 ### opam pin list | '\(at .*\)' -> '(at <git-revision>)'
-abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at <git-revision>)
-pin-dep-lib.dev    (uninstalled)  git  git+file://${BASEDIR}/pin-dep-lib           (at <git-revision>)
 ### opam install ./abort-install --deps-only
+The following additional pinnings are required by abort-install.dev:
+  - pin-dep-lib.dev at git+file://${BASEDIR}/pin-dep-lib
+Pin and install them? [Y/n] y
+[NOTE] Package pin-dep-lib does not exist in opam repositories registered in the current switch.
+[pin-dep-lib.dev] synchronised (no changes)
+pin-dep-lib is now pinned to git+file://${BASEDIR}/pin-dep-lib (version dev)
 The following actions will be performed:
 === install 2 packages
   - install dep-lib     1            [required by abort-install]
   - install pin-dep-lib dev (pinned) [required by abort-install]
 
 Proceed with 2 installations? [Y/n] n
+Unpinning packages pinned during install:
+  - pin-dep-lib
+Ok, pin-dep-lib is no longer pinned to git+file://${BASEDIR}/pin-dep-lib (version dev)
 # Return code 10 #
 ### opam pin list | '\(at .*\)' -> '(at <git-revision>)'
-abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at <git-revision>)
-pin-dep-lib.dev    (uninstalled)  git  git+file://${BASEDIR}/pin-dep-lib           (at <git-revision>)
 ### opam install ./abort-install --check
+The following additional pinnings are required by abort-install.dev:
+  - pin-dep-lib.dev at git+file://${BASEDIR}/pin-dep-lib
+Pin and install them? [Y/n] y
+[NOTE] Package pin-dep-lib does not exist in opam repositories registered in the current switch.
+[pin-dep-lib.dev] synchronised (no changes)
+pin-dep-lib is now pinned to git+file://${BASEDIR}/pin-dep-lib (version dev)
 Missing dependencies:
 dep-lib pin-dep-lib
 # Return code 1 #
 ### opam pin list | '\(at .*\)' -> '(at <git-revision>)'
-abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at <git-revision>)
-pin-dep-lib.dev    (uninstalled)  git  git+file://${BASEDIR}/pin-dep-lib           (at <git-revision>)
+pin-dep-lib.dev  (uninstalled)  git  git+file://${BASEDIR}/pin-dep-lib  (at <git-revision>)

--- a/tests/reftests/autopin.test
+++ b/tests/reftests/autopin.test
@@ -442,13 +442,14 @@ bug-reports: "foo.com/bugs"
 license: "MIT"
 synopsis: "Test pkg please ignore"
 depends: [ "dep-lib" ]
-### <pkg:dep-lib.1>
-opam-version: "2.0"
 ### git -C abort-install init -q --initial-branch=master
 ### git -C abort-install config core.autocrlf false
 ### git -C abort-install add abort-install.opam
 ### git -C abort-install commit -qm 'init'
-### opam install ./abort-install --no
+### <pkg:dep-lib.1>
+opam-version: "2.0"
+### OPAMAUTOANSWER=install-pin-depends=yes:proceed-actions=no
+### opam install ./abort-install
 [NOTE] Package abort-install does not exist in opam repositories registered in the current switch.
 abort-install is now pinned to git+file://${BASEDIR}/abort-install#master (version dev)
 The following actions will be performed:
@@ -460,3 +461,101 @@ Proceed with 2 installations? [Y/n] n
 # Return code 10 #
 ### opam pin list
 abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at error while fetching current revision)
+### opam install ./abort-install --deps-only
+The following actions will be performed:
+=== install 1 package
+  - install dep-lib 1 [required by abort-install]
+
+Proceed with 1 installation? [Y/n] n
+# Return code 10 #
+### opam pin list
+abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at error while fetching current revision)
+### opam install ./abort-install --check
+Missing dependencies:
+dep-lib
+# Return code 1 #
+### opam pin list
+abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at error while fetching current revision)
+### opam install ./abort-install --dry-run
+The following actions will be simulated:
+=== install 2 packages
+  - install abort-install dev (pinned)
+  - install dep-lib       1            [required by abort-install]
+
+Proceed with 2 installations? [Y/n] n
+# Return code 10 #
+### opam pin list
+abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at error while fetching current revision)
+### :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+### : Autopin removal on aborted install should also correctly handle
+### : pin-depends
+### :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+### <abort-install/abort-install.opam>
+opam-version: "2.0"
+name: "abort-install"
+maintainer: "me"
+authors: "me"
+homepage: "foo.com"
+bug-reports: "foo.com/bugs"
+license: "MIT"
+synopsis: "Test pkg please ignore"
+depends: [ "dep-lib" "pin-dep-lib" ]
+### <add-pin-depends.sh>
+set -eu
+basedir=$(printf '%s' "$BASEDIR" | sed 's/\\/\\\\/g')
+cat >> abort-install/abort-install.opam << EOF
+pin-depends: [["pin-dep-lib.dev" "git+file://$basedir/pin-dep-lib"]]
+EOF
+### sh add-pin-depends.sh
+### git -C abort-install add abort-install.opam
+### git -C abort-install commit -qm 'init'
+### <pin-dep-lib/pin-dep-lib.opam>
+opam-version:"2.0"
+maintainer: "me"
+authors: "me"
+homepage: "foo.com"
+bug-reports: "foo.com/bugs"
+license: "MIT"
+synopsis: "Test pkg please ignore"
+### git -C pin-dep-lib init -q --initial-branch=master
+### git -C pin-dep-lib config core.autocrlf false
+### git -C pin-dep-lib add pin-dep-lib.opam
+### git -C pin-dep-lib commit -qm 'init'
+### opam install ./abort-install
+The following additional pinnings are required by abort-install.dev:
+  - pin-dep-lib.dev at git+file://${BASEDIR}/pin-dep-lib
+Pin and install them? [Y/n] y
+[NOTE] Package pin-dep-lib does not exist in opam repositories registered in the current switch.
+[pin-dep-lib.dev] synchronised (no changes)
+pin-dep-lib is now pinned to git+file://${BASEDIR}/pin-dep-lib (version dev)
+abort-install is now pinned to git+file://${BASEDIR}/abort-install#master (version dev)
+[abort-install.dev] synchronised (git+file://${BASEDIR}/abort-install#master)
+The following actions will be performed:
+=== install 3 packages
+  - install abort-install dev (pinned)
+  - install dep-lib       1            [required by abort-install]
+  - install pin-dep-lib   dev (pinned) [required by abort-install]
+
+Proceed with 3 installations? [Y/n] n
+# Return code 10 #
+### opam pin list | '\(at .*\)' -> '(at <git-revision>)'
+abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at <git-revision>)
+pin-dep-lib.dev    (uninstalled)  git  git+file://${BASEDIR}/pin-dep-lib           (at <git-revision>)
+### opam install ./abort-install --deps-only
+The following actions will be performed:
+=== install 2 packages
+  - install dep-lib     1            [required by abort-install]
+  - install pin-dep-lib dev (pinned) [required by abort-install]
+
+Proceed with 2 installations? [Y/n] n
+# Return code 10 #
+### opam pin list | '\(at .*\)' -> '(at <git-revision>)'
+abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at <git-revision>)
+pin-dep-lib.dev    (uninstalled)  git  git+file://${BASEDIR}/pin-dep-lib           (at <git-revision>)
+### opam install ./abort-install --check
+Missing dependencies:
+dep-lib pin-dep-lib
+# Return code 1 #
+### opam pin list | '\(at .*\)' -> '(at <git-revision>)'
+abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (at <git-revision>)
+pin-dep-lib.dev    (uninstalled)  git  git+file://${BASEDIR}/pin-dep-lib           (at <git-revision>)


### PR DESCRIPTION
This PR adds a prompt when an `opam install` command fails to install packages or is aborted, offering them to remove packages that were automatically pinned as part of the process.

This mostly affects installation of local packages, i.e. when `opam install` is passed a file or directory as this triggers an automatic pin of the given opam file or any opam file found within the directory, alongside their pin-depends.

It allows users to quickly clean up if they realize that was not their intent or if they are unable to proceed with the install.

Queued on
* [x] #6910