### PR TITLE
Fix `opam config subst` handling of absolute paths

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -176,6 +176,7 @@ users)
   * Fix `extrafile` test : remove trailing mkdir, the error was fixed in #6679 [#6970 rjbou]
   * Fix trailing full path for `tar` call in `no-depexts-sandboxed.unix.test` [#6970 @rjbou]
   * Fix some forgotten sed in `extrasource` and `update` tests in #6734 [#6970 @rjbou]
+  * Add a test for `opam config subst` [#6936 @NathanReb]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -40,6 +40,7 @@ users)
 ## Switch
 
 ## Config
+  * Fix `opam config subst` so it works with absolute paths [#6936 @NathanReb - fix #6925]
 
 ## Pin
 
@@ -223,6 +224,7 @@ users)
   * `OpamSolution` remove the heuristic of recomputing depexts of additional (pinned) packages. [#6489 @arozovyk]
   * `OpamClient` update the system package status check for dependencies during `opam install --deps-only`, including support for pinned packages; also update this in `OpamAuxCommands.autopin` [#6489 @arozovyk]
   * `OpamSolution.get_depexts` remove no longer needed `recover` option that was used with `--depext-only` option  [#6489 @arozovyk]
+  * `OpamConfigCommand.subst` now takes a `filename` instead of a `basename` [#6936 @NathanReb]
 
 ## opam-repository
   * `OpamRepositoryPath` was moved to `opam-format` [#6917 @rjbou]

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1479,7 +1479,7 @@ let config cli =
     | Some `subst, (_::_ as files) ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
       `Ok (OpamConfigCommand.subst gt
-             (List.map OpamFilename.Base.of_string files))
+             (List.map OpamFilename.of_string files))
     | Some `pef, params ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
       OpamSwitchState.with_ `Lock_none gt @@ fun st ->

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -378,11 +378,7 @@ let subst gt fs =
   log "config-substitute";
   OpamSwitchState.with_ `Lock_none gt @@ fun st ->
   let env = OpamPackageVar.resolve st in
-  List.iter
-    (fun b ->
-       let file = OpamFilename.of_basename b in
-       OpamFilter.expand_interpolations_in_file env file)
-    fs
+  List.iter (OpamFilter.expand_interpolations_in_file env) fs
 
 let expand gt str =
   log "config-expand";

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -38,7 +38,7 @@ val print_eval_env: csh:bool -> sexp:bool -> fish:bool -> pwsh:bool -> cmd:bool 
 val list: 'a switch_state -> name list -> unit
 
 (** Substitute files *)
-val subst: 'a global_state -> basename list -> unit
+val subst: 'a global_state -> filename list -> unit
 
 (** Prints expansion of variables in string *)
 val expand: 'a global_state -> string -> unit

--- a/tests/reftests/config.test
+++ b/tests/reftests/config.test
@@ -227,10 +227,6 @@ Done.
 ### opam config subst some-dir/relative
 ### cat some-dir/relative
 ${BASEDIR}/OPAM
-### opam config subst $BASEDIR/some-dir/absolute | 'OpamSystem.File_not_found.*' -> 'OpamSystem.File_not_found...'
-Fatal error:
-OpamSystem.File_not_found...
-# Return code 99 #
+### opam config subst $BASEDIR/some-dir/absolute
 ### cat some-dir/absolute
-cat: some-dir/absolute: No such file or directory
-# Return code 1 #
+${BASEDIR}/OPAM

--- a/tests/reftests/config.test
+++ b/tests/reftests/config.test
@@ -217,3 +217,20 @@ Done.
 # invariant            ["meta-compiler" "depopt-compiler"]
 # compiler-packages    compiler.1, dep-compiler.1, depopt-compiler.1
 # meta-compiler:compvar something
+### :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+### :III: opam config subst must accept relative and absolute paths
+### :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+### <some-dir/relative.in>
+%{root}%
+### <some-dir/absolute.in>
+%{root}%
+### opam config subst some-dir/relative
+### cat some-dir/relative
+${BASEDIR}/OPAM
+### opam config subst $BASEDIR/some-dir/absolute | 'OpamSystem.File_not_found.*' -> 'OpamSystem.File_not_found...'
+Fatal error:
+OpamSystem.File_not_found...
+# Return code 99 #
+### cat some-dir/absolute
+cat: some-dir/absolute: No such file or directory
+# Return code 1 #


### PR DESCRIPTION
Fixes #6925 

This PR fixes `opam config subst` so that it treats absolute paths correctly.

What this PR does not do is change the current `subst` behaviour which is in my opinion a bit shady. `opam config subst <path>` will not rewrite `<path>` in place, substituting variables, as is described in the manual/command's `--help` section but instead expects to find a `<path>.in` file and will write the result of the substitution in `<path>`.

The fact this hasn't been reported seem to indicate it is probably unused but I thought that fixing the absolute paths handling to be necessary since I touched this particular part of the code in #6910.