### PR TITLE
Use `tar` library instead of `tar` tool for some operations

### DIFF
--- a/configure
+++ b/configure
@@ -622,6 +622,9 @@ ac_ct_CXX
 CXXFLAGS
 CXX
 OCAML_PKG_mccs
+OCAML_PKG_decompress
+OCAML_PKG_checkseum
+OCAML_PKG_tar
 OCAML_PKG_patch
 OCAML_PKG_swhid_core
 OCAML_PKG_sha
@@ -5933,7 +5936,7 @@ x$ax_compare_version_B" | sed 's/^ *//' | sort -r | sed "s/x${ax_compare_version
 
   fi
 
-  echo "(-noautolink -cclib -l${unix_lib_name} -cclib -lmccs_stubs -cclib -lmccs_glpk_stubs -cclib -lsha_stubs -cclib -lopam_core_stubs ${platform_dependent_stuff})" > src/client/linking.sexp
+  echo "(-noautolink -cclib -l${unix_lib_name} -cclib -lmccs_stubs -cclib -lmccs_glpk_stubs -cclib -lsha_stubs -cclib -lopam_core_stubs -cclib -lcheckseum_c_stubs ${platform_dependent_stuff})" > src/client/linking.sexp
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: static" >&5
 printf "%s\n" "static" >&6; }
 
@@ -6834,6 +6837,192 @@ else $as_nop
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
     OCAML_PKG_patch=no
+
+fi
+
+
+
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for OCaml findlib package tar 3.3.0 or later" >&5
+printf %s "checking for OCaml findlib package tar 3.3.0 or later... " >&6; }
+
+  if version=`$OCAMLFIND query tar -format '%v' 2>/dev/null`
+then :
+
+
+
+
+  # Used to indicate true or false condition
+  ax_compare_version=false
+
+  # Convert the two version strings to be compared into a format that
+  # allows a simple string comparison.  The end result is that a version
+  # string of the form 1.12.5-r617 will be converted to the form
+  # 0001001200050617.  In other words, each number is zero padded to four
+  # digits, and non digits are removed.
+
+  ax_compare_version_A=`echo "$version" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
+                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/[^0-9]//g'`
+
+
+  ax_compare_version_B=`echo "3.3.0" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
+                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/[^0-9]//g'`
+
+
+    ax_compare_version=`echo "x$ax_compare_version_A
+x$ax_compare_version_B" | sed 's/^ *//' | sort -r | sed "s/x${ax_compare_version_A}/false/;s/x${ax_compare_version_B}/true/;1q"`
+
+
+
+    if test "$ax_compare_version" = "true" ; then
+
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no ($version installed)" >&5
+printf "%s\n" "no ($version installed)" >&6; }
+      OCAML_PKG_tar=no
+
+    else
+      OCAML_PKG_tar=tar
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found $version" >&5
+printf "%s\n" "found $version" >&6; }
+
+  fi
+
+
+else $as_nop
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+    OCAML_PKG_tar=no
+
+fi
+
+
+
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for OCaml findlib package checkseum 0.5.2 or later" >&5
+printf %s "checking for OCaml findlib package checkseum 0.5.2 or later... " >&6; }
+
+  if version=`$OCAMLFIND query checkseum -format '%v' 2>/dev/null`
+then :
+
+
+
+
+  # Used to indicate true or false condition
+  ax_compare_version=false
+
+  # Convert the two version strings to be compared into a format that
+  # allows a simple string comparison.  The end result is that a version
+  # string of the form 1.12.5-r617 will be converted to the form
+  # 0001001200050617.  In other words, each number is zero padded to four
+  # digits, and non digits are removed.
+
+  ax_compare_version_A=`echo "$version" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
+                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/[^0-9]//g'`
+
+
+  ax_compare_version_B=`echo "0.5.2" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
+                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/[^0-9]//g'`
+
+
+    ax_compare_version=`echo "x$ax_compare_version_A
+x$ax_compare_version_B" | sed 's/^ *//' | sort -r | sed "s/x${ax_compare_version_A}/false/;s/x${ax_compare_version_B}/true/;1q"`
+
+
+
+    if test "$ax_compare_version" = "true" ; then
+
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no ($version installed)" >&5
+printf "%s\n" "no ($version installed)" >&6; }
+      OCAML_PKG_checkseum=no
+
+    else
+      OCAML_PKG_checkseum=checkseum
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found $version" >&5
+printf "%s\n" "found $version" >&6; }
+
+  fi
+
+
+else $as_nop
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+    OCAML_PKG_checkseum=no
+
+fi
+
+
+
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for OCaml findlib package decompress 1.5.1 or later" >&5
+printf %s "checking for OCaml findlib package decompress 1.5.1 or later... " >&6; }
+
+  if version=`$OCAMLFIND query decompress -format '%v' 2>/dev/null`
+then :
+
+
+
+
+  # Used to indicate true or false condition
+  ax_compare_version=false
+
+  # Convert the two version strings to be compared into a format that
+  # allows a simple string comparison.  The end result is that a version
+  # string of the form 1.12.5-r617 will be converted to the form
+  # 0001001200050617.  In other words, each number is zero padded to four
+  # digits, and non digits are removed.
+
+  ax_compare_version_A=`echo "$version" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
+                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/[^0-9]//g'`
+
+
+  ax_compare_version_B=`echo "1.5.1" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
+                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
+                     -e 's/[^0-9]//g'`
+
+
+    ax_compare_version=`echo "x$ax_compare_version_A
+x$ax_compare_version_B" | sed 's/^ *//' | sort -r | sed "s/x${ax_compare_version_A}/false/;s/x${ax_compare_version_B}/true/;1q"`
+
+
+
+    if test "$ax_compare_version" = "true" ; then
+
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no ($version installed)" >&5
+printf "%s\n" "no ($version installed)" >&6; }
+      OCAML_PKG_decompress=no
+
+    else
+      OCAML_PKG_decompress=decompress
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found $version" >&5
+printf "%s\n" "found $version" >&6; }
+
+  fi
+
+
+else $as_nop
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+    OCAML_PKG_decompress=no
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -374,7 +374,7 @@ AS_IF([test "${enable_static}" = yes],[
   ],[
     unix_lib_name=unixnat
   ])
-  echo "(-noautolink -cclib -l${unix_lib_name} -cclib -lmccs_stubs -cclib -lmccs_glpk_stubs -cclib -lsha_stubs -cclib -lopam_core_stubs ${platform_dependent_stuff})" > src/client/linking.sexp
+  echo "(-noautolink -cclib -l${unix_lib_name} -cclib -lmccs_stubs -cclib -lmccs_glpk_stubs -cclib -lsha_stubs -cclib -lopam_core_stubs -cclib -lcheckseum_c_stubs ${platform_dependent_stuff})" > src/client/linking.sexp
   AC_MSG_RESULT([static])
 ],[
   AC_MSG_RESULT([shared])
@@ -398,6 +398,9 @@ AC_CHECK_OCAML_PKG_AT_LEAST([uutf], [1.0.3])
 AC_CHECK_OCAML_PKG_AT_LEAST([sha], [1.13])
 AC_CHECK_OCAML_PKG_AT_LEAST([swhid_core], [0.1])
 AC_CHECK_OCAML_PKG_AT_LEAST([patch], [3.0.0])
+AC_CHECK_OCAML_PKG_AT_LEAST([tar], [3.3.0])
+AC_CHECK_OCAML_PKG_AT_LEAST([checkseum], [0.5.2])
+AC_CHECK_OCAML_PKG_AT_LEAST([decompress], [1.5.1])
 
 # Optional dependencies
 AC_CHECK_OCAML_PKG_AT_LEAST([mccs],[1.1+17])

--- a/doc/index.html
+++ b/doc/index.html
@@ -186,6 +186,8 @@ td.sublib {
   <td>Mercurial support (through OpamVCS)</td></tr>
 <tr><th><a href="opam-repository/OpamRepository">opamRepository.ml</a></th>
   <td>Operations on repositories (update, fetch...) based on the above backends</td></tr>
+<tr><th><a href="opam-repository/OpamTar">opamTar.ml</a></th>
+  <td>Tar gaz archives manipulations: creations, folding, writing</td></tr>
 
 <tr class="lib">
   <th><a href="opam-solver"><code>src/solver</code></a></th>

--- a/master_changes.md
+++ b/master_changes.md
@@ -65,6 +65,7 @@ users)
 ## Lint
 
 ## Repository
+  * No longer call tar tool to create archives, use tar library instead [#6945 @kit-ty-kate]
 
 ## Lock
 
@@ -217,6 +218,7 @@ users)
   * `OpamRepositoryPath` was moved to `opam-format` [#6917 @rjbou]
   * `OpamRepositoryRoot` was added [#6680 @kit-ty-kate @rjbou]
   * `OpamTar`: add module to manipulate tar gz archive. It handles only files, not directories [#6945 @kit-ty-kate @rjbou]
+  * `OpamRepositoryCommand.update_with_auto_upgrade`, `OpamUpdate.repository`: no longer call an external process to create an archive [#6945 @kit-ty-kate]
 
 ## opam-state
   * `OpamStateConfig.t`: replace `no_depexts` fields that contains disabling informations by `depexts` field that returns if the depexts mechanism is enabled. This field is automatically update by global config value in `OpamStateConfig.load_defaults` [#6489 @rjbou]
@@ -282,3 +284,5 @@ users)
   * `OpamSystem.{command,commands,read_command_output}`: add a `?dir: dirname` optional arg to launch the command in a specific directory [#6910 @NathanReb]
   * `OpamFilename.Unix`: add `starts_with` [#6945 @rjbou]
   * `OpamCompat.Seq`: add `to_dispenser` [#6945 @kit-ty-kate]
+  * `OpamSystem.directories_with_links`, `OpamSystem.rec_files`, `OpamFilename.rec_files`: add optional `?except_vcs` that default to false to exclude VCS directories [#6945 @kit-ty-kate @rjbou]
+  * `OpamFilename.make_tar_gz{_job}`: rename `make_tar_gz_job` into `make_tar_gz` as it no longer need an external process call [#6945 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -279,3 +279,4 @@ users)
   * `OpamSystem.in_dir`: removed [#6910 @NathanReb]
   * `OpamSystem.chdir`: removed [#6910 @NathanReb]
   * `OpamSystem.{command,commands,read_command_output}`: add a `?dir: dirname` optional arg to launch the command in a specific directory [#6910 @NathanReb]
+  * `OpamFilename.Unix`: add `starts_with` [#6945 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -216,6 +216,7 @@ users)
 ## opam-repository
   * `OpamRepositoryPath` was moved to `opam-format` [#6917 @rjbou]
   * `OpamRepositoryRoot` was added [#6680 @kit-ty-kate @rjbou]
+  * `OpamTar`: add module to manipulate tar gz archive. It handles only files, not directories [#6945 @kit-ty-kate @rjbou]
 
 ## opam-state
   * `OpamStateConfig.t`: replace `no_depexts` fields that contains disabling informations by `depexts` field that returns if the depexts mechanism is enabled. This field is automatically update by global config value in `OpamStateConfig.load_defaults` [#6489 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -280,3 +280,4 @@ users)
   * `OpamSystem.chdir`: removed [#6910 @NathanReb]
   * `OpamSystem.{command,commands,read_command_output}`: add a `?dir: dirname` optional arg to launch the command in a specific directory [#6910 @NathanReb]
   * `OpamFilename.Unix`: add `starts_with` [#6945 @rjbou]
+  * `OpamCompat.Seq`: add `to_dispenser` [#6945 @kit-ty-kate]

--- a/opam-repository.opam
+++ b/opam-repository.opam
@@ -32,4 +32,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "opam-format" {= version}
   "patch" {>= "3.0.0"}
+  "tar" {>= "3.3.0"}
+  "checkseum" {>= "0.5.2"}
+  "decompress" {>= "1.5.1"}
 ]

--- a/release/Makefile
+++ b/release/Makefile
@@ -66,25 +66,25 @@ build/%.image: build/Dockerfile.%
 
 CLINKING_linux = \
 -Wl,-Bstatic \
--lunix -lmccs_stubs -lmccs_glpk_stubs -lsha_stubs -lopam_core_stubs \
+-lunix -lmccs_stubs -lmccs_glpk_stubs -lsha_stubs -lopam_core_stubs -lcheckseum_c_stubs \
 -lstdc++ \
 -static-libgcc \
 -static
 # -Wl,-Bdynamic
 
 CLINKING_macos = \
--lunix -lmccs_stubs -lmccs_glpk_stubs -lsha_stubs -lopam_core_stubs \
+-lunix -lmccs_stubs -lmccs_glpk_stubs -lsha_stubs -lopam_core_stubs -lcheckseum_c_stubs \
 -lstdc++
 
 CLINKING_freebsd = $(CLINKING_macos)
 CLINKING_netbsd = $(CLINKING_macos)
 
 CLINKING_openbsd = \
--lunix -lmccs_stubs -lmccs_glpk_stubs -lsha_stubs -lopam_core_stubs \
+-lunix -lmccs_stubs -lmccs_glpk_stubs -lsha_stubs -lopam_core_stubs -lcheckseum_c_stubs \
 -lstdc++ -lc++ -lc++abi -static
 
 CLINKING_windows = \
--lunix -lmccs_stubs -lmccs_glpk_stubs -lsha_stubs -lopam_core_stubs \
+-lunix -lmccs_stubs -lmccs_glpk_stubs -lsha_stubs -lopam_core_stubs -lcheckseum_c_stubs \
 -l:libstdc++.a -l:libpthread.a \
 -Wl,-static \
 -ladvapi32 -lgdi32 -luser32 -lshell32 -lole32 -luuid -luserenv

--- a/src/client/opamRepositoryCommand.ml
+++ b/src/client/opamRepositoryCommand.ml
@@ -259,23 +259,15 @@ let update_with_auto_upgrade rt repo_names =
                 OpamRepositoryState.Cache.remove ());
              OpamConsole.msg "Upgrading repository \"%s\"...\n"
                (OpamRepositoryName.to_string r.repo_name);
-             let open OpamProcess.Job.Op in
              let repo_root =
                match OpamRepositoryState.get_repo_root rt r with
                | OpamRepositoryRoot.Dir x -> x
              in
              OpamAdminRepoUpgrade.do_upgrade repo_root;
              if OpamRepositoryConfig.(!r.repo_tarring) then
-               OpamProcess.Job.run
-                 (OpamRepositoryRoot.make_tar_gz_job
-                    (OpamRepositoryPath.tar rt.repos_global.root r.repo_name)
-                    repo_root
-                  @@| function
-                  | Some e ->
-                    Printf.ksprintf failwith
-                      "Failed to regenerate local repository archive: %s"
-                      (Printexc.to_string e)
-                  | None -> ());
+               OpamRepositoryRoot.make_tar_gz
+                 (OpamRepositoryPath.tar rt.repos_global.root r.repo_name)
+                 repo_root;
              let def =
                OpamRepositoryRoot.Dir.Path.repo repo_root
                |> OpamFile.Repo.safe_read

--- a/src/core/opamCompat.ml
+++ b/src/core/opamCompat.ml
@@ -76,6 +76,14 @@ module Seq = struct
       | Some _ as result ->
           result
 
+  (** NOTE: OCaml >= 4.14 *)
+  let to_dispenser seq =
+    let r = ref seq in
+    fun () ->
+      match !r () with
+      | Seq.Nil -> None
+      | Seq.Cons (x, xs) -> r := xs; Some x
+
   include Seq
 end
 

--- a/src/core/opamCompat.mli
+++ b/src/core/opamCompat.mli
@@ -34,6 +34,9 @@ end
 module Seq : sig
   (* NOTE: OCaml >= 4.14 *)
   val find_map: ('a -> 'b option) -> 'a Seq.t -> 'b option
+
+  (* NOTE: OCaml >= 4.14 *)
+  val to_dispenser : 'a Seq.t -> unit -> 'a option
 end
 
 module Either : sig

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -392,9 +392,6 @@ let extract_in filename dirname =
 let extract_in_job filename dirname =
   OpamSystem.extract_in_job (to_string filename) ~dir:(Dir.to_string dirname)
 
-let make_tar_gz_job filename dirname =
-  OpamSystem.make_tar_gz_job (to_string filename) ~dir:(Dir.to_string dirname)
-
 type generic_file =
   | D of Dir.t
   | F of t

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -810,4 +810,11 @@ module Unix = struct
 
   let of_filename x = OpamSystem.back_to_forward (concat x.dirname x.basename)
   let to_filename x = {dirname = dirname x; basename = basename x}
+
+  let starts_with prefix filename =
+    if prefix = (filename : string) then true
+    else
+      let prefix = concat prefix "" in
+      OpamCompat.String.starts_with ~prefix filename
+
 end

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -423,4 +423,8 @@ module Unix : sig
   val of_filename : filename -> t
 
   val to_filename : t -> filename
+
+  (** Check whether a filename starts by a given Dir.t *)
+  val starts_with: Dir.t -> t -> bool
+
 end

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -251,8 +251,6 @@ val extract_in: t -> Dir.t -> unit
 
 val extract_in_job: t -> Dir.t -> exn option OpamProcess.job
 
-val make_tar_gz_job: t -> Dir.t -> exn option OpamProcess.job
-
 (** Extract a generic file *)
 val extract_generic_file: generic_file -> Dir.t -> unit
 

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -937,17 +937,6 @@ module Tar = struct
           make_command tar_cmd [ Printf.sprintf "xf%c" c ; f file; "-C" ; f dir ]
         in
         command (extract_option typ))
-
-  let compress_command =
-    fun file dir ->
-      let f = Lazy.force cygpath_tar in
-      let tar_cmd = Lazy.force tar_cmd in
-      make_command tar_cmd [
-        "cfz"; f file;
-        "-C" ; f (Filename.dirname dir);
-        f (Filename.basename dir)
-      ]
-
 end
 
 module Zip = struct
@@ -987,16 +976,6 @@ let is_archive file =
 let extract_command file =
   if Zip.is_archive file then Zip.extract_command file
   else Tar.extract_command file
-
-let make_tar_gz_job ~dir file =
-  let tmpfile = file ^ ".tmp" in
-  remove_file tmpfile;
-  Tar.compress_command tmpfile dir @@> fun r ->
-  OpamProcess.cleanup r;
-  if OpamProcess.is_success r then
-    (mv tmpfile file; Done None)
-  else
-    (remove_file tmpfile; Done (Some (Process_error r)))
 
 let extract_job ~dir file =
   if not (Sys.file_exists file) then

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -287,8 +287,6 @@ val extract_in: dir:string -> string -> unit
 (** [extract_in_job] is similar to [extract_in], but as a job *)
 val extract_in_job: dir:string -> string -> exn option OpamProcess.job
 
-val make_tar_gz_job: dir:string -> string -> exn option OpamProcess.job
-
 (** Create a directory. Do not fail if the directory already
     exist. *)
 val mkdir: string -> unit

--- a/src/repository/dune
+++ b/src/repository/dune
@@ -3,7 +3,7 @@
   (public_name opam-repository)
   (synopsis    "OCaml Package Manager remote repository handling library")
   ; TODO: Remove (re_export ...) when CI uses the OCaml version that includes https://github.com/ocaml/ocaml/pull/11989
-  (libraries   (re_export opam-format) patch)
+  (libraries   (re_export opam-format) patch tar tar.gz checkseum.c decompress.gz)
   (flags       (:standard
                (:include ../ocaml-flags-standard.sexp)
                (:include ../ocaml-flags-configure.sexp)

--- a/src/repository/opamRepositoryRoot.ml
+++ b/src/repository/opamRepositoryRoot.ml
@@ -55,7 +55,7 @@ module Dir = struct
     end)
 end
 
-let make_tar_gz_job = OpamFilename.make_tar_gz_job
+let make_tar_gz = OpamTar.create
 let extract_in_job = OpamFilename.extract_in_job
 
 type t =

--- a/src/repository/opamRepositoryRoot.mli
+++ b/src/repository/opamRepositoryRoot.mli
@@ -54,7 +54,7 @@ module Dir : sig
      and type 'a typed_file = 'a OpamFile.t
 end
 
-val make_tar_gz_job : filename -> Dir.t -> exn option OpamProcess.job
+val make_tar_gz : filename -> Dir.t -> unit
 val extract_in_job : filename -> Dir.t -> exn option OpamProcess.job
 
 type t =

--- a/src/repository/opamTar.ml
+++ b/src/repository/opamTar.ml
@@ -18,45 +18,50 @@ type archived_file_content = string
 
 let log ?level fmt = OpamConsole.log "TAR" ?level fmt
 
+exception Tar of archive * string
+let raise_error tar fmt =
+  Printf.ksprintf (fun str -> raise (Tar (tar, str))) fmt
+
 let rec safe_read fd buf off len =
   try Unix.read fd buf off len
   with Unix.Unix_error (Unix.EINTR, _, _) -> safe_read fd buf off len
 
-let rec run : type a. Unix.file_descr -> (a, _, _) Tar.t -> a = fun fd -> function
-  | Tar.Read len ->
-    let b = Bytes.create len in
-    let read = safe_read fd b 0 len in
-    if read = 0 then
-      failwith "unexpected end of file"
-    else if len = (read : int) then
-      Bytes.unsafe_to_string b
-    else
-      Bytes.sub_string b 0 read
-  | Tar.Really_read len ->
-    let rec loop fd buf offset len =
-      if offset < (len : int) then
-        let n = safe_read fd buf offset (len - offset) in
-        if n = 0 then
-          failwith "unexpected end of file"
-        else
-          loop fd buf (offset + n) len
-    in
-    let buf = Bytes.create len in
-    loop fd buf 0 len;
-    Bytes.unsafe_to_string buf
-  | Tar.Return (Ok x) -> x
-  | Tar.Return (Error e) ->
-    let error =
-      match e with
-      | `Fatal e -> Format.asprintf "Fatal: %a" Tar.pp_error e
-      | `Eof -> "EOF"
-      | `Gz s -> "gz: "^s
-    in
-    failwith error
-  | Tar.High _ | Tar.Write _ | Tar.Seek _ -> assert false
-  | Tar.Bind (x, f) -> run fd (f (run fd x))
+let run archive =
+  let raise_error fmt = raise_error archive fmt in
+  let rec run : type a. Unix.file_descr -> (a, _, _) Tar.t -> a = fun fd -> function
+    | Tar.Read len ->
+      let b = Bytes.create len in
+      let read = safe_read fd b 0 len in
+      if read = 0 then
+        raise_error "unexpected end of file"
+      else if len = (read : int) then
+        Bytes.unsafe_to_string b
+      else
+        Bytes.sub_string b 0 read
+    | Tar.Really_read len ->
+      let rec loop fd buf offset len =
+        if offset < (len : int) then
+          let n = safe_read fd buf offset (len - offset) in
+          if n = 0 then
+            raise_error "unexpected end of file"
+          else
+            loop fd buf (offset + n) len
+      in
+      let buf = Bytes.create len in
+      loop fd buf 0 len;
+      Bytes.unsafe_to_string buf
+    | Tar.Return (Ok x) -> x
+    | Tar.Return (Error e) ->
+      raise_error "%s"
+        (match e with
+         | `Fatal e -> Format.asprintf "Fatal: %a" Tar.pp_error e
+         | `Eof -> "EOF"
+         | `Gz s -> "gz: "^s)
+    | Tar.High _ | Tar.Write _ | Tar.Seek _ -> assert false
+    | Tar.Bind (x, f) -> run fd (f (run fd x))
+  in run
 
-let fold_reg_files_aux f acc fd =
+let fold_reg_files_aux archive f acc fd =
   let go ?global:_ hdr acc =
     match hdr.Tar.Header.link_indicator with
     | Normal ->
@@ -74,12 +79,12 @@ let fold_reg_files_aux f acc fd =
     | LongLink -> failwith "longlinks unsupported"
     | LongName -> failwith "longnames unsupported"
   in
-  run fd (Tar_gz.in_gzipped (Tar.fold go acc))
+  run archive fd (Tar_gz.in_gzipped (Tar.fold go acc))
 
 let fold_reg_files f acc archive =
   let fd = Unix.openfile (OpamFilename.to_string archive) [Unix.O_RDONLY] 0 in
   Fun.protect ~finally:(fun () -> Unix.close fd) @@ fun () ->
-  fold_reg_files_aux f acc fd
+  fold_reg_files_aux archive f acc fd
 
 module Inplace = struct
   module Map = OpamFilename.Unix.Map
@@ -95,7 +100,8 @@ module Inplace = struct
     f {
       archive = archive;
       fd;
-      content = fold_reg_files_aux (fun acc k x -> Map.add k x acc) Map.empty fd
+      content =
+        fold_reg_files_aux archive (fun acc k x -> Map.add k x acc) Map.empty fd
     }
 
   let fold_reg_files f acc t =
@@ -136,8 +142,8 @@ module Inplace = struct
           assert false
         | Tar.Return (Ok value) ->
           value
-        | Tar.Return (Error _) ->
-          failwith "something went wrong"
+        | Tar.Return (Error e) ->
+          raise_error t.archive "%s" (match e with | `Msg e -> e)
         | Tar.Bind (x, f) ->
           run buf (f (run buf x))
       in

--- a/src/repository/opamTar.ml
+++ b/src/repository/opamTar.ml
@@ -76,24 +76,24 @@ let fold_reg_files_aux f acc fd =
   in
   run fd (Tar_gz.in_gzipped (Tar.fold go acc))
 
-let fold_reg_files f acc fname =
-  let fd = Unix.openfile (OpamFilename.to_string fname) [Unix.O_RDONLY] 0 in
+let fold_reg_files f acc archive =
+  let fd = Unix.openfile (OpamFilename.to_string archive) [Unix.O_RDONLY] 0 in
   Fun.protect ~finally:(fun () -> Unix.close fd) @@ fun () ->
   fold_reg_files_aux f acc fd
 
 module Inplace = struct
   module Map = OpamFilename.Unix.Map
   type t = {
-    filename: filename;
+    archive: archive;
     fd : Unix.file_descr;
     content : archived_file_content Map.t;
   }
 
-  let with_open_out fname f =
-    let fd = Unix.openfile (OpamFilename.to_string fname) [Unix.O_RDWR] 0o640 in
+  let with_open_out archive f =
+    let fd = Unix.openfile (OpamFilename.to_string archive) [Unix.O_RDWR] 0o640 in
     Fun.protect ~finally:(fun () -> Unix.close fd) @@ fun () ->
     f {
-      filename = fname;
+      archive = archive;
       fd;
       content = fold_reg_files_aux (fun acc k x -> Map.add k x acc) Map.empty fd
     }
@@ -128,7 +128,7 @@ module Inplace = struct
     { t with content }
 
   let write (t:t) =
-    let to_buffer (buf:Buffer.t) t =
+    let to_buffer (buf:Buffer.t) tar =
       let rec run : type a. Buffer.t -> (a, 'err, _) Tar.t -> a = fun buf -> function
         | Tar.Write str ->
           Buffer.add_string buf str
@@ -141,7 +141,7 @@ module Inplace = struct
         | Tar.Bind (x, f) ->
           run buf (f (run buf x))
       in
-      run buf t
+      run buf tar
     in
     let entries =
       let dispenser =
@@ -172,7 +172,7 @@ module Inplace = struct
     let str = Buffer.contents buf in
     let _ : int = Unix.lseek t.fd 0 Unix.SEEK_SET in
     Unix.ftruncate t.fd 0;
-    log ~level:3 "Writing archive %s" (OpamFilename.to_string t.filename);
+    log ~level:3 "Writing archive %s" (OpamFilename.to_string t.archive);
     let _ : int = Unix.write_substring t.fd str 0 (String.length str) in
     ()
 
@@ -195,4 +195,4 @@ let create tar dir =
         Inplace.Map.add k (OpamFilename.read f) map)
       Inplace.Map.empty files
   in
-  Inplace.write { filename = tar; fd; content }
+  Inplace.write { archive = tar; fd; content }

--- a/src/repository/opamTar.ml
+++ b/src/repository/opamTar.ml
@@ -1,0 +1,198 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2025-2026 Kate Deplaix                                    *)
+(*    Copyright 2026 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+open OpamTypes
+open Tar.Syntax
+
+type archive = filename
+type archived_file = OpamFilename.Unix.t
+type archived_file_content = string
+
+let log ?level fmt = OpamConsole.log "TAR" ?level fmt
+
+let rec safe_read fd buf off len =
+  try Unix.read fd buf off len
+  with Unix.Unix_error (Unix.EINTR, _, _) -> safe_read fd buf off len
+
+let rec run : type a. Unix.file_descr -> (a, _, _) Tar.t -> a = fun fd -> function
+  | Tar.Read len ->
+    let b = Bytes.create len in
+    let read = safe_read fd b 0 len in
+    if read = 0 then
+      failwith "unexpected end of file"
+    else if len = (read : int) then
+      Bytes.unsafe_to_string b
+    else
+      Bytes.sub_string b 0 read
+  | Tar.Really_read len ->
+    let rec loop fd buf offset len =
+      if offset < (len : int) then
+        let n = safe_read fd buf offset (len - offset) in
+        if n = 0 then
+          failwith "unexpected end of file"
+        else
+          loop fd buf (offset + n) len
+    in
+    let buf = Bytes.create len in
+    loop fd buf 0 len;
+    Bytes.unsafe_to_string buf
+  | Tar.Return (Ok x) -> x
+  | Tar.Return (Error e) ->
+    let error =
+      match e with
+      | `Fatal e -> Format.asprintf "Fatal: %a" Tar.pp_error e
+      | `Eof -> "EOF"
+      | `Gz s -> "gz: "^s
+    in
+    failwith error
+  | Tar.High _ | Tar.Write _ | Tar.Seek _ -> assert false
+  | Tar.Bind (x, f) -> run fd (f (run fd x))
+
+let fold_reg_files_aux f acc fd =
+  let go ?global:_ hdr acc =
+    match hdr.Tar.Header.link_indicator with
+    | Normal ->
+      let* content = Tar.really_read (Int64.to_int hdr.file_size) in
+      let acc = f acc (OpamFilename.Unix.of_string hdr.file_name) content in
+      Tar.return (Ok acc)
+    | Directory -> Tar.return (Ok acc)
+    | Hard -> failwith "hardlinks unsupported"
+    | Symbolic -> failwith "symlinks unsupported"
+    | Character -> failwith "char devices unsupported"
+    | Block -> failwith "block devices unsupported"
+    | FIFO -> failwith "fifo unsupported"
+    | GlobalExtendedHeader -> failwith "global extended header unsupported"
+    | PerFileExtendedHeader -> failwith "perfile extended header unsupported"
+    | LongLink -> failwith "longlinks unsupported"
+    | LongName -> failwith "longnames unsupported"
+  in
+  run fd (Tar_gz.in_gzipped (Tar.fold go acc))
+
+let fold_reg_files f acc fname =
+  let fd = Unix.openfile (OpamFilename.to_string fname) [Unix.O_RDONLY] 0 in
+  Fun.protect ~finally:(fun () -> Unix.close fd) @@ fun () ->
+  fold_reg_files_aux f acc fd
+
+module Inplace = struct
+  module Map = OpamFilename.Unix.Map
+  type t = {
+    filename: filename;
+    fd : Unix.file_descr;
+    content : archived_file_content Map.t;
+  }
+
+  let with_open_out fname f =
+    let fd = Unix.openfile (OpamFilename.to_string fname) [Unix.O_RDWR] 0o640 in
+    Fun.protect ~finally:(fun () -> Unix.close fd) @@ fun () ->
+    f {
+      filename = fname;
+      fd;
+      content = fold_reg_files_aux (fun acc k x -> Map.add k x acc) Map.empty fd
+    }
+
+  let fold_reg_files f acc t =
+    Map.fold (fun k x acc -> f acc k x) t.content acc
+
+  let exists fname t = Map.mem fname t.content
+
+  let read fname t = Map.find fname t.content
+
+  let add fname content t =
+    { t with content = Map.add fname content t.content }
+
+  let mv ~src ~dst t =
+    let file_content = read src t in
+    let content =
+      Map.remove src t.content
+      |> Map.add dst file_content
+    in
+    { t with content }
+
+  let remove fname t =
+    { t with content = Map.remove fname t.content }
+
+  let remove_dir dname t =
+    let content =
+      Map.filter (fun fname _ ->
+          not (OpamFilename.Unix.starts_with dname fname))
+        t.content
+    in
+    { t with content }
+
+  let write (t:t) =
+    let to_buffer (buf:Buffer.t) t =
+      let rec run : type a. Buffer.t -> (a, 'err, _) Tar.t -> a = fun buf -> function
+        | Tar.Write str ->
+          Buffer.add_string buf str
+        | Tar.Read _ | Tar.Really_read _ | Tar.Seek _ | Tar.High _ ->
+          assert false
+        | Tar.Return (Ok value) ->
+          value
+        | Tar.Return (Error _) ->
+          failwith "something went wrong"
+        | Tar.Bind (x, f) ->
+          run buf (f (run buf x))
+      in
+      run buf t
+    in
+    let entries =
+      let dispenser =
+        Map.to_seq t.content
+        |> Seq.map (fun (path, content) ->
+            let path = OpamFilename.Unix.to_string path in
+            let hdr =
+              Tar.Header.make ~file_mode:0o640 ~mod_time:0L ~user_id:0 ~group_id:0
+                path (Int64.of_int (String.length content))
+            in
+            let data =
+              let closed = ref false in
+              fun () -> match !closed with
+                | false -> closed := true; Tar.return (Ok (Some content))
+                | true -> Tar.return (Ok None) in
+            Some Tar.Header.Ustar, hdr, data)
+        |> OpamCompat.Seq.to_dispenser
+      in
+      fun () ->
+        match dispenser () with
+        | None -> Tar.return (Ok None)
+        | Some x -> Tar.return (Ok (Some x))
+    in
+    let tar = Tar.out ~level:Ustar entries in
+    let tar = Tar_gz.out_gzipped ~level:4 ~mtime:0l Gz.Unix tar in
+    let buf = Buffer.create 10_485_760 in
+    to_buffer buf tar;
+    let str = Buffer.contents buf in
+    let _ : int = Unix.lseek t.fd 0 Unix.SEEK_SET in
+    Unix.ftruncate t.fd 0;
+    log ~level:3 "Writing archive %s" (OpamFilename.to_string t.filename);
+    let _ : int = Unix.write_substring t.fd str 0 (String.length str) in
+    ()
+
+end
+
+let create tar dir =
+  log "creating archive %s from %s"
+    (OpamFilename.to_string tar)
+    (OpamFilename.Dir.to_string dir);
+  let fd =
+    Unix.openfile (OpamFilename.to_string tar)
+      [Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY] 0o640
+  in
+  Fun.protect ~finally:(fun () -> Unix.close fd) @@ fun () ->
+  let files = OpamFilename.rec_files dir in
+  let content =
+    let remove_prefix = OpamFilename.remove_prefix (OpamFilename.dirname_dir dir) in
+    List.fold_left (fun map f ->
+        let k = OpamFilename.Unix.of_string (remove_prefix f) in
+        Inplace.Map.add k (OpamFilename.read f) map)
+      Inplace.Map.empty files
+  in
+  Inplace.write { filename = tar; fd; content }

--- a/src/repository/opamTar.mli
+++ b/src/repository/opamTar.mli
@@ -1,0 +1,71 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2025-2026 Kate Deplaix                                    *)
+(*    Copyright 2026 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Tar gz archives manipulation *)
+(* The current implementation handles only files not directories *)
+
+open OpamTypes
+
+(* The archive file *)
+type archive = filename
+
+(* Filename of compressed file in archive *)
+type archived_file = unix_filename
+
+(* Archive compressed file content *)
+type archived_file_content = string
+
+(* Fold over files of an archive *)
+val fold_reg_files :
+  ('acc -> archived_file -> archived_file_content -> 'acc) -> 'acc -> archive
+  -> 'acc
+
+(* [create archive dir] Creates an compressed archive [archive] containing the
+   [dir] at root.
+   If the directory contains a VCS directory, it is not integrated in the
+   archive. *)
+val create : archive -> dirname -> unit
+
+(* This module contains helpers to act on the archive once openned *)
+module Inplace : sig
+  type t
+
+  (* Open an archive and fold over it *)
+  val with_open_out : archive -> (t -> 'a) -> 'a
+
+  (* Fold over files of an archive *)
+  val fold_reg_files :
+    ('acc -> archived_file -> archived_file_content -> 'acc) ->
+    'acc -> t -> 'acc
+
+  (* Return the content of the filename from the archive *)
+  val read: archived_file -> t -> archived_file_content
+
+  (* Add a file in an archive *)
+  val add : archived_file -> archived_file_content -> t -> t
+
+  (* Remove a file from an archive *)
+  val remove : archived_file -> t -> t
+
+  (* Remove the content of a directory from an archive *)
+  val remove_dir : unix_dirname -> t -> t
+
+  (* Move a file in the archive *)
+  val mv: src:archived_file -> dst:archived_file -> t -> t
+
+  (* Return true if the filename exists in the archive *)
+  val exists: archived_file -> t -> bool
+
+  (* Write the archive on disk.
+     Files will be written with permission 640, no timestamps (0), user id 0,
+     and group id 0. *)
+  val write : t -> unit
+end

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -125,8 +125,8 @@ let repository rt repo =
     let tarred_repo = OpamRepositoryPath.tar gt.root repo.repo_name in
     (if OpamRepositoryConfig.(!r.repo_tarring) then
        match repo_root with
-       | Dir dir -> OpamRepositoryRoot.make_tar_gz_job tarred_repo dir
-     else Done None)
+       | Dir dir -> OpamRepositoryRoot.make_tar_gz tarred_repo dir);
+    Done None
     @@+ function
     | Some e ->
       OpamStd.Exn.fatal e;

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -27,7 +27,8 @@ endif
 SRC_EXTS = \
   cppo base64 extlib re ocamlgraph cudf dose3 opam-file-format \
   stdlib-shims spdx_licenses opam-0install-cudf 0install-solver uutf \
-  jsonm sha swhid_core menhir patch
+  jsonm sha swhid_core menhir patch checkseum optint decompress tar \
+  dune-local
 
 ifeq ($(MCCS_ENABLED),true)
 SRC_EXTS := $(SRC_EXTS) mccs

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -56,3 +56,15 @@ MD5_menhir = 5ecb7f71cf374147d3d3137c6e2fe382
 
 URL_patch = https://github.com/hannesm/patch/releases/download/v3.1.0/patch-3.1.0.tbz
 MD5_patch = afda4079f824f3c2ae69f5064bcf870b
+
+URL_checkseum = https://github.com/mirage/checkseum/releases/download/v0.5.2/checkseum-0.5.2.tbz
+MD5_checkseum = 2e41c0d1ec16aca3f33b148b06ded014
+
+URL_optint = https://github.com/mirage/optint/releases/download/v0.3.0/optint-0.3.0.tbz
+MD5_optint = 46cc1b8bd00872529ac01407f908d389
+
+URL_decompress = https://github.com/mirage/decompress/releases/download/v1.5.3/decompress-1.5.3.tbz
+MD5_decompress = 6c22cdd6368a6c66fbcae2944578fdd7
+
+URL_tar = https://github.com/mirage/ocaml-tar/releases/download/v3.3.0/tar-3.3.0.tbz
+MD5_tar = ee524f7b7049342eaf2bcad0ef40d331

--- a/tests/reftests/action-disk.test
+++ b/tests/reftests/action-disk.test
@@ -1,5 +1,5 @@
 N0REP0
-### OPAMDEBUGSECTIONS="SYSTEM FILE(config) FILE(repos-config) FILE(repo) FILE(switch-config) FILE(switch-state) FILE(opam) FILE(environment) FILE(package-version-list) FILE(.install) FILE(changes) FILE(.config) CACHE(installed) CACHE(repository)"
+### OPAMDEBUGSECTIONS="TAR SYSTEM FILE(config) FILE(repos-config) FILE(repo) FILE(switch-config) FILE(switch-state) FILE(opam) FILE(environment) FILE(package-version-list) FILE(.install) FILE(changes) FILE(.config) CACHE(installed) CACHE(repository)"
 ### OPAMDEBUG=-5
 ### OPAMVERBOSE=2
 ### OPAMYES=1

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -35,8 +35,8 @@ build: ["test" "-f" "baz"]
 ### <REPO/packages/foo/foo.2/files/baz>
 some content
 ### sh hash.sh REPO foo.2
-### opam update default -vv | grep '^\+' | sed-cmd tar
-+ tar "cfz" "${BASEDIR}/OPAM/repo/default.tar.gz.tmp" "-C" "${BASEDIR}/OPAM/repo" "default"
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS=TAR opam update default | grep TAR
+TAR                             creating archive ${BASEDIR}/OPAM/repo/default.tar.gz from ${BASEDIR}/OPAM/repo/default
 ### ls $OPAMROOT/repo | grep -v "cache"
 default.tar.gz
 lock
@@ -72,9 +72,9 @@ build: ["test" "-f" "baz"]
 ### <REPO/packages/foo/foo.4/files/baz>
 some content
 ### sh hash.sh REPO foo.4
-### opam update -vv | grep '^\+' | sed-cmd tar
+### OPAMDEBUG=-1 OPAMDEBUGSECTIONS=TAR opam update -vv | grep '^(\+|TAR)' | sed-cmd tar
 + tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
-+ tar "cfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz.tmp" "-C" "${OPAMTMP}" "tarred"
+TAR                             creating archive ${BASEDIR}/OPAM/repo/tarred.tar.gz from ${OPAMTMP}/tarred
 ### opam install foo.4 -vv | grep '^\+' | sed-cmd test tar
 + tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${OPAMTMP}"
 + test "-f" "baz" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.4)


### PR DESCRIPTION
This PR adds in the API functions to manipulate `tar.gz` archives and use it to create archives in the code.
This new `OpamTar` module will be used in #6625 to open and read archives (internal representation of some repositories) without io.
Original work done by @kit-ty-kate

* [x] Queued on #6939
 
In the story of #6625
