### PR TITLE
Fix `undefined variable` error when a lock file filter contains an undefined variable

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -70,6 +70,7 @@ users)
   * No longer call tar tool to create archives, use tar library instead [#6945 @kit-ty-kate]
 
 ## Lock
+  * [BUG] Fix `undefined variable` error when a lock file filter contains an undefined variables: fail gracefully with strict mode, continue and default the variable to false on normal mode [#6947 @rjbou - fix #6946]
 
 ## Clean
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -180,6 +180,7 @@ users)
   * Fix trailing full path for `tar` call in `no-depexts-sandboxed.unix.test` [#6970 @rjbou]
   * Fix some forgotten sed in `extrasource` and `update` tests in #6734 [#6970 @rjbou]
   * Add a test for `opam config subst` [#6936 @NathanReb]
+  * Add a lock test for undefined variables in a lock file [#6947 @rjbou - fix #6946]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/src/state/opamPinned.ml
+++ b/src/state/opamPinned.ml
@@ -66,12 +66,12 @@ let check_locked ?locked default =
            OpamPackage.Name.Set.empty lock_depends
        in
        let base_formula =
-         OpamFilter.filter_deps ~build:true ~post:true ~test:false ~doc:false
-           ~dev_setup:false ~dev:false base_depends
+         OpamFilter.filter_deps ~default:false ~build:true ~post:true
+           ~test:false ~doc:false ~dev_setup:false ~dev:false base_depends
        in
        let lock_formula =
-         OpamFilter.filter_deps ~build:true ~post:true ~test:false ~doc:false
-           ~dev_setup:false ~dev:false lock_depends
+         OpamFilter.filter_deps ~default:false ~build:true ~post:true
+           ~test:false ~doc:false ~dev_setup:false ~dev:false lock_depends
        in
        let lpkg_f =
          lock_formula

--- a/tests/reftests/lock.test
+++ b/tests/reftests/lock.test
@@ -1370,3 +1370,20 @@ name: "distant-x"
 opam-version: "2.0"
 pin-depends: [["local-one.dev" "file://${BASEDIR}/local-one"] ["local-two.dev" "file://${BASEDIR}/local-two"]]
 version: "1"
+### : Undefined variables in lock files shouldn't fail on non strict mode :
+### <pin:with-nope/with-nope.opam>
+opam-version: "2.0"
+### <pin:with-nope/with-nope.opam.locked>
+opam-version: "2.0"
+depends: [ "nope" {with-nope} ]
+### # we need to disable strict mode to see the default behaviour
+### OPAMSTRICT=0
+### opam switch create undef-var --empty
+### opam pin ./with-nope --locked
+Fatal error: Undefined boolean filter value: with-nope
+# Return code 99 #
+### OPAMSTRICT=1
+### opam switch create undef-var-strict --empty
+### opam pin ./with-nope --locked
+Fatal error: Undefined boolean filter value: with-nope
+# Return code 99 #

--- a/tests/reftests/lock.test
+++ b/tests/reftests/lock.test
@@ -1380,10 +1380,23 @@ depends: [ "nope" {with-nope} ]
 ### OPAMSTRICT=0
 ### opam switch create undef-var --empty
 ### opam pin ./with-nope --locked
-Fatal error: Undefined boolean filter value: with-nope
-# Return code 99 #
+[NOTE] Package with-nope does not exist in opam repositories registered in the current switch.
+with-nope is now pinned to file://${BASEDIR}/with-nope (version dev)
+
+The following actions will be performed:
+=== install 1 package
+  - install with-nope dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved with-nope.dev  (file://${BASEDIR}/with-nope)
+-> installed with-nope.dev
+Done.
 ### OPAMSTRICT=1
 ### opam switch create undef-var-strict --empty
 ### opam pin ./with-nope --locked
-Fatal error: Undefined boolean filter value: with-nope
-# Return code 99 #
+[NOTE] Package with-nope does not exist in opam repositories registered in the current switch.
+with-nope is now pinned to file://${BASEDIR}/with-nope (version dev)
+
+[ERROR] Undefined filter variable with-nope in dependencies of with-nope.dev
+[NOTE] Pinning command successful, but your installed packages may be out of sync.
+# Return code 30 #


### PR DESCRIPTION
On strict mode, it fails gracefully, and on normal mode, it is "ignored", which is default to false.
fix #6946
