### PR TITLE
Reftests add repository layout test

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -58,6 +58,7 @@ users)
   * Update depexts availability repository state cache when running `opam update --depexts` [#6489 @arozovyk - fix #6461]
   * Display status message while loading system package availability during `opam update` [#6489 @arozovyk - fix #6461]
   * `opam update` now supports updating a repository that changed a file to a directory of the same name and vice versa [#6915 @rjbou @arozovyk - fix #3830]
+  * Add some debug logging for opam files loading from repository (dir vs diff) [#6941 @rjbou]
 
 ## Tree
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -267,6 +267,7 @@ users)
   * `OpamUpdate.get_sys_available`: factorize depexts availability computation logic from `OpamUpdate.repositories` [#6489 @arozovyk]
   * `OpamRepositoryState`: add `syspkgs_available` that returns the stored depext availability status in repository state [#6489 @rjbou]
   * `OpamSysInteract`: add `available_packages_and_family` that returns availability status and the os family [#6489 @rjbou]
+  * `OpamRepositoryState.load_opams_from_dir`: now sorts files and directories read from disk before processing them [#6941 @rjbou]
 
 
 ## opam-solver

--- a/master_changes.md
+++ b/master_changes.md
@@ -187,6 +187,7 @@ users)
   * Add a test for `opam config subst` [#6936 @NathanReb]
   * Add a lock test for undefined variables in a lock file [#6947 @rjbou - fix #6946]
   * Add a test showing the behaviour of `opam repo add` and `opam update` when faced with a repository containing an `opam` directory [#6995 @kit-ty-kate]
+  * Add a tests for the several layouts of packages in a repository [#6941 @rjbou]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -132,6 +132,7 @@ let load_opams_from_dir repo_name repo_root =
       let dir_str = OpamFilename.Dir.to_string dir in
       let fnames = Sys.readdir dir_str in
       let ( / ) = Filename.concat in
+      Array.sort String.compare fnames;
       if Array.exists (fun f -> String.equal f OpamPathName.opam_f &&
                                 not (Sys.is_directory (dir_str / f))) fnames then
         match read_package_opam ~repo_name ~repo_root dir with

--- a/src/state/opamRepositoryState.ml
+++ b/src/state/opamRepositoryState.ml
@@ -12,7 +12,7 @@
 open OpamTypes
 open OpamStateTypes
 
-let log fmt = OpamConsole.log "RSTATE" fmt
+let log ?level fmt = OpamConsole.log ?level "RSTATE" fmt
 let slog = OpamConsole.slog
 
 module Cache = struct
@@ -127,6 +127,8 @@ let load_opams_from_dir repo_name repo_root =
     OpamConsole.status_line "Processing: [%s: loading data]"
       (OpamConsole.colorise `blue (OpamRepositoryName.to_string repo_name));
   (* FIXME: why is this different from OpamPackage.list ? *)
+  log ~level:3 "load repo %a from dir"
+    (slog OpamRepositoryName.to_string) repo_name;
   let rec aux r dir =
     if OpamFilename.exists_dir dir then
       let dir_str = OpamFilename.Dir.to_string dir in
@@ -153,6 +155,8 @@ let load_opams_from_diff repo diffs rt =
   if OpamConsole.disp_status_line () || OpamConsole.verbose () then
     OpamConsole.status_line "Processing: [%s: loading data]"
       (OpamConsole.colorise `blue (OpamRepositoryName.to_string repo.repo_name));
+  log ~level:3 "load repo %a from diff"
+    (slog OpamRepositoryName.to_string) repo.repo_name;
   let existing_opams =
     OpamRepositoryName.Map.find repo.repo_name rt.repo_opams
   in

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1890,6 +1890,27 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:repository-http.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-repository-layout)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (action
+  (diff repository-layout.test repository-layout.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (deps (alias reftest-repository-layout)))
+
+(rule
+ (targets repository-layout.out)
+ (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:repository-layout.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-repository-patchdiff)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action

--- a/tests/reftests/repository-http.test
+++ b/tests/reftests/repository-http.test
@@ -52,6 +52,7 @@ REPOSITORY                      http-repo: applying update from scratch at ${BAS
 [http-repo] Initialised
 UPDATE                          Repository has new changes
 Processing: [http-repo: loading data]
+RSTATE                          load repo http-repo from dir
 ### unset OPAMDEBUGSECTIONS
 ### unset OPAMDEBUG
 ### unset OPAMVERBOSE
@@ -93,6 +94,7 @@ REPO_BACKEND                    Internal diff (non-empty, 3 changed files) done 
 REPOSITORY                      http-repo: applying patch update at ${BASEDIR}/OPAM/log/patch-xxx
 UPDATE                          Repository has new changes
 Processing: [http-repo: loading data]
+RSTATE                          load repo http-repo from diff
 Now run 'opam upgrade' to apply any package updates.
 ### unset OPAMDEBUGSECTIONS
 ### unset OPAMDEBUG
@@ -131,6 +133,7 @@ REPO_BACKEND                    Internal diff (non-empty, 1 changed files) done 
 REPOSITORY                      http-repo: applying patch update at ${BASEDIR}/OPAM/log/patch-xxx
 UPDATE                          Repository has new changes
 Processing: [http-repo: loading data]
+RSTATE                          load repo http-repo from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/http-repo/packages/tujuh/tujuh.7/opam, ignored
 Now run 'opam upgrade' to apply any package updates.
 ### unset OPAMDEBUGSECTIONS
@@ -171,6 +174,7 @@ REPO_BACKEND                    Internal diff (non-empty, 1 changed files) done 
 REPOSITORY                      http-repo: applying patch update at ${BASEDIR}/OPAM/log/patch-xxx
 UPDATE                          Repository has new changes
 Processing: [http-repo: loading data]
+RSTATE                          load repo http-repo from diff
 ### unset OPAMDEBUGSECTIONS
 ### unset OPAMDEBUG
 ### unset OPAMVERBOSE

--- a/tests/reftests/repository-layout.test
+++ b/tests/reftests/repository-layout.test
@@ -146,6 +146,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default-strict from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -153,6 +154,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 ### :I:1:b: List available package
 ### opam switch create good-sw-from-scratch --empty --repo=new-default,new-default-strict
@@ -186,6 +188,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/good/good.1/opam in 0.000s
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/good/good.1/files/un/der/opam, ignored
 Now run 'opam upgrade' to apply any package updates.
@@ -197,6 +200,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/good/good.1/opam in 0.000s
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/good/good.1/files/un/der/opam, ignored
 Now run 'opam upgrade' to apply any package updates.
@@ -234,6 +238,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/good/good.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/good/good.1: missing from 'files' directory (1)
 Now run 'opam upgrade' to apply any package updates.
@@ -245,6 +250,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/good/good.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/good/good.1: missing from 'files' directory (1)
 Now run 'opam upgrade' to apply any package updates.
@@ -258,6 +264,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/good/good.1/files/un/der/opam, ignored
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -267,6 +274,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/good/good.1/files/un/der/opam, ignored
 ### :I:3:b: List available package
 ### opam switch create good-sw-xfiles --empty --repo=default,default-strict
@@ -310,6 +318,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default-strict from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
@@ -318,6 +327,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
 ### :II:1:b: List available package
@@ -353,6 +363,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/not/no-n-nv.1/opam in 0.000s
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/not/no-n-nv.1/files/un/der/opam, ignored
 Now run 'opam upgrade' to apply any package updates.
@@ -364,6 +375,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/not/no-n-nv.1/opam in 0.000s
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not/no-n-nv.1/files/un/der/opam, ignored
 Now run 'opam upgrade' to apply any package updates.
@@ -401,6 +413,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/not/no-n-nv.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/not/no-n-nv.1: missing from 'files' directory (1)
 Now run 'opam upgrade' to apply any package updates.
@@ -412,6 +425,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/not/no-n-nv.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/not/no-n-nv.1: missing from 'files' directory (1)
 Now run 'opam upgrade' to apply any package updates.
@@ -425,6 +439,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/not/no-n-nv.1/files/un/der/opam, ignored
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -434,6 +449,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not/no-n-nv.1/files/un/der/opam, ignored
 ### :II:3:b: List available package
 ### opam switch create no-n-nv-sw-xfiles --empty --repo=default,default-strict
@@ -478,6 +494,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default-strict from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
@@ -487,6 +504,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
@@ -524,6 +542,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/v/e/r/y/very-inner-nv.1/files/un/der/opam, ignored
 Now run 'opam upgrade' to apply any package updates.
@@ -535,6 +554,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/v/e/r/y/very-inner-nv.1/files/un/der/opam, ignored
 Now run 'opam upgrade' to apply any package updates.
@@ -572,6 +592,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/v/e/r/y/very-inner-nv.1: missing from 'files' directory (1)
 Now run 'opam upgrade' to apply any package updates.
@@ -583,6 +604,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/v/e/r/y/very-inner-nv.1: missing from 'files' directory (1)
 Now run 'opam upgrade' to apply any package updates.
@@ -596,6 +618,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/v/e/r/y/very-inner-nv.1/files/un/der/opam, ignored
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -605,6 +628,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/v/e/r/y/very-inner-nv.1/files/un/der/opam, ignored
 ### :III:3:b: List available package
 ### opam switch create very-inner-nv-sw-xfiles --empty --repo=default,default-strict
@@ -650,6 +674,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default-strict from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
@@ -660,10 +685,17 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+[new-default] no changes from file://${BASEDIR}/REPO
+UPDATE                          Repository did not change: nothing to do.
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
 ### :IV:1:b: List available package
 ### opam switch create very-inner-n-nv-sw-from-scratch --empty --repo=new-default,new-default-strict
 ### opam repository --this-switch
@@ -699,6 +731,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/files/un/der/opam, ignored
 Now run 'opam upgrade' to apply any package updates.
@@ -710,6 +743,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/files/un/der/opam, ignored
 Now run 'opam upgrade' to apply any package updates.
@@ -747,6 +781,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1: missing from 'files' directory (1)
 Now run 'opam upgrade' to apply any package updates.
@@ -758,6 +793,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1: missing from 'files' directory (1)
 Now run 'opam upgrade' to apply any package updates.
@@ -771,6 +807,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/files/un/der/opam, ignored
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -780,6 +817,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/files/un/der/opam, ignored
 ### :IV:3:b: List available package
 ### opam switch create very-inner-n-nv-sw-xfiles --empty --repo=default,default-strict
@@ -826,6 +864,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default-strict from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -837,6 +876,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -878,6 +918,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/direct-root.1/opam in 0.000s
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/direct-root.1/files/un/der/opam, ignored
 Now run 'opam upgrade' to apply any package updates.
@@ -889,6 +930,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/direct-root.1/opam in 0.000s
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/direct-root.1/files/un/der/opam, ignored
 Now run 'opam upgrade' to apply any package updates.
@@ -926,6 +968,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/direct-root.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/direct-root.1: missing from 'files' directory (1)
 Now run 'opam upgrade' to apply any package updates.
@@ -937,6 +980,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/direct-root.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/direct-root.1: missing from 'files' directory (1)
 Now run 'opam upgrade' to apply any package updates.
@@ -950,6 +994,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/direct-root.1/files/un/der/opam, ignored
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -959,6 +1004,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/direct-root.1/files/un/der/opam, ignored
 ### :V:3:b: List available package
 ### opam switch create direct-root-sw-xfiles --empty --repo=default,default-strict
@@ -1007,6 +1053,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default-strict from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1020,6 +1067,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1058,6 +1106,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/no-nv/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/no-nv/opam
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/no-nv/files/un/der/opam, ignored
@@ -1069,6 +1118,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/no-nv/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/no-nv/opam
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/no-nv/files/un/der/opam, ignored
@@ -1102,6 +1152,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/no-nv/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/no-nv: missing from 'files' directory (1)
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/no-nv/opam
@@ -1113,6 +1164,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/no-nv/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/no-nv: missing from 'files' directory (1)
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/no-nv/opam
@@ -1126,6 +1178,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/no-nv/files/un/der/opam, ignored
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -1135,6 +1188,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/no-nv/files/un/der/opam, ignored
 ### :VI:3:b: List available package
 ### opam switch create no-nv-sw-xfiles --empty --repo=default,default-strict
@@ -1178,6 +1232,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default-strict from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1191,6 +1246,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1229,6 +1285,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/root-no-nv/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/root-no-nv/opam
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/root-no-nv/files/un/der/opam, ignored
@@ -1240,6 +1297,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/root-no-nv/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/root-no-nv/opam
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/root-no-nv/files/un/der/opam, ignored
@@ -1273,6 +1331,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/root-no-nv/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/root-no-nv: missing from 'files' directory (1)
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/root-no-nv/opam
@@ -1284,6 +1343,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/root-no-nv/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/root-no-nv: missing from 'files' directory (1)
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/root-no-nv/opam
@@ -1297,6 +1357,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/root-no-nv/files/un/der/opam, ignored
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -1306,6 +1367,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/root-no-nv/files/un/der/opam, ignored
 ### :VII:3:b: List available package
 ### opam switch create root-no-nv-sw-xfiles --empty --repo=default,default-strict
@@ -1349,6 +1411,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default-strict from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1367,6 +1430,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1412,6 +1476,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 [ERROR] In ${BASEDIR}/OPAM/repo/default-strict/packages/not-same-nv-in/not-same-nv-in.2/opam:
         This file is for package 'not-same-nv-in.2' but has mismatching fields 'name:different 'version:1.
 [ERROR] Strict mode: aborting
@@ -1425,6 +1490,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not-same-nv-in/not-same-nv-in.2/files/un/der/opam, ignored
 Now run 'opam upgrade' to apply any package updates.
@@ -1463,6 +1529,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 [ERROR] In ${BASEDIR}/OPAM/repo/default-strict/packages/not-same-nv-in/not-same-nv-in.2/opam:
         This file is for package 'not-same-nv-in.2' but has mismatching fields 'name:different 'version:1.
 [ERROR] Strict mode: aborting
@@ -1476,6 +1543,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/not-same-nv-in/not-same-nv-in.2: missing from 'files' directory (1)
 Now run 'opam upgrade' to apply any package updates.
@@ -1489,6 +1557,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/not-same-nv-in/not-same-nv-in.2/files/un/der/opam, ignored
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -1498,6 +1567,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not-same-nv-in/not-same-nv-in.2/files/un/der/opam, ignored
 ### :VIII:3:b: List available package
 ### opam switch create not-same-nv-in-sw-xfiles --empty --repo=default,default-strict
@@ -1557,6 +1627,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default-strict from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1571,6 +1642,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1611,6 +1683,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/not-opam-filename/not-opam-filename.1/opam, ignored
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/not-opam-filename/not-opam-filename.1/files/un/der/opam, ignored
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
@@ -1621,6 +1694,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not-opam-filename/not-opam-filename.1/opam, ignored
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not-opam-filename/not-opam-filename.1/files/un/der/opam, ignored
 ### :IX:2:b List available package
@@ -1653,6 +1727,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/not-opam-filename/not-opam-filename.1/opam, ignored
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -1662,6 +1737,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not-opam-filename/not-opam-filename.1/opam, ignored
 ### :IX:3:b: Add the last extrafile and update
 ### sh xfile.sh packages/not-opam-filename/not-opam-filename.1
@@ -1673,6 +1749,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/not-opam-filename/not-opam-filename.1/files/un/der/opam, ignored
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -1682,6 +1759,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not-opam-filename/not-opam-filename.1/files/un/der/opam, ignored
 ### :IX:3:b: List available package
 ### opam switch create not-opam-filename-sw-xfiles --empty --repo=default,default-strict
@@ -1725,6 +1803,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default-strict from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1741,6 +1820,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1783,6 +1863,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/opam
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/files/un/der/opam, ignored
@@ -1794,6 +1875,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/opam-dir-nv/opam-dir-nv.1/opam/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/opam-dir-nv/opam-dir-nv.1/opam/opam
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/opam-dir-nv/opam-dir-nv.1/opam/files/un/der/opam, ignored
@@ -1826,6 +1908,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam: missing from 'files' directory (1)
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/opam
@@ -1837,6 +1920,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/opam-dir-nv/opam-dir-nv.1/opam/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/opam-dir-nv/opam-dir-nv.1/opam: missing from 'files' directory (1)
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/opam-dir-nv/opam-dir-nv.1/opam/opam
@@ -1850,6 +1934,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/files/un/der/opam, ignored
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -1859,6 +1944,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/opam-dir-nv/opam-dir-nv.1/opam/files/un/der/opam, ignored
 ### :X:3:b: List available package
 ### opam switch create opam-dir-nv-sw-xfiles --empty --repo=default,default-strict
@@ -1902,6 +1988,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default-strict from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1920,6 +2007,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1964,6 +2052,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-n/opam/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-n/opam/opam
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-n/opam/files/un/der/opam, ignored
@@ -1975,6 +2064,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/opam-dir-n/opam/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/opam-dir-n/opam/opam
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/opam-dir-n/opam/files/un/der/opam, ignored
@@ -2007,6 +2097,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-n/opam/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-n/opam: missing from 'files' directory (1)
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-n/opam/opam
@@ -2018,6 +2109,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/opam-dir-n/opam/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/opam-dir-n/opam: missing from 'files' directory (1)
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/opam-dir-n/opam/opam
@@ -2031,6 +2123,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-n/opam/files/un/der/opam, ignored
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -2040,6 +2133,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/opam-dir-n/opam/files/un/der/opam, ignored
 ### :XI:3:b: List available package
 ### opam switch create opam-dir-n-sw-xfiles --empty --repo=default,default-strict
@@ -2084,6 +2178,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default-strict from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
@@ -2092,6 +2187,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/opam
 ### :XII:1:b: List available package
@@ -2120,6 +2216,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/opam
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/files/un/der/opam, ignored
@@ -2131,6 +2228,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/opam
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/files/un/der/opam, ignored
@@ -2164,6 +2262,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages: missing from 'files' directory (1)
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/opam
@@ -2175,6 +2274,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages: missing from 'files' directory (1)
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/opam
@@ -2188,6 +2288,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/files/un/der/opam, ignored
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -2197,6 +2298,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/files/un/der/opam, ignored
 ### :XII:3:b: List available package
 ### opam switch create opam-at-root-pkg-sw-xfiles --empty --repo=default,default-strict
@@ -2240,6 +2342,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default-strict from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
@@ -2248,6 +2351,7 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
+RSTATE                          load repo new-default from dir
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/opam
 ### :XIII:1:b: List available package
@@ -2276,6 +2380,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/pkg/z-good/z-good.1/opam in 0.000s
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/pkg/z-good/z-good.1/files/un/der/opam, ignored
 Now run 'opam upgrade' to apply any package updates.
@@ -2287,6 +2392,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/pkg/z-good/z-good.1/opam in 0.000s
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/pkg/z-good/z-good.1/files/un/der/opam, ignored
 Now run 'opam upgrade' to apply any package updates.
@@ -2324,6 +2430,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/pkg/z-good/z-good.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/pkg/z-good/z-good.1: missing from 'files' directory (1)
 Now run 'opam upgrade' to apply any package updates.
@@ -2335,6 +2442,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/pkg/z-good/z-good.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/pkg/z-good/z-good.1: missing from 'files' directory (1)
 Now run 'opam upgrade' to apply any package updates.
@@ -2348,6 +2456,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/pkg/z-good/z-good.1/files/un/der/opam, ignored
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -2357,6 +2466,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/pkg/z-good/z-good.1/files/un/der/opam, ignored
 ### :XIII:3:b: List available package
 ### opam switch create z-good-sw-xfiles --empty --repo=default,default-strict
@@ -2430,6 +2540,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default-strict from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/wrong-opamf-updated/wrong-opamf-updated.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/wrong-opamf-updated/wrong-opamf-updated.1: missing from 'files' directory (1)
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/another-good/another-good.1/opam in 0.000s
@@ -2442,6 +2553,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
+RSTATE                          load repo default from diff
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/wrong-opamf-updated/wrong-opamf-updated.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/wrong-opamf-updated/wrong-opamf-updated.1: missing from 'files' directory (1)
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/another-good/another-good.1/opam in 0.000s
@@ -2461,6 +2573,7 @@ Now run 'opam upgrade' to apply any package updates.
 ### rmdir REPO.dir
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE" OPAMDEBUG=-3 opam admin list
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          load repo local from dir
 FILE(opam)                      Read ${BASEDIR}/packages/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/packages/opam
 # Packages matching: available

--- a/tests/reftests/repository-layout.test
+++ b/tests/reftests/repository-layout.test
@@ -1,0 +1,2459 @@
+N0REP0
+### :::::::::::
+### : We test here the several layout of opam packages paths in an opam repository
+### :   the one that are handled and the one that aren't
+### :
+### : We uses 4 opam repositories, pointing to the same directory ./REPO, each one
+### :   for a test purpose:
+### :   - 'default' to be updated via load from diff
+### :   - 'default-strict' to be updated via load from diff with strict mode
+### :   - 'new-default' to be added, via load from dir
+### :   - 'new-default-strict' to be added, via load from dir, with strict mode
+### :   that will be called with the '--strict' option
+### :
+### : For each layout, we have 3 steps :
+### :  - :.:1: Add repository ('new-default*') to load it with plain loading
+### :      (no diff), with and without strict mode and check available packages
+### :       and if they are installable (if extra-files were well retrieved)
+### :  - :.:2: Update repository ('default*') via incremental diff loading with
+### :      new packages, with and without strict mode and check available
+### :      packages and if they are installable (if extra-files were well
+### :      retrieved)
+### :  - :.:3: Update repository ('default*') via incremental diff loading with
+### :      changes in packages. We first add in the opam file an extra files
+### :      declaration without adding the extra-file.  We want to check then
+### :      what is updated (layout) and if extra-file mismatching is well
+### :      detected.  Then we add only the extra files and update repositories.
+### :      It is updated with and without strict mode, then check available
+### :      packages and if they are installable (if new extra-files were well
+### :      retrieved)
+### :
+### : Tested layouts
+### :I:    packages/good/good.1/opam : the "good" layout 'packages/name/name.version/opam'
+### :II:   packages/not/no-n-nv.1/opam : name repository with a name that
+### :        doesn't match
+### :III:  packages/v/e/r/y/very-inner-nv.1/opam : package in an very inner
+### :        directory, with pattern 'name/opam'
+### :IV:   packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam : package in
+### :        an very inner directory, with pattern 'name/name.version/opam'
+### :V:    packages/direct-root.1/opam : package with a pattern
+### :       'name.version/opam" directly under 'packages'
+### :VI:   packages/no-nv/opam : package without 'name.version' in directory
+### :VII:  root-no-nv/opam : packages directory only with 'name' at root of the
+### :        repository
+### :VIII: packages/not-same-nv-in/not-same-nv-in.2/opam : package with the
+### :        good layout,but with specified version in the opam fille different
+### :IX:   packages/not-opam-filename/not-opam-filename.1/not-opam-filename :
+### :        package with the good layout, but the opam file is not named 'opam'
+### :X:    packages/opam-dir-nv/opam-dir-nv.1/opam/opam : opam file is under an
+### :        opam directory, with pattern 'packages/name/name.version/opam'
+### :XI:   packages/opam-dir-n/opam/opam : opam file is under an opam directory,
+### :        with pattern 'packages/name/opam'
+### :XII:  packahes/opam: a lone opam file at the root of the packages directory
+### :XIII: pkg/z-good/z-good.1 : root directory is not 'packages'
+### :
+### : Test :C: test a specific case where there is an unrelated update of a package
+### :  because of adjacent valid opam file not named opam changed
+### : Test :CI: show opam admin outputs with all these layouts.
+### :  This test need to stay the last one as it removes all the REPO directory
+### :
+### :::::::::::
+### :: Setup ::
+### # extrafiles that we will copy
+### <fst>
+I'm the root one
+### <snd>
+I'm the second one, in a directory
+### <thrd>
+yet another file, no longer ignored!
+### openssl md5 fst | '.*= ' -> '' >$ FST_MD5
+### openssl md5 snd | '.*= ' -> '' >$ SND_MD5
+### openssl md5 thrd | '.*= ' -> '' >$ THRD_MD5
+### <populate.sh>
+# creates an opam package in the give paths and add 'fst' and 'snd' files in
+# opam package and in 'files/'
+set -eu
+path="REPO/$1"
+files="$path/files"
+under="un/der"
+innerfiles="$files/$under"
+mkdir -p "$innerfiles"
+cp fst "$files/"
+cp snd "$innerfiles/"
+cat > "$path/opam" << EOF
+opam-version: "2.0"
+extra-files: [
+  ["fst" "md5=$FST_MD5"]
+  ["$under/snd" "md5=$SND_MD5"]
+]
+build: [
+  [ "test" "-f" "fst" ]
+  [ "test" "-f" "$under/snd" ]
+]
+EOF
+### <add-nv.sh>
+#  add a name & version to given opam package
+set -ue
+n="$1"
+path="REPO/$2"
+cat >> "$path/opam" << EOF
+name: "$n"
+version: "1"
+EOF
+### <xfile-opam.sh>
+# rewrites opam file, adding 'thrd' to the extra-files field
+set -eu
+path="REPO/$1"
+files="$path/files"
+under="un/der"
+innerfiles="$files/$under"
+cat > "$path/opam" << EOF
+opam-version: "2.0"
+extra-files: [
+  ["fst" "md5=$FST_MD5"]
+  ["$under/snd" "md5=$SND_MD5"]
+  ["$under/thrd" "md5=$THRD_MD5"]
+]
+build: [
+  [ "test" "-f" "fst" ]
+  [ "test" "-f" "$under/snd" ]
+  [ "test" "-f" "$under/thrd" ]
+]
+EOF
+### <xfile.sh>
+# this script adds 'thrd' files under 'files/'
+set -eu
+path="REPO/$1"
+files="$path/files"
+under="un/der"
+innerfiles="$files/$under"
+cp thrd "$innerfiles/"
+### OPAMYES=1 OPAMSTRICT=0
+### # add the strict repo
+### opam repository add default-strict ./REPO --set-default
+[default-strict] Initialised
+### # have at lest one switch enabled
+### opam switch create meta-sw --empty
+### ::::::::::::::::::::::
+### :I: packages/good/good.1/opam :
+### :     the "good" layout 'name/name.version/opam'
+### ::::::::::::::::::::::
+### sh populate.sh packages/good/good.1
+### :I:1:a: Add new repository 'new-default*', load from scratch
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default-strict ./REPO --this-switch --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default-strict] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
+### :I:1:b: List available package
+### opam switch create good-sw-from-scratch --empty --repo=new-default,new-default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch good-sw-from-scratch <><><><><><><><><>
+ 1 new-default        file://${BASEDIR}/REPO
+ 2 new-default-strict file://${BASEDIR}/REPO
+### opam list -A --repo new-default-strict
+# Packages matching: from-repository(new-default-strict) & any
+# No matches found
+### opam list -A --repo new-default
+# Packages matching: from-repository(new-default) & any
+# Name # Installed # Synopsis
+good   --
+### :I:1:c: Install available package
+### opam install good.1
+The following actions will be performed:
+=== install 1 package
+  - install good 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed good.1
+Done.
+### :I:2:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/good/good.1/opam in 0.000s
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/good/good.1/files/un/der/opam, ignored
+Now run 'opam upgrade' to apply any package updates.
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/good/good.1/opam in 0.000s
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/good/good.1/files/un/der/opam, ignored
+Now run 'opam upgrade' to apply any package updates.
+### :I:2:b List available package
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# No matches found
+### :I:2:c: Install available package
+### opam switch create good-sw --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch good-sw ><><><><><><><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam install good.1
+The following actions will be performed:
+=== install 1 package
+  - install good 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed good.1
+Done.
+### :I:3: Extra-files handling
+### # Add extra-files in the opam files
+### sh xfile-opam.sh packages/good/good.1
+### :I:3:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/good/good.1/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/good/good.1: missing from 'files' directory (1)
+Now run 'opam upgrade' to apply any package updates.
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/good/good.1/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/good/good.1: missing from 'files' directory (1)
+Now run 'opam upgrade' to apply any package updates.
+### :I:3:b: Add the last extrafile and update
+### sh xfile.sh packages/good/good.1
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/good/good.1/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/good/good.1/files/un/der/opam, ignored
+### :I:3:b: List available package
+### opam switch create good-sw-xfiles --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch good-sw-xfiles <><><><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# Name # Installed # Synopsis
+good   --
+### :I:3:c: Install available package
+### opam install good.1
+The following actions will be performed:
+=== install 1 package
+  - install good 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed good.1
+Done.
+### :I:4: Cleaning
+### opam repository remove --all new-default-strict new-default
+### opam switch remove good-sw  good-sw-from-scratch good-sw-xfiles
+Switch good-sw and all its packages will be wiped. Are you sure? [Y/n] y
+Switch good-sw-from-scratch and all its packages will be wiped. Are you sure? [Y/n] y
+Switch good-sw-xfiles and all its packages will be wiped. Are you sure? [Y/n] y
+### opam switch meta-sw
+### ::::::::::::::::::::::
+### :II: packages/not/no-n-nv.1/opam :
+### :      name repository with a name that doesn't match
+### ::::::::::::::::::::::
+### sh populate.sh packages/not/no-n-nv.1
+### :II:1:a: Add new repository 'new-default*', load from scratch
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default-strict ./REPO --this-switch --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default-strict] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
+### :II:1:b: List available package
+### opam switch create no-n-nv-sw-from-scratch --empty --repo=new-default,new-default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch no-n-nv-sw-from-scratch ><><><><><><><>
+ 1 new-default        file://${BASEDIR}/REPO
+ 2 new-default-strict file://${BASEDIR}/REPO
+### opam list -A --repo new-default-strict
+# Packages matching: from-repository(new-default-strict) & any
+# No matches found
+### opam list -A --repo new-default
+# Packages matching: from-repository(new-default) & any
+# Name  # Installed # Synopsis
+good    --
+no-n-nv --
+### :II:1:c: Install available package
+### opam install no-n-nv.1
+The following actions will be performed:
+=== install 1 package
+  - install no-n-nv 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed no-n-nv.1
+Done.
+### :II:2:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/not/no-n-nv.1/opam in 0.000s
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/not/no-n-nv.1/files/un/der/opam, ignored
+Now run 'opam upgrade' to apply any package updates.
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/not/no-n-nv.1/opam in 0.000s
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not/no-n-nv.1/files/un/der/opam, ignored
+Now run 'opam upgrade' to apply any package updates.
+### :II:2:b List available package
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# No matches found
+### :II:2:c: Install available package
+### opam switch create no-n-nv-sw --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch no-n-nv-sw <><><><><><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam install no-n-nv.1
+The following actions will be performed:
+=== install 1 package
+  - install no-n-nv 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed no-n-nv.1
+Done.
+### :II:3: Extra-files handling
+### # Add extra-files in the opam files
+### sh xfile-opam.sh packages/not/no-n-nv.1
+### :II:3:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/not/no-n-nv.1/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/not/no-n-nv.1: missing from 'files' directory (1)
+Now run 'opam upgrade' to apply any package updates.
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/not/no-n-nv.1/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/not/no-n-nv.1: missing from 'files' directory (1)
+Now run 'opam upgrade' to apply any package updates.
+### :II:3:b: Add the last extrafile and update
+### sh xfile.sh packages/not/no-n-nv.1
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/not/no-n-nv.1/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not/no-n-nv.1/files/un/der/opam, ignored
+### :II:3:b: List available package
+### opam switch create no-n-nv-sw-xfiles --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch no-n-nv-sw-xfiles ><><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# Name  # Installed # Synopsis
+good    --
+no-n-nv --
+### :II:3:c: Install available package
+### opam install no-n-nv.1
+The following actions will be performed:
+=== install 1 package
+  - install no-n-nv 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed no-n-nv.1
+Done.
+### :II:4: Cleaning
+### opam repository remove --all new-default-strict new-default
+### opam switch remove no-n-nv-sw  no-n-nv-sw-from-scratch no-n-nv-sw-xfiles
+Switch no-n-nv-sw and all its packages will be wiped. Are you sure? [Y/n] y
+Switch no-n-nv-sw-from-scratch and all its packages will be wiped. Are you sure? [Y/n] y
+Switch no-n-nv-sw-xfiles and all its packages will be wiped. Are you sure? [Y/n] y
+### opam switch meta-sw
+### ::::::::::::::::::::::
+### :III: packages/v/e/r/y/very-inner-nv.1/opam :
+### :       package in an very inner directory, with pattern 'name/opam'
+### ::::::::::::::::::::::
+### sh populate.sh packages/v/e/r/y/very-inner-nv.1
+### :III:1:a: Add new repository 'new-default*', load from scratch
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default-strict ./REPO --this-switch --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default-strict] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+### :III:1:b: List available package
+### opam switch create very-inner-nv-sw-from-scratch --empty --repo=new-default,new-default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch very-inner-nv-sw-from-scratch ><><><><>
+ 1 new-default        file://${BASEDIR}/REPO
+ 2 new-default-strict file://${BASEDIR}/REPO
+### opam list -A --repo new-default-strict
+# Packages matching: from-repository(new-default-strict) & any
+# No matches found
+### opam list -A --repo new-default
+# Packages matching: from-repository(new-default) & any
+# Name        # Installed # Synopsis
+good          --
+no-n-nv       --
+very-inner-nv --
+### :III:1:c: Install available package
+### opam install very-inner-nv.1
+The following actions will be performed:
+=== install 1 package
+  - install very-inner-nv 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed very-inner-nv.1
+Done.
+### :III:2:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/v/e/r/y/very-inner-nv.1/files/un/der/opam, ignored
+Now run 'opam upgrade' to apply any package updates.
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/v/e/r/y/very-inner-nv.1/files/un/der/opam, ignored
+Now run 'opam upgrade' to apply any package updates.
+### :III:2:b List available package
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# No matches found
+### :III:2:c: Install available package
+### opam switch create very-inner-nv-sw --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch very-inner-nv-sw <><><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam install very-inner-nv.1
+The following actions will be performed:
+=== install 1 package
+  - install very-inner-nv 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed very-inner-nv.1
+Done.
+### :III:3: Extra-files handling
+### # Add extra-files in the opam files
+### sh xfile-opam.sh packages/v/e/r/y/very-inner-nv.1
+### :III:3:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/v/e/r/y/very-inner-nv.1: missing from 'files' directory (1)
+Now run 'opam upgrade' to apply any package updates.
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/v/e/r/y/very-inner-nv.1: missing from 'files' directory (1)
+Now run 'opam upgrade' to apply any package updates.
+### :III:3:b: Add the last extrafile and update
+### sh xfile.sh packages/v/e/r/y/very-inner-nv.1
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/v/e/r/y/very-inner-nv.1/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/v/e/r/y/very-inner-nv.1/files/un/der/opam, ignored
+### :III:3:b: List available package
+### opam switch create very-inner-nv-sw-xfiles --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch very-inner-nv-sw-xfiles ><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# Name        # Installed # Synopsis
+good          --
+no-n-nv       --
+very-inner-nv --
+### :III:3:c: Install available package
+### opam install very-inner-nv.1
+The following actions will be performed:
+=== install 1 package
+  - install very-inner-nv 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed very-inner-nv.1
+Done.
+### :III:4: Cleaning
+### opam repository remove --all new-default-strict new-default
+### opam switch remove very-inner-nv-sw  very-inner-sw-from-scratch very-inner-sw-xfiles
+Switch very-inner-nv-sw and all its packages will be wiped. Are you sure? [Y/n] y
+The compiler switch very-inner-sw-from-scratch does not exist.
+# Return code 5 #
+### opam switch meta-sw
+### ::::::::::::::::::::::
+### :IV: packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam :
+### :      package in an very inner directory, with pattern 'name/name.version/opam'
+### ::::::::::::::::::::::
+### sh populate.sh packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1
+### :IV:1:a: Add new repository 'new-default*', load from scratch
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default-strict ./REPO --this-switch --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default-strict] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
+### :IV:1:b: List available package
+### opam switch create very-inner-n-nv-sw-from-scratch --empty --repo=new-default,new-default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch very-inner-n-nv-sw-from-scratch ><><><>
+ 1 new-default        file://${BASEDIR}/REPO
+ 2 new-default-strict file://${BASEDIR}/REPO
+### opam list -A --repo new-default-strict
+# Packages matching: from-repository(new-default-strict) & any
+# No matches found
+### opam list -A --repo new-default
+# Packages matching: from-repository(new-default) & any
+# Name          # Installed # Synopsis
+good            --
+no-n-nv         --
+very-inner-n-nv --
+very-inner-nv   --
+### :IV:1:c: Install available package
+### opam install very-inner-n-nv.1
+The following actions will be performed:
+=== install 1 package
+  - install very-inner-n-nv 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed very-inner-n-nv.1
+Done.
+### :IV:2:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/files/un/der/opam, ignored
+Now run 'opam upgrade' to apply any package updates.
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/files/un/der/opam, ignored
+Now run 'opam upgrade' to apply any package updates.
+### :IV:2:b List available package
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# No matches found
+### :IV:2:c: Install available package
+### opam switch create very-inner-n-nv-sw --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch very-inner-n-nv-sw <><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam install very-inner-n-nv.1
+The following actions will be performed:
+=== install 1 package
+  - install very-inner-n-nv 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed very-inner-n-nv.1
+Done.
+### :IV:3: Extra-files handling
+### # Add extra-files in the opam files
+### sh xfile-opam.sh packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1
+### :IV:3:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1: missing from 'files' directory (1)
+Now run 'opam upgrade' to apply any package updates.
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1: missing from 'files' directory (1)
+Now run 'opam upgrade' to apply any package updates.
+### :IV:3:b: Add the last extrafile and update
+### sh xfile.sh packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/files/un/der/opam, ignored
+### :IV:3:b: List available package
+### opam switch create very-inner-n-nv-sw-xfiles --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch very-inner-n-nv-sw-xfiles ><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# Name          # Installed # Synopsis
+good            --
+no-n-nv         --
+very-inner-n-nv --
+very-inner-nv   --
+### :IV:3:c: Install available package
+### opam install very-inner-n-nv.1
+The following actions will be performed:
+=== install 1 package
+  - install very-inner-n-nv 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed very-inner-n-nv.1
+Done.
+### :IV:4: Cleaning
+### opam repository remove --all new-default-strict new-default
+### opam switch remove very-inner-n-nv-sw  very-inner-n-nv-sw-from-scratch very-inner-n-nv-sw-xfiles
+Switch very-inner-n-nv-sw and all its packages will be wiped. Are you sure? [Y/n] y
+Switch very-inner-n-nv-sw-from-scratch and all its packages will be wiped. Are you sure? [Y/n] y
+Switch very-inner-n-nv-sw-xfiles and all its packages will be wiped. Are you sure? [Y/n] y
+### opam switch meta-sw
+### ::::::::::::::::::::::
+### :V: packages/direct-root.1/opam :
+### :     package with a pattern 'name.version/opam" directly under 'packages'
+### ::::::::::::::::::::::
+### sh populate.sh packages/direct-root.1
+### :V:1:a: Add new repository 'new-default*', load from scratch
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default-strict ./REPO --this-switch --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default-strict] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
+### :V:1:b: List available package
+### opam switch create direct-root-sw-from-scratch --empty --repo=new-default,new-default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch direct-root-sw-from-scratch ><><><><><>
+ 1 new-default        file://${BASEDIR}/REPO
+ 2 new-default-strict file://${BASEDIR}/REPO
+### opam list -A --repo new-default-strict
+# Packages matching: from-repository(new-default-strict) & any
+# No matches found
+### opam list -A --repo new-default
+# Packages matching: from-repository(new-default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+very-inner-n-nv --
+very-inner-nv   --
+### :V:1:c: Install available package
+### opam install direct-root.1
+The following actions will be performed:
+=== install 1 package
+  - install direct-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed direct-root.1
+Done.
+### :V:2:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/direct-root.1/opam in 0.000s
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/direct-root.1/files/un/der/opam, ignored
+Now run 'opam upgrade' to apply any package updates.
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/direct-root.1/opam in 0.000s
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/direct-root.1/files/un/der/opam, ignored
+Now run 'opam upgrade' to apply any package updates.
+### :V:2:b List available package
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# No matches found
+### :V:2:c: Install available package
+### opam switch create direct-root-sw --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch direct-root-sw <><><><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam install direct-root.1
+The following actions will be performed:
+=== install 1 package
+  - install direct-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed direct-root.1
+Done.
+### :V:3: Extra-files handling
+### # Add extra-files in the opam files
+### sh xfile-opam.sh packages/direct-root.1
+### :V:3:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/direct-root.1/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/direct-root.1: missing from 'files' directory (1)
+Now run 'opam upgrade' to apply any package updates.
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/direct-root.1/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/direct-root.1: missing from 'files' directory (1)
+Now run 'opam upgrade' to apply any package updates.
+### :V:3:b: Add the last extrafile and update
+### sh xfile.sh packages/direct-root.1
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/direct-root.1/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/direct-root.1/files/un/der/opam, ignored
+### :V:3:b: List available package
+### opam switch create direct-root-sw-xfiles --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch direct-root-sw-xfiles ><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+very-inner-n-nv --
+very-inner-nv   --
+### :V:3:c: Install available package
+### opam install direct-root.1
+The following actions will be performed:
+=== install 1 package
+  - install direct-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed direct-root.1
+Done.
+### :V:4: Cleaning
+### opam repository remove --all new-default-strict new-default
+### opam switch remove direct-root-sw  direct-root-sw-from-scratch direct-root-sw-xfiles
+Switch direct-root-sw and all its packages will be wiped. Are you sure? [Y/n] y
+Switch direct-root-sw-from-scratch and all its packages will be wiped. Are you sure? [Y/n] y
+Switch direct-root-sw-xfiles and all its packages will be wiped. Are you sure? [Y/n] y
+### opam switch meta-sw
+### ::::::::::::::::::::::
+### :VI: packages/no-nv/opam :
+### :      package without 'name.version' in directory
+### ::::::::::::::::::::::
+### sh populate.sh packages/no-nv
+### sh add-nv.sh   no-nv packages/no-nv
+### :VI:1:a: Add new repository 'new-default*', load from scratch
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default-strict ./REPO --this-switch --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default-strict] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
+### :VI:1:b: List available package
+### opam switch create no-nv-sw-from-scratch --empty --repo=new-default,new-default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch no-nv-sw-from-scratch ><><><><><><><><>
+ 1 new-default        file://${BASEDIR}/REPO
+ 2 new-default-strict file://${BASEDIR}/REPO
+### opam list -A --repo new-default-strict
+# Packages matching: from-repository(new-default-strict) & any
+# No matches found
+### opam list -A --repo new-default
+# Packages matching: from-repository(new-default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+very-inner-n-nv --
+very-inner-nv   --
+### :VI:1:c: Install available package
+### opam install no-nv
+[ERROR] No package named no-nv found.
+# Return code 5 #
+### :VI:2:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/no-nv/opam
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/no-nv/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/no-nv/opam
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/no-nv/files/un/der/opam, ignored
+### :VI:2:b List available package
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# No matches found
+### :VI:2:c: Install available package
+### opam switch create no-nv-sw --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch no-nv-sw <><><><><><><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam install no-nv
+[ERROR] No package named no-nv found.
+# Return code 5 #
+### :VI:3: Extra-files handling
+### # Add extra-files in the opam files
+### sh xfile-opam.sh packages/no-nv
+### sh add-nv.sh     no-nv packages/no-nv
+### :VI:3:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/no-nv/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/no-nv: missing from 'files' directory (1)
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/no-nv/opam
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/no-nv/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/no-nv: missing from 'files' directory (1)
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/no-nv/opam
+### :VI:3:b: Add the last extrafile and update
+### sh xfile.sh packages/no-nv
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/no-nv/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/no-nv/files/un/der/opam, ignored
+### :VI:3:b: List available package
+### opam switch create no-nv-sw-xfiles --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch no-nv-sw-xfiles ><><><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+very-inner-n-nv --
+very-inner-nv   --
+### :VI:3:c: Install available package
+### opam install no-nv
+[ERROR] No package named no-nv found.
+# Return code 5 #
+### :VI:4: Cleaning
+### opam repository remove --all new-default-strict new-default
+### opam switch remove no-nv-sw  no-nv-sw-from-scratch no-nv-sw-xfiles
+Switch no-nv-sw and all its packages will be wiped. Are you sure? [Y/n] y
+Switch no-nv-sw-from-scratch and all its packages will be wiped. Are you sure? [Y/n] y
+Switch no-nv-sw-xfiles and all its packages will be wiped. Are you sure? [Y/n] y
+### opam switch meta-sw
+### ::::::::::::::::::::::
+### :VII: root-no-nv/opam :
+### :       packages directory only with 'name' at root of the repository
+### ::::::::::::::::::::::
+### sh populate.sh root-no-nv
+### sh add-nv.sh   root-no-nv root-no-nv
+### :VII:1:a: Add new repository 'new-default*', load from scratch
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default-strict ./REPO --this-switch --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default-strict] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
+### :VII:1:b: List available package
+### opam switch create root-no-nv-sw-from-scratch --empty --repo=new-default,new-default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch root-no-nv-sw-from-scratch <><><><><><>
+ 1 new-default        file://${BASEDIR}/REPO
+ 2 new-default-strict file://${BASEDIR}/REPO
+### opam list -A --repo new-default-strict
+# Packages matching: from-repository(new-default-strict) & any
+# No matches found
+### opam list -A --repo new-default
+# Packages matching: from-repository(new-default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+very-inner-n-nv --
+very-inner-nv   --
+### :VII:1:c: Install available package
+### opam install root-no-nv
+[ERROR] No package named root-no-nv found.
+# Return code 5 #
+### :VII:2:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/root-no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/root-no-nv/opam
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/root-no-nv/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/root-no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/root-no-nv/opam
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/root-no-nv/files/un/der/opam, ignored
+### :VII:2:b List available package
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# No matches found
+### :VII:2:c: Install available package
+### opam switch create root-no-nv-sw --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch root-no-nv-sw ><><><><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam install root-no-nv
+[ERROR] No package named root-no-nv found.
+# Return code 5 #
+### :VII:3: Extra-files handling
+### # Add extra-files in the opam files
+### sh xfile-opam.sh root-no-nv
+### sh add-nv.sh     root-no-nv root-no-nv
+### :VII:3:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/root-no-nv/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/root-no-nv: missing from 'files' directory (1)
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/root-no-nv/opam
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/root-no-nv/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/root-no-nv: missing from 'files' directory (1)
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/root-no-nv/opam
+### :VII:3:b: Add the last extrafile and update
+### sh xfile.sh root-no-nv
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/root-no-nv/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/root-no-nv/files/un/der/opam, ignored
+### :VII:3:b: List available package
+### opam switch create root-no-nv-sw-xfiles --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch root-no-nv-sw-xfiles <><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+very-inner-n-nv --
+very-inner-nv   --
+### :VII:3:c: Install available package
+### opam install root-no-nv
+[ERROR] No package named root-no-nv found.
+# Return code 5 #
+### :VII:4: Cleaning
+### opam repository remove --all new-default-strict new-default
+### opam switch remove root-no-nv-sw  root-no-nv-sw-from-scratch root-no-nv-sw-xfiles
+Switch root-no-nv-sw and all its packages will be wiped. Are you sure? [Y/n] y
+Switch root-no-nv-sw-from-scratch and all its packages will be wiped. Are you sure? [Y/n] y
+Switch root-no-nv-sw-xfiles and all its packages will be wiped. Are you sure? [Y/n] y
+### opam switch meta-sw
+### ::::::::::::::::::::::
+### :VIII: packages/not-same-nv-in/not-same-nv-in.2/opam :
+### :        package with the good layout, but with specified version in the opam fille different from 'name.version' directory
+### ::::::::::::::::::::::
+### sh populate.sh packages/not-same-nv-in/not-same-nv-in.2
+### sh add-nv.sh   different packages/not-same-nv-in/not-same-nv-in.2
+### :VIII:1:a: Add new repository 'new-default*', load from scratch
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default-strict ./REPO --this-switch --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default-strict] Initialised
+UPDATE                          Repository has new changes
+[ERROR] In ${BASEDIR}/OPAM/repo/new-default-strict/packages/not-same-nv-in/not-same-nv-in.2/opam:
+        This file is for package 'not-same-nv-in.2' but has mismatching fields 'name:different 'version:1.
+[ERROR] Strict mode: aborting
+[ERROR] Could not update repository "new-default-strict": OpamStd.OpamSys.Exit(30)
+[ERROR] Initial repository fetch failed
+# Return code 40 #
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
+### :VIII:1:b: List available package
+### opam switch create not-same-nv-in-sw-from-scratch --empty --repo=new-default,new-default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch not-same-nv-in-sw-from-scratch <><><><>
+ 1 new-default        file://${BASEDIR}/REPO
+ 2 new-default-strict not found
+### opam list -A --repo new-default-strict
+# Packages matching: from-repository(new-default-strict) & any
+# No matches found
+### opam list -A --repo new-default
+# Packages matching: from-repository(new-default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+not-same-nv-in  --
+very-inner-n-nv --
+very-inner-nv   --
+### :VIII:1:c: Install available package
+### opam install not-same-nv-in.2
+The following actions will be performed:
+=== install 1 package
+  - install not-same-nv-in 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed not-same-nv-in.2
+Done.
+### :VIII:2:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+[ERROR] In ${BASEDIR}/OPAM/repo/default-strict/packages/not-same-nv-in/not-same-nv-in.2/opam:
+        This file is for package 'not-same-nv-in.2' but has mismatching fields 'name:different 'version:1.
+[ERROR] Strict mode: aborting
+[ERROR] Could not update repository "default-strict": OpamStd.OpamSys.Exit(30)
+# Return code 40 #
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not-same-nv-in/not-same-nv-in.2/files/un/der/opam, ignored
+Now run 'opam upgrade' to apply any package updates.
+### :VIII:2:b List available package
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# No matches found
+### :VIII:2:c: Install available package
+### opam switch create not-same-nv-in-sw --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch not-same-nv-in-sw ><><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam install not-same-nv-in.2
+The following actions will be performed:
+=== install 1 package
+  - install not-same-nv-in 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed not-same-nv-in.2
+Done.
+### :VIII:3: Extra-files handling
+### # Add extra-files in the opam files
+### sh xfile-opam.sh packages/not-same-nv-in/not-same-nv-in.2
+### sh add-nv.sh     different packages/not-same-nv-in/not-same-nv-in.2
+### :VIII:3:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+[ERROR] In ${BASEDIR}/OPAM/repo/default-strict/packages/not-same-nv-in/not-same-nv-in.2/opam:
+        This file is for package 'not-same-nv-in.2' but has mismatching fields 'name:different 'version:1.
+[ERROR] Strict mode: aborting
+[ERROR] Could not update repository "default-strict": OpamStd.OpamSys.Exit(30)
+# Return code 40 #
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/not-same-nv-in/not-same-nv-in.2: missing from 'files' directory (1)
+Now run 'opam upgrade' to apply any package updates.
+### :VIII:3:b: Add the last extrafile and update
+### sh xfile.sh packages/not-same-nv-in/not-same-nv-in.2
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/not-same-nv-in/not-same-nv-in.2/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not-same-nv-in/not-same-nv-in.2/files/un/der/opam, ignored
+### :VIII:3:b: List available package
+### opam switch create not-same-nv-in-sw-xfiles --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch not-same-nv-in-sw-xfiles <><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+not-same-nv-in  --
+very-inner-n-nv --
+very-inner-nv   --
+### :VIII:3:c: Install available package
+### opam install not-same-nv-in.2
+The following actions will be performed:
+=== install 1 package
+  - install not-same-nv-in 2
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed not-same-nv-in.2
+Done.
+### :VIII:4: Cleaning
+### opam repository remove --all new-default-strict new-default
+[WARNING] No configured repositories by these names found: new-default-strict
+### opam switch remove not-same-nv-in-sw  not-same-nv-in-sw-from-scratch not-same-nv-in-sw-xfiles
+Switch not-same-nv-in-sw and all its packages will be wiped. Are you sure? [Y/n] y
+Switch not-same-nv-in-sw-from-scratch and all its packages will be wiped. Are you sure? [Y/n] y
+Switch not-same-nv-in-sw-xfiles and all its packages will be wiped. Are you sure? [Y/n] y
+### opam switch meta-sw
+### # We clean this one, as it will broke all next repository loadings in strict mode
+### sh xfile-opam.sh packages/not-same-nv-in/not-same-nv-in.2
+### opam update --all
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+[default-strict] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### ::::::::::::::::::::::
+### :IX: packages/not-opam-filename/not-opam-filename.1/not-opam-filename :
+### :      package with the good layout, but the opam file is not named 'opam'
+### ::::::::::::::::::::::
+### # for this one, we update only the file not named opam
+### sh populate.sh packages/not-opam-filename/not-opam-filename.1
+### mv REPO/packages/not-opam-filename/not-opam-filename.1/opam REPO/packages/not-opam-filename/not-opam-filename.1/not-opam-filename
+### :IX:1:a: Add new repository 'new-default*', load from scratch
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default-strict ./REPO --this-switch --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default-strict] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
+### :IX:1:b: List available package
+### opam switch create not-opam-filename-sw-from-scratch --empty --repo=new-default,new-default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch not-opam-filename-sw-from-scratch ><><>
+ 1 new-default        file://${BASEDIR}/REPO
+ 2 new-default-strict file://${BASEDIR}/REPO
+### opam list -A --repo new-default-strict
+# Packages matching: from-repository(new-default-strict) & any
+# No matches found
+### opam list -A --repo new-default
+# Packages matching: from-repository(new-default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+not-same-nv-in  --
+very-inner-n-nv --
+very-inner-nv   --
+### :IX:1:c: Install available package
+### opam install not-opam-filename.1
+[ERROR] No package named not-opam-filename found.
+# Return code 5 #
+### :IX:2:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/not-opam-filename/not-opam-filename.1/opam, ignored
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/not-opam-filename/not-opam-filename.1/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not-opam-filename/not-opam-filename.1/opam, ignored
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not-opam-filename/not-opam-filename.1/files/un/der/opam, ignored
+### :IX:2:b List available package
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# No matches found
+### :IX:2:c: Install available package
+### opam switch create not-opam-filename-sw --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch not-opam-filename-sw <><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam install not-opam-filename.1
+[ERROR] No package named not-opam-filename found.
+# Return code 5 #
+### :IX:3: Extra-files handling
+### # Add extra-files in the opam files
+### sh xfile-opam.sh packages/not-opam-filename/not-opam-filename.1
+### mv REPO/packages/not-opam-filename/not-opam-filename.1/opam REPO/packages/not-opam-filename/not-opam-filename.1/not-opam-filename
+### :IX:3:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/not-opam-filename/not-opam-filename.1/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not-opam-filename/not-opam-filename.1/opam, ignored
+### :IX:3:b: Add the last extrafile and update
+### sh xfile.sh packages/not-opam-filename/not-opam-filename.1
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/not-opam-filename/not-opam-filename.1/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not-opam-filename/not-opam-filename.1/files/un/der/opam, ignored
+### :IX:3:b: List available package
+### opam switch create not-opam-filename-sw-xfiles --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch not-opam-filename-sw-xfiles ><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+not-same-nv-in  --
+very-inner-n-nv --
+very-inner-nv   --
+### :IX:3:c: Install available package
+### opam install not-opam-filename.1
+[ERROR] No package named not-opam-filename found.
+# Return code 5 #
+### :IX:4: Cleaning
+### opam repository remove --all new-default-strict new-default
+### opam switch remove not-opam-filename-sw  not-opam-filename-sw-from-scratch not-opam-filename-sw-xfiles
+Switch not-opam-filename-sw and all its packages will be wiped. Are you sure? [Y/n] y
+Switch not-opam-filename-sw-from-scratch and all its packages will be wiped. Are you sure? [Y/n] y
+Switch not-opam-filename-sw-xfiles and all its packages will be wiped. Are you sure? [Y/n] y
+### opam switch meta-sw
+### ::::::::::::::::::::::
+### :X: packages/opam-dir-nv/opam-dir-nv.1/opam/opam :
+### :     opam file is under an opam directory, with pattern 'packages/name/name.version/opam'
+### ::::::::::::::::::::::
+### sh populate.sh packages/opam-dir-nv/opam-dir-nv.1/opam
+### :X:1:a: Add new repository 'new-default*', load from scratch
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default-strict ./REPO --this-switch --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default-strict] Initialised
+UPDATE                          Repository has new changes
+[ERROR] At ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam:1:0-1:0::
+        Parse error
+[ERROR] Strict mode: aborting
+[ERROR] Could not update repository "new-default-strict": OpamStd.OpamSys.Exit(30)
+[ERROR] Initial repository fetch failed
+# Return code 40 #
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default] Initialised
+UPDATE                          Repository has new changes
+[WARNING] Could not read file ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam. skipping:
+          At ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam:1:0-1:0::
+          Parse error
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam, ignored
+### :X:1:b: List available package
+### opam switch create opam-dir-nv-sw-from-scratch --empty --repo=new-default,new-default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch opam-dir-nv-sw-from-scratch ><><><><><>
+ 1 new-default        file://${BASEDIR}/REPO
+ 2 new-default-strict not found
+### opam list -A --repo new-default-strict
+# Packages matching: from-repository(new-default-strict) & any
+# No matches found
+### opam list -A --repo new-default
+# Packages matching: from-repository(new-default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+not-same-nv-in  --
+very-inner-n-nv --
+very-inner-nv   --
+### :X:1:c: Install available package
+### opam install opam-dir-nv.1
+[ERROR] No package named opam-dir-nv found.
+# Return code 5 #
+### :X:2:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/opam
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/opam-dir-nv/opam-dir-nv.1/opam/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/opam-dir-nv/opam-dir-nv.1/opam/opam
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/opam-dir-nv/opam-dir-nv.1/opam/files/un/der/opam, ignored
+### :X:2:b List available package
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# No matches found
+### :X:2:c: Install available package
+### opam switch create opam-dir-nv-sw --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch opam-dir-nv-sw <><><><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam install opam-dir-nv.1
+[ERROR] No package named opam-dir-nv found.
+# Return code 5 #
+### :X:3: Extra-files handling
+### # Add extra-files in the opam files
+### sh xfile-opam.sh packages/opam-dir-nv/opam-dir-nv.1/opam
+### :X:3:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam: missing from 'files' directory (1)
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/opam
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/opam-dir-nv/opam-dir-nv.1/opam/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/opam-dir-nv/opam-dir-nv.1/opam: missing from 'files' directory (1)
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/opam-dir-nv/opam-dir-nv.1/opam/opam
+### :X:3:b: Add the last extrafile and update
+### sh xfile.sh packages/opam-dir-nv/opam-dir-nv.1/opam
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/opam-dir-nv/opam-dir-nv.1/opam/files/un/der/opam, ignored
+### :X:3:b: List available package
+### opam switch create opam-dir-nv-sw-xfiles --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch opam-dir-nv-sw-xfiles ><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+not-same-nv-in  --
+very-inner-n-nv --
+very-inner-nv   --
+### :X:3:c: Install available package
+### opam install opam-dir-nv.1
+[ERROR] No package named opam-dir-nv found.
+# Return code 5 #
+### :X:4: Cleaning
+### opam repository remove --all new-default-strict new-default
+[WARNING] No configured repositories by these names found: new-default-strict
+### opam switch remove opam-dir-nv-sw  opam-dir-nv-sw-from-scratch opam-dir-nv-sw-xfiles
+Switch opam-dir-nv-sw and all its packages will be wiped. Are you sure? [Y/n] y
+Switch opam-dir-nv-sw-from-scratch and all its packages will be wiped. Are you sure? [Y/n] y
+Switch opam-dir-nv-sw-xfiles and all its packages will be wiped. Are you sure? [Y/n] y
+### opam switch meta-sw
+### ::::::::::::::::::::::
+### :XI: packages/opam-dir-n/opam/opam :
+### :      opam file is under an opam directory, with pattern 'packages/name/opam'
+### ::::::::::::::::::::::
+### sh populate.sh packages/opam-dir-n/opam
+### :XI:1:a: Add new repository 'new-default*', load from scratch
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default-strict ./REPO --this-switch --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default-strict] Initialised
+UPDATE                          Repository has new changes
+[ERROR] At ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam-dir-n/opam:1:0-1:0::
+        Parse error
+[ERROR] Strict mode: aborting
+[ERROR] Could not update repository "new-default-strict": OpamStd.OpamSys.Exit(30)
+[ERROR] Initial repository fetch failed
+# Return code 40 #
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default] Initialised
+UPDATE                          Repository has new changes
+[WARNING] Could not read file ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-n/opam. skipping:
+          At ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-n/opam:1:0-1:0::
+          Parse error
+[WARNING] Could not read file ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam. skipping:
+          At ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam:1:0-1:0::
+          Parse error
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-n/opam, ignored
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam, ignored
+### :XI:1:b: List available package
+### opam switch create opam-dir-n-sw-from-scratch --empty --repo=new-default,new-default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch opam-dir-n-sw-from-scratch <><><><><><>
+ 1 new-default        file://${BASEDIR}/REPO
+ 2 new-default-strict not found
+### opam list -A --repo new-default-strict
+# Packages matching: from-repository(new-default-strict) & any
+# No matches found
+### opam list -A --repo new-default
+# Packages matching: from-repository(new-default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+not-same-nv-in  --
+very-inner-n-nv --
+very-inner-nv   --
+### :XI:1:c: Install available package
+### opam install opam-dir-n.1
+[ERROR] No package named opam-dir-n found.
+# Return code 5 #
+### :XI:2:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-n/opam/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-n/opam/opam
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-n/opam/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/opam-dir-n/opam/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/opam-dir-n/opam/opam
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/opam-dir-n/opam/files/un/der/opam, ignored
+### :XI:2:b List available package
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# No matches found
+### :XI:2:c: Install available package
+### opam switch create opam-dir-n-sw --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch opam-dir-n-sw ><><><><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam install opam-dir-n.1
+[ERROR] No package named opam-dir-n found.
+# Return code 5 #
+### :XI:3: Extra-files handling
+### # Add extra-files in the opam files
+### sh xfile-opam.sh packages/opam-dir-n/opam
+### :XI:3:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-n/opam/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-n/opam: missing from 'files' directory (1)
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-n/opam/opam
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/opam-dir-n/opam/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/opam-dir-n/opam: missing from 'files' directory (1)
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/opam-dir-n/opam/opam
+### :XI:3:b: Add the last extrafile and update
+### sh xfile.sh packages/opam-dir-n/opam
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/opam-dir-n/opam/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/opam-dir-n/opam/files/un/der/opam, ignored
+### :XI:3:b: List available package
+### opam switch create opam-dir-n-sw-xfiles --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch opam-dir-n-sw-xfiles <><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+not-same-nv-in  --
+very-inner-n-nv --
+very-inner-nv   --
+### :XI:3:c: Install available package
+### opam install opam-dir-n.1
+[ERROR] No package named opam-dir-n found.
+# Return code 5 #
+### :XI:4: Cleaning
+### opam repository remove --all new-default-strict new-default
+[WARNING] No configured repositories by these names found: new-default-strict
+### opam switch remove opam-dir-n-sw  opam-dir-n-sw-from-scratch opam-dir-n-sw-xfiles
+Switch opam-dir-n-sw and all its packages will be wiped. Are you sure? [Y/n] y
+Switch opam-dir-n-sw-from-scratch and all its packages will be wiped. Are you sure? [Y/n] y
+Switch opam-dir-n-sw-xfiles and all its packages will be wiped. Are you sure? [Y/n] y
+### opam switch meta-sw
+### ::::::::::::::::::::::
+### :XII: packages/opam :
+### :       opam file directly under packages
+### ::::::::::::::::::::::
+### sh populate.sh packages
+### sh add-nv.sh   opam-at-root-pkg packages
+### :XII:1:a: Add new repository 'new-default*', load from scratch
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default-strict ./REPO --this-switch --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default-strict] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/opam
+### :XII:1:b: List available package
+### opam switch create opam-at-root-pkg-sw-from-scratch --empty --repo=new-default,new-default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch opam-at-root-pkg-sw-from-scratch <><><>
+ 1 new-default        file://${BASEDIR}/REPO
+ 2 new-default-strict file://${BASEDIR}/REPO
+### opam list -A --repo new-default-strict
+# Packages matching: from-repository(new-default-strict) & any
+# No matches found
+### opam list -A --repo new-default
+# Packages matching: from-repository(new-default) & any
+# No matches found
+### :XII:1:c: Install available package
+### opam install opam-at-root-pkg
+[ERROR] No package named opam-at-root-pkg found.
+# Return code 5 #
+### :XII:2:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/opam
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/opam
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/files/un/der/opam, ignored
+### :XII:2:b List available package
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# No matches found
+### :XII:2:c: Install available package
+### opam switch create opam-at-root-pkg-sw --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch opam-at-root-pkg-sw ><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam install opam-at-root-pkg
+[ERROR] No package named opam-at-root-pkg found.
+# Return code 5 #
+### :XII:3: Extra-files handling
+### # Add extra-files in the opam files
+### sh xfile-opam.sh packages
+### sh add-nv.sh     opam-at-root-pkg packages
+### :XII:3:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages: missing from 'files' directory (1)
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/opam
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages: missing from 'files' directory (1)
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/opam
+### :XII:3:b: Add the last extrafile and update
+### sh xfile.sh packages
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/packages/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/files/un/der/opam, ignored
+### :XII:3:b: List available package
+### opam switch create opam-at-root-pkg-sw-xfiles --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch opam-at-root-pkg-sw-xfiles <><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+not-same-nv-in  --
+very-inner-n-nv --
+very-inner-nv   --
+### :XII:3:c: Install available package
+### opam install opam-at-root-pkg
+[ERROR] No package named opam-at-root-pkg found.
+# Return code 5 #
+### :XII:4: Cleaning
+### opam repository remove --all new-default-strict new-default
+### opam switch remove opam-at-root-pkg-sw  opam-at-root-pkg-sw-from-scratch opam-at-root-pkg-sw-xfiles
+Switch opam-at-root-pkg-sw and all its packages will be wiped. Are you sure? [Y/n] y
+Switch opam-at-root-pkg-sw-from-scratch and all its packages will be wiped. Are you sure? [Y/n] y
+Switch opam-at-root-pkg-sw-xfiles and all its packages will be wiped. Are you sure? [Y/n] y
+### opam switch meta-sw
+### ::::::::::::::::::::::
+### :XIII: pkg/z-good/z-good.1 :
+### :        root directory is not 'packages'
+### ::::::::::::::::::::::
+### sh populate.sh pkg/z-good/z-good.1
+### :XIII:1:a: Add new repository 'new-default*', load from scratch
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default-strict ./REPO --this-switch --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default-strict] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+[new-default] Initialised
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/opam
+### :XIII:1:b: List available package
+### opam switch create z-good-sw-from-scratch --empty --repo=new-default,new-default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch z-good-sw-from-scratch <><><><><><><><>
+ 1 new-default        file://${BASEDIR}/REPO
+ 2 new-default-strict file://${BASEDIR}/REPO
+### opam list -A --repo new-default-strict
+# Packages matching: from-repository(new-default-strict) & any
+# No matches found
+### opam list -A --repo new-default
+# Packages matching: from-repository(new-default) & any
+# No matches found
+### :XIII:1:c: Install available package
+### opam install z-good.1
+[ERROR] No package named z-good found.
+# Return code 5 #
+### :XIII:2:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/pkg/z-good/z-good.1/opam in 0.000s
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/pkg/z-good/z-good.1/files/un/der/opam, ignored
+Now run 'opam upgrade' to apply any package updates.
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/pkg/z-good/z-good.1/opam in 0.000s
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/pkg/z-good/z-good.1/files/un/der/opam, ignored
+Now run 'opam upgrade' to apply any package updates.
+### :XIII:2:b List available package
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# No matches found
+### :XIII:2:c: Install available package
+### opam switch create z-good-sw --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch z-good-sw ><><><><><><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam install z-good.1
+The following actions will be performed:
+=== install 1 package
+  - install z-good 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed z-good.1
+Done.
+### :XIII:3: Extra-files handling
+### # Add extra-files in the opam files
+### sh xfile-opam.sh pkg/z-good/z-good.1
+### :XIII:3:a: Update repositories 'default*', load from diff
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/pkg/z-good/z-good.1/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/pkg/z-good/z-good.1: missing from 'files' directory (1)
+Now run 'opam upgrade' to apply any package updates.
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/pkg/z-good/z-good.1/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/pkg/z-good/z-good.1: missing from 'files' directory (1)
+Now run 'opam upgrade' to apply any package updates.
+### :XIII:3:b: Add the last extrafile and update
+### sh xfile.sh pkg/z-good/z-good.1
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default-strict/pkg/z-good/z-good.1/files/un/der/opam, ignored
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/pkg/z-good/z-good.1/files/un/der/opam, ignored
+### :XIII:3:b: List available package
+### opam switch create z-good-sw-xfiles --empty --repo=default,default-strict
+### opam repository --this-switch
+
+<><> Repository configuration for switch z-good-sw-xfiles <><><><><><><><><><><>
+ 1 default        file://${BASEDIR}/REPO
+ 2 default-strict file://${BASEDIR}/REPO
+### opam list -A --repo default-strict
+# Packages matching: from-repository(default-strict) & any
+# No matches found
+### opam list -A --repo default
+# Packages matching: from-repository(default) & any
+# Name          # Installed # Synopsis
+direct-root     --
+good            --
+no-n-nv         --
+not-same-nv-in  --
+very-inner-n-nv --
+very-inner-nv   --
+z-good          --
+### :XIII:3:c: Install available package
+### opam install z-good.1
+The following actions will be performed:
+=== install 1 package
+  - install z-good 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed z-good.1
+Done.
+### :XIII:4: Cleaning
+### opam repository remove --all new-default-strict new-default
+### opam switch remove z-good-sw  z-good-sw-from-scratch z-good-sw-xfiles
+Switch z-good-sw and all its packages will be wiped. Are you sure? [Y/n] y
+Switch z-good-sw-from-scratch and all its packages will be wiped. Are you sure? [Y/n] y
+Switch z-good-sw-xfiles and all its packages will be wiped. Are you sure? [Y/n] y
+### opam switch meta-sw
+### ::::::::::::::::::::::
+### :C: Unnecessary loading when a non opam file is updated.
+### :    In incremental loading, if next to an opam file a file not named opam
+### :    and containing a valid opam file content is updated (and only that
+### :    file in the package directory), the correspondant opam package
+### :    shouldn't be loaded. This is shown by the mismatch extra file message
+### ::::::::::::::::::::::
+### # we create the layout we want : an opam file, extra files, and a nother file opam.xxx
+### sh populate.sh packages/wrong-opamf-updated/wrong-opamf-updated.1
+### cp REPO/packages/wrong-opamf-updated/wrong-opamf-updated.1/opam REPO/packages/wrong-opamf-updated/wrong-opamf-updated.1/opam.xxx
+### sh xfile-opam.sh packages/wrong-opamf-updated/wrong-opamf-updated.1
+### # First update of repositories
+### opam update default-strict --strict
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### opam update default
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### # unrelated new package, it is just here to highlight the unrelated update of wrong-opamf-updated
+### <REPO/packages/another-good/another-good.1/opam>
+opam-version: "2.0"
+### # we add change in opam.xxx
+### sh -c "echo >> REPO/packages/wrong-opamf-updated/wrong-opamf-updated.1/opam.xxx"
+### :C:1: Update of repositories
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default-strict] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/wrong-opamf-updated/wrong-opamf-updated.1/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/wrong-opamf-updated/wrong-opamf-updated.1: missing from 'files' directory (1)
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/another-good/another-good.1/opam in 0.000s
+Now run 'opam upgrade' to apply any package updates.
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/wrong-opamf-updated/wrong-opamf-updated.1/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default/packages/wrong-opamf-updated/wrong-opamf-updated.1: missing from 'files' directory (1)
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default/packages/another-good/another-good.1/opam in 0.000s
+Now run 'opam upgrade' to apply any package updates.
+### ::::::::::::::::::::::
+### :CI: opam admin repository reading
+### :       We test here the packages that are taken into account by opam admin
+### ::::::::::::::::::::::
+### # We put back case :VIII:, we removed it because it broke all repo loading on strict mode
+### sh add-nv.sh     different packages/not-same-nv-in/not-same-nv-in.2
+### # This dance is required on windows since the FS is case-insensitive
+### # we need to have repository layout at root as we use 'opam admin' to create the archive
+### mv REPO/repo repo.tmp
+### mv REPO REPO.dir
+### mv repo.tmp repo
+### sh -c "mv REPO.dir/* ."
+### rmdir REPO.dir
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE" OPAMDEBUG=-3 opam admin list | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+FILE(opam)                      Read ${BASEDIR}/packages/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/packages/opam
+# No matches found
+# Packages matching: available

--- a/tests/reftests/repository-layout.test
+++ b/tests/reftests/repository-layout.test
@@ -147,7 +147,7 @@ RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -226,7 +226,7 @@ Done.
 ### # Add extra-files in the opam files
 ### sh xfile-opam.sh packages/good/good.1
 ### :I:3:a: Update repositories 'default*', load from diff
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -250,7 +250,7 @@ opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/
 Now run 'opam upgrade' to apply any package updates.
 ### :I:3:b: Add the last extrafile and update
 ### sh xfile.sh packages/good/good.1
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -310,9 +310,9 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -393,7 +393,7 @@ Done.
 ### # Add extra-files in the opam files
 ### sh xfile-opam.sh packages/not/no-n-nv.1
 ### :II:3:a: Update repositories 'default*', load from diff
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -417,7 +417,7 @@ opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/
 Now run 'opam upgrade' to apply any package updates.
 ### :II:3:b: Add the last extrafile and update
 ### sh xfile.sh packages/not/no-n-nv.1
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -478,10 +478,10 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -564,7 +564,7 @@ Done.
 ### # Add extra-files in the opam files
 ### sh xfile-opam.sh packages/v/e/r/y/very-inner-nv.1
 ### :III:3:a: Update repositories 'default*', load from diff
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -588,7 +588,7 @@ opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/
 Now run 'opam upgrade' to apply any package updates.
 ### :III:3:b: Add the last extrafile and update
 ### sh xfile.sh packages/v/e/r/y/very-inner-nv.1
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -650,12 +650,11 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -664,6 +663,7 @@ UPDATE                          Repository has new changes
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 ### :IV:1:b: List available package
 ### opam switch create very-inner-n-nv-sw-from-scratch --empty --repo=new-default,new-default-strict
 ### opam repository --this-switch
@@ -739,7 +739,7 @@ Done.
 ### # Add extra-files in the opam files
 ### sh xfile-opam.sh packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1
 ### :IV:3:a: Update repositories 'default*', load from diff
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -763,7 +763,7 @@ opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/
 Now run 'opam upgrade' to apply any package updates.
 ### :IV:3:b: Add the last extrafile and update
 ### sh xfile.sh packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -827,21 +827,21 @@ RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 ### :V:1:b: List available package
 ### opam switch create direct-root-sw-from-scratch --empty --repo=new-default,new-default-strict
 ### opam repository --this-switch
@@ -918,7 +918,7 @@ Done.
 ### # Add extra-files in the opam files
 ### sh xfile-opam.sh packages/direct-root.1
 ### :V:3:a: Update repositories 'default*', load from diff
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -942,7 +942,7 @@ opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/
 Now run 'opam upgrade' to apply any package updates.
 ### :V:3:b: Add the last extrafile and update
 ### sh xfile.sh packages/direct-root.1
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -1007,26 +1007,26 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 ### :VI:1:b: List available package
 ### opam switch create no-nv-sw-from-scratch --empty --repo=new-default,new-default-strict
 ### opam repository --this-switch
@@ -1094,7 +1094,7 @@ RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default
 ### sh xfile-opam.sh packages/no-nv
 ### sh add-nv.sh     no-nv packages/no-nv
 ### :VI:3:a: Update repositories 'default*', load from diff
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -1118,7 +1118,7 @@ opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/no-nv/opam
 ### :VI:3:b: Add the last extrafile and update
 ### sh xfile.sh packages/no-nv
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -1178,26 +1178,26 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 ### :VII:1:b: List available package
 ### opam switch create root-no-nv-sw-from-scratch --empty --repo=new-default,new-default-strict
 ### opam repository --this-switch
@@ -1265,7 +1265,7 @@ RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default
 ### sh xfile-opam.sh root-no-nv
 ### sh add-nv.sh     root-no-nv root-no-nv
 ### :VII:3:a: Update repositories 'default*', load from diff
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -1289,7 +1289,7 @@ opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/root-no-nv/opam
 ### :VII:3:b: Add the last extrafile and update
 ### sh xfile.sh root-no-nv
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -1349,19 +1349,24 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
 [ERROR] In ${BASEDIR}/OPAM/repo/new-default-strict/packages/not-same-nv-in/not-same-nv-in.2/opam:
         This file is for package 'not-same-nv-in.2' but has mismatching fields 'name:different 'version:1.
 [ERROR] Strict mode: aborting
 [ERROR] Could not update repository "new-default-strict": OpamStd.OpamSys.Exit(30)
 [ERROR] Initial repository fetch failed
 # Return code 40 #
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1369,6 +1374,7 @@ FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/n
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 ### :VIII:1:b: List available package
 ### opam switch create not-same-nv-in-sw-from-scratch --empty --repo=new-default,new-default-strict
 ### opam repository --this-switch
@@ -1449,7 +1455,7 @@ Done.
 ### sh xfile-opam.sh packages/not-same-nv-in/not-same-nv-in.2
 ### sh add-nv.sh     different packages/not-same-nv-in/not-same-nv-in.2
 ### :VIII:3:a: Update repositories 'default*', load from diff
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -1475,7 +1481,7 @@ opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/
 Now run 'opam upgrade' to apply any package updates.
 ### :VIII:3:b: Add the last extrafile and update
 ### sh xfile.sh packages/not-same-nv-in/not-same-nv-in.2
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -1551,21 +1557,20 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1573,6 +1578,7 @@ FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/n
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 ### :IX:1:b: List available package
 ### opam switch create not-opam-filename-sw-from-scratch --empty --repo=new-default,new-default-strict
 ### opam repository --this-switch
@@ -1639,7 +1645,7 @@ RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default
 ### sh xfile-opam.sh packages/not-opam-filename/not-opam-filename.1
 ### mv REPO/packages/not-opam-filename/not-opam-filename.1/opam REPO/packages/not-opam-filename/not-opam-filename.1/not-opam-filename
 ### :IX:3:a: Update repositories 'default*', load from diff
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -1659,7 +1665,7 @@ UPDATE                          Repository has new changes
 RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default/packages/not-opam-filename/not-opam-filename.1/opam, ignored
 ### :IX:3:b: Add the last extrafile and update
 ### sh xfile.sh packages/not-opam-filename/not-opam-filename.1
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -1719,22 +1725,22 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
-[ERROR] At ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam:1:0-1:0::
-        Parse error
-[ERROR] Strict mode: aborting
-[ERROR] Could not update repository "new-default-strict": OpamStd.OpamSys.Exit(30)
-[ERROR] Initial repository fetch failed
-# Return code 40 #
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
-[WARNING] Could not read file ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam. skipping:
-          At ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam:1:0-1:0::
-          Parse error
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1742,14 +1748,16 @@ FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/n
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
-RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam, ignored
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 ### :X:1:b: List available package
 ### opam switch create opam-dir-nv-sw-from-scratch --empty --repo=new-default,new-default-strict
 ### opam repository --this-switch
 
 <><> Repository configuration for switch opam-dir-nv-sw-from-scratch ><><><><><>
  1 new-default        file://${BASEDIR}/REPO
- 2 new-default-strict not found
+ 2 new-default-strict file://${BASEDIR}/REPO
 ### opam list -A --repo new-default-strict
 # Packages matching: from-repository(new-default-strict) & any
 # No matches found
@@ -1810,7 +1818,7 @@ RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default
 ### # Add extra-files in the opam files
 ### sh xfile-opam.sh packages/opam-dir-nv/opam-dir-nv.1/opam
 ### :X:3:a: Update repositories 'default*', load from diff
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -1834,7 +1842,7 @@ opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/opam-dir-nv/opam-dir-nv.1/opam/opam
 ### :X:3:b: Add the last extrafile and update
 ### sh xfile.sh packages/opam-dir-nv/opam-dir-nv.1/opam
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -1877,7 +1885,6 @@ very-inner-nv   --
 # Return code 5 #
 ### :X:4: Cleaning
 ### opam repository remove --all new-default-strict new-default
-[WARNING] No configured repositories by these names found: new-default-strict
 ### opam switch remove opam-dir-nv-sw  opam-dir-nv-sw-from-scratch opam-dir-nv-sw-xfiles
 Switch opam-dir-nv-sw and all its packages will be wiped. Are you sure? [Y/n] y
 Switch opam-dir-nv-sw-from-scratch and all its packages will be wiped. Are you sure? [Y/n] y
@@ -1895,25 +1902,24 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default-strict] Initialised
 UPDATE                          Repository has new changes
-[ERROR] At ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam-dir-n/opam:1:0-1:0::
-        Parse error
-[ERROR] Strict mode: aborting
-[ERROR] Could not update repository "new-default-strict": OpamStd.OpamSys.Exit(30)
-[ERROR] Initial repository fetch failed
-# Return code 40 #
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/direct-root.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/good/good.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/no-nv/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not/no-n-nv.1/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam-dir-n/opam/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam-dir-n/opam/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam-dir-nv/opam-dir-nv.1/opam/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
 [new-default] Initialised
 UPDATE                          Repository has new changes
-[WARNING] Could not read file ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-n/opam. skipping:
-          At ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-n/opam:1:0-1:0::
-          Parse error
-[WARNING] Could not read file ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam. skipping:
-          At ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam:1:0-1:0::
-          Parse error
-FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/direct-root.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/good/good.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/i/n/e/r/very-inner-n-nv/very-inner-n-nv.1/opam in 0.000s
@@ -1921,15 +1927,18 @@ FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/n
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/no-nv/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not/no-n-nv.1/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/not-same-nv-in/not-same-nv-in.2/opam in 0.000s
-RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-n/opam, ignored
-RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam, ignored
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-n/opam/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-n/opam/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam/opam in 0.000s
+RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default/packages/opam-dir-nv/opam-dir-nv.1/opam/opam
+FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default/packages/v/e/r/y/very-inner-nv.1/opam in 0.000s
 ### :XI:1:b: List available package
 ### opam switch create opam-dir-n-sw-from-scratch --empty --repo=new-default,new-default-strict
 ### opam repository --this-switch
 
 <><> Repository configuration for switch opam-dir-n-sw-from-scratch <><><><><><>
  1 new-default        file://${BASEDIR}/REPO
- 2 new-default-strict not found
+ 2 new-default-strict file://${BASEDIR}/REPO
 ### opam list -A --repo new-default-strict
 # Packages matching: from-repository(new-default-strict) & any
 # No matches found
@@ -1990,7 +1999,7 @@ RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default
 ### # Add extra-files in the opam files
 ### sh xfile-opam.sh packages/opam-dir-n/opam
 ### :XI:3:a: Update repositories 'default*', load from diff
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -2014,7 +2023,7 @@ opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/opam-dir-n/opam/opam
 ### :XI:3:b: Add the last extrafile and update
 ### sh xfile.sh packages/opam-dir-n/opam
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -2057,7 +2066,6 @@ very-inner-nv   --
 # Return code 5 #
 ### :XI:4: Cleaning
 ### opam repository remove --all new-default-strict new-default
-[WARNING] No configured repositories by these names found: new-default-strict
 ### opam switch remove opam-dir-n-sw  opam-dir-n-sw-from-scratch opam-dir-n-sw-xfiles
 Switch opam-dir-n-sw and all its packages will be wiped. Are you sure? [Y/n] y
 Switch opam-dir-n-sw-from-scratch and all its packages will be wiped. Are you sure? [Y/n] y
@@ -2078,7 +2086,7 @@ RSTATE                          Cache found
 UPDATE                          Repository has new changes
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -2148,7 +2156,7 @@ RSTATE                          ERR: Could not load ${BASEDIR}/OPAM/repo/default
 ### sh xfile-opam.sh packages
 ### sh add-nv.sh     opam-at-root-pkg packages
 ### :XII:3:a: Update repositories 'default*', load from diff
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -2156,8 +2164,8 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default-strict] synchronised from file://${BASEDIR}/REPO
 UPDATE                          Repository has new changes
-opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages: missing from 'files' directory (1)
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/opam in 0.000s
+opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages: missing from 'files' directory (1)
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default-strict/packages/opam
 ### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -2172,7 +2180,7 @@ opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/default/packages/opam
 ### :XII:3:b: Add the last extrafile and update
 ### sh xfile.sh packages
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -2234,7 +2242,7 @@ RSTATE                          Cache found
 UPDATE                          Repository has new changes
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/OPAM/repo/new-default-strict/packages/opam
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam repository add new-default ./REPO --this-switch
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -2308,7 +2316,7 @@ Done.
 ### # Add extra-files in the opam files
 ### sh xfile-opam.sh pkg/z-good/z-good.1
 ### :XIII:3:a: Update repositories 'default*', load from diff
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -2332,7 +2340,7 @@ opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/
 Now run 'opam upgrade' to apply any package updates.
 ### :XIII:3:b: Add the last extrafile and update
 ### sh xfile.sh pkg/z-good/z-good.1
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -2414,7 +2422,7 @@ opam-version: "2.0"
 ### # we add change in opam.xxx
 ### sh -c "echo >> REPO/packages/wrong-opamf-updated/wrong-opamf-updated.1/opam.xxx"
 ### :C:1: Update of repositories
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default-strict --strict
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -2426,7 +2434,7 @@ FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/package
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/default-strict/packages/wrong-opamf-updated/wrong-opamf-updated.1: missing from 'files' directory (1)
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/default-strict/packages/another-good/another-good.1/opam in 0.000s
 Now run 'opam upgrade' to apply any package updates.
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE UPDATE" OPAMDEBUG=-3 opam update default
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          Cache found
@@ -2451,9 +2459,9 @@ Now run 'opam upgrade' to apply any package updates.
 ### mv repo.tmp repo
 ### sh -c "mv REPO.dir/* ."
 ### rmdir REPO.dir
-### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE" OPAMDEBUG=-3 opam admin list | unordered
+### OPAMDEBUGSECTIONS="FILE(opam) opam-file RSTATE" OPAMDEBUG=-3 opam admin list
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(opam)                      Read ${BASEDIR}/packages/opam in 0.000s
 RSTATE                          ERR: directory name not a valid package: ignored ${BASEDIR}/packages/opam
-# No matches found
 # Packages matching: available
+# No matches found


### PR DESCRIPTION
Add a test that shows the handled paths for opam packages, how and if they are read or processed by opam client (update & admin commands).

This mechanism was reworked by #6614 that introduced incremental loading (from diff instead of reading again the whole repository).

It highlights and permit to follow some errors that were unseen during #6614 and that are resolved by #6871 & #6924 (previous handled paths are seen in first commit[1]).

This PR adds the test, that is good to have before #6625 rewriting, to ensure non change on behaviour (even if erroneous).
However, in this PR we change a little bit the behaviour: first by adding a new logging to differentiate load from dir & load from diff calls ; and we sort the files read from disk during loading from dir to ensure an cross system reftest output (especially with `---strict` that error at the first error encountered).

~It also fixes a bug, a different behaviour between Unix & Windows. Stdlib `open_in` functions opens directories on Unix but error on Windows. Now, `OpamSystem.open_in*` error on all platforms if the filename is a directory.~

[1] ~The first commit is here for my personal use. It will be removed from the final version., it higlights the output of the test before before incremental loading merge (at commit https://github.com/ocaml/opam/commit/f3703519e0cdfb2bdd8232c1c897501df13c188a). It will be removed on merge.~ The commit that contains the result of the reftest before incremental loading is in on top of the branch [rjbou/bef-load-from-diff-reftests-repository-layout](https://github.com/rjbou/opam/tree/bef-load-from-diff-reftests-repository-layout)

In the story of #6625
Queued on https://github.com/ocaml/opam/pull/6995