### PR TITLE
Apply opam-specific git config if not full_fetch

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -73,6 +73,7 @@ users)
 ## Source
   * When fetching a git repository (i.e. `--dev-repo` or a package with git url), the resulting git branch is now deterministically named `main` instead of taking the system's `init.defaultBranch` [#6992 @kit-ty-kate]
   * `opam source` no longer sets opam-specific git configuration options [#6955 @sporkl]
+  * `opam source` now uses VCS `clone` when possible [#6955 @sporkl]
 
 ## Lint
 
@@ -310,6 +311,7 @@ users)
   * `OpamRepositoryBackend.get_diff`: now computes the diff between two repository roots (dir, archive), instead of only dirs [#6625 @rjbou]
   * `OpamRepositoryRoot`: add `Tgz` module for tar gz archive repository root support [#6625 @rjbou @kit-ty-kate]
   * `OpamVCS.init`: add an optional `?for_source` argument [#6955 @sporkl]
+  * `OpamVCS.clone`: add new VCS `clone` function [#6955 @sporkl]
 
 ## opam-state
   * `OpamStateConfig.t`: replace `no_depexts` fields that contains disabling informations by `depexts` field that returns if the depexts mechanism is enabled. This field is automatically update by global config value in `OpamStateConfig.load_defaults` [#6489 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -72,6 +72,7 @@ users)
 
 ## Source
   * When fetching a git repository (i.e. `--dev-repo` or a package with git url), the resulting git branch is now deterministically named `main` instead of taking the system's `init.defaultBranch` [#6992 @kit-ty-kate]
+  * `opam source` no longer sets opam-specific git configuration options [#6955 @sporkl]
 
 ## Lint
 
@@ -292,6 +293,8 @@ users)
 ## opam-repository
   * `OpamGit.env` was added [#6992 @kit-ty-kate]
   * `OpamGit`: git is now always called with the `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` environment variables set to `/dev/null` [#6992 @kit-ty-kate]
+  * `OpamRepository.pull{,shared}_tree`: add an optional `?for_source` argument [#6955 @sporkl]
+  * `OpamRepositoryBackend.S.pull_url`: add an optional `?for_source` argument [#6955 @sporkl]
   * `OpamRepositoryPath` was moved to `opam-format` [#6917 @rjbou]
   * `OpamRepositoryRoot` was added [#6680 @kit-ty-kate @rjbou]
   * `OpamTar`: add module to manipulate tar gz archive. It handles only files, not directories [#6945 @kit-ty-kate @rjbou]
@@ -304,6 +307,7 @@ users)
   * `OpamRepositoryRoot`: add `read_file` that reads an `OpamFile.t` using its pp from the archive [#6625 @rjbou]
   * `OpamRepositoryBackend.get_diff`: now computes the diff between two repository roots (dir, archive), instead of only dirs [#6625 @rjbou]
   * `OpamRepositoryRoot`: add `Tgz` module for tar gz archive repository root support [#6625 @rjbou @kit-ty-kate]
+  * `OpamVCS.init`: add an optional `?for_source` argument [#6955 @sporkl]
 
 ## opam-state
   * `OpamStateConfig.t`: replace `no_depexts` fields that contains disabling informations by `depexts` field that returns if the depexts mechanism is enabled. This field is automatically update by global config value in `OpamStateConfig.load_defaults` [#6489 @rjbou]
@@ -322,6 +326,7 @@ users)
   * `OpamStateTypes`: add available system package status field `repos_syspkgs_available` (and its type `repo_syspkgs_available`) in `repos_state` for all the depexts declared in repo's packages. The new field is also added to the cache. [#6489 @arozovyk @rjbou]
   * `OpamRepositoryState.load`: load repo's available system packages [#6489 @arozovyk]
   * `OpamFileTools`: add `opams_depexts` to consolidate depexts extraction logic from individual opam files and package maps [#6489 @arozovyk]
+  * `OpamUpdate.download_package_source`: add an optional `?for_source` argument [#6955 @sporkl]
   * `OpamUpdate`: add `update_sys_available_cache` to update the system package availability cache in repository state [#6489 @arozovyk]
   * `OpamUpdate.get_sys_available`: factorize depexts availability computation logic from `OpamUpdate.repositories` [#6489 @arozovyk]
   * `OpamRepositoryState`: add `syspkgs_available` that returns the stored depext availability status in repository state [#6489 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -222,6 +222,7 @@ users)
   * Add a test showing the order of install actions for each relevant commands [#6864 @kit-ty-kate]
   * Add a test showing some of the internal steps of `opam init` [#6957 @kit-ty-kate]
   * Add tests for `.install` `root` and `rootexec` fields [#6938 @rjbou]
+  * Add a test showing the git commands called by `opam source` [#6955 @sporkl]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -224,6 +224,8 @@ users)
   * Add a test showing some of the internal steps of `opam init` [#6957 @kit-ty-kate]
   * Add tests for `.install` `root` and `rootexec` fields [#6938 @rjbou]
   * Add a test showing the git commands called by `opam source` [#6955 @sporkl]
+  * Add tests checking installation and source for mercurial repositories [#6955 @sporkl]
+  * Add tests checking installation and source for darcs repositories [#6955 @sporkl]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3822,6 +3822,7 @@ let source cli =
            match
              OpamProcess.Job.run
                (OpamRepository.pull_tree
+                  ~for_source:true
                   ~full_fetch:true
                   ~cache_dir:(OpamRepositoryPath.download_cache
                                 OpamStateConfig.(!r.root_dir))
@@ -3839,7 +3840,8 @@ let source cli =
       else
         (let job =
            let open OpamProcess.Job.Op in
-           OpamUpdate.download_package_source t nv dir @@+ function
+           OpamUpdate.download_package_source ~for_source:true t nv dir
+           @@+ function
            | Some (Not_available (_,s)), _ | _, (_, Not_available (_, s)) :: _ ->
              OpamConsole.error_and_exit `Sync_error "Download failed: %s" s
            | None, _ | Some (Result _ | Up_to_date _), _ ->

--- a/src/repository/opamDarcs.ml
+++ b/src/repository/opamDarcs.ml
@@ -35,6 +35,25 @@ module VCS = struct
     OpamSystem.raise_on_process_error r;
     Done ()
 
+  let clone ?full_fetch:_ repo_root url =
+    let repo_str =
+      match OpamUrl.local_dir url with
+      | Some path -> OpamFilename.Dir.to_string path
+      | None -> OpamUrl.base_url url
+    in
+    OpamFilename.with_tmp_dir_job @@ fun tmpdir ->
+    (* cannot clone directly into repo_root, so clone elsewhere and move *)
+    let repodir = tmpdir / "repo" in
+    darcs tmpdir [
+      "clone"; repo_str;
+      "--repodir"; OpamFilename.Dir.to_string repodir;
+      "--quiet"; "--lazy" ]
+    @@> fun r ->
+    OpamSystem.raise_on_process_error r;
+    OpamFilename.rmdir repo_root;
+    OpamFilename.move_dir ~src:repodir ~dst:repo_root;
+    Done ()
+
   let vc_dir repo_root = repo_root / "_darcs"
 
   (* Darcs has no branches, no proper diff, no way to reset, can't return a

--- a/src/repository/opamDarcs.ml
+++ b/src/repository/opamDarcs.ml
@@ -28,7 +28,7 @@ module VCS = struct
     | None -> fun cmd -> cmd
     | Some t -> fun cmd -> cmd @ [ "-t"; t ]
 
-  let init repo_root _repo_url =
+  let init ?for_source:_ repo_root _repo_url =
     OpamFilename.mkdir repo_root;
     darcs repo_root [ "init" ]
     @@> fun r ->

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -41,28 +41,39 @@ module VCS : OpamVCS.VCS = struct
       let env = env () in
       OpamSystem.make_command ~env ?verbose ?stdout "git" ("-C"::dir::args)
 
-  let init repo_root repo_url =
+  let init ?(for_source = false) repo_root repo_url =
     OpamFilename.mkdir repo_root;
-    OpamProcess.Job.of_list [
-      git repo_root [ "init"; "--initial-branch=main" ];
-      (* Enforce this option, it can break our use of git if set *)
-      git repo_root [ "config" ; "--local" ; "fetch.prune"; "false"];
-      (* We reset diff.noprefix to ensure we get a `-p1` patch and avoid <https://github.com/ocaml/opam/issues/3627>. *)
-      git repo_root [ "config" ; "--local" ; "diff.noprefix"; "false"];
-      (* Disable automatic line-ending conversion and switch core.eol to Unix.
-         THIS DOES NOT MEAN ALL FILES GET LF-ONLY LINE-ENDINGS!
-         This combination of settings means that files will be checked out
-         exactly as they appear in the repository, so if files are checked in
-         with CRLF line-endings (either by not having .gitattributes with
-         core.autocrlf = false, or having an explicit eol=crlf in
-         .gitattributes), then they will still be checked out with CRLF endings.
-       *)
-      git repo_root [ "config" ; "--local" ; "core.autocrlf"; "false"];
-      git repo_root [ "config" ; "--local" ; "core.eol"; "lf"];
-      git repo_root [ "config" ; "--local" ; "color.ui"; "false" ];
-      (* Document the remote for user-friendliness (we don't use it) *)
-      git repo_root [ "remote"; "add"; "origin"; OpamUrl.base_url repo_url ];
-    ] @@+ function
+    let if_not_for_source =
+      if not for_source then Option.some else Fun.const Option.none
+    in
+    (OpamProcess.Job.of_list @@ List.filter_map Fun.id [
+        Some (git repo_root [ "init"; "--initial-branch=main" ]);
+        (* Enforce this option, it can break our use of git if set *)
+        if_not_for_source
+          (git repo_root [ "config" ; "--local" ; "fetch.prune"; "false"]);
+        (* We reset diff.noprefix to ensure we get a `-p1` patch and avoid
+           https://github.com/ocaml/opam/issues/3627 *)
+        if_not_for_source
+          (git repo_root [ "config" ; "--local" ; "diff.noprefix"; "false"]);
+        (* Disable automatic line-ending conversion and switch core.eol to Unix.
+           THIS DOES NOT MEAN ALL FILES GET LF-ONLY LINE-ENDINGS!
+           This combination of settings means that files will be checked out
+           exactly as they appear in the repository, so if files are checked in
+           with CRLF line-endings (either by not having .gitattributes with
+           core.autocrlf = false, or having an explicit eol=crlf in
+           .gitattributes), then they will still be checked out with CRLF
+           endings.
+        *)
+        if_not_for_source
+          (git repo_root [ "config" ; "--local" ; "core.autocrlf"; "false" ]);
+        if_not_for_source
+          (git repo_root [ "config" ; "--local" ; "core.eol"; "lf" ]);
+        if_not_for_source
+          (git repo_root [ "config" ; "--local" ; "color.ui"; "false" ]);
+        (* Document the remote for user-friendliness (we don't use it) *)
+        Some (git repo_root
+                [ "remote"; "add"; "origin"; OpamUrl.base_url repo_url ]);
+      ]) @@+ function
     | None -> Done ()
     | Some (_,err) -> OpamSystem.process_error err
 

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -77,6 +77,27 @@ module VCS : OpamVCS.VCS = struct
     | None -> Done ()
     | Some (_,err) -> OpamSystem.process_error err
 
+  let clone ?(full_fetch = true) repo_root url =
+    OpamFilename.mkdir repo_root;
+    if full_fetch then
+      git repo_root [ "clone"; OpamUrl.base_url url; "." ]
+      @@> fun r ->
+      OpamSystem.raise_on_process_error r;
+      git repo_root
+        [ "submodule"; "update"; "--init"; "--recursive" ]
+      @@> fun r ->
+      OpamSystem.raise_on_process_error r;
+      Done ()
+    else
+      git repo_root [ "clone"; OpamUrl.base_url url; "."; "--depth"; "1" ]
+      @@> fun r ->
+      OpamSystem.raise_on_process_error r;
+      git repo_root
+        [ "submodule"; "update"; "--init"; "--recursive"; "--depth"; "1" ]
+      @@> fun r ->
+      OpamSystem.raise_on_process_error r;
+      Done ()
+
   let remote_ref url =
     match url.OpamUrl.hash with
     | Some h -> "refs/remotes/opam-ref-"^h

--- a/src/repository/opamHTTP.ml
+++ b/src/repository/opamHTTP.ml
@@ -68,7 +68,7 @@ module B = struct
 
   let repo_update_complete _ _ = Done ()
 
-  let pull_url ?full_fetch:_ ?cache_dir:_ ?subpath:_ dirname checksum remote_url =
+  let pull_url ?for_source:_ ?full_fetch:_ ?cache_dir:_ ?subpath:_ dirname checksum remote_url =
     log "pull-file into %a: %a"
       (slog OpamFilename.Dir.to_string) dirname
       (slog OpamUrl.to_string) remote_url;

--- a/src/repository/opamHg.ml
+++ b/src/repository/opamHg.ml
@@ -32,6 +32,12 @@ module VCS = struct
     OpamSystem.raise_on_process_error r;
     Done ()
 
+  let clone ?full_fetch:_ repo_root url =
+    OpamFilename.mkdir repo_root;
+    hg repo_root [ "clone"; OpamUrl.base_url url; "." ] @@> fun r ->
+    OpamSystem.raise_on_process_error r;
+    Done ()
+
   let mark_from_url url =
     match url.OpamUrl.hash with
     | None -> mark_prefix

--- a/src/repository/opamHg.ml
+++ b/src/repository/opamHg.ml
@@ -26,7 +26,7 @@ module VCS = struct
     fun ?verbose ?env ?stdout args ->
       OpamSystem.make_command ~dir ?verbose ?env ?stdout "hg" args
 
-  let init repo_root _repo_url =
+  let init ?for_source:_ repo_root _repo_url =
     OpamFilename.mkdir repo_root;
     hg repo_root [ "init" ] @@> fun r ->
     OpamSystem.raise_on_process_error r;

--- a/src/repository/opamLocal.ml
+++ b/src/repository/opamLocal.ml
@@ -203,7 +203,8 @@ module B = struct
 
   let repo_update_complete _ _ = Done ()
 
-  let pull_url ?full_fetch:_ ?cache_dir:_ ?subpath local_dirname _checksum remote_url =
+  let pull_url ?for_source:_ ?full_fetch:_ ?cache_dir:_ ?subpath
+      local_dirname _checksum remote_url =
     let local_dirname = OpamFilename.SubPath.(local_dirname /? subpath) in
     OpamFilename.mkdir local_dirname;
     let dir = OpamFilename.Dir.to_string local_dirname in

--- a/src/repository/opamRepository.ml
+++ b/src/repository/opamRepository.ml
@@ -171,7 +171,7 @@ let validate_and_add_to_cache label url cache_dir file checksums =
 
 (* [cache_dir] used to add to cache only *)
 let pull_from_upstream
-    label ?full_fetch ?(working_dir=false) ?subpath
+    label ?for_source ?full_fetch ?(working_dir=false) ?subpath
     cache_dir destdir checksums url =
   let module B = (val url_backend url: OpamRepositoryBackend.S) in
   let cksum = match checksums with [] -> None | c::_ -> Some c in
@@ -214,7 +214,7 @@ let pull_from_upstream
        )
      else url, B.pull_url
    in
-   pull ?full_fetch ?cache_dir ?subpath destdir cksum url
+   pull ?for_source ?full_fetch ?cache_dir ?subpath destdir cksum url
   )
   @@| function
   | (Result (Some file) | Up_to_date (Some file)) as ret ->
@@ -227,16 +227,16 @@ let pull_from_upstream
   | (Result None | Up_to_date None) as ret -> ret
   | Not_available _ as na -> na
 
-let pull_from_mirrors label ?full_fetch ?working_dir ?subpath
+let pull_from_mirrors label ?for_source ?full_fetch ?working_dir ?subpath
     cache_dir destdir checksums urls =
   let rec aux = function
-    | [] -> invalid_arg "pull_from_mirrors: empty mirror list"
+    | [] -> invalid_arg "?for_source pull_from_mirrors: empty mirror list"
     | [url] ->
-      pull_from_upstream label ?full_fetch ?working_dir ?subpath
+      pull_from_upstream label ?for_source ?full_fetch ?working_dir ?subpath
         cache_dir destdir checksums url
       @@| fun r -> url, r
     | url::mirrors ->
-      pull_from_upstream label ?full_fetch ?working_dir ?subpath
+      pull_from_upstream label ?for_source ?full_fetch ?working_dir ?subpath
         cache_dir destdir checksums url
       @@+ function
       | Not_available (_,s) ->
@@ -257,7 +257,7 @@ let pull_from_mirrors label ?full_fetch ?working_dir ?subpath
 
 (* handle subpathes *)
 let pull_tree_t
-    ?full_fetch ?cache_dir ?(cache_urls=[]) ?working_dir
+    ?for_source ?full_fetch ?cache_dir ?(cache_urls=[]) ?working_dir
     dirnames checksums remote_urls =
   let extract_archive =
     let fallback success = function
@@ -377,7 +377,7 @@ let pull_tree_t
         in
         fun label checksums remote_urls ->
           pull_from_mirrors (OpamStd.Option.default label label0)
-            ?full_fetch ?working_dir ?subpath cache_dir destdir
+            ?for_source ?full_fetch ?working_dir ?subpath cache_dir destdir
             checksums remote_urls
           @@| fun (url, res) ->
           (OpamUrl.to_string_w_subpath subpath url),
@@ -393,13 +393,14 @@ let pull_tree_t
 
 
 let pull_tree label
-    ?full_fetch ?cache_dir ?(cache_urls=[]) ?working_dir ?subpath
+    ?for_source ?full_fetch ?cache_dir ?(cache_urls=[]) ?working_dir ?subpath
     local_dirname  =
-  pull_tree_t ?full_fetch ?cache_dir ~cache_urls ?working_dir
+  pull_tree_t ?for_source ?full_fetch ?cache_dir ~cache_urls ?working_dir
     [label, local_dirname, subpath]
 
-let pull_shared_tree ?cache_dir ?(cache_urls=[]) dirnames checksums remote_urls =
-  pull_tree_t ?cache_dir ~cache_urls dirnames checksums remote_urls
+let pull_shared_tree
+    ?for_source ?cache_dir ?(cache_urls=[]) dirnames checksums remote_urls =
+  pull_tree_t ?for_source ?cache_dir ~cache_urls dirnames checksums remote_urls
 
 let revision dirname url =
   let kind = url.OpamUrl.backend in

--- a/src/repository/opamRepository.mli
+++ b/src/repository/opamRepository.mli
@@ -31,7 +31,8 @@ val update:
   repository -> OpamRepositoryRoot.t ->
   [`Changes of Patch.operation list |`No_changes] OpamProcess.job
 
-(** [pull_shared_tree ?cache_dir ?cache_url labels_dirnames checksums urls]
+(** [pull_shared_tree ?for_source ?cache_dir ?cache_url
+     labels_dirnames checksums urls]
     Fetch an URL and put the resulting tree into the supplied directories
     specified in [labels_dirnames]. The string in [labels_dirnames] are text
     labels of this given dirname for display. [urls] must either point to a
@@ -39,8 +40,11 @@ val update:
     [cache_dir] is used and supplied the hashes verified, then the archive
     uncompressed. In case of a version-controlled URL, it's checked out, or
     synchronised directly if local and [working_dir] was set.  [cache_urls] is
-    used to retrieve from repository caches. *)
+    used to retrieve from repository caches. [for_source] should be set to [true]
+    to indicate the call is meant to be used by [opam source], and will prevent
+    opam-specific VCS configuration from being applied. *)
 val pull_shared_tree:
+  ?for_source:bool ->
   ?cache_dir:dirname ->
   ?cache_urls:OpamUrl.t list ->
   (string * OpamFilename.Dir.t * subpath option) list -> OpamHash.t list ->
@@ -50,7 +54,7 @@ val pull_shared_tree:
    If [full_fetch] is set to false, VCS repository is retrieved with shallow
    history (by default, full history). *)
 val pull_tree:
-  string -> ?full_fetch:bool -> ?cache_dir:dirname -> ?cache_urls:url list ->
+  string -> ?for_source:bool -> ?full_fetch:bool -> ?cache_dir:dirname -> ?cache_urls:url list ->
   ?working_dir:bool -> ?subpath:subpath ->
   dirname -> OpamHash.t list -> url list ->
   string download OpamProcess.job

--- a/src/repository/opamRepositoryBackend.ml
+++ b/src/repository/opamRepositoryBackend.ml
@@ -22,7 +22,7 @@ type update =
 module type S = sig
   val name: OpamUrl.backend
   val pull_url:
-    ?full_fetch:bool ->
+    ?for_source:bool -> ?full_fetch:bool ->
     ?cache_dir:dirname -> ?subpath:subpath -> dirname -> OpamHash.t option -> url ->
     filename option download OpamProcess.job
   val fetch_repo_update:

--- a/src/repository/opamRepositoryBackend.mli
+++ b/src/repository/opamRepositoryBackend.mli
@@ -52,7 +52,7 @@ module type S = sig
       directory.
       If [subpath] is given, only that [subpath] of the url is retrieved. *)
   val pull_url:
-    ?full_fetch:bool ->
+    ?for_source:bool -> ?full_fetch:bool ->
     ?cache_dir:dirname -> ?subpath:subpath -> dirname -> OpamHash.t option ->
     url -> filename option download OpamProcess.job
 

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -15,7 +15,7 @@ open OpamProcess.Job.Op
 module type VCS = sig
   val name: OpamUrl.backend
   val exists: dirname -> bool
-  val init: dirname -> url -> unit OpamProcess.job
+  val init: ?for_source:bool -> dirname -> url -> unit OpamProcess.job
   val fetch:
     ?full_fetch:bool -> ?cache_dir:dirname -> ?subpath:subpath -> dirname -> url ->
     unit OpamProcess.job
@@ -43,6 +43,7 @@ module Make (VCS: VCS) = struct
   let fetch_repo_update repo_name ?cache_dir repo_root repo_url =
     match repo_root with
     | OpamRepositoryRoot.Dir repo_root ->
+      let for_source = false in
       let full_fetch = false in
       let repo_root_dir = OpamRepositoryRoot.Dir.to_dir repo_root in
       if VCS.exists repo_root_dir then
@@ -68,7 +69,7 @@ module Make (VCS: VCS) = struct
             Done (OpamRepositoryBackend.Update_err e))
         @@ fun () ->
         OpamRepositoryBackend.job_text repo_name "init"
-          (VCS.init repo_root_dir repo_url)
+          (VCS.init ~for_source repo_root_dir repo_url)
         @@+ fun () ->
         OpamRepositoryBackend.job_text repo_name "sync"
           (VCS.fetch ~full_fetch ?cache_dir repo_root_dir repo_url)
@@ -93,7 +94,7 @@ module Make (VCS: VCS) = struct
     | OpamRepositoryRoot.Tgz _ ->
       assert false (* VCS repository are always repositories *)
 
-  let pull_url ?full_fetch ?cache_dir ?subpath dirname checksum url =
+  let pull_url ?for_source ?full_fetch ?cache_dir ?subpath dirname checksum url =
     if checksum <> None then invalid_arg "VC pull_url doesn't allow checksums";
     OpamProcess.Job.catch
       (fun e ->
@@ -113,7 +114,7 @@ module Make (VCS: VCS) = struct
         Done (Result None)
     else
       (OpamFilename.mkdir dirname;
-       VCS.init dirname url @@+ fun () ->
+       VCS.init ?for_source dirname url @@+ fun () ->
        VCS.fetch ?full_fetch ?cache_dir ?subpath dirname url @@+ fun () ->
        VCS.reset_tree dirname url @@+ fun () ->
        Done (Result None))

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -16,6 +16,7 @@ module type VCS = sig
   val name: OpamUrl.backend
   val exists: dirname -> bool
   val init: ?for_source:bool -> dirname -> url -> unit OpamProcess.job
+  val clone: ?full_fetch:bool -> dirname -> url -> unit OpamProcess.job
   val fetch:
     ?full_fetch:bool -> ?cache_dir:dirname -> ?subpath:subpath -> dirname -> url ->
     unit OpamProcess.job
@@ -94,7 +95,8 @@ module Make (VCS: VCS) = struct
     | OpamRepositoryRoot.Tgz _ ->
       assert false (* VCS repository are always repositories *)
 
-  let pull_url ?for_source ?full_fetch ?cache_dir ?subpath dirname checksum url =
+  let pull_url ?(for_source = false)  ?full_fetch ?cache_dir ?subpath
+    dirname checksum url =
     if checksum <> None then invalid_arg "VC pull_url doesn't allow checksums";
     OpamProcess.Job.catch
       (fun e ->
@@ -112,9 +114,12 @@ module Make (VCS: VCS) = struct
       | false ->
         VCS.reset_tree dirname url @@+ fun () ->
         Done (Result None)
+    else if for_source then
+      VCS.clone ?full_fetch dirname url @@+ fun() ->
+      Done (Result None)
     else
       (OpamFilename.mkdir dirname;
-       VCS.init ?for_source dirname url @@+ fun () ->
+       VCS.init ~for_source dirname url @@+ fun () ->
        VCS.fetch ?full_fetch ?cache_dir ?subpath dirname url @@+ fun () ->
        VCS.reset_tree dirname url @@+ fun () ->
        Done (Result None))

--- a/src/repository/opamVCS.mli
+++ b/src/repository/opamVCS.mli
@@ -25,6 +25,9 @@ module type VCS = sig
       If [for_source] is set to true, opam-specific VCS configuration
       will be avoided. *)
   val init: ?for_source:bool -> dirname -> url -> unit OpamProcess.job
+  
+  (** Clone a repository. *)
+  val clone: ?full_fetch:bool -> dirname -> url -> unit OpamProcess.job
 
   (** Fetch changes from upstream. This is supposed to put the changes
       in a staging area.

--- a/src/repository/opamVCS.mli
+++ b/src/repository/opamVCS.mli
@@ -21,8 +21,10 @@ module type VCS = sig
   (** Test whether the given repository is correctly initialized. *)
   val exists: dirname -> bool
 
-  (** Init a repository. *)
-  val init: dirname -> url -> unit OpamProcess.job
+  (** Init a repository.
+      If [for_source] is set to true, opam-specific VCS configuration
+      will be avoided. *)
+  val init: ?for_source:bool -> dirname -> url -> unit OpamProcess.job
 
   (** Fetch changes from upstream. This is supposed to put the changes
       in a staging area.

--- a/src/state/opamUpdate.ml
+++ b/src/state/opamUpdate.ml
@@ -653,7 +653,7 @@ let cleanup_source st old_opam_opt new_opam =
     OpamFilename.rmdir
       (OpamSwitchState.source_dir st (OpamFile.OPAM.package new_opam))
 
-let download_package_source_t st url nv_dirs =
+let download_package_source_t ?for_source st url nv_dirs =
   let cache_dir = OpamRepositoryPath.download_cache st.switch_global.root in
   let cache_urls = active_caches st (List.map fst nv_dirs) in
   let fetch_source_job =
@@ -669,7 +669,7 @@ let download_package_source_t st url nv_dirs =
           nv_dirs
       in
       let checksums = OpamFile.URL.checksum url in
-      (OpamRepository.pull_shared_tree ~cache_dir ~cache_urls
+      (OpamRepository.pull_shared_tree ?for_source ~cache_dir ~cache_urls
          dirnames checksums
          (OpamFile.URL.url url :: OpamFile.URL.mirrors url))
       @@+ function
@@ -709,8 +709,8 @@ let download_shared_package_source st url nvs =
   download_package_source_t st url
     (List.map (fun nv -> nv, OpamSwitchState.source_dir st nv) nvs)
 
-let download_package_source st nv dirname =
-  download_package_source_t st
+let download_package_source ?for_source st nv dirname =
+  download_package_source_t ?for_source st
     (OpamFile.OPAM.url (OpamSwitchState.opam st nv))
     [nv, dirname]
   @@| fun (sources, extra_sources) ->

--- a/src/state/opamUpdate.mli
+++ b/src/state/opamUpdate.mli
@@ -92,13 +92,15 @@ val pinned_package:
     any.
     If an archive is not found, it launches Software Heritage fallback (see
     {!OpamDownload.SWHID}).
+    If [for_source] is set to [true], opam-specific VCS configuration will be
+    avoided.
 
     Stops on first error. The extra downloads list is reverted, so that the
     error is always first if any.
 
     Does not print the results as it used to. *)
 val download_package_source:
-  'a switch_state -> package -> dirname ->
+  ?for_source:bool -> 'a switch_state -> package -> dirname ->
   (string download option * (string * string download) list) OpamProcess.job
 
 (** As {!download_package_source} but for several packages sharing the same

--- a/tests/reftests/darcs.test
+++ b/tests/reftests/darcs.test
@@ -48,25 +48,19 @@ The following actions will be performed:
 -> installed darkdore.3
 Done.
 ### opam source -vv darkdore | sed-cmd darcs | grep '^\+ darcs'
-+ darcs "init" (CWD=${BASEDIR}/darkdore.3)
-+ darcs "get" "${BASEDIR}/darkdev" "--repodir" "${OPAMTMP}/repo" "--quiet" "--lazy" (CWD=${BASEDIR}/darkdore.3)
-+ darcs "tag" "opam-remote-tag" "-A" "opam" (CWD=${BASEDIR}/darkdore.3)
-+ darcs "record" "-l" "--boring" "--all" "-m" "opam-revert-laststate" "-A" "opam" (CWD=${BASEDIR}/darkdore.3)
-+ darcs "tag" "opam-local-tag" "-A" "opam" (CWD=${BASEDIR}/darkdore.3)
-+ darcs "obliterate" "--all" "-t" "opam-local-tag" (CWD=${BASEDIR}/darkdore.3)
-+ darcs "obliterate" "--all" "-p" "opam-revert-laststate" (CWD=${BASEDIR}/darkdore.3)
++ darcs "clone" "${BASEDIR}/darkdev" "--repodir" "${OPAMTMP}/repo" "--quiet" "--lazy" (CWD=${OPAMTMP})
 ### find darkdore.3 | grep -v '_darcs/' | unordered
 darkdore.3
 darkdore.3/opam
+darkdore.3/root.ml
 darkdore.3/_darcs
+darkdore.3/src
+darkdore.3/src/src.ml
 ### opam source -vv --dev darkdore | sed-cmd darcs | grep '^\+ darcs'
-+ darcs "init" (CWD=${BASEDIR}/darkdore)
-+ darcs "get" "${BASEDIR}/darkdev" "--repodir" "${OPAMTMP}/repo" "--quiet" "--lazy" (CWD=${BASEDIR}/darkdore)
-+ darcs "tag" "opam-remote-tag" "-A" "opam" (CWD=${BASEDIR}/darkdore)
-+ darcs "record" "-l" "--boring" "--all" "-m" "opam-revert-laststate" "-A" "opam" (CWD=${BASEDIR}/darkdore)
-+ darcs "tag" "opam-local-tag" "-A" "opam" (CWD=${BASEDIR}/darkdore)
-+ darcs "obliterate" "--all" "-t" "opam-local-tag" (CWD=${BASEDIR}/darkdore)
-+ darcs "obliterate" "--all" "-p" "opam-revert-laststate" (CWD=${BASEDIR}/darkdore)
++ darcs "clone" "${BASEDIR}/darkdev" "--repodir" "${OPAMTMP}/repo" "--quiet" "--lazy" (CWD=${OPAMTMP})
 ### find darkdore | grep -v '_darcs/' | unordered
 darkdore
+darkdore/root.ml
 darkdore/_darcs
+darkdore/src
+darkdore/src/src.ml

--- a/tests/reftests/darcs.test
+++ b/tests/reftests/darcs.test
@@ -1,0 +1,72 @@
+N0REP0
+### <darkdev/src/src.ml>
+print_endline "I am a source code"
+### <darkdev/root.ml>
+print_endline "I am root"
+### tar czf origin.tgz darkdev
+### darcs init ./darkdev
+Finished initializing repository.
+### darcs add --repodir ./darkdev --recursive .
+WARNING: Some files were not added because they are already in the repository.
+Adding './root.ml'
+Adding './src'
+Adding './src/src.ml'
+Finished adding:
+./root.ml
+./src
+./src/src.ml
+### darcs record --repodir ./darkdev --author "test" -m "init" -a
+Finished recording patch 'init'
+### <pkg:darkdore.3>
+opam-version: "2.0"
+### <mkurl.sh>
+p=darkdore.3
+arch=origin
+file="REPO/packages/${p%.*}/$p/opam"
+MD5=$(openssl md5 $arch.tgz | cut -d' ' -f2)
+basedir=$(printf '%s' "$BASEDIR" | sed 's/\\/\\\\/g')
+cat >> "$file" << EOF
+url {
+  darcs: "$basedir/darkdev"
+}
+dev-repo: "darcs+file://${basedir}/darkdev"
+EOF
+### sh mkurl.sh
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### opam switch create phantom --empty
+### opam install darkdore
+The following actions will be performed:
+=== install 1 package
+  - install darkdore 3
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved darkdore.3  (darcs+file://${BASEDIR}/darkdev)
+-> installed darkdore.3
+Done.
+### opam source -vv darkdore | sed-cmd darcs | grep '^\+ darcs'
++ darcs "init" (CWD=${BASEDIR}/darkdore.3)
++ darcs "get" "${BASEDIR}/darkdev" "--repodir" "${OPAMTMP}/repo" "--quiet" "--lazy" (CWD=${BASEDIR}/darkdore.3)
++ darcs "tag" "opam-remote-tag" "-A" "opam" (CWD=${BASEDIR}/darkdore.3)
++ darcs "record" "-l" "--boring" "--all" "-m" "opam-revert-laststate" "-A" "opam" (CWD=${BASEDIR}/darkdore.3)
++ darcs "tag" "opam-local-tag" "-A" "opam" (CWD=${BASEDIR}/darkdore.3)
++ darcs "obliterate" "--all" "-t" "opam-local-tag" (CWD=${BASEDIR}/darkdore.3)
++ darcs "obliterate" "--all" "-p" "opam-revert-laststate" (CWD=${BASEDIR}/darkdore.3)
+### find darkdore.3 | grep -v '_darcs/' | unordered
+darkdore.3
+darkdore.3/opam
+darkdore.3/_darcs
+### opam source -vv --dev darkdore | sed-cmd darcs | grep '^\+ darcs'
++ darcs "init" (CWD=${BASEDIR}/darkdore)
++ darcs "get" "${BASEDIR}/darkdev" "--repodir" "${OPAMTMP}/repo" "--quiet" "--lazy" (CWD=${BASEDIR}/darkdore)
++ darcs "tag" "opam-remote-tag" "-A" "opam" (CWD=${BASEDIR}/darkdore)
++ darcs "record" "-l" "--boring" "--all" "-m" "opam-revert-laststate" "-A" "opam" (CWD=${BASEDIR}/darkdore)
++ darcs "tag" "opam-local-tag" "-A" "opam" (CWD=${BASEDIR}/darkdore)
++ darcs "obliterate" "--all" "-t" "opam-local-tag" (CWD=${BASEDIR}/darkdore)
++ darcs "obliterate" "--all" "-p" "opam-revert-laststate" (CWD=${BASEDIR}/darkdore)
+### find darkdore | grep -v '_darcs/' | unordered
+darkdore
+darkdore/_darcs

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -483,6 +483,27 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:cve-2026-57825.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-darcs)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (action
+  (diff darcs.test darcs.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (deps (alias reftest-darcs)))
+
+(rule
+ (targets darcs.out)
+ (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:darcs.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-depext-only)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
@@ -1048,6 +1069,27 @@
   (with-stdout-to
    %{targets}
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:git.test} %{read-lines:testing-env}))))
+
+(rule
+ (alias reftest-hg)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (action
+  (diff hg.test hg.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (deps (alias reftest-hg)))
+
+(rule
+ (targets hg.out)
+ (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:hg.test} %{read-lines:testing-env}))))
 
 (rule
  (alias reftest-hooks-variables)

--- a/tests/reftests/hg.test
+++ b/tests/reftests/hg.test
@@ -1,0 +1,67 @@
+N0REP0
+### <hugdev/src/src.ml>
+print_endline "I am a source code"
+### <hugdev/root.ml>
+print_endline "I am root"
+### tar czf origin.tgz hugdev
+### hg --cwd ./hugdev init
+### <hugdev/.hg/hgrc>
+[ui]
+username = test
+### hg --cwd ./hugdev add
+adding root.ml
+adding src/src.ml
+### hg --cwd ./hugdev commit -m "init"
+### <pkg:hugdore.3>
+opam-version: "2.0"
+### <mkurl.sh>
+p=hugdore.3
+arch=origin
+file="REPO/packages/${p%.*}/$p/opam"
+MD5=$(openssl md5 $arch.tgz | cut -d' ' -f2)
+basedir=$(printf '%s' "$BASEDIR" | sed 's/\\/\\\\/g')
+cat >> "$file" << EOF
+url {
+  hg: "$basedir/hugdev"
+}
+dev-repo: "hg+file://${basedir}/hugdev"
+EOF
+### sh mkurl.sh
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### opam switch create phantom --empty
+### opam install hugdore
+The following actions will be performed:
+=== install 1 package
+  - install hugdore 3
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved hugdore.3  (hg+file://${BASEDIR}/hugdev)
+-> installed hugdore.3
+Done.
+### opam source -vv hugdore | sed-cmd hg | grep '^\+ hg'
++ hg "init" (CWD=${BASEDIR}/hugdore.3)
++ hg "pull" "--rev" "default" "file://${BASEDIR}/hugdev" (CWD=${BASEDIR}/hugdore.3)
++ hg "bookmark" "--force" "--rev" "default" "opam-mark" (CWD=${BASEDIR}/hugdore.3)
++ hg "update" "--clean" "--rev" "opam-mark" (CWD=${BASEDIR}/hugdore.3)
+### find hugdore.3 | grep -v '.hg/' | unordered
+hugdore.3
+hugdore.3/opam
+hugdore.3/root.ml
+hugdore.3/.hg
+hugdore.3/src
+hugdore.3/src/src.ml
+### opam source -vv --dev hugdore | sed-cmd hg | grep '^\+ hg'
++ hg "init" (CWD=${BASEDIR}/hugdore)
++ hg "pull" "--rev" "default" "file://${BASEDIR}/hugdev" (CWD=${BASEDIR}/hugdore)
++ hg "bookmark" "--force" "--rev" "default" "opam-mark" (CWD=${BASEDIR}/hugdore)
++ hg "update" "--clean" "--rev" "opam-mark" (CWD=${BASEDIR}/hugdore)
+### find hugdore | grep -v '.hg/' | unordered
+hugdore
+hugdore/root.ml
+hugdore/.hg
+hugdore/src
+hugdore/src/src.ml

--- a/tests/reftests/hg.test
+++ b/tests/reftests/hg.test
@@ -43,10 +43,7 @@ The following actions will be performed:
 -> installed hugdore.3
 Done.
 ### opam source -vv hugdore | sed-cmd hg | grep '^\+ hg'
-+ hg "init" (CWD=${BASEDIR}/hugdore.3)
-+ hg "pull" "--rev" "default" "file://${BASEDIR}/hugdev" (CWD=${BASEDIR}/hugdore.3)
-+ hg "bookmark" "--force" "--rev" "default" "opam-mark" (CWD=${BASEDIR}/hugdore.3)
-+ hg "update" "--clean" "--rev" "opam-mark" (CWD=${BASEDIR}/hugdore.3)
++ hg "clone" "file://${BASEDIR}/hugdev" "." (CWD=${BASEDIR}/hugdore.3)
 ### find hugdore.3 | grep -v '.hg/' | unordered
 hugdore.3
 hugdore.3/opam
@@ -55,10 +52,7 @@ hugdore.3/.hg
 hugdore.3/src
 hugdore.3/src/src.ml
 ### opam source -vv --dev hugdore | sed-cmd hg | grep '^\+ hg'
-+ hg "init" (CWD=${BASEDIR}/hugdore)
-+ hg "pull" "--rev" "default" "file://${BASEDIR}/hugdev" (CWD=${BASEDIR}/hugdore)
-+ hg "bookmark" "--force" "--rev" "default" "opam-mark" (CWD=${BASEDIR}/hugdore)
-+ hg "update" "--clean" "--rev" "opam-mark" (CWD=${BASEDIR}/hugdore)
++ hg "clone" "file://${BASEDIR}/hugdev" "." (CWD=${BASEDIR}/hugdore)
 ### find hugdore | grep -v '.hg/' | unordered
 hugdore
 hugdore/root.ml

--- a/tests/reftests/source.test
+++ b/tests/reftests/source.test
@@ -50,8 +50,18 @@ pandore2/root.ml
 pandore2/src
 pandore2/src/src.ml
 ### rm -rf pandore.3
-### opam source pandore --dev
-Successfully fetched pandore development repo to ${BASEDIR}/pandore
+### opam source -vv pandore --dev | sed-cmd git | grep '^\+ git'
++ git "-C" "${BASEDIR}/pandore" "init" "--initial-branch=main"
++ git "-C" "${BASEDIR}/pandore" "config" "--local" "fetch.prune" "false"
++ git "-C" "${BASEDIR}/pandore" "config" "--local" "diff.noprefix" "false"
++ git "-C" "${BASEDIR}/pandore" "config" "--local" "core.autocrlf" "false"
++ git "-C" "${BASEDIR}/pandore" "config" "--local" "core.eol" "lf"
++ git "-C" "${BASEDIR}/pandore" "config" "--local" "color.ui" "false"
++ git "-C" "${BASEDIR}/pandore" "remote" "add" "origin" "file://${BASEDIR}/pandev"
++ git "-C" "${BASEDIR}/pandore" "remote" "set-url" "origin" "file://${BASEDIR}/pandev"
++ git "-C" "${BASEDIR}/pandore" "fetch" "-q" "file://${BASEDIR}/pandev" "--update-shallow" "+HEAD:refs/remotes/opam-ref"
++ git "-C" "${BASEDIR}/pandore" "reset" "--hard" "refs/remotes/opam-ref" "--"
++ git "-C" "${BASEDIR}/pandore" "clean" "-fdx"
 ### find pandore | grep -v '.git/' | unordered
 pandore
 pandore/.git
@@ -133,8 +143,18 @@ EOF
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [default] synchronised from file://${BASEDIR}/REPO
 Now run 'opam upgrade' to apply any package updates.
-### opam source pandore.4 --dir pandore5
-Successfully extracted to ${BASEDIR}/pandore5
+### opam source -vv pandore.4 --dir pandore5 | sed-cmd git | grep '^\+ git'
++ git "-C" "${BASEDIR}/pandore5" "init" "--initial-branch=main"
++ git "-C" "${BASEDIR}/pandore5" "config" "--local" "fetch.prune" "false"
++ git "-C" "${BASEDIR}/pandore5" "config" "--local" "diff.noprefix" "false"
++ git "-C" "${BASEDIR}/pandore5" "config" "--local" "core.autocrlf" "false"
++ git "-C" "${BASEDIR}/pandore5" "config" "--local" "core.eol" "lf"
++ git "-C" "${BASEDIR}/pandore5" "config" "--local" "color.ui" "false"
++ git "-C" "${BASEDIR}/pandore5" "remote" "add" "origin" "file://${BASEDIR}/pandev"
++ git "-C" "${BASEDIR}/pandore5" "remote" "set-url" "origin" "file://${BASEDIR}/pandev"
++ git "-C" "${BASEDIR}/pandore5" "fetch" "-q" "file://${BASEDIR}/pandev" "--update-shallow" "+HEAD:refs/remotes/opam-ref"
++ git "-C" "${BASEDIR}/pandore5" "reset" "--hard" "refs/remotes/opam-ref" "--"
++ git "-C" "${BASEDIR}/pandore5" "clean" "-fdx"
 ### git -C pandore5 rev-list --all --count
 2
 ### opam source pandore.4 --dev --dir pandore6
@@ -147,3 +167,4 @@ Successfully fetched pandore development repo to ${BASEDIR}/pandore6
 ### git -C pandore6 remote -v
 origin	file://${BASEDIR}/pandev (fetch)
 origin	file://${BASEDIR}/pandev (push)
+### : Actions

--- a/tests/reftests/source.test
+++ b/tests/reftests/source.test
@@ -52,11 +52,6 @@ pandore2/src/src.ml
 ### rm -rf pandore.3
 ### opam source -vv pandore --dev | sed-cmd git | grep '^\+ git'
 + git "-C" "${BASEDIR}/pandore" "init" "--initial-branch=main"
-+ git "-C" "${BASEDIR}/pandore" "config" "--local" "fetch.prune" "false"
-+ git "-C" "${BASEDIR}/pandore" "config" "--local" "diff.noprefix" "false"
-+ git "-C" "${BASEDIR}/pandore" "config" "--local" "core.autocrlf" "false"
-+ git "-C" "${BASEDIR}/pandore" "config" "--local" "core.eol" "lf"
-+ git "-C" "${BASEDIR}/pandore" "config" "--local" "color.ui" "false"
 + git "-C" "${BASEDIR}/pandore" "remote" "add" "origin" "file://${BASEDIR}/pandev"
 + git "-C" "${BASEDIR}/pandore" "remote" "set-url" "origin" "file://${BASEDIR}/pandev"
 + git "-C" "${BASEDIR}/pandore" "fetch" "-q" "file://${BASEDIR}/pandev" "--update-shallow" "+HEAD:refs/remotes/opam-ref"
@@ -145,11 +140,6 @@ EOF
 Now run 'opam upgrade' to apply any package updates.
 ### opam source -vv pandore.4 --dir pandore5 | sed-cmd git | grep '^\+ git'
 + git "-C" "${BASEDIR}/pandore5" "init" "--initial-branch=main"
-+ git "-C" "${BASEDIR}/pandore5" "config" "--local" "fetch.prune" "false"
-+ git "-C" "${BASEDIR}/pandore5" "config" "--local" "diff.noprefix" "false"
-+ git "-C" "${BASEDIR}/pandore5" "config" "--local" "core.autocrlf" "false"
-+ git "-C" "${BASEDIR}/pandore5" "config" "--local" "core.eol" "lf"
-+ git "-C" "${BASEDIR}/pandore5" "config" "--local" "color.ui" "false"
 + git "-C" "${BASEDIR}/pandore5" "remote" "add" "origin" "file://${BASEDIR}/pandev"
 + git "-C" "${BASEDIR}/pandore5" "remote" "set-url" "origin" "file://${BASEDIR}/pandev"
 + git "-C" "${BASEDIR}/pandore5" "fetch" "-q" "file://${BASEDIR}/pandev" "--update-shallow" "+HEAD:refs/remotes/opam-ref"

--- a/tests/reftests/source.test
+++ b/tests/reftests/source.test
@@ -51,12 +51,8 @@ pandore2/src
 pandore2/src/src.ml
 ### rm -rf pandore.3
 ### opam source -vv pandore --dev | sed-cmd git | grep '^\+ git'
-+ git "-C" "${BASEDIR}/pandore" "init" "--initial-branch=main"
-+ git "-C" "${BASEDIR}/pandore" "remote" "add" "origin" "file://${BASEDIR}/pandev"
-+ git "-C" "${BASEDIR}/pandore" "remote" "set-url" "origin" "file://${BASEDIR}/pandev"
-+ git "-C" "${BASEDIR}/pandore" "fetch" "-q" "file://${BASEDIR}/pandev" "--update-shallow" "+HEAD:refs/remotes/opam-ref"
-+ git "-C" "${BASEDIR}/pandore" "reset" "--hard" "refs/remotes/opam-ref" "--"
-+ git "-C" "${BASEDIR}/pandore" "clean" "-fdx"
++ git "-C" "${BASEDIR}/pandore" "clone" "file://${BASEDIR}/pandev" "."
++ git "-C" "${BASEDIR}/pandore" "submodule" "update" "--init" "--recursive"
 ### find pandore | grep -v '.git/' | unordered
 pandore
 pandore/.git
@@ -139,12 +135,8 @@ EOF
 [default] synchronised from file://${BASEDIR}/REPO
 Now run 'opam upgrade' to apply any package updates.
 ### opam source -vv pandore.4 --dir pandore5 | sed-cmd git | grep '^\+ git'
-+ git "-C" "${BASEDIR}/pandore5" "init" "--initial-branch=main"
-+ git "-C" "${BASEDIR}/pandore5" "remote" "add" "origin" "file://${BASEDIR}/pandev"
-+ git "-C" "${BASEDIR}/pandore5" "remote" "set-url" "origin" "file://${BASEDIR}/pandev"
-+ git "-C" "${BASEDIR}/pandore5" "fetch" "-q" "file://${BASEDIR}/pandev" "--update-shallow" "+HEAD:refs/remotes/opam-ref"
-+ git "-C" "${BASEDIR}/pandore5" "reset" "--hard" "refs/remotes/opam-ref" "--"
-+ git "-C" "${BASEDIR}/pandore5" "clean" "-fdx"
++ git "-C" "${BASEDIR}/pandore5" "clone" "file://${BASEDIR}/pandev" "."
++ git "-C" "${BASEDIR}/pandore5" "submodule" "update" "--init" "--recursive"
 ### git -C pandore5 rev-list --all --count
 2
 ### opam source pandore.4 --dev --dir pandore6
@@ -152,8 +144,9 @@ Successfully fetched pandore development repo to ${BASEDIR}/pandore6
 ### git -C pandore6 rev-list --all --count
 2
 ### git -C pandore6 branch -avv | ' [a-f0-9]+ ' -> ' +hash+ '
-* main             +hash+ second empty commit
-  remotes/opam-ref +hash+ second empty commit
+* master                +hash+ [origin/master] second empty commit
+  remotes/origin/HEAD   -> origin/master
+  remotes/origin/master +hash+ second empty commit
 ### git -C pandore6 remote -v
 origin	file://${BASEDIR}/pandev (fetch)
 origin	file://${BASEDIR}/pandev (push)


### PR DESCRIPTION
`opam source --dev` should not apply opam-specific `git config`s. This commit adds a `will_full_fetch` argument to VCS.init, and only applies opam-specific git configurations when this is false. Also, default to full_fetch=false to mimic prior behavior. This should resolve #6451 .

I do have some failing tests locally, but it looks like the same tests fail on master for me.

Relatively new to contributing to open source, so any feedback is appreciated! I have a fair amount of free time these days, so looking to contribute more to the OCaml ecosystem.