### PR TITLE
Upgrade opam root: add conditionnal hard upgrade

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -83,6 +83,7 @@ users)
 
 ## Format upgrade
   * Fix switch and repo format upgrade on Windows. A block occurred because the global lock fd was reopened instead of using the one already opened.  [#6839 @rjbou]
+  * Add opam root format upgrade conditional mechanism for hard upgrades [#6949 @rjbou]
 
 ## Sandbox
   * Allow the macOS sandbox to write in the `/var/folders/` and `/var/db/mds/` directories as it is required by some of macOS core tools [#4797 @kit-ty-kate - fix #4389 #6460]

--- a/src/state/opamFormatUpgrade.ml
+++ b/src/state/opamFormatUpgrade.ml
@@ -1174,7 +1174,17 @@ let latest_version = OpamFile.Config.root_version
    Essentially, a "Hard" upgrade is used where the change is difficult (or even
    impossible) to perform in-memory. We try our hardest to keep all format
    upgrades "Light" - i.e. the aim is that this version below should never
-   change. *)
+   change.
+
+   Nonetheless, in 2.6, we needed to do an hard upgrade (not possible to have
+   in-memory update), but only for a tiny number of users under some
+   circumstances. We decided to add the conditional hard upgrade. By default,
+   all users won't need to upgrade their opam root, but for a small number, it
+   will trigger an hard upgrade to that version. For each condition hard
+   upgrade, if the condition is not met, it will be a no-op light upgrade.
+   We want to keep the invariant that if there is an conditional hard upgrade,
+   there is no light upgrade associated to the same version.
+   *)
 let latest_hard_upgrade = (* to *) v2_0_beta5
 
 (* intermediate roots that need a hard upgrade when upgrading from them *)
@@ -1212,41 +1222,83 @@ let flock_root =
         "Could not acquire lock for performing format upgrade."
 
 (* returns hard upgrades * light upgrades lists *)
-let upgrades root_version =
+let upgrades root_version root config =
   let is_2_1_intermediate_root =
     List.exists (OpamVersion.equal root_version) v2_1_intermediate_roots
   in
-  let latest_hard_upgrade =
-    if is_2_1_intermediate_root then v2_1_rc else latest_hard_upgrade
+  let all_upgrades =
+    (if is_2_1_intermediate_root then [
+        v2_1_alpha,  from_2_0_to_2_1_alpha,        None;
+        v2_1_alpha2, from_2_1_alpha_to_2_1_alpha2, None;
+        v2_1_rc,     from_2_1_alpha2_to_2_1_rc,    None;
+        v2_1,        from_2_1_rc_to_2_1,           None;
+      ] else [
+       v1_1,        from_1_0_to_1_1,               None;
+       v1_2,        from_1_1_to_1_2,               None;
+       v1_3_dev2,   from_1_2_to_1_3_dev2,          None;
+       v1_3_dev5,   from_1_3_dev2_to_1_3_dev5,     None;
+       v1_3_dev6,   from_1_3_dev5_to_1_3_dev6,     None;
+       v1_3_dev7,   from_1_3_dev6_to_1_3_dev7,     None;
+       v2_0_alpha,  from_1_3_dev7_to_2_0_alpha,    None;
+       v2_0_alpha2, from_2_0_alpha_to_2_0_alpha2,  None;
+       v2_0_alpha3, from_2_0_alpha2_to_2_0_alpha3, None;
+       v2_0_beta,   from_2_0_alpha3_to_2_0_beta,   None;
+       v2_0_beta5,  from_2_0_beta_to_2_0_beta5,    None;
+       v2_0,        from_2_0_beta5_to_2_0,         None;
+       v2_1,        from_2_0_to_2_1,               None;
+     ]) @ [
+      v2_2_alpha,  from_2_1_to_2_2_alpha,          None;
+      v2_2_beta,   from_2_2_alpha_to_2_2_beta,     None;
+      v2_2,        from_2_2_beta_to_2_2,           None;
+    ]
   in
-  (if is_2_1_intermediate_root then [
-      v2_1_alpha,  from_2_0_to_2_1_alpha;
-      v2_1_alpha2, from_2_1_alpha_to_2_1_alpha2;
-      v2_1_rc,     from_2_1_alpha2_to_2_1_rc;
-      v2_1,        from_2_1_rc_to_2_1;
-    ] else [
-     v1_1,        from_1_0_to_1_1;
-     v1_2,        from_1_1_to_1_2;
-     v1_3_dev2,   from_1_2_to_1_3_dev2;
-     v1_3_dev5,   from_1_3_dev2_to_1_3_dev5;
-     v1_3_dev6,   from_1_3_dev5_to_1_3_dev6;
-     v1_3_dev7,   from_1_3_dev6_to_1_3_dev7;
-     v2_0_alpha,  from_1_3_dev7_to_2_0_alpha;
-     v2_0_alpha2, from_2_0_alpha_to_2_0_alpha2;
-     v2_0_alpha3, from_2_0_alpha2_to_2_0_alpha3;
-     v2_0_beta,   from_2_0_alpha3_to_2_0_beta;
-     v2_0_beta5,  from_2_0_beta_to_2_0_beta5;
-     v2_0,        from_2_0_beta5_to_2_0;
-     v2_1,        from_2_0_to_2_1;
-   ]) @ [
-    v2_2_alpha,  from_2_1_to_2_2_alpha;
-    v2_2_beta,   from_2_2_alpha_to_2_2_beta;
-    v2_2,        from_2_2_beta_to_2_2;
-  ]
-  |> List.filter (fun (v,_) ->
-      OpamVersion.compare root_version v < 0)
-  |> List.partition (fun (v,_) ->
-      OpamVersion.compare v latest_hard_upgrade <= 0)
+  (* First we filter the unneeded upgrades *)
+  let from_root_version =
+    List.filter (fun (v,_,_) ->
+        OpamVersion.compare root_version v < 0)
+      all_upgrades
+  in
+  (* We retrieve hard upgrades version : conditional and unconditional *)
+  let all_hard_upgrades =
+    let latest_hard_upgrade =
+      if is_2_1_intermediate_root then v2_1_rc
+      else latest_hard_upgrade
+    in
+    (latest_hard_upgrade
+     :: List.filter_map (function
+         | _, _, None -> None
+         | v, _, Some cond ->
+           if cond root config then Some v else None)
+       from_root_version)
+  in
+  let hard_upg, light_upg =
+    (* We take the last hard upgrade *)
+    let hard_upgrades =
+      List.filter (fun v ->
+          OpamVersion.compare root_version v < 0)
+        all_hard_upgrades
+      |> List.sort (fun v v' -> -(OpamVersion.compare v v'))
+    in
+    match hard_upgrades with
+    | latest_hard_upgrade::_ ->
+      List.partition (fun (v,_,_cond) ->
+          OpamVersion.compare v latest_hard_upgrade <= 0)
+        from_root_version
+    | [] ->
+      [],
+      (* If there is no hard upgrade, we add a light upgrade for conditional
+         hard upgrade versions *)
+      List.map (fun (v, f, cond) ->
+          let f =
+            match cond with
+            | Some _ -> fun ~on_the_fly:_ _ conf -> conf, gtc_none
+            | None -> f
+          in
+          v, f, cond)
+        from_root_version
+  in
+  let clean (x,y,_) = (x,y) in
+  List.map clean hard_upg, List.map clean light_upg
 
 let default_opam_root_version = v2_1_alpha
 
@@ -1270,7 +1322,7 @@ let as_necessary ?reinit requested_lock global_lock root config =
   let root_version = get_root_version root config in
   let cmp = OpamVersion.(compare OpamFile.Config.root_version root_version) in
   if cmp <= 0 then config, gtc_none (* newer or same *) else
-  let hard_upg, light_upg = upgrades root_version in
+  let hard_upg, light_upg = upgrades root_version root config in
   let need_hard_upg = hard_upg <> [] in
   let on_the_fly, global_lock_kind =
     if not need_hard_upg && requested_lock <> `Lock_write then
@@ -1416,7 +1468,7 @@ let as_necessary_repo_switch_t updates read_f lock_kind gt =
         (* we keep only light upgrades as hard upgrade is already handled by
            global state loading, so we must not have to handle hard upgrades
            as this point. *)
-        let _, upgrades = upgrades written_root_version in
+        let _, upgrades = upgrades written_root_version root config in
         let config =
           OpamStd.Option.default config
             (OpamFile.Config.BestEffort.read_opt config_f)

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -2908,11 +2908,11 @@ RSTATE                          Cache found
        Run `opam repository add root-config --all-switches|--set-default' to use it in all existing switches, or in newly created switches, respectively.
 
 ### # rw global state
-### opam option jobs=4 | "${OPAMROOTVERSION}$" -> "current"
+### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Light config upgrade, from 2.2~beta to current
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version 2.2, which can't be reverted.
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version current which can't be reverted.
 You may want to back it up before going further.
 
 Continue? [Y/n] y
@@ -2979,11 +2979,11 @@ The following actions will be performed:
 STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
-### opam option jobs=4 | "${OPAMROOTVERSION}$" -> "current"
+### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Light config upgrade, from 2.2~beta to current
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version 2.2, which can't be reverted.
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version current which can't be reverted.
 You may want to back it up before going further.
 
 Continue? [Y/n] y
@@ -3050,11 +3050,11 @@ The following actions will be performed:
 STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
-### opam option jobs=4 | "${OPAMROOTVERSION}$" -> "current"
+### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Light config upgrade, from 2.2~beta to current
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version 2.2, which can't be reverted.
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version current which can't be reverted.
 You may want to back it up before going further.
 
 Continue? [Y/n] y
@@ -3122,11 +3122,11 @@ The following actions will be performed:
 STATE                           dependencies (0.000) result={ i-am-sys-compiler.2 }
 Done.
 ### # rw global state
-### opam option jobs=4 | "${OPAMROOTVERSION}$" -> "current"
+### opam option jobs=4 | "${OPAMROOTVERSION}($|,)" -> "current"
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
 FMT_UPG                         Light config upgrade, from 2.2~beta to current
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version 2.2, which can't be reverted.
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version current which can't be reverted.
 You may want to back it up before going further.
 
 Continue? [Y/n] y
@@ -3162,12 +3162,12 @@ opam-version: "2.0"
 roots: ["i-am-package.2" "i-am-sys-compiler.2"]
 ### :V:7:e: reinit from 2.2~beta
 ### ocaml generate.ml 2.2~beta
-### opam init --reinit --bypass-checks --no-setup | grep -v Cygwin
+### opam init --reinit --bypass-checks --no-setup | "${OPAMROOTVERSION}($|,)" -> "current" | grep -v Cygwin
 No configuration file found, using built-in defaults.
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 [WARNING] Removing global switch 'this-internal-error' as it no longer exists
-FMT_UPG                         Light config upgrade, from 2.2~beta to 2.2
-This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version 2.2, which can't be reverted.
+FMT_UPG                         Light config upgrade, from 2.2~beta to current
+This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.2~beta to version current which can't be reverted.
 You may want to back it up before going further.
 
 Continue? [Y/n] y


### PR DESCRIPTION
For #6625, we need to perform an hard upgrade for a specific case that is not common.
We add then a in this PR a mechanism to perform conditional hard upgrade, like that most people are not affected by the hard upgrade.
We also add some invariant on conditional hard upgrade, if there is a conditional hard upgrade on a version X:
* there is no defined light upgrade in the upgrade code for version X
* there is an automatic generation of a no-op light upgrade, that sets the opam root to version X

In the story of #6625
