### PR TITLE
GHA: trigger CI upon changes in doc/

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -53,6 +53,7 @@ on:
       - 'tests/**'
       - '!tests/bench/**'
       - 'shell/**'
+      - 'doc/**'
   push:
     branches:
       - 'master'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ on:
       - 'tests/**'
       - '!tests/bench/**'
       - 'shell/**'
+      - 'doc/**'
   push:
     branches:
       - 'master'

--- a/master_changes.md
+++ b/master_changes.md
@@ -179,6 +179,7 @@ users)
   * Upgrade to use opam 2.5.1 [#6904 @kit-ty-kate]
   * depexts: Always use the latest 'stable' version of each distribution [#6905 @kit-ty-kate]
   * depexts: Always use the already installed ocaml package via ocaml-system [#6905 @kit-ty-kate]
+  * Trigger CI upon changes in `doc/` [#6927 @kit-ty-kate - fix #6810]
 
 ## Doc
   * Add spacing between two words in `--locked` man section [#6806 @yosefAlsuhaibani]


### PR DESCRIPTION
Fixes #6810
This isn't an ideal fix as any changes of any kind will trigger all the jobs but we can't really do anything about it without splitting `main.yml` into several new workflow files. I've opened https://github.com/ocaml/opam/issues/6926 to track that.