### PR TITLE
Add support for terminal resizing detection on Solaris/Illumos

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -36,6 +36,7 @@ users)
   * Read full lines when asking for user input when `TERM=dumb` [#6829 @arvidj - fix #6828]
   * Fix a typo in the note telling users about new a depexts bypass [#6489 @rjbou @kit-ty-kate]
   * Opam files parsing error now prints the origin repository of the failing opam file if relevant [#6971 @rjbou]
+  * Add support for terminal resizing detection on Solaris/Illumos [#6933 @kit-ty-kate]
 
 ## Switch
 
@@ -292,6 +293,7 @@ users)
   * `OpamCompat.MAP.filter_map`: was removed [#6879 @kit-ty-kate]
   * `OpamCompat.Map.add_to_list`: was added [#6818 @dra27]
   * `OpamPatch` was created [#6934 @rjbou]
+  * `OpamCompat.Sys.sigwinch` was added [#6933 @kit-ty-kate]
   * `OpamSystem`: add `is_dir_read_only` [#6489 @rjbou]
   * `OpamSystem.*patch` were moved to `OpamPatch` [#6934 @rjbou]
   * `OpamFilename`: add `is_dir_read_only` [#6489 @rjbou]

--- a/src/core/opamCompat.ml
+++ b/src/core/opamCompat.ml
@@ -175,3 +175,12 @@ module Int = struct
 
   include Stdlib.Int
 end
+
+module Sys = struct
+  [@@@warning "-32"]
+
+  (* NOTE: OCaml >= 5.4 *)
+  let sigwinch = 28
+
+  include Stdlib.Sys
+end

--- a/src/core/opamCompat.mli
+++ b/src/core/opamCompat.mli
@@ -85,3 +85,8 @@ module Int : sig
   (** NOTE: OCaml >= 4.13 *)
   val min : int -> int -> int
 end
+
+module Sys : sig
+  (* NOTE: OCaml >= 5.4 *)
+  val sigwinch : int
+end

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -857,7 +857,7 @@ module OpamSys = struct
   let terminal_columns =
     let v = ref (lazy (get_terminal_columns ())) in
     let () =
-      try Sys.set_signal 28 (* SIGWINCH *)
+      try Sys.set_signal OpamCompat.Sys.sigwinch
             (Sys.Signal_handle
                (fun _ -> v := lazy (get_terminal_columns ())))
       with Invalid_argument _ -> ()


### PR DESCRIPTION
28 is the correct signal number on at least Linux, macOS, FreeBSD, OpenBSD, NetBSD and DragonFly BSD, but not on Illumos where it is 20. Most signal numbers are undefined by POSIX.

The fix only applies if opam is compiled with OCaml 5.4 or newer.