### PR TITLE
reftest: add '.install' exhaustive test for all fields

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -202,6 +202,7 @@ users)
   * Add in `repository` test cases for switching automatically from directory to archive format & vice versa [#6625 @rjbou]
   * Add in `repository` test cases for upgrade opam root from 2.5 with repo tarring or 2.1 to 2.6, with `OPAMREPOSITORYTARRING` enabled (trigger upgrade) [#6625 @rjbou]
   * Add 2.6 root test cases in opamroot-versions [#6625 @rjbou]
+  * Add tests for `.install` fields handling [#6956 @rjbou]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -206,6 +206,7 @@ users)
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]
   * Add to automatic path subsitutions lines that contains `packages` [#6625 @rjbou]
+  * Add to automatic path substitutions lines that contains switch installation paths [#6956 @rjbou]
 
 ## Github Actions
   * Add OCaml 5.4 to the test matrix [#6732 @kit-ty-kate]

--- a/tests/reftests/dot-install-exe-fields.unix.test
+++ b/tests/reftests/dot-install-exe-fields.unix.test
@@ -1,0 +1,1213 @@
+N0REP0
+### :::::::
+### : In this test, we test all executable fields of `.install` files
+### : For each fields, we test 5 cases:
+### :   * default install with binary as exe (+x) : [ "filename" ]
+### :   * install with target : [ "filename" {"target"} ]
+### :   * optional install : [ "?non-existing-filename" ]
+### :   * non existing filename : [ "non-existing-filename" ]
+### :   * default install with binary not as exe (-x) : [ "filename" ]
+### :
+### : Fields are : bin, sbin, stublibs, libexec, libexec_root
+### : Non executable fields are tested in dot-install-exec-fields.*.test
+### :
+### : For each package, there is no install target. The only side effect is
+### : that it doesn't trigger switch root directory tracking, all addition and
+### :  removal are done according install file
+### :  There is some specific fields that have some additional tests:
+### :    * misc: it needs a target and an absolute path
+### :    * man: it needs a specific file format
+### :::::::
+### OPAMYES=1
+### # we neeed the precise tracking to have a sha in changes file instead of timestamp
+### OPAMPRECISETRACKING=1
+### OPAMDEBUGSECTIONS="TRACK ACTION"
+### # Print the installed file 'installed-bin' in switch (or root)
+### <cat.ml>
+#directory "+str"
+#directory "+unix"
+#load "str.cma"
+#load "unix.cma"
+
+(* check if the file is executable, from OpamSystem *)
+let is_exec file =
+  let stat = Unix.stat file in
+  stat.Unix.st_kind = Unix.S_REG &&
+  stat.Unix.st_perm land 0o111 <> 0
+
+(* print information about a file:
+  - its path
+  - if it is executable
+  - it not found
+  - if empty *)
+let cat file =
+  if Sys.file_exists file then
+    let header = if is_exec file then file^" (+x)" else file in
+    Printf.printf "==> %s\n" header ;
+    let error () =
+      let ic = open_in file in
+      let _ : char = input_char ic in
+      close_in ic
+    in
+    try error () with
+    | exn ->
+      let err =
+        match exn with
+        | End_of_file -> "Empty file"
+        | exn -> (Printexc.to_string exn)
+      in
+      Printf.printf "%s" err; exit 1
+  else
+    Printf.printf "--> %s: not found\n" file
+
+let switch = Sys.argv.(1)
+let pkg = Sys.argv.(2)
+let root = Sys.getenv "OPAMROOT"
+let (/) = Filename.concat
+
+let fname = "installed-file"
+let bname = "installed-bin"
+let root_file = try Some Sys.argv.(3) with Invalid_argument _ -> None
+let files =
+  match root_file with
+  | None -> []
+  | Some f -> [ root / f ]
+
+(* retrieve all files names 'installed-file' in switch prefix *)
+let files =
+  let rec aux files cwd =
+    let ls = Sys.readdir cwd |> Array.to_list in
+    let dirs, cwd_files =
+      List.partition (fun f -> Sys.is_directory (cwd / f)) ls
+    in
+    let dirs =
+      if (cwd : string) = root / switch then
+        List.filter (fun f -> f <> ".opam-switch") dirs
+      else dirs
+    in
+    let files =
+      files
+      @ List.filter_map (fun f ->
+          if String.starts_with ~prefix:bname f then
+            Some (cwd / f) else None)
+        cwd_files
+    in
+    if dirs = [] then files else
+      List.fold_left (fun files dir -> aux files (cwd / dir)) files dirs
+  in
+  aux files (root / switch)
+  |> List.sort String.compare
+
+let () =
+  match files with
+  | [] -> Printf.printf "==> No '%s' found" bname
+  | _ -> List.iter cat files
+
+### # the binary to install
+### <tiny.ml>
+print_endline "youhou i'm installed!"
+### ocamlc tiny.ml -o installed-bin
+### openssl md5 installed-bin | '.*= ' -> '' >$ BINMD5
+### ::::::::::::::::
+### :I: Field 'bin'
+### ::::::::::::::::
+### mkdir -p REPO/packages/pkg-bin/pkg-bin.1/files
+### cp installed-bin REPO/packages/pkg-bin/pkg-bin.1/files/installed-bin
+### opam switch create sw-bin --empty
+### :I:1: No defined destination path
+### <pkg:pkg-bin.1>
+opam-version: "2.0"
+### <pkg:pkg-bin.1:pkg-bin.install>
+bin: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-bin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-bin.1
+ACTION                          prepare_package_source: pkg-bin.1 at ${BASEDIR}/OPAM/sw-bin/.opam-switch/build/pkg-bin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-bin.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-bin.1: 1 items (addition: 1)
+-> installed pkg-bin.1
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes | sed-hash $BINMD5 hash
+added: "bin/installed-bin" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-bin pkg-bin
+==> ${BASEDIR}/OPAM/sw-bin/bin/installed-bin (+x)
+### OPAMDEBUG=-5 opam remove pkg-bin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-bin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-bin.1: files bin/installed-bin were already removed
+-> removed   pkg-bin.1
+ACTION                          Cleaning up artefacts of pkg-bin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes
+# OPAM/sw-bin/.opam-switch/install/pkg-bin.changes not found
+### ocaml cat.ml sw-bin pkg-bin
+==> No 'installed-bin' found
+### :I:2: Specify destination path
+### <pkg:pkg-bin.1>
+opam-version: "2.0"
+### <pkg:pkg-bin.1:pkg-bin.install>
+bin: [ "installed-bin" {"installed-bin.bin"} ]
+### OPAMDEBUG=-5 opam install pkg-bin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-bin.1
+ACTION                          prepare_package_source: pkg-bin.1 at ${BASEDIR}/OPAM/sw-bin/.opam-switch/build/pkg-bin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-bin.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-bin.1: 1 items (addition: 1)
+-> installed pkg-bin.1
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes | sed-hash $BINMD5 hash
+added: "bin/installed-bin.bin" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-bin pkg-bin
+==> ${BASEDIR}/OPAM/sw-bin/bin/installed-bin.bin (+x)
+### OPAMDEBUG=-5 opam remove pkg-bin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-bin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-bin.1: files bin/installed-bin.bin were already removed
+-> removed   pkg-bin.1
+ACTION                          Cleaning up artefacts of pkg-bin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes
+# OPAM/sw-bin/.opam-switch/install/pkg-bin.changes not found
+### ocaml cat.ml sw-bin pkg-bin
+==> No 'installed-bin' found
+### :I:3: Non existing filename, with optional argument
+### <pkg:pkg-bin.1>
+opam-version: "2.0"
+### <pkg:pkg-bin.1:pkg-bin.install>
+bin: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-bin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-bin.1
+ACTION                          prepare_package_source: pkg-bin.1 at ${BASEDIR}/OPAM/sw-bin/.opam-switch/build/pkg-bin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-bin.1.
+
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-bin/.opam-switch/build/pkg-bin.1/finst is not present and optional.
+TRACK                           after install: 1 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-bin.1: 0 items
+-> installed pkg-bin.1
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-bin pkg-bin
+==> No 'installed-bin' found
+### OPAMDEBUG=-5 opam remove pkg-bin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-bin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-bin.1
+ACTION                          Cleaning up artefacts of pkg-bin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes
+# OPAM/sw-bin/.opam-switch/install/pkg-bin.changes not found
+### ocaml cat.ml sw-bin pkg-bin
+==> No 'installed-bin' found
+### :I:4: Non existing filename
+### <pkg:pkg-bin.1>
+opam-version: "2.0"
+### <pkg:pkg-bin.1:pkg-bin.install>
+bin: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-bin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-bin.1
+ACTION                          prepare_package_source: pkg-bin.1 at ${BASEDIR}/OPAM/sw-bin/.opam-switch/build/pkg-bin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-bin.1.
+
+[ERROR] Installation of pkg-bin.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-bin/.opam-switch/install/pkg-bin.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-bin/.opam-switch/build/pkg-bin.1/finst to ${BASEDIR}/OPAM/sw-bin/bin
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-bin 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes
+# OPAM/sw-bin/.opam-switch/install/pkg-bin.changes not found
+### ocaml cat.ml sw-bin pkg-bin
+==> No 'installed-bin' found
+### :I:5: Default install with no executable bit
+### chmod -x REPO/packages/pkg-bin/pkg-bin.1/files/installed-bin
+### <pkg:pkg-bin.1>
+opam-version: "2.0"
+### <pkg:pkg-bin.1:pkg-bin.install>
+bin: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-bin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-bin.1
+ACTION                          prepare_package_source: pkg-bin.1 at ${BASEDIR}/OPAM/sw-bin/.opam-switch/build/pkg-bin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-bin.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-bin.1: 1 items (addition: 1)
+-> installed pkg-bin.1
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes | sed-hash $BINMD5 hash
+added: "bin/installed-bin" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-bin pkg-bin
+==> ${BASEDIR}/OPAM/sw-bin/bin/installed-bin (+x)
+### OPAMDEBUG=-5 opam remove pkg-bin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-bin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-bin.1: files bin/installed-bin were already removed
+-> removed   pkg-bin.1
+ACTION                          Cleaning up artefacts of pkg-bin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes
+# OPAM/sw-bin/.opam-switch/install/pkg-bin.changes not found
+### ocaml cat.ml sw-bin pkg-bin
+==> No 'installed-bin' found
+### ::::::::::::::::::
+### :II: Field 'sbin'
+### ::::::::::::::::::
+### mkdir -p REPO/packages/pkg-sbin/pkg-sbin.1/files
+### cp installed-bin REPO/packages/pkg-sbin/pkg-sbin.1/files/installed-bin
+### opam switch create sw-sbin --empty
+### :II:1: No defined destination path
+### <pkg:pkg-sbin.1>
+opam-version: "2.0"
+### <pkg:pkg-sbin.1:pkg-sbin.install>
+sbin: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-sbin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-sbin.1
+ACTION                          prepare_package_source: pkg-sbin.1 at ${BASEDIR}/OPAM/sw-sbin/.opam-switch/build/pkg-sbin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-sbin.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-sbin.1: 1 items (addition: 1)
+-> installed pkg-sbin.1
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes | sed-hash $BINMD5 hash
+added: "sbin/installed-bin" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-sbin pkg-sbin
+==> ${BASEDIR}/OPAM/sw-sbin/sbin/installed-bin (+x)
+### OPAMDEBUG=-5 opam remove pkg-sbin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-sbin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-sbin.1: files sbin/installed-bin were already removed
+-> removed   pkg-sbin.1
+ACTION                          Cleaning up artefacts of pkg-sbin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes
+# OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes not found
+### ocaml cat.ml sw-sbin pkg-sbin
+==> No 'installed-bin' found
+### :II:2: Specify destination path
+### <pkg:pkg-sbin.1>
+opam-version: "2.0"
+### <pkg:pkg-sbin.1:pkg-sbin.install>
+sbin: [ "installed-bin" {"installed-bin.sbin"} ]
+### OPAMDEBUG=-5 opam install pkg-sbin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-sbin.1
+ACTION                          prepare_package_source: pkg-sbin.1 at ${BASEDIR}/OPAM/sw-sbin/.opam-switch/build/pkg-sbin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-sbin.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-sbin.1: 1 items (addition: 1)
+-> installed pkg-sbin.1
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes | sed-hash $BINMD5 hash
+added: "sbin/installed-bin.sbin" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-sbin pkg-sbin
+==> ${BASEDIR}/OPAM/sw-sbin/sbin/installed-bin.sbin (+x)
+### OPAMDEBUG=-5 opam remove pkg-sbin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-sbin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-sbin.1: files sbin/installed-bin.sbin were already removed
+-> removed   pkg-sbin.1
+ACTION                          Cleaning up artefacts of pkg-sbin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes
+# OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes not found
+### ocaml cat.ml sw-sbin pkg-sbin
+==> No 'installed-bin' found
+### :II:3: Non existing filename, with optional argument
+### <pkg:pkg-sbin.1>
+opam-version: "2.0"
+### <pkg:pkg-sbin.1:pkg-sbin.install>
+sbin: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-sbin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-sbin.1
+ACTION                          prepare_package_source: pkg-sbin.1 at ${BASEDIR}/OPAM/sw-sbin/.opam-switch/build/pkg-sbin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-sbin.1.
+
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-sbin/.opam-switch/build/pkg-sbin.1/finst is not present and optional.
+TRACK                           after install: 1 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-sbin.1: 0 items
+-> installed pkg-sbin.1
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-sbin pkg-sbin
+==> No 'installed-bin' found
+### OPAMDEBUG=-5 opam remove pkg-sbin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-sbin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-sbin.1
+ACTION                          Cleaning up artefacts of pkg-sbin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes
+# OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes not found
+### ocaml cat.ml sw-sbin pkg-sbin
+==> No 'installed-bin' found
+### :II:4: Non existing filename
+### <pkg:pkg-sbin.1>
+opam-version: "2.0"
+### <pkg:pkg-sbin.1:pkg-sbin.install>
+sbin: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-sbin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-sbin.1
+ACTION                          prepare_package_source: pkg-sbin.1 at ${BASEDIR}/OPAM/sw-sbin/.opam-switch/build/pkg-sbin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-sbin.1.
+
+[ERROR] Installation of pkg-sbin.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-sbin/.opam-switch/install/pkg-sbin.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-sbin/.opam-switch/build/pkg-sbin.1/finst to ${BASEDIR}/OPAM/sw-sbin/sbin
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-sbin 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes
+# OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes not found
+### ocaml cat.ml sw-sbin pkg-sbin
+==> No 'installed-bin' found
+### :II:5: Default install with no executable bit
+### chmod -x REPO/packages/pkg-sbin/pkg-sbin.1/files/installed-bin
+### <pkg:pkg-sbin.1>
+opam-version: "2.0"
+### <pkg:pkg-sbin.1:pkg-sbin.install>
+sbin: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-sbin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-sbin.1
+ACTION                          prepare_package_source: pkg-sbin.1 at ${BASEDIR}/OPAM/sw-sbin/.opam-switch/build/pkg-sbin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-sbin.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-sbin.1: 1 items (addition: 1)
+-> installed pkg-sbin.1
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes | sed-hash $BINMD5 hash
+added: "sbin/installed-bin" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-sbin pkg-sbin
+==> ${BASEDIR}/OPAM/sw-sbin/sbin/installed-bin (+x)
+### OPAMDEBUG=-5 opam remove pkg-sbin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-sbin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-sbin.1: files sbin/installed-bin were already removed
+-> removed   pkg-sbin.1
+ACTION                          Cleaning up artefacts of pkg-sbin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes
+# OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes not found
+### ocaml cat.ml sw-sbin pkg-sbin
+==> No 'installed-bin' found
+### :::::::::::::::::::::
+### :III: Field 'stublibs'
+### :::::::::::::::::::::
+### mkdir -p REPO/packages/pkg-stublibs/pkg-stublibs.1/files
+### cp installed-bin REPO/packages/pkg-stublibs/pkg-stublibs.1/files/installed-bin
+### opam switch create sw-stublibs --empty
+### :III:1: No defined destination path
+### <pkg:pkg-stublibs.1>
+opam-version: "2.0"
+### <pkg:pkg-stublibs.1:pkg-stublibs.install>
+stublibs: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-stublibs
+The following actions will be performed:
+=== install 1 package
+  - install pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-stublibs.1
+ACTION                          prepare_package_source: pkg-stublibs.1 at ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/build/pkg-stublibs.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-stublibs.1.
+
+TRACK                           after install: 3 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-stublibs.1: 1 items (addition: 1)
+-> installed pkg-stublibs.1
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes | sed-hash $BINMD5 hash
+added: "lib/stublibs/installed-bin" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> ${BASEDIR}/OPAM/sw-stublibs/lib/stublibs/installed-bin (+x)
+### OPAMDEBUG=-5 opam remove pkg-stublibs
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-stublibs.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-stublibs.1: files lib/stublibs/installed-bin were already removed
+-> removed   pkg-stublibs.1
+ACTION                          Cleaning up artefacts of pkg-stublibs.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes
+# OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes not found
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> No 'installed-bin' found
+### :III:2: Specify destination path
+### <pkg:pkg-stublibs.1>
+opam-version: "2.0"
+### <pkg:pkg-stublibs.1:pkg-stublibs.install>
+stublibs: [ "installed-bin" {"installed-bin.stublibs"} ]
+### OPAMDEBUG=-5 opam install pkg-stublibs
+The following actions will be performed:
+=== install 1 package
+  - install pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-stublibs.1
+ACTION                          prepare_package_source: pkg-stublibs.1 at ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/build/pkg-stublibs.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-stublibs.1.
+
+TRACK                           after install: 3 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-stublibs.1: 1 items (addition: 1)
+-> installed pkg-stublibs.1
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes | sed-hash $BINMD5 hash
+added: "lib/stublibs/installed-bin.stublibs" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> ${BASEDIR}/OPAM/sw-stublibs/lib/stublibs/installed-bin.stublibs (+x)
+### OPAMDEBUG=-5 opam remove pkg-stublibs
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-stublibs.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-stublibs.1: files lib/stublibs/installed-bin.stublibs were already removed
+-> removed   pkg-stublibs.1
+ACTION                          Cleaning up artefacts of pkg-stublibs.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes
+# OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes not found
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> No 'installed-bin' found
+### :III:3: Non existing filename, with optional argument
+### <pkg:pkg-stublibs.1>
+opam-version: "2.0"
+### <pkg:pkg-stublibs.1:pkg-stublibs.install>
+stublibs: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-stublibs
+The following actions will be performed:
+=== install 1 package
+  - install pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-stublibs.1
+ACTION                          prepare_package_source: pkg-stublibs.1 at ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/build/pkg-stublibs.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-stublibs.1.
+
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/build/pkg-stublibs.1/finst is not present and optional.
+TRACK                           after install: 2 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-stublibs.1: 0 items
+-> installed pkg-stublibs.1
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> No 'installed-bin' found
+### OPAMDEBUG=-5 opam remove pkg-stublibs
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-stublibs.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-stublibs.1
+ACTION                          Cleaning up artefacts of pkg-stublibs.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes
+# OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes not found
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> No 'installed-bin' found
+### :III:4: Non existing filename
+### <pkg:pkg-stublibs.1>
+opam-version: "2.0"
+### <pkg:pkg-stublibs.1:pkg-stublibs.install>
+stublibs: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-stublibs
+The following actions will be performed:
+=== install 1 package
+  - install pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-stublibs.1
+ACTION                          prepare_package_source: pkg-stublibs.1 at ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/build/pkg-stublibs.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-stublibs.1.
+
+[ERROR] Installation of pkg-stublibs.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/build/pkg-stublibs.1/finst to ${BASEDIR}/OPAM/sw-stublibs/lib/stublibs
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-stublibs 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes
+# OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes not found
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> No 'installed-bin' found
+### :III:5: Default install with no executable bit
+### chmod -x REPO/packages/pkg-stublibs/pkg-stublibs.1/files/installed-bin
+### <pkg:pkg-stublibs.1>
+opam-version: "2.0"
+### <pkg:pkg-stublibs.1:pkg-stublibs.install>
+stublibs: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-stublibs
+The following actions will be performed:
+=== install 1 package
+  - install pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-stublibs.1
+ACTION                          prepare_package_source: pkg-stublibs.1 at ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/build/pkg-stublibs.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-stublibs.1.
+
+TRACK                           after install: 3 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-stublibs.1: 1 items (addition: 1)
+-> installed pkg-stublibs.1
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes | sed-hash $BINMD5 hash
+added: "lib/stublibs/installed-bin" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> ${BASEDIR}/OPAM/sw-stublibs/lib/stublibs/installed-bin (+x)
+### OPAMDEBUG=-5 opam remove pkg-stublibs
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-stublibs.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-stublibs.1: files lib/stublibs/installed-bin were already removed
+-> removed   pkg-stublibs.1
+ACTION                          Cleaning up artefacts of pkg-stublibs.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes
+# OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes not found
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> No 'installed-bin' found
+### :::::::::::::::::::::
+### :IV: Field 'libexec'
+### :::::::::::::::::::::
+### mkdir -p REPO/packages/pkg-libexec/pkg-libexec.1/files
+### cp installed-bin REPO/packages/pkg-libexec/pkg-libexec.1/files/installed-bin
+### opam switch create sw-libexec --empty
+### :IV:1: No defined destination path
+### <pkg:pkg-libexec.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec.1:pkg-libexec.install>
+libexec: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-libexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec.1
+ACTION                          prepare_package_source: pkg-libexec.1 at ${BASEDIR}/OPAM/sw-libexec/.opam-switch/build/pkg-libexec.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec
+TRACK                           after install: 3 elements, 2 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-libexec.1: 2 items (addition: 2)
+-> installed pkg-libexec.1
+Done.
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes | sed-hash $BINMD5 hash
+added: ["lib/pkg-libexec" {"D"} "lib/pkg-libexec/installed-bin" {"F:+hash+"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-libexec pkg-libexec
+==> ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec/installed-bin (+x)
+### OPAMDEBUG=-5 opam remove pkg-libexec
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-libexec.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-libexec.1: files lib/pkg-libexec/installed-bin, lib/pkg-libexec were already removed
+-> removed   pkg-libexec.1
+ACTION                          Cleaning up artefacts of pkg-libexec.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes
+# OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes not found
+### ocaml cat.ml sw-libexec pkg-libexec
+==> No 'installed-bin' found
+### :IV:2: Specify destination path
+### <pkg:pkg-libexec.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec.1:pkg-libexec.install>
+libexec: [ "installed-bin" {"installed-bin.libexec"} ]
+### OPAMDEBUG=-5 opam install pkg-libexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec.1
+ACTION                          prepare_package_source: pkg-libexec.1 at ${BASEDIR}/OPAM/sw-libexec/.opam-switch/build/pkg-libexec.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec
+TRACK                           after install: 3 elements, 2 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-libexec.1: 2 items (addition: 2)
+-> installed pkg-libexec.1
+Done.
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes | sed-hash $BINMD5 hash
+added: ["lib/pkg-libexec" {"D"} "lib/pkg-libexec/installed-bin.libexec" {"F:+hash+"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-libexec pkg-libexec
+==> ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec/installed-bin.libexec (+x)
+### OPAMDEBUG=-5 opam remove pkg-libexec
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-libexec.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-libexec.1: files lib/pkg-libexec/installed-bin.libexec, lib/pkg-libexec were already removed
+-> removed   pkg-libexec.1
+ACTION                          Cleaning up artefacts of pkg-libexec.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes
+# OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes not found
+### ocaml cat.ml sw-libexec pkg-libexec
+==> No 'installed-bin' found
+### :IV:3: Non existing filename, with optional argument
+### <pkg:pkg-libexec.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec.1:pkg-libexec.install>
+libexec: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-libexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec.1
+ACTION                          prepare_package_source: pkg-libexec.1 at ${BASEDIR}/OPAM/sw-libexec/.opam-switch/build/pkg-libexec.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-libexec/.opam-switch/build/pkg-libexec.1/finst is not present and optional.
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-libexec.1: 1 items (addition: 1)
+-> installed pkg-libexec.1
+Done.
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes
+added: "lib/pkg-libexec" {"D"}
+opam-version: "2.0"
+### ocaml cat.ml sw-libexec pkg-libexec
+==> No 'installed-bin' found
+### OPAMDEBUG=-5 opam remove pkg-libexec
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-libexec.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-libexec.1: files lib/pkg-libexec were already removed
+-> removed   pkg-libexec.1
+ACTION                          Cleaning up artefacts of pkg-libexec.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes
+# OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes not found
+### ocaml cat.ml sw-libexec pkg-libexec
+==> No 'installed-bin' found
+### :IV:4: Non existing filename
+### <pkg:pkg-libexec.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec.1:pkg-libexec.install>
+libexec: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-libexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec.1
+ACTION                          prepare_package_source: pkg-libexec.1 at ${BASEDIR}/OPAM/sw-libexec/.opam-switch/build/pkg-libexec.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec
+[ERROR] Installation of pkg-libexec.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-libexec/.opam-switch/install/pkg-libexec.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-libexec/.opam-switch/build/pkg-libexec.1/finst to ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-libexec 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes
+# OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes not found
+### ocaml cat.ml sw-libexec pkg-libexec
+==> No 'installed-bin' found
+### :IV:5: Default install with no executable bit
+### chmod -x REPO/packages/pkg-libexec/pkg-libexec.1/files/installed-bin
+### <pkg:pkg-libexec.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec.1:pkg-libexec.install>
+libexec: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-libexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec.1
+ACTION                          prepare_package_source: pkg-libexec.1 at ${BASEDIR}/OPAM/sw-libexec/.opam-switch/build/pkg-libexec.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec.1.
+
+TRACK                           after install: 3 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-libexec.1: 1 items (addition: 1)
+-> installed pkg-libexec.1
+Done.
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes | sed-hash $BINMD5 hash
+added: "lib/pkg-libexec/installed-bin" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-libexec pkg-libexec
+==> ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec/installed-bin (+x)
+### OPAMDEBUG=-5 opam remove pkg-libexec
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-libexec.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-libexec.1: files lib/pkg-libexec/installed-bin were already removed
+-> removed   pkg-libexec.1
+ACTION                          Cleaning up artefacts of pkg-libexec.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes
+# OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes not found
+### ocaml cat.ml sw-libexec pkg-libexec
+==> No 'installed-bin' found
+### ::::::::::::::::::::::::::
+### :V: Field 'libexec_root'
+### ::::::::::::::::::::::::::
+### mkdir -p REPO/packages/pkg-libexec_root/pkg-libexec_root.1/files
+### cp installed-bin REPO/packages/pkg-libexec_root/pkg-libexec_root.1/files/installed-bin
+### opam switch create sw-libexec_root --empty
+### :V:1: No defined destination path
+### <pkg:pkg-libexec_root.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec_root.1:pkg-libexec_root.install>
+libexec_root: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-libexec_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec_root.1
+ACTION                          prepare_package_source: pkg-libexec_root.1 at ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/build/pkg-libexec_root.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec_root.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-libexec_root.1: 1 items (addition: 1)
+-> installed pkg-libexec_root.1
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes | sed-hash $BINMD5 hash
+added: "lib/installed-bin" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> ${BASEDIR}/OPAM/sw-libexec_root/lib/installed-bin (+x)
+### OPAMDEBUG=-5 opam remove pkg-libexec_root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-libexec_root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-libexec_root.1
+ACTION                          Cleaning up artefacts of pkg-libexec_root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes
+# OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes not found
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> No 'installed-bin' found
+### :V:2: Specify destination path
+### <pkg:pkg-libexec_root.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec_root.1:pkg-libexec_root.install>
+libexec_root: [ "installed-bin" {"installed-bin.libexec_root"} ]
+### OPAMDEBUG=-5 opam install pkg-libexec_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec_root.1
+ACTION                          prepare_package_source: pkg-libexec_root.1 at ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/build/pkg-libexec_root.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec_root.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-libexec_root.1: 1 items (addition: 1)
+-> installed pkg-libexec_root.1
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes | sed-hash $BINMD5 hash
+added: "lib/installed-bin.libexec_root" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> ${BASEDIR}/OPAM/sw-libexec_root/lib/installed-bin.libexec_root (+x)
+### OPAMDEBUG=-5 opam remove pkg-libexec_root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-libexec_root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-libexec_root.1
+ACTION                          Cleaning up artefacts of pkg-libexec_root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes
+# OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes not found
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> No 'installed-bin' found
+### :V:3: Non existing filename, with optional argument
+### <pkg:pkg-libexec_root.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec_root.1:pkg-libexec_root.install>
+libexec_root: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-libexec_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec_root.1
+ACTION                          prepare_package_source: pkg-libexec_root.1 at ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/build/pkg-libexec_root.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec_root.1.
+
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/build/pkg-libexec_root.1/finst is not present and optional.
+TRACK                           after install: 1 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-libexec_root.1: 0 items
+-> installed pkg-libexec_root.1
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> No 'installed-bin' found
+### OPAMDEBUG=-5 opam remove pkg-libexec_root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-libexec_root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-libexec_root.1
+ACTION                          Cleaning up artefacts of pkg-libexec_root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes
+# OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes not found
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> No 'installed-bin' found
+### :V:4: Non existing filename
+### <pkg:pkg-libexec_root.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec_root.1:pkg-libexec_root.install>
+libexec_root: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-libexec_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec_root.1
+ACTION                          prepare_package_source: pkg-libexec_root.1 at ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/build/pkg-libexec_root.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec_root.1.
+
+[ERROR] Installation of pkg-libexec_root.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/build/pkg-libexec_root.1/finst to ${BASEDIR}/OPAM/sw-libexec_root/lib
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-libexec_root 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes
+# OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes not found
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> No 'installed-bin' found
+### :V:5: Default install with no executable bit
+### chmod -x REPO/packages/pkg-libexec_root/pkg-libexec_root.1/files/installed-bin
+### <pkg:pkg-libexec_root.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec_root.1:pkg-libexec_root.install>
+libexec_root: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-libexec_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec_root.1
+ACTION                          prepare_package_source: pkg-libexec_root.1 at ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/build/pkg-libexec_root.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec_root.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-libexec_root.1: 1 items (addition: 1)
+-> installed pkg-libexec_root.1
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes | sed-hash $BINMD5 hash
+added: "lib/installed-bin" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> ${BASEDIR}/OPAM/sw-libexec_root/lib/installed-bin (+x)
+### OPAMDEBUG=-5 opam remove pkg-libexec_root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-libexec_root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-libexec_root.1
+ACTION                          Cleaning up artefacts of pkg-libexec_root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes
+# OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes not found
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> No 'installed-bin' found

--- a/tests/reftests/dot-install-exe-fields.win32.test
+++ b/tests/reftests/dot-install-exe-fields.win32.test
@@ -1,0 +1,1202 @@
+N0REP0
+### :::::::
+### : In this test, we test all executable fields of `.install` files
+### : For each fields, we test 5 cases:
+### :   * default install with binary as exe (.exe ext) : [ "filename" ]
+### :   * install with target : [ "filename" {"target"} ]
+### :   * optional install : [ "?non-existing-filename" ]
+### :   * non existing filename : [ "non-existing-filename" ]
+### :   * default install with binary not as exe (no .exe ext) : [ "filename" ]
+### :
+### : Fields are : bin, sbin, stublibs, libexec, libexec_root
+### : Non executable fields are tested in dot-install-exec-fields.*.test
+### :
+### : For each package, there is no install target. The only side effect is
+### : that it doesn't trigger switch root directory tracking, all addition and
+### :  removal are done according install file
+### :  There is some specific fields that have some additional tests:
+### :    * misc: it needs a target and an absolute path
+### :    * man: it needs a specific file format
+### :::::::
+### OPAMYES=1
+### # we need to disable strict bc of erroring warnings
+### OPAMSTRICT=0
+### # we neeed the precise tracking to have a sha in changes file instead of timestamp
+### OPAMPRECISETRACKING=1
+### OPAMDEBUGSECTIONS="TRACK ACTION"
+### # Print the installed file 'installed-bin*' in switch (or root)
+### <cat.ml>
+#directory "+str"
+#load "str.cma"
+
+(* check if the file is executable, by extension *)
+let is_exec file = Filename.check_suffix file ".exe"
+
+(* print information about a file:
+  - its path
+  - if it is executable
+  - it not found
+  - if empty *)
+let cat file =
+  if Sys.file_exists file then
+    let header = if is_exec file then file^" (+x)" else file in
+    Printf.printf "==> %s\n" header ;
+    let error () =
+      let ic = open_in file in
+      let _ : char = input_char ic in
+      close_in ic
+    in
+    try error () with
+    | exn ->
+      let err =
+        match exn with
+        | End_of_file -> "Empty file"
+        | exn -> (Printexc.to_string exn)
+      in
+      Printf.printf "%s" err; exit 1
+  else
+    Printf.printf "--> %s: not found\n" file
+
+let switch = Sys.argv.(1)
+let pkg = Sys.argv.(2)
+let root = Sys.getenv "OPAMROOT"
+let (/) = Filename.concat
+
+let bname = "installed-bin"
+let root_file = try Some Sys.argv.(3) with Invalid_argument _ -> None
+let files =
+  match root_file with
+  | None -> []
+  | Some f -> [ root / f ]
+
+(* retrieve all files names 'installed-file' in switch prefix *)
+let files =
+  let rec aux files cwd =
+    let ls = Sys.readdir cwd |> Array.to_list in
+    let dirs, cwd_files =
+      List.partition (fun f -> Sys.is_directory (cwd / f)) ls
+    in
+    let dirs =
+      if (cwd : string) = root / switch then
+        List.filter (fun f -> f <> ".opam-switch") dirs
+      else dirs
+    in
+    let files =
+      files
+      @ List.filter_map (fun f ->
+          if String.starts_with ~prefix:bname f then
+            Some (cwd / f) else None)
+        cwd_files
+    in
+    if dirs = [] then files else
+      List.fold_left (fun files dir -> aux files (cwd / dir)) files dirs
+  in
+  aux files (root / switch)
+  |> List.sort String.compare
+
+let () =
+  match files with
+  | [] -> Printf.printf "==> No '%s*' found" bname
+  | _ -> List.iter cat files
+
+### <tiny.ml>
+print_endline "youhou i'm installed!"
+### ocamlc tiny.ml -o installed-bin.exe
+### openssl md5 installed-bin.exe | '.*= ' -> '' >$ BINMD5
+### ::::::::::::::::
+### :I: Field 'bin'
+### ::::::::::::::::
+### mkdir -p REPO/packages/pkg-bin/pkg-bin.1/files
+### cp installed-bin.exe REPO/packages/pkg-bin/pkg-bin.1/files/installed-bin.exe
+### opam switch create sw-bin --empty
+### :I:1: No defined destination path
+### <pkg:pkg-bin.1>
+opam-version: "2.0"
+### <pkg:pkg-bin.1:pkg-bin.install>
+bin: [ "installed-bin.exe" ]
+### OPAMDEBUG=-5 opam install pkg-bin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-bin.1
+ACTION                          prepare_package_source: pkg-bin.1 at ${BASEDIR}/OPAM/sw-bin/.opam-switch/build/pkg-bin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-bin.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-bin.1: 1 items (addition: 1)
+-> installed pkg-bin.1
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes | sed-hash $BINMD5 hash
+added: "bin/installed-bin.exe" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-bin pkg-bin
+==> ${BASEDIR}/OPAM/sw-bin/bin/installed-bin.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-bin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-bin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-bin.1: files bin/installed-bin.exe were already removed
+-> removed   pkg-bin.1
+ACTION                          Cleaning up artefacts of pkg-bin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes
+# OPAM/sw-bin/.opam-switch/install/pkg-bin.changes not found
+### ocaml cat.ml sw-bin pkg-bin
+==> No 'installed-bin*' found
+### :I:2: Specify destination path
+### <pkg:pkg-bin.1>
+opam-version: "2.0"
+### <pkg:pkg-bin.1:pkg-bin.install>
+bin: [ "installed-bin.exe" {"installed-bin.bin.exe"} ]
+### OPAMDEBUG=-5 opam install pkg-bin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-bin.1
+ACTION                          prepare_package_source: pkg-bin.1 at ${BASEDIR}/OPAM/sw-bin/.opam-switch/build/pkg-bin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-bin.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-bin.1: 1 items (addition: 1)
+-> installed pkg-bin.1
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes | sed-hash $BINMD5 hash
+added: "bin/installed-bin.bin.exe" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-bin pkg-bin
+==> ${BASEDIR}/OPAM/sw-bin/bin/installed-bin.bin.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-bin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-bin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-bin.1: files bin/installed-bin.bin.exe were already removed
+-> removed   pkg-bin.1
+ACTION                          Cleaning up artefacts of pkg-bin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes
+# OPAM/sw-bin/.opam-switch/install/pkg-bin.changes not found
+### ocaml cat.ml sw-bin pkg-bin
+==> No 'installed-bin*' found
+### :I:3: Non existing filename, with optional argument
+### <pkg:pkg-bin.1>
+opam-version: "2.0"
+### <pkg:pkg-bin.1:pkg-bin.install>
+bin: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-bin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-bin.1
+ACTION                          prepare_package_source: pkg-bin.1 at ${BASEDIR}/OPAM/sw-bin/.opam-switch/build/pkg-bin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-bin.1.
+
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-bin/.opam-switch/build/pkg-bin.1/finst is not present and optional.
+TRACK                           after install: 1 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-bin.1: 0 items
+-> installed pkg-bin.1
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-bin pkg-bin
+==> No 'installed-bin*' found
+### OPAMDEBUG=-5 opam remove pkg-bin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-bin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-bin.1
+ACTION                          Cleaning up artefacts of pkg-bin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes
+# OPAM/sw-bin/.opam-switch/install/pkg-bin.changes not found
+### ocaml cat.ml sw-bin pkg-bin
+==> No 'installed-bin*' found
+### :I:4: Non existing filename
+### <pkg:pkg-bin.1>
+opam-version: "2.0"
+### <pkg:pkg-bin.1:pkg-bin.install>
+bin: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-bin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-bin.1
+ACTION                          prepare_package_source: pkg-bin.1 at ${BASEDIR}/OPAM/sw-bin/.opam-switch/build/pkg-bin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-bin.1.
+
+[ERROR] Installation of pkg-bin.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-bin/.opam-switch/install/pkg-bin.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-bin/.opam-switch/build/pkg-bin.1/finst to ${BASEDIR}/OPAM/sw-bin/bin
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-bin 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes
+# OPAM/sw-bin/.opam-switch/install/pkg-bin.changes not found
+### ocaml cat.ml sw-bin pkg-bin
+==> No 'installed-bin*' found
+### :I:5: Default install with no executable bit
+### mv REPO/packages/pkg-bin/pkg-bin.1/files/installed-bin.exe REPO/packages/pkg-bin/pkg-bin.1/files/installed-bin
+### <pkg:pkg-bin.1>
+opam-version: "2.0"
+### <pkg:pkg-bin.1:pkg-bin.install>
+bin: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-bin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-bin.1
+ACTION                          prepare_package_source: pkg-bin.1 at ${BASEDIR}/OPAM/sw-bin/.opam-switch/build/pkg-bin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-bin.1.
+
+[WARNING] Automatically adding .exe to ${BASEDIR}/OPAM/sw-bin/bin/installed-bin
+TRACK                           after install: 1 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-bin.1: 0 items
+-> installed pkg-bin.1
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-bin pkg-bin
+==> ${BASEDIR}/OPAM/sw-bin/bin/installed-bin.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-bin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-bin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-bin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-bin.1
+ACTION                          Cleaning up artefacts of pkg-bin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-bin/.opam-switch/install/pkg-bin.changes
+# OPAM/sw-bin/.opam-switch/install/pkg-bin.changes not found
+### ocaml cat.ml sw-bin pkg-bin
+==> ${BASEDIR}/OPAM/sw-bin/bin/installed-bin.exe (+x)
+### ::::::::::::::::::
+### :II: Field 'sbin'
+### ::::::::::::::::::
+### mkdir -p REPO/packages/pkg-sbin/pkg-sbin.1/files
+### cp installed-bin.exe REPO/packages/pkg-sbin/pkg-sbin.1/files/installed-bin.exe
+### opam switch create sw-sbin --empty
+### :II:1: No defined destination path
+### <pkg:pkg-sbin.1>
+opam-version: "2.0"
+### <pkg:pkg-sbin.1:pkg-sbin.install>
+sbin: [ "installed-bin.exe" ]
+### OPAMDEBUG=-5 opam install pkg-sbin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-sbin.1
+ACTION                          prepare_package_source: pkg-sbin.1 at ${BASEDIR}/OPAM/sw-sbin/.opam-switch/build/pkg-sbin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-sbin.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-sbin.1: 1 items (addition: 1)
+-> installed pkg-sbin.1
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes | sed-hash $BINMD5 hash
+added: "sbin/installed-bin.exe" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-sbin pkg-sbin
+==> ${BASEDIR}/OPAM/sw-sbin/sbin/installed-bin.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-sbin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-sbin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-sbin.1: files sbin/installed-bin.exe were already removed
+-> removed   pkg-sbin.1
+ACTION                          Cleaning up artefacts of pkg-sbin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes
+# OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes not found
+### ocaml cat.ml sw-sbin pkg-sbin
+==> No 'installed-bin*' found
+### :II:2: Specify destination path
+### <pkg:pkg-sbin.1>
+opam-version: "2.0"
+### <pkg:pkg-sbin.1:pkg-sbin.install>
+sbin: [ "installed-bin.exe" {"installed-bin.sbin.exe"} ]
+### OPAMDEBUG=-5 opam install pkg-sbin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-sbin.1
+ACTION                          prepare_package_source: pkg-sbin.1 at ${BASEDIR}/OPAM/sw-sbin/.opam-switch/build/pkg-sbin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-sbin.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-sbin.1: 1 items (addition: 1)
+-> installed pkg-sbin.1
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes | sed-hash $BINMD5 hash
+added: "sbin/installed-bin.sbin.exe" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-sbin pkg-sbin
+==> ${BASEDIR}/OPAM/sw-sbin/sbin/installed-bin.sbin.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-sbin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-sbin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-sbin.1: files sbin/installed-bin.sbin.exe were already removed
+-> removed   pkg-sbin.1
+ACTION                          Cleaning up artefacts of pkg-sbin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes
+# OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes not found
+### ocaml cat.ml sw-sbin pkg-sbin
+==> No 'installed-bin*' found
+### :II:3: Non existing filename, with optional argument
+### <pkg:pkg-sbin.1>
+opam-version: "2.0"
+### <pkg:pkg-sbin.1:pkg-sbin.install>
+sbin: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-sbin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-sbin.1
+ACTION                          prepare_package_source: pkg-sbin.1 at ${BASEDIR}/OPAM/sw-sbin/.opam-switch/build/pkg-sbin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-sbin.1.
+
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-sbin/.opam-switch/build/pkg-sbin.1/finst is not present and optional.
+TRACK                           after install: 1 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-sbin.1: 0 items
+-> installed pkg-sbin.1
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-sbin pkg-sbin
+==> No 'installed-bin*' found
+### OPAMDEBUG=-5 opam remove pkg-sbin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-sbin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-sbin.1
+ACTION                          Cleaning up artefacts of pkg-sbin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes
+# OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes not found
+### ocaml cat.ml sw-sbin pkg-sbin
+==> No 'installed-bin*' found
+### :II:4: Non existing filename
+### <pkg:pkg-sbin.1>
+opam-version: "2.0"
+### <pkg:pkg-sbin.1:pkg-sbin.install>
+sbin: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-sbin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-sbin.1
+ACTION                          prepare_package_source: pkg-sbin.1 at ${BASEDIR}/OPAM/sw-sbin/.opam-switch/build/pkg-sbin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-sbin.1.
+
+[ERROR] Installation of pkg-sbin.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-sbin/.opam-switch/install/pkg-sbin.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-sbin/.opam-switch/build/pkg-sbin.1/finst to ${BASEDIR}/OPAM/sw-sbin/sbin
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-sbin 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes
+# OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes not found
+### ocaml cat.ml sw-sbin pkg-sbin
+==> No 'installed-bin*' found
+### :II:5: Default install with no executable bit
+### mv REPO/packages/pkg-sbin/pkg-sbin.1/files/installed-bin.exe REPO/packages/pkg-sbin/pkg-sbin.1/files/installed-bin
+### <pkg:pkg-sbin.1>
+opam-version: "2.0"
+### <pkg:pkg-sbin.1:pkg-sbin.install>
+sbin: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-sbin
+The following actions will be performed:
+=== install 1 package
+  - install pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-sbin.1
+ACTION                          prepare_package_source: pkg-sbin.1 at ${BASEDIR}/OPAM/sw-sbin/.opam-switch/build/pkg-sbin.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-sbin.1.
+
+[WARNING] Automatically adding .exe to ${BASEDIR}/OPAM/sw-sbin/sbin/installed-bin
+TRACK                           after install: 1 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-sbin.1: 0 items
+-> installed pkg-sbin.1
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-sbin pkg-sbin
+==> ${BASEDIR}/OPAM/sw-sbin/sbin/installed-bin.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-sbin
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-sbin 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-sbin.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-sbin.1
+ACTION                          Cleaning up artefacts of pkg-sbin.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes
+# OPAM/sw-sbin/.opam-switch/install/pkg-sbin.changes not found
+### ocaml cat.ml sw-sbin pkg-sbin
+==> ${BASEDIR}/OPAM/sw-sbin/sbin/installed-bin.exe (+x)
+### :::::::::::::::::::::
+### :III: Field 'stublibs'
+### :::::::::::::::::::::
+### mkdir -p REPO/packages/pkg-stublibs/pkg-stublibs.1/files
+### cp installed-bin.exe REPO/packages/pkg-stublibs/pkg-stublibs.1/files/installed-bin.exe
+### opam switch create sw-stublibs --empty
+### :III:1: No defined destination path
+### <pkg:pkg-stublibs.1>
+opam-version: "2.0"
+### <pkg:pkg-stublibs.1:pkg-stublibs.install>
+stublibs: [ "installed-bin.exe" ]
+### OPAMDEBUG=-5 opam install pkg-stublibs
+The following actions will be performed:
+=== install 1 package
+  - install pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-stublibs.1
+ACTION                          prepare_package_source: pkg-stublibs.1 at ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/build/pkg-stublibs.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-stublibs.1.
+
+TRACK                           after install: 3 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-stublibs.1: 1 items (addition: 1)
+-> installed pkg-stublibs.1
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes | sed-hash $BINMD5 hash
+added: "lib/stublibs/installed-bin.exe" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> ${BASEDIR}/OPAM/sw-stublibs/lib/stublibs/installed-bin.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-stublibs
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-stublibs.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-stublibs.1: files lib/stublibs/installed-bin.exe were already removed
+-> removed   pkg-stublibs.1
+ACTION                          Cleaning up artefacts of pkg-stublibs.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes
+# OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes not found
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> No 'installed-bin*' found
+### :III:2: Specify destination path
+### <pkg:pkg-stublibs.1>
+opam-version: "2.0"
+### <pkg:pkg-stublibs.1:pkg-stublibs.install>
+stublibs: [ "installed-bin.exe" {"installed-bin.stublibs.exe"} ]
+### OPAMDEBUG=-5 opam install pkg-stublibs
+The following actions will be performed:
+=== install 1 package
+  - install pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-stublibs.1
+ACTION                          prepare_package_source: pkg-stublibs.1 at ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/build/pkg-stublibs.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-stublibs.1.
+
+TRACK                           after install: 3 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-stublibs.1: 1 items (addition: 1)
+-> installed pkg-stublibs.1
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes | sed-hash $BINMD5 hash
+added: "lib/stublibs/installed-bin.stublibs.exe" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> ${BASEDIR}/OPAM/sw-stublibs/lib/stublibs/installed-bin.stublibs.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-stublibs
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-stublibs.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-stublibs.1: files lib/stublibs/installed-bin.stublibs.exe were already removed
+-> removed   pkg-stublibs.1
+ACTION                          Cleaning up artefacts of pkg-stublibs.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes
+# OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes not found
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> No 'installed-bin*' found
+### :III:3: Non existing filename, with optional argument
+### <pkg:pkg-stublibs.1>
+opam-version: "2.0"
+### <pkg:pkg-stublibs.1:pkg-stublibs.install>
+stublibs: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-stublibs
+The following actions will be performed:
+=== install 1 package
+  - install pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-stublibs.1
+ACTION                          prepare_package_source: pkg-stublibs.1 at ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/build/pkg-stublibs.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-stublibs.1.
+
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/build/pkg-stublibs.1/finst is not present and optional.
+TRACK                           after install: 2 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-stublibs.1: 0 items
+-> installed pkg-stublibs.1
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> No 'installed-bin*' found
+### OPAMDEBUG=-5 opam remove pkg-stublibs
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-stublibs.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-stublibs.1
+ACTION                          Cleaning up artefacts of pkg-stublibs.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes
+# OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes not found
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> No 'installed-bin*' found
+### :III:4: Non existing filename
+### <pkg:pkg-stublibs.1>
+opam-version: "2.0"
+### <pkg:pkg-stublibs.1:pkg-stublibs.install>
+stublibs: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-stublibs
+The following actions will be performed:
+=== install 1 package
+  - install pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-stublibs.1
+ACTION                          prepare_package_source: pkg-stublibs.1 at ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/build/pkg-stublibs.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-stublibs.1.
+
+[ERROR] Installation of pkg-stublibs.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/build/pkg-stublibs.1/finst to ${BASEDIR}/OPAM/sw-stublibs/lib/stublibs
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-stublibs 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes
+# OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes not found
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> No 'installed-bin*' found
+### :III:5: Default install with no executable bit
+### mv REPO/packages/pkg-stublibs/pkg-stublibs.1/files/installed-bin.exe REPO/packages/pkg-stublibs/pkg-stublibs.1/files/installed-bin
+### <pkg:pkg-stublibs.1>
+opam-version: "2.0"
+### <pkg:pkg-stublibs.1:pkg-stublibs.install>
+stublibs: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-stublibs
+The following actions will be performed:
+=== install 1 package
+  - install pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-stublibs.1
+ACTION                          prepare_package_source: pkg-stublibs.1 at ${BASEDIR}/OPAM/sw-stublibs/.opam-switch/build/pkg-stublibs.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-stublibs.1.
+
+[WARNING] Automatically adding .exe to ${BASEDIR}/OPAM/sw-stublibs/lib/stublibs/installed-bin
+TRACK                           after install: 2 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-stublibs.1: 0 items
+-> installed pkg-stublibs.1
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> ${BASEDIR}/OPAM/sw-stublibs/lib/stublibs/installed-bin.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-stublibs
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-stublibs 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-stublibs.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-stublibs.1
+ACTION                          Cleaning up artefacts of pkg-stublibs.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes
+# OPAM/sw-stublibs/.opam-switch/install/pkg-stublibs.changes not found
+### ocaml cat.ml sw-stublibs pkg-stublibs
+==> ${BASEDIR}/OPAM/sw-stublibs/lib/stublibs/installed-bin.exe (+x)
+### :::::::::::::::::::::
+### :IV: Field 'libexec'
+### :::::::::::::::::::::
+### mkdir -p REPO/packages/pkg-libexec/pkg-libexec.1/files
+### cp installed-bin.exe REPO/packages/pkg-libexec/pkg-libexec.1/files/installed-bin.exe
+### opam switch create sw-libexec --empty
+### :IV:1: No defined destination path
+### <pkg:pkg-libexec.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec.1:pkg-libexec.install>
+libexec: [ "installed-bin.exe" ]
+### OPAMDEBUG=-5 opam install pkg-libexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec.1
+ACTION                          prepare_package_source: pkg-libexec.1 at ${BASEDIR}/OPAM/sw-libexec/.opam-switch/build/pkg-libexec.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec
+TRACK                           after install: 3 elements, 2 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-libexec.1: 2 items (addition: 2)
+-> installed pkg-libexec.1
+Done.
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes | sed-hash $BINMD5 hash
+added: ["lib/pkg-libexec" {"D"} "lib/pkg-libexec/installed-bin.exe" {"F:+hash+"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-libexec pkg-libexec
+==> ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec/installed-bin.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-libexec
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-libexec.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-libexec.1: files lib/pkg-libexec/installed-bin.exe, lib/pkg-libexec were already removed
+-> removed   pkg-libexec.1
+ACTION                          Cleaning up artefacts of pkg-libexec.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes
+# OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes not found
+### ocaml cat.ml sw-libexec pkg-libexec
+==> No 'installed-bin*' found
+### :IV:2: Specify destination path
+### <pkg:pkg-libexec.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec.1:pkg-libexec.install>
+libexec: [ "installed-bin.exe" {"installed-bin.libexec.exe"} ]
+### OPAMDEBUG=-5 opam install pkg-libexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec.1
+ACTION                          prepare_package_source: pkg-libexec.1 at ${BASEDIR}/OPAM/sw-libexec/.opam-switch/build/pkg-libexec.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec
+TRACK                           after install: 3 elements, 2 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-libexec.1: 2 items (addition: 2)
+-> installed pkg-libexec.1
+Done.
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes | sed-hash $BINMD5 hash
+added: ["lib/pkg-libexec" {"D"} "lib/pkg-libexec/installed-bin.libexec.exe" {"F:+hash+"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-libexec pkg-libexec
+==> ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec/installed-bin.libexec.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-libexec
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-libexec.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-libexec.1: files lib/pkg-libexec/installed-bin.libexec.exe, lib/pkg-libexec were already removed
+-> removed   pkg-libexec.1
+ACTION                          Cleaning up artefacts of pkg-libexec.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes
+# OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes not found
+### ocaml cat.ml sw-libexec pkg-libexec
+==> No 'installed-bin*' found
+### :IV:3: Non existing filename, with optional argument
+### <pkg:pkg-libexec.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec.1:pkg-libexec.install>
+libexec: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-libexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec.1
+ACTION                          prepare_package_source: pkg-libexec.1 at ${BASEDIR}/OPAM/sw-libexec/.opam-switch/build/pkg-libexec.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-libexec/.opam-switch/build/pkg-libexec.1/finst is not present and optional.
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-libexec.1: 1 items (addition: 1)
+-> installed pkg-libexec.1
+Done.
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes
+added: "lib/pkg-libexec" {"D"}
+opam-version: "2.0"
+### ocaml cat.ml sw-libexec pkg-libexec
+==> No 'installed-bin*' found
+### OPAMDEBUG=-5 opam remove pkg-libexec
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-libexec.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-libexec.1: files lib/pkg-libexec were already removed
+-> removed   pkg-libexec.1
+ACTION                          Cleaning up artefacts of pkg-libexec.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes
+# OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes not found
+### ocaml cat.ml sw-libexec pkg-libexec
+==> No 'installed-bin*' found
+### :IV:4: Non existing filename
+### <pkg:pkg-libexec.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec.1:pkg-libexec.install>
+libexec: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-libexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec.1
+ACTION                          prepare_package_source: pkg-libexec.1 at ${BASEDIR}/OPAM/sw-libexec/.opam-switch/build/pkg-libexec.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec
+[ERROR] Installation of pkg-libexec.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-libexec/.opam-switch/install/pkg-libexec.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-libexec/.opam-switch/build/pkg-libexec.1/finst to ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-libexec 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes
+# OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes not found
+### ocaml cat.ml sw-libexec pkg-libexec
+==> No 'installed-bin*' found
+### :IV:5: Default install with no executable bit
+### mv REPO/packages/pkg-libexec/pkg-libexec.1/files/installed-bin.exe REPO/packages/pkg-libexec/pkg-libexec.1/files/installed-bin
+### <pkg:pkg-libexec.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec.1:pkg-libexec.install>
+libexec: [ "installed-bin.exe" ]
+### OPAMDEBUG=-5 opam install pkg-libexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec.1
+ACTION                          prepare_package_source: pkg-libexec.1 at ${BASEDIR}/OPAM/sw-libexec/.opam-switch/build/pkg-libexec.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec.1.
+
+[ERROR] Installation of pkg-libexec.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-libexec/.opam-switch/install/pkg-libexec.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-libexec/.opam-switch/build/pkg-libexec.1/installed-bin.exe to ${BASEDIR}/OPAM/sw-libexec/lib/pkg-libexec
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-libexec 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes
+# OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes not found
+### ocaml cat.ml sw-libexec pkg-libexec
+==> No 'installed-bin*' found
+### OPAMDEBUG=-5 opam remove pkg-libexec
+[NOTE] pkg-libexec is not installed.
+
+Nothing to do.
+### opam-cat OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes
+# OPAM/sw-libexec/.opam-switch/install/pkg-libexec.changes not found
+### ocaml cat.ml sw-libexec pkg-libexec
+==> No 'installed-bin*' found
+### ::::::::::::::::::::::::::
+### :V: Field 'libexec_root'
+### ::::::::::::::::::::::::::
+### mkdir -p REPO/packages/pkg-libexec_root/pkg-libexec_root.1/files
+### cp installed-bin.exe REPO/packages/pkg-libexec_root/pkg-libexec_root.1/files/installed-bin.exe
+### opam switch create sw-libexec_root --empty
+### :V:1: No defined destination path
+### <pkg:pkg-libexec_root.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec_root.1:pkg-libexec_root.install>
+libexec_root: [ "installed-bin.exe" ]
+### OPAMDEBUG=-5 opam install pkg-libexec_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec_root.1
+ACTION                          prepare_package_source: pkg-libexec_root.1 at ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/build/pkg-libexec_root.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec_root.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-libexec_root.1: 1 items (addition: 1)
+-> installed pkg-libexec_root.1
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes | sed-hash $BINMD5 hash
+added: "lib/installed-bin.exe" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> ${BASEDIR}/OPAM/sw-libexec_root/lib/installed-bin.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-libexec_root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-libexec_root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-libexec_root.1
+ACTION                          Cleaning up artefacts of pkg-libexec_root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes
+# OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes not found
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> No 'installed-bin*' found
+### :V:2: Specify destination path
+### <pkg:pkg-libexec_root.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec_root.1:pkg-libexec_root.install>
+libexec_root: [ "installed-bin.exe" {"installed-bin.libexec_root.exe"} ]
+### OPAMDEBUG=-5 opam install pkg-libexec_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec_root.1
+ACTION                          prepare_package_source: pkg-libexec_root.1 at ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/build/pkg-libexec_root.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec_root.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-libexec_root.1: 1 items (addition: 1)
+-> installed pkg-libexec_root.1
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes | sed-hash $BINMD5 hash
+added: "lib/installed-bin.libexec_root.exe" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> ${BASEDIR}/OPAM/sw-libexec_root/lib/installed-bin.libexec_root.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-libexec_root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-libexec_root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-libexec_root.1
+ACTION                          Cleaning up artefacts of pkg-libexec_root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes
+# OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes not found
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> No 'installed-bin*' found
+### :V:3: Non existing filename, with optional argument
+### <pkg:pkg-libexec_root.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec_root.1:pkg-libexec_root.install>
+libexec_root: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-libexec_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec_root.1
+ACTION                          prepare_package_source: pkg-libexec_root.1 at ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/build/pkg-libexec_root.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec_root.1.
+
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/build/pkg-libexec_root.1/finst is not present and optional.
+TRACK                           after install: 1 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-libexec_root.1: 0 items
+-> installed pkg-libexec_root.1
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> No 'installed-bin*' found
+### OPAMDEBUG=-5 opam remove pkg-libexec_root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-libexec_root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-libexec_root.1
+ACTION                          Cleaning up artefacts of pkg-libexec_root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes
+# OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes not found
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> No 'installed-bin*' found
+### :V:4: Non existing filename
+### <pkg:pkg-libexec_root.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec_root.1:pkg-libexec_root.install>
+libexec_root: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-libexec_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec_root.1
+ACTION                          prepare_package_source: pkg-libexec_root.1 at ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/build/pkg-libexec_root.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec_root.1.
+
+[ERROR] Installation of pkg-libexec_root.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/build/pkg-libexec_root.1/finst to ${BASEDIR}/OPAM/sw-libexec_root/lib
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-libexec_root 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes
+# OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes not found
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> No 'installed-bin*' found
+### :V:5: Default install with no executable bit
+### mv REPO/packages/pkg-libexec_root/pkg-libexec_root.1/files/installed-bin.exe REPO/packages/pkg-libexec_root/pkg-libexec_root.1/files/installed-bin
+### <pkg:pkg-libexec_root.1>
+opam-version: "2.0"
+### <pkg:pkg-libexec_root.1:pkg-libexec_root.install>
+libexec_root: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-libexec_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-libexec_root.1
+ACTION                          prepare_package_source: pkg-libexec_root.1 at ${BASEDIR}/OPAM/sw-libexec_root/.opam-switch/build/pkg-libexec_root.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-libexec_root.1.
+
+[WARNING] Automatically adding .exe to ${BASEDIR}/OPAM/sw-libexec_root/lib/installed-bin
+TRACK                           after install: 1 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-libexec_root.1: 0 items
+-> installed pkg-libexec_root.1
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> ${BASEDIR}/OPAM/sw-libexec_root/lib/installed-bin.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-libexec_root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-libexec_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-libexec_root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-libexec_root.1
+ACTION                          Cleaning up artefacts of pkg-libexec_root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes
+# OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes not found
+### ocaml cat.ml sw-libexec_root pkg-libexec_root
+==> ${BASEDIR}/OPAM/sw-libexec_root/lib/installed-bin.exe (+x)

--- a/tests/reftests/dot-install-non-exe-fields.test
+++ b/tests/reftests/dot-install-non-exe-fields.test
@@ -1,0 +1,1797 @@
+N0REP0
+### :::::::
+### : In this test, we test all non executable fields of `.install` files
+### : For each fields, we test 4 cases:
+### :   * default install : [ "filename" ]
+### :   * install with target : [ "filename" {"target"} ]
+### :   * optional install : [ "?non-existing-filename" ]
+### :   * non existing filename : [ "non-existing-filename" ]
+### :
+### : Fields are : lib, misc, toplevel, share, share_root, etc, doc, man, lib_root,
+### : Executable fields are tested in dot-install-exec-fields.*.test
+### :
+### : For each package, there is no install target. The only side effect is
+### : that it doesn't trigger switch root directory tracking, all addition and
+### :  removal are done according install file
+### :  There is some specific fields that have some additional tests:
+### :    * misc: it needs a target and an absolute path
+### :    * man: it needs a specific file format
+### :::::::
+### OPAMYES=1
+### # we neeed the precise tracking to have a sha in changes file instead of timestamp
+### OPAMPRECISETRACKING=1
+### OPAMDEBUGSECTIONS="TRACK ACTION"
+### # Print the installed file 'installed-file' in switch (or root)
+### <cat.ml>
+#directory "+str"
+#directory "+unix"
+#load "str.cma"
+#load "unix.cma"
+
+(* print information about a file:
+  - its path
+  - if it is executable
+  - it not found
+  - if empty *)
+let cat file =
+  if Sys.file_exists file then
+    (Printf.printf "==> %s\n" file ;
+     let error () =
+       let ic = open_in file in
+       let _ : char = input_char ic in
+       close_in ic
+     in
+     try error () with
+     | exn ->
+       let err =
+         match exn with
+         | End_of_file -> "Empty file"
+         | exn -> (Printexc.to_string exn)
+       in
+       Printf.printf "%s" err; exit 1)
+  else
+    Printf.printf "--> %s: not found\n" file
+
+let switch = Sys.argv.(1)
+let pkg = Sys.argv.(2)
+let root = Sys.getenv "OPAMROOT"
+let (/) = Filename.concat
+
+let fname = "installed-file"
+let root_file = try Some Sys.argv.(3) with Invalid_argument _ -> None
+let files =
+  match root_file with
+  | None -> []
+  | Some f -> [ root / f ]
+
+(* retrieve all files names 'installed-file' in switch prefix *)
+let files =
+  let rec aux files cwd =
+    let ls = Sys.readdir cwd |> Array.to_list in
+    let dirs, cwd_files =
+      List.partition (fun f -> Sys.is_directory (cwd / f)) ls
+    in
+    let dirs =
+      if (cwd : string) = root / switch then
+        List.filter (fun f -> f <> ".opam-switch") dirs
+      else dirs
+    in
+    let files =
+      files
+      @ List.filter_map (fun f ->
+          if String.starts_with ~prefix:fname f then
+            Some (cwd / f) else None)
+        cwd_files
+    in
+    if dirs = [] then files else
+      List.fold_left (fun files dir -> aux files (cwd / dir)) files dirs
+  in
+  aux files (root / switch)
+  |> List.sort String.compare
+
+let () =
+  match files with
+  | [] -> Printf.printf "==> No '%s' found" fname
+  | _ -> List.iter cat files
+
+### <installed-file>
+youhou, i'm installed!
+### :::::::::::::::
+### :I: Field 'lib'
+### :::::::::::::::
+### <pkg:pkg-lib.1:installed-file>
+
+### opam switch create sw-lib --empty
+### :I:1: No defined destination path
+### <pkg:pkg-lib.1>
+opam-version: "2.0"
+### <pkg:pkg-lib.1:pkg-lib.install>
+lib: [ "installed-file" ]
+### OPAMDEBUG=-5 opam install pkg-lib
+The following actions will be performed:
+=== install 1 package
+  - install pkg-lib 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-lib.1
+ACTION                          prepare_package_source: pkg-lib.1 at ${BASEDIR}/OPAM/sw-lib/.opam-switch/build/pkg-lib.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-lib.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-lib/lib/pkg-lib
+TRACK                           after install: 3 elements, 2 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-lib.1: 2 items (addition: 2)
+-> installed pkg-lib.1
+Done.
+### opam-cat OPAM/sw-lib/.opam-switch/install/pkg-lib.changes
+added: ["lib/pkg-lib" {"D"} "lib/pkg-lib/installed-file" {"F:68b329da9893e34099c7d8ad5cb9c940"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-lib pkg-lib
+==> ${BASEDIR}/OPAM/sw-lib/lib/pkg-lib/installed-file
+### OPAMDEBUG=-5 opam remove pkg-lib
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-lib 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-lib.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-lib.1: files lib/pkg-lib/installed-file, lib/pkg-lib were already removed
+-> removed   pkg-lib.1
+ACTION                          Cleaning up artefacts of pkg-lib.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-lib/.opam-switch/install/pkg-lib.changes
+# OPAM/sw-lib/.opam-switch/install/pkg-lib.changes not found
+### ocaml cat.ml sw-lib pkg-lib
+==> No 'installed-file' found
+### :I:2: Specify destination path
+### <pkg:pkg-lib.1>
+opam-version: "2.0"
+### <pkg:pkg-lib.1:pkg-lib.install>
+lib: [ "installed-file" {"installed-file.lib"} ]
+### OPAMDEBUG=-5 opam install pkg-lib
+The following actions will be performed:
+=== install 1 package
+  - install pkg-lib 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-lib.1
+ACTION                          prepare_package_source: pkg-lib.1 at ${BASEDIR}/OPAM/sw-lib/.opam-switch/build/pkg-lib.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-lib.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-lib/lib/pkg-lib
+TRACK                           after install: 3 elements, 2 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-lib.1: 2 items (addition: 2)
+-> installed pkg-lib.1
+Done.
+### opam-cat OPAM/sw-lib/.opam-switch/install/pkg-lib.changes
+added: ["lib/pkg-lib" {"D"} "lib/pkg-lib/installed-file.lib" {"F:68b329da9893e34099c7d8ad5cb9c940"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-lib pkg-lib
+==> ${BASEDIR}/OPAM/sw-lib/lib/pkg-lib/installed-file.lib
+### OPAMDEBUG=-5 opam remove pkg-lib
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-lib 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-lib.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-lib.1: files lib/pkg-lib/installed-file.lib, lib/pkg-lib were already removed
+-> removed   pkg-lib.1
+ACTION                          Cleaning up artefacts of pkg-lib.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-lib/.opam-switch/install/pkg-lib.changes
+# OPAM/sw-lib/.opam-switch/install/pkg-lib.changes not found
+### ocaml cat.ml sw-lib pkg-lib
+==> No 'installed-file' found
+### :I:3: Non existing filename, with optional argument
+### <pkg:pkg-lib.1>
+opam-version: "2.0"
+### <pkg:pkg-lib.1:pkg-lib.install>
+lib: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-lib
+The following actions will be performed:
+=== install 1 package
+  - install pkg-lib 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-lib.1
+ACTION                          prepare_package_source: pkg-lib.1 at ${BASEDIR}/OPAM/sw-lib/.opam-switch/build/pkg-lib.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-lib.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-lib/lib/pkg-lib
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-lib/.opam-switch/build/pkg-lib.1/finst is not present and optional.
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-lib.1: 1 items (addition: 1)
+-> installed pkg-lib.1
+Done.
+### opam-cat OPAM/sw-lib/.opam-switch/install/pkg-lib.changes
+added: "lib/pkg-lib" {"D"}
+opam-version: "2.0"
+### ocaml cat.ml sw-lib pkg-lib
+==> No 'installed-file' found
+### OPAMDEBUG=-5 opam remove pkg-lib
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-lib 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-lib.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-lib.1: files lib/pkg-lib were already removed
+-> removed   pkg-lib.1
+ACTION                          Cleaning up artefacts of pkg-lib.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-lib/.opam-switch/install/pkg-lib.changes
+# OPAM/sw-lib/.opam-switch/install/pkg-lib.changes not found
+### ocaml cat.ml sw-lib pkg-lib
+==> No 'installed-file' found
+### :I:4: Non existing filename
+### <pkg:pkg-lib.1>
+opam-version: "2.0"
+### <pkg:pkg-lib.1:pkg-lib.install>
+lib: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-lib
+The following actions will be performed:
+=== install 1 package
+  - install pkg-lib 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-lib.1
+ACTION                          prepare_package_source: pkg-lib.1 at ${BASEDIR}/OPAM/sw-lib/.opam-switch/build/pkg-lib.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-lib.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-lib/lib/pkg-lib
+[ERROR] Installation of pkg-lib.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-lib/.opam-switch/install/pkg-lib.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-lib/.opam-switch/build/pkg-lib.1/finst to ${BASEDIR}/OPAM/sw-lib/lib/pkg-lib
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-lib 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-lib/.opam-switch/install/pkg-lib.changes
+# OPAM/sw-lib/.opam-switch/install/pkg-lib.changes not found
+### ocaml cat.ml sw-lib pkg-lib
+==> No 'installed-file' found
+### :::::::::::::::::
+### :II: Field 'misc'
+### :::::::::::::::::
+### # special cases for this test as misc require to have a destination that is
+### # an absolute path
+### mkdir -p REPO/packages/pkg-misc/pkg-misc.1/files
+### cp installed-file REPO/packages/pkg-misc/pkg-misc.1/files/installed-file
+### opam switch create sw-misc --empty
+### :II:1: No defined destination path
+### <pkg:pkg-misc.1>
+opam-version: "2.0"
+### <pkg:pkg-misc.1:pkg-misc.install>
+misc: [ "installed-file" ]
+### OPAMDEBUG=-5 opam install pkg-misc
+The following actions will be performed:
+=== install 1 package
+  - install pkg-misc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-misc.1
+ACTION                          prepare_package_source: pkg-misc.1 at ${BASEDIR}/OPAM/sw-misc/.opam-switch/build/pkg-misc.1
+[WARNING] Errors in ${BASEDIR}/OPAM/sw-misc/.opam-switch/build/pkg-misc.1/pkg-misc.install, some fields have been ignored:
+            - At ${BASEDIR}/OPAM/sw-misc/.opam-switch/build/pkg-misc.1/pkg-misc.install:1:8-1:24::
+              expected abs-filename
+
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-misc.1.
+
+TRACK                           after install: 0 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-misc.1: 0 items
+-> installed pkg-misc.1
+Done.
+### opam-cat OPAM/sw-misc/.opam-switch/install/pkg-misc.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-misc pkg-misc installed-file
+--> ${BASEDIR}/OPAM/installed-file: not found
+### OPAMDEBUG=-5 opam remove pkg-misc
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-misc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-misc.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-misc.1
+ACTION                          Cleaning up artefacts of pkg-misc.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-misc/.opam-switch/install/pkg-misc.changes
+# OPAM/sw-misc/.opam-switch/install/pkg-misc.changes not found
+### ocaml cat.ml sw-misc pkg-misc installed-file
+--> ${BASEDIR}/OPAM/installed-file: not found
+### :II:2: Specify destination path
+### <pkg:pkg-misc.1>
+opam-version: "2.0"
+substs: "pkg-misc.install"
+### <pkg:pkg-misc.1:pkg-misc.install.in>
+misc: [ "installed-file" {"%{root}%/installed-file.misc"} ]
+### OPAMDEBUG=-5 opam install pkg-misc
+The following actions will be performed:
+=== install 1 package
+  - install pkg-misc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-misc.1
+ACTION                          prepare_package_source: pkg-misc.1 at ${BASEDIR}/OPAM/sw-misc/.opam-switch/build/pkg-misc.1
+ACTION                          pkg-misc: expanding opam variables in pkg-misc.install.in, generating pkg-misc.install.
+
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-misc.1.
+
+Installing installed-file to ${BASEDIR}/OPAM/installed-file.misc.
+Continue? [Y/n] y
+TRACK                           after install: 0 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-misc.1: 0 items
+-> installed pkg-misc.1
+Done.
+### opam-cat OPAM/sw-misc/.opam-switch/install/pkg-misc.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-misc pkg-misc installed-file.misc
+==> ${BASEDIR}/OPAM/installed-file.misc
+### OPAMDEBUG=-5 opam remove pkg-misc
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-misc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-misc.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+Removing ${BASEDIR}/OPAM/installed-file.misc.Continue? [Y/n] y
+-> removed   pkg-misc.1
+ACTION                          Cleaning up artefacts of pkg-misc.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-misc/.opam-switch/install/pkg-misc.changes
+# OPAM/sw-misc/.opam-switch/install/pkg-misc.changes not found
+### ocaml cat.ml sw-misc pkg-misc installed-file.misc
+--> ${BASEDIR}/OPAM/installed-file.misc: not found
+### :II:3: Non existing filename, with optional argument
+### <pkg:pkg-misc.1>
+opam-version: "2.0"
+substs: "pkg-misc.install"
+### <pkg:pkg-misc.1:pkg-misc.install.in>
+misc: [ "?finst" {"%{root}%/installed-file.misc"} ]
+### OPAMDEBUG=-5 opam install pkg-misc
+The following actions will be performed:
+=== install 1 package
+  - install pkg-misc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-misc.1
+ACTION                          prepare_package_source: pkg-misc.1 at ${BASEDIR}/OPAM/sw-misc/.opam-switch/build/pkg-misc.1
+ACTION                          pkg-misc: expanding opam variables in pkg-misc.install.in, generating pkg-misc.install.
+
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-misc.1.
+
+Installing finst to ${BASEDIR}/OPAM/installed-file.misc.
+Continue? [Y/n] y
+
+Sys_error("${BASEDIR}/OPAM/sw-misc/.opam-switch/build/pkg-misc.1/finst: No such file or directory")
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-misc 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-misc/.opam-switch/install/pkg-misc.changes
+# OPAM/sw-misc/.opam-switch/install/pkg-misc.changes not found
+### ocaml cat.ml sw-misc pkg-misc installed-file.misc
+--> ${BASEDIR}/OPAM/installed-file.misc: not found
+### OPAMDEBUG=-5 opam remove pkg-misc
+[NOTE] pkg-misc is not installed.
+
+Nothing to do.
+### opam-cat OPAM/sw-misc/.opam-switch/install/pkg-misc.changes
+# OPAM/sw-misc/.opam-switch/install/pkg-misc.changes not found
+### ocaml cat.ml sw-misc pkg-misc installed-file.misc
+--> ${BASEDIR}/OPAM/installed-file.misc: not found
+### :II:4: Non existing filename
+### <pkg:pkg-misc.1>
+opam-version: "2.0"
+substs: "pkg-misc.install"
+### <pkg:pkg-misc.1:pkg-misc.install.in>
+misc: [ "finst"  {"%{root}%/installed-file.misc"}]
+### OPAMDEBUG=-5 opam install pkg-misc
+The following actions will be performed:
+=== install 1 package
+  - install pkg-misc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-misc.1
+ACTION                          prepare_package_source: pkg-misc.1 at ${BASEDIR}/OPAM/sw-misc/.opam-switch/build/pkg-misc.1
+ACTION                          pkg-misc: expanding opam variables in pkg-misc.install.in, generating pkg-misc.install.
+
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-misc.1.
+
+Installing finst to ${BASEDIR}/OPAM/installed-file.misc.
+Continue? [Y/n] y
+
+Sys_error("${BASEDIR}/OPAM/sw-misc/.opam-switch/build/pkg-misc.1/finst: No such file or directory")
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-misc 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-misc/.opam-switch/install/pkg-misc.changes
+# OPAM/sw-misc/.opam-switch/install/pkg-misc.changes not found
+### ocaml cat.ml sw-misc pkg-misc installed-file.misc
+--> ${BASEDIR}/OPAM/installed-file.misc: not found
+### :II:4: Non existing filename
+### <pkg:pkg-misc.1>
+opam-version: "2.0"
+### <pkg:pkg-misc.1:pkg-misc.install>
+misc: [ "finst"  {"installed-file.misc"}]
+### OPAMDEBUG=-5 opam install pkg-misc
+The following actions will be performed:
+=== install 1 package
+  - install pkg-misc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-misc.1
+ACTION                          prepare_package_source: pkg-misc.1 at ${BASEDIR}/OPAM/sw-misc/.opam-switch/build/pkg-misc.1
+[WARNING] Errors in ${BASEDIR}/OPAM/sw-misc/.opam-switch/build/pkg-misc.1/pkg-misc.install, some fields have been ignored:
+            - At ${BASEDIR}/OPAM/sw-misc/.opam-switch/build/pkg-misc.1/pkg-misc.install:1:18-1:39::
+              installed-file.misc is not an absolute filename.
+
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-misc.1.
+
+TRACK                           after install: 0 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-misc.1: 0 items
+-> installed pkg-misc.1
+Done.
+### opam-cat OPAM/sw-misc/.opam-switch/install/pkg-misc.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-misc pkg-misc installed-file.misc
+--> ${BASEDIR}/OPAM/installed-file.misc: not found
+### ::::::::::::::::::::
+### :III: Field 'toplevel'
+### ::::::::::::::::::::
+### mkdir -p REPO/packages/pkg-toplevel/pkg-toplevel.1/files
+### cp installed-file REPO/packages/pkg-toplevel/pkg-toplevel.1/files/installed-file
+### opam switch create sw-toplevel --empty
+### :III:1: No defined destination path
+### <pkg:pkg-toplevel.1>
+opam-version: "2.0"
+### <pkg:pkg-toplevel.1:pkg-toplevel.install>
+toplevel: [ "installed-file" ]
+### OPAMDEBUG=-5 opam install pkg-toplevel
+The following actions will be performed:
+=== install 1 package
+  - install pkg-toplevel 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-toplevel.1
+ACTION                          prepare_package_source: pkg-toplevel.1 at ${BASEDIR}/OPAM/sw-toplevel/.opam-switch/build/pkg-toplevel.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-toplevel.1.
+
+TRACK                           after install: 3 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-toplevel.1: 1 items (addition: 1)
+-> installed pkg-toplevel.1
+Done.
+### opam-cat OPAM/sw-toplevel/.opam-switch/install/pkg-toplevel.changes
+added: "lib/toplevel/installed-file" {"F:a611026bf7b99362c57473c4e1ef30a0"}
+opam-version: "2.0"
+### ocaml cat.ml sw-toplevel pkg-toplevel
+==> ${BASEDIR}/OPAM/sw-toplevel/lib/toplevel/installed-file
+### OPAMDEBUG=-5 opam remove pkg-toplevel
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-toplevel 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-toplevel.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-toplevel.1
+ACTION                          Cleaning up artefacts of pkg-toplevel.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-toplevel/.opam-switch/install/pkg-toplevel.changes
+# OPAM/sw-toplevel/.opam-switch/install/pkg-toplevel.changes not found
+### ocaml cat.ml sw-toplevel pkg-toplevel
+==> No 'installed-file' found
+### :III:1: Specify destination path
+### <pkg:pkg-toplevel.1>
+opam-version: "2.0"
+### <pkg:pkg-toplevel.1:pkg-toplevel.install>
+toplevel: [ "installed-file" {"installed-file.toplevel"} ]
+### OPAMDEBUG=-5 opam install pkg-toplevel
+The following actions will be performed:
+=== install 1 package
+  - install pkg-toplevel 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-toplevel.1
+ACTION                          prepare_package_source: pkg-toplevel.1 at ${BASEDIR}/OPAM/sw-toplevel/.opam-switch/build/pkg-toplevel.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-toplevel.1.
+
+TRACK                           after install: 3 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-toplevel.1: 1 items (addition: 1)
+-> installed pkg-toplevel.1
+Done.
+### opam-cat OPAM/sw-toplevel/.opam-switch/install/pkg-toplevel.changes
+added: "lib/toplevel/installed-file.toplevel" {"F:a611026bf7b99362c57473c4e1ef30a0"}
+opam-version: "2.0"
+### ocaml cat.ml sw-toplevel pkg-toplevel
+==> ${BASEDIR}/OPAM/sw-toplevel/lib/toplevel/installed-file.toplevel
+### OPAMDEBUG=-5 opam remove pkg-toplevel
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-toplevel 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-toplevel.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-toplevel.1
+ACTION                          Cleaning up artefacts of pkg-toplevel.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-toplevel/.opam-switch/install/pkg-toplevel.changes
+# OPAM/sw-toplevel/.opam-switch/install/pkg-toplevel.changes not found
+### ocaml cat.ml sw-toplevel pkg-toplevel
+==> No 'installed-file' found
+### :III:3: Non existing filename, with optional argument
+### <pkg:pkg-toplevel.1>
+opam-version: "2.0"
+### <pkg:pkg-toplevel.1:pkg-toplevel.install>
+toplevel: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-toplevel
+The following actions will be performed:
+=== install 1 package
+  - install pkg-toplevel 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-toplevel.1
+ACTION                          prepare_package_source: pkg-toplevel.1 at ${BASEDIR}/OPAM/sw-toplevel/.opam-switch/build/pkg-toplevel.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-toplevel.1.
+
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-toplevel/.opam-switch/build/pkg-toplevel.1/finst is not present and optional.
+TRACK                           after install: 2 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-toplevel.1: 0 items
+-> installed pkg-toplevel.1
+Done.
+### opam-cat OPAM/sw-toplevel/.opam-switch/install/pkg-toplevel.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-toplevel pkg-toplevel
+==> No 'installed-file' found
+### OPAMDEBUG=-5 opam remove pkg-toplevel
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-toplevel 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-toplevel.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-toplevel.1
+ACTION                          Cleaning up artefacts of pkg-toplevel.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-toplevel/.opam-switch/install/pkg-toplevel.changes
+# OPAM/sw-toplevel/.opam-switch/install/pkg-toplevel.changes not found
+### ocaml cat.ml sw-toplevel pkg-toplevel
+==> No 'installed-file' found
+### :III:4: Non existing filename
+### <pkg:pkg-toplevel.1>
+opam-version: "2.0"
+### <pkg:pkg-toplevel.1:pkg-toplevel.install>
+toplevel: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-toplevel
+The following actions will be performed:
+=== install 1 package
+  - install pkg-toplevel 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-toplevel.1
+ACTION                          prepare_package_source: pkg-toplevel.1 at ${BASEDIR}/OPAM/sw-toplevel/.opam-switch/build/pkg-toplevel.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-toplevel.1.
+
+[ERROR] Installation of pkg-toplevel.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-toplevel/.opam-switch/install/pkg-toplevel.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-toplevel/.opam-switch/build/pkg-toplevel.1/finst to ${BASEDIR}/OPAM/sw-toplevel/lib/toplevel
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-toplevel 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-toplevel/.opam-switch/install/pkg-toplevel.changes
+# OPAM/sw-toplevel/.opam-switch/install/pkg-toplevel.changes not found
+### ocaml cat.ml sw-toplevel pkg-toplevel
+==> No 'installed-file' found
+### ::::::::::::::::::
+### :IV: Field 'share'
+### ::::::::::::::::::
+### mkdir -p REPO/packages/pkg-share/pkg-share.1/files
+### cp installed-file REPO/packages/pkg-share/pkg-share.1/files/installed-file
+### opam switch create sw-share --empty
+### :IV:1: No defined destination path
+### <pkg:pkg-share.1>
+opam-version: "2.0"
+### <pkg:pkg-share.1:pkg-share.install>
+share: [ "installed-file" ]
+### OPAMDEBUG=-5 opam install pkg-share
+The following actions will be performed:
+=== install 1 package
+  - install pkg-share 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-share.1
+ACTION                          prepare_package_source: pkg-share.1 at ${BASEDIR}/OPAM/sw-share/.opam-switch/build/pkg-share.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-share.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-share/share/pkg-share
+TRACK                           after install: 3 elements, 3 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-share.1: 3 items (addition: 3)
+-> installed pkg-share.1
+Done.
+### opam-cat OPAM/sw-share/.opam-switch/install/pkg-share.changes
+added: ["share" {"D"} "share/pkg-share" {"D"} "share/pkg-share/installed-file" {"F:a611026bf7b99362c57473c4e1ef30a0"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-share pkg-share
+==> ${BASEDIR}/OPAM/sw-share/share/pkg-share/installed-file
+### OPAMDEBUG=-5 opam remove pkg-share
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-share 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-share.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-share.1: files share/pkg-share/installed-file, share/pkg-share were already removed
+-> removed   pkg-share.1
+ACTION                          Cleaning up artefacts of pkg-share.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-share/.opam-switch/install/pkg-share.changes
+# OPAM/sw-share/.opam-switch/install/pkg-share.changes not found
+### ocaml cat.ml sw-share pkg-share
+==> No 'installed-file' found
+### :IV:2: Specify destination path
+### <pkg:pkg-share.1>
+opam-version: "2.0"
+### <pkg:pkg-share.1:pkg-share.install>
+share: [ "installed-file" {"installed-file.share"} ]
+### OPAMDEBUG=-5 opam install pkg-share
+The following actions will be performed:
+=== install 1 package
+  - install pkg-share 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-share.1
+ACTION                          prepare_package_source: pkg-share.1 at ${BASEDIR}/OPAM/sw-share/.opam-switch/build/pkg-share.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-share.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-share/share/pkg-share
+TRACK                           after install: 3 elements, 3 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-share.1: 3 items (addition: 3)
+-> installed pkg-share.1
+Done.
+### opam-cat OPAM/sw-share/.opam-switch/install/pkg-share.changes
+added: ["share" {"D"} "share/pkg-share" {"D"} "share/pkg-share/installed-file.share" {"F:a611026bf7b99362c57473c4e1ef30a0"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-share pkg-share
+==> ${BASEDIR}/OPAM/sw-share/share/pkg-share/installed-file.share
+### OPAMDEBUG=-5 opam remove pkg-share
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-share 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-share.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-share.1: files share/pkg-share/installed-file.share, share/pkg-share were already removed
+-> removed   pkg-share.1
+ACTION                          Cleaning up artefacts of pkg-share.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-share/.opam-switch/install/pkg-share.changes
+# OPAM/sw-share/.opam-switch/install/pkg-share.changes not found
+### ocaml cat.ml sw-share pkg-share
+==> No 'installed-file' found
+### :IV:3: Non existing filename, with optional argument
+### <pkg:pkg-share.1>
+opam-version: "2.0"
+### <pkg:pkg-share.1:pkg-share.install>
+share: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-share
+The following actions will be performed:
+=== install 1 package
+  - install pkg-share 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-share.1
+ACTION                          prepare_package_source: pkg-share.1 at ${BASEDIR}/OPAM/sw-share/.opam-switch/build/pkg-share.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-share.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-share/share/pkg-share
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-share/.opam-switch/build/pkg-share.1/finst is not present and optional.
+TRACK                           after install: 2 elements, 2 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-share.1: 2 items (addition: 2)
+-> installed pkg-share.1
+Done.
+### opam-cat OPAM/sw-share/.opam-switch/install/pkg-share.changes
+added: ["share" {"D"} "share/pkg-share" {"D"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-share pkg-share
+==> No 'installed-file' found
+### OPAMDEBUG=-5 opam remove pkg-share
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-share 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-share.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-share.1: files share/pkg-share were already removed
+-> removed   pkg-share.1
+ACTION                          Cleaning up artefacts of pkg-share.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-share/.opam-switch/install/pkg-share.changes
+# OPAM/sw-share/.opam-switch/install/pkg-share.changes not found
+### ocaml cat.ml sw-share pkg-share
+==> No 'installed-file' found
+### :IV:4: Non existing filename
+### <pkg:pkg-share.1>
+opam-version: "2.0"
+### <pkg:pkg-share.1:pkg-share.install>
+share: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-share
+The following actions will be performed:
+=== install 1 package
+  - install pkg-share 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-share.1
+ACTION                          prepare_package_source: pkg-share.1 at ${BASEDIR}/OPAM/sw-share/.opam-switch/build/pkg-share.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-share.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-share/share/pkg-share
+[ERROR] Installation of pkg-share.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-share/.opam-switch/install/pkg-share.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-share/.opam-switch/build/pkg-share.1/finst to ${BASEDIR}/OPAM/sw-share/share/pkg-share
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-share 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-share/.opam-switch/install/pkg-share.changes
+# OPAM/sw-share/.opam-switch/install/pkg-share.changes not found
+### ocaml cat.ml sw-share pkg-share
+==> No 'installed-file' found
+### :::::::::::::::::::::::::
+### :V: Field 'share_root'
+### :::::::::::::::::::::::::
+### mkdir -p REPO/packages/pkg-share_root/pkg-share_root.1/files
+### cp installed-file REPO/packages/pkg-share_root/pkg-share_root.1/files/installed-file
+### opam switch create sw-share_root --empty
+### :V:1: No defined destination path
+### <pkg:pkg-share_root.1>
+opam-version: "2.0"
+### <pkg:pkg-share_root.1:pkg-share_root.install>
+share_root: [ "installed-file" ]
+### OPAMDEBUG=-5 opam install pkg-share_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-share_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-share_root.1
+ACTION                          prepare_package_source: pkg-share_root.1 at ${BASEDIR}/OPAM/sw-share_root/.opam-switch/build/pkg-share_root.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-share_root.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-share_root/share
+TRACK                           after install: 2 elements, 2 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-share_root.1: 2 items (addition: 2)
+-> installed pkg-share_root.1
+Done.
+### opam-cat OPAM/sw-share_root/.opam-switch/install/pkg-share_root.changes
+added: ["share" {"D"} "share/installed-file" {"F:a611026bf7b99362c57473c4e1ef30a0"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-share_root pkg-share_root
+==> ${BASEDIR}/OPAM/sw-share_root/share/installed-file
+### OPAMDEBUG=-5 opam remove pkg-share_root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-share_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-share_root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-share_root.1: files share/installed-file were already removed
+-> removed   pkg-share_root.1
+ACTION                          Cleaning up artefacts of pkg-share_root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-share_root/.opam-switch/install/pkg-share_root.changes
+# OPAM/sw-share_root/.opam-switch/install/pkg-share_root.changes not found
+### ocaml cat.ml sw-share_root pkg-share_root
+==> No 'installed-file' found
+### :V:2: Specify destination path
+### <pkg:pkg-share_root.1>
+opam-version: "2.0"
+### <pkg:pkg-share_root.1:pkg-share_root.install>
+share_root: [ "installed-file" {"installed-file.share_root"} ]
+### OPAMDEBUG=-5 opam install pkg-share_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-share_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-share_root.1
+ACTION                          prepare_package_source: pkg-share_root.1 at ${BASEDIR}/OPAM/sw-share_root/.opam-switch/build/pkg-share_root.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-share_root.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-share_root/share
+TRACK                           after install: 2 elements, 2 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-share_root.1: 2 items (addition: 2)
+-> installed pkg-share_root.1
+Done.
+### opam-cat OPAM/sw-share_root/.opam-switch/install/pkg-share_root.changes
+added: ["share" {"D"} "share/installed-file.share_root" {"F:a611026bf7b99362c57473c4e1ef30a0"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-share_root pkg-share_root
+==> ${BASEDIR}/OPAM/sw-share_root/share/installed-file.share_root
+### OPAMDEBUG=-5 opam remove pkg-share_root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-share_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-share_root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-share_root.1: files share/installed-file.share_root were already removed
+-> removed   pkg-share_root.1
+ACTION                          Cleaning up artefacts of pkg-share_root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-share_root/.opam-switch/install/pkg-share_root.changes
+# OPAM/sw-share_root/.opam-switch/install/pkg-share_root.changes not found
+### ocaml cat.ml sw-share_root pkg-share_root
+==> No 'installed-file' found
+### :V:3: Non existing filename, with optional argument
+### <pkg:pkg-share_root.1>
+opam-version: "2.0"
+### <pkg:pkg-share_root.1:pkg-share_root.install>
+share_root: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-share_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-share_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-share_root.1
+ACTION                          prepare_package_source: pkg-share_root.1 at ${BASEDIR}/OPAM/sw-share_root/.opam-switch/build/pkg-share_root.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-share_root.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-share_root/share
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-share_root/.opam-switch/build/pkg-share_root.1/finst is not present and optional.
+TRACK                           after install: 1 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-share_root.1: 1 items (addition: 1)
+-> installed pkg-share_root.1
+Done.
+### opam-cat OPAM/sw-share_root/.opam-switch/install/pkg-share_root.changes
+added: "share" {"D"}
+opam-version: "2.0"
+### ocaml cat.ml sw-share_root pkg-share_root
+==> No 'installed-file' found
+### OPAMDEBUG=-5 opam remove pkg-share_root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-share_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-share_root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-share_root.1
+ACTION                          Cleaning up artefacts of pkg-share_root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-share_root/.opam-switch/install/pkg-share_root.changes
+# OPAM/sw-share_root/.opam-switch/install/pkg-share_root.changes not found
+### ocaml cat.ml sw-share_root pkg-share_root
+==> No 'installed-file' found
+### :V:4: Non existing filename
+### <pkg:pkg-share_root.1>
+opam-version: "2.0"
+### <pkg:pkg-share_root.1:pkg-share_root.install>
+share_root: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-share_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-share_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-share_root.1
+ACTION                          prepare_package_source: pkg-share_root.1 at ${BASEDIR}/OPAM/sw-share_root/.opam-switch/build/pkg-share_root.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-share_root.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-share_root/share
+[ERROR] Installation of pkg-share_root.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-share_root/.opam-switch/install/pkg-share_root.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-share_root/.opam-switch/build/pkg-share_root.1/finst to ${BASEDIR}/OPAM/sw-share_root/share
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-share_root 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-share_root/.opam-switch/install/pkg-share_root.changes
+# OPAM/sw-share_root/.opam-switch/install/pkg-share_root.changes not found
+### ocaml cat.ml sw-share_root pkg-share_root
+==> No 'installed-file' found
+### ::::::::::::::::
+### :VI: Field 'etc'
+### ::::::::::::::::
+### mkdir -p REPO/packages/pkg-etc/pkg-etc.1/files
+### cp installed-file REPO/packages/pkg-etc/pkg-etc.1/files/installed-file
+### opam switch create sw-etc --empty
+### :VI:1: No defined destination path
+### <pkg:pkg-etc.1>
+opam-version: "2.0"
+### <pkg:pkg-etc.1:pkg-etc.install>
+etc: [ "installed-file" ]
+### OPAMDEBUG=-5 opam install pkg-etc
+The following actions will be performed:
+=== install 1 package
+  - install pkg-etc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-etc.1
+ACTION                          prepare_package_source: pkg-etc.1 at ${BASEDIR}/OPAM/sw-etc/.opam-switch/build/pkg-etc.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-etc.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-etc/etc/pkg-etc
+TRACK                           after install: 3 elements, 3 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-etc.1: 3 items (addition: 3)
+-> installed pkg-etc.1
+Done.
+### opam-cat OPAM/sw-etc/.opam-switch/install/pkg-etc.changes
+added: ["etc" {"D"} "etc/pkg-etc" {"D"} "etc/pkg-etc/installed-file" {"F:a611026bf7b99362c57473c4e1ef30a0"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-etc pkg-etc
+==> ${BASEDIR}/OPAM/sw-etc/etc/pkg-etc/installed-file
+### OPAMDEBUG=-5 opam remove pkg-etc
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-etc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-etc.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-etc.1: files etc/pkg-etc/installed-file, etc/pkg-etc were already removed
+-> removed   pkg-etc.1
+ACTION                          Cleaning up artefacts of pkg-etc.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-etc/.opam-switch/install/pkg-etc.changes
+# OPAM/sw-etc/.opam-switch/install/pkg-etc.changes not found
+### ocaml cat.ml sw-etc pkg-etc
+==> No 'installed-file' found
+### :VI:2: Specify destination path
+### <pkg:pkg-etc.1>
+opam-version: "2.0"
+### <pkg:pkg-etc.1:pkg-etc.install>
+etc: [ "installed-file" {"installed-file.etc"} ]
+### OPAMDEBUG=-5 opam install pkg-etc
+The following actions will be performed:
+=== install 1 package
+  - install pkg-etc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-etc.1
+ACTION                          prepare_package_source: pkg-etc.1 at ${BASEDIR}/OPAM/sw-etc/.opam-switch/build/pkg-etc.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-etc.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-etc/etc/pkg-etc
+TRACK                           after install: 3 elements, 3 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-etc.1: 3 items (addition: 3)
+-> installed pkg-etc.1
+Done.
+### opam-cat OPAM/sw-etc/.opam-switch/install/pkg-etc.changes
+added: ["etc" {"D"} "etc/pkg-etc" {"D"} "etc/pkg-etc/installed-file.etc" {"F:a611026bf7b99362c57473c4e1ef30a0"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-etc pkg-etc
+==> ${BASEDIR}/OPAM/sw-etc/etc/pkg-etc/installed-file.etc
+### OPAMDEBUG=-5 opam remove pkg-etc
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-etc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-etc.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-etc.1: files etc/pkg-etc/installed-file.etc, etc/pkg-etc were already removed
+-> removed   pkg-etc.1
+ACTION                          Cleaning up artefacts of pkg-etc.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-etc/.opam-switch/install/pkg-etc.changes
+# OPAM/sw-etc/.opam-switch/install/pkg-etc.changes not found
+### ocaml cat.ml sw-etc pkg-etc
+==> No 'installed-file' found
+### :VI:3: Non existing filename, with optional argument
+### <pkg:pkg-etc.1>
+opam-version: "2.0"
+### <pkg:pkg-etc.1:pkg-etc.install>
+etc: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-etc
+The following actions will be performed:
+=== install 1 package
+  - install pkg-etc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-etc.1
+ACTION                          prepare_package_source: pkg-etc.1 at ${BASEDIR}/OPAM/sw-etc/.opam-switch/build/pkg-etc.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-etc.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-etc/etc/pkg-etc
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-etc/.opam-switch/build/pkg-etc.1/finst is not present and optional.
+TRACK                           after install: 2 elements, 2 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-etc.1: 2 items (addition: 2)
+-> installed pkg-etc.1
+Done.
+### opam-cat OPAM/sw-etc/.opam-switch/install/pkg-etc.changes
+added: ["etc" {"D"} "etc/pkg-etc" {"D"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-etc pkg-etc
+==> No 'installed-file' found
+### OPAMDEBUG=-5 opam remove pkg-etc
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-etc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-etc.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-etc.1: files etc/pkg-etc were already removed
+-> removed   pkg-etc.1
+ACTION                          Cleaning up artefacts of pkg-etc.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-etc/.opam-switch/install/pkg-etc.changes
+# OPAM/sw-etc/.opam-switch/install/pkg-etc.changes not found
+### ocaml cat.ml sw-etc pkg-etc
+==> No 'installed-file' found
+### :VI:4: Non existing filename
+### <pkg:pkg-etc.1>
+opam-version: "2.0"
+### <pkg:pkg-etc.1:pkg-etc.install>
+etc: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-etc
+The following actions will be performed:
+=== install 1 package
+  - install pkg-etc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-etc.1
+ACTION                          prepare_package_source: pkg-etc.1 at ${BASEDIR}/OPAM/sw-etc/.opam-switch/build/pkg-etc.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-etc.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-etc/etc/pkg-etc
+[ERROR] Installation of pkg-etc.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-etc/.opam-switch/install/pkg-etc.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-etc/.opam-switch/build/pkg-etc.1/finst to ${BASEDIR}/OPAM/sw-etc/etc/pkg-etc
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-etc 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-etc/.opam-switch/install/pkg-etc.changes
+# OPAM/sw-etc/.opam-switch/install/pkg-etc.changes not found
+### ocaml cat.ml sw-etc pkg-etc
+==> No 'installed-file' found
+### :::::::::::::::
+### :VII: Field 'doc'
+### :::::::::::::::
+### mkdir -p REPO/packages/pkg-doc/pkg-doc.1/files
+### cp installed-file REPO/packages/pkg-doc/pkg-doc.1/files/installed-file
+### opam switch create sw-doc --empty
+### :VII:1: No defined destination path
+### <pkg:pkg-doc.1>
+opam-version: "2.0"
+### <pkg:pkg-doc.1:pkg-doc.install>
+doc: [ "installed-file" ]
+### OPAMDEBUG=-5 opam install pkg-doc
+The following actions will be performed:
+=== install 1 package
+  - install pkg-doc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-doc.1
+ACTION                          prepare_package_source: pkg-doc.1 at ${BASEDIR}/OPAM/sw-doc/.opam-switch/build/pkg-doc.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-doc.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-doc/doc/pkg-doc
+TRACK                           after install: 3 elements, 2 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-doc.1: 2 items (addition: 2)
+-> installed pkg-doc.1
+Done.
+### opam-cat OPAM/sw-doc/.opam-switch/install/pkg-doc.changes
+added: ["doc/pkg-doc" {"D"} "doc/pkg-doc/installed-file" {"F:a611026bf7b99362c57473c4e1ef30a0"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-doc pkg-doc
+==> ${BASEDIR}/OPAM/sw-doc/doc/pkg-doc/installed-file
+### OPAMDEBUG=-5 opam remove pkg-doc
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-doc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-doc.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-doc.1: files doc/pkg-doc/installed-file, doc/pkg-doc were already removed
+-> removed   pkg-doc.1
+ACTION                          Cleaning up artefacts of pkg-doc.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-doc/.opam-switch/install/pkg-doc.changes
+# OPAM/sw-doc/.opam-switch/install/pkg-doc.changes not found
+### ocaml cat.ml sw-doc pkg-doc
+==> No 'installed-file' found
+### :VII:2: Specify destination path
+### <pkg:pkg-doc.1>
+opam-version: "2.0"
+### <pkg:pkg-doc.1:pkg-doc.install>
+doc: [ "installed-file" {"installed-file.doc"} ]
+### OPAMDEBUG=-5 opam install pkg-doc
+The following actions will be performed:
+=== install 1 package
+  - install pkg-doc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-doc.1
+ACTION                          prepare_package_source: pkg-doc.1 at ${BASEDIR}/OPAM/sw-doc/.opam-switch/build/pkg-doc.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-doc.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-doc/doc/pkg-doc
+TRACK                           after install: 3 elements, 2 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-doc.1: 2 items (addition: 2)
+-> installed pkg-doc.1
+Done.
+### opam-cat OPAM/sw-doc/.opam-switch/install/pkg-doc.changes
+added: ["doc/pkg-doc" {"D"} "doc/pkg-doc/installed-file.doc" {"F:a611026bf7b99362c57473c4e1ef30a0"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-doc pkg-doc
+==> ${BASEDIR}/OPAM/sw-doc/doc/pkg-doc/installed-file.doc
+### OPAMDEBUG=-5 opam remove pkg-doc
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-doc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-doc.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-doc.1: files doc/pkg-doc/installed-file.doc, doc/pkg-doc were already removed
+-> removed   pkg-doc.1
+ACTION                          Cleaning up artefacts of pkg-doc.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-doc/.opam-switch/install/pkg-doc.changes
+# OPAM/sw-doc/.opam-switch/install/pkg-doc.changes not found
+### ocaml cat.ml sw-doc pkg-doc
+==> No 'installed-file' found
+### :VII:3: Non existing filename, with optional argument
+### <pkg:pkg-doc.1>
+opam-version: "2.0"
+### <pkg:pkg-doc.1:pkg-doc.install>
+doc: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-doc
+The following actions will be performed:
+=== install 1 package
+  - install pkg-doc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-doc.1
+ACTION                          prepare_package_source: pkg-doc.1 at ${BASEDIR}/OPAM/sw-doc/.opam-switch/build/pkg-doc.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-doc.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-doc/doc/pkg-doc
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-doc/.opam-switch/build/pkg-doc.1/finst is not present and optional.
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-doc.1: 1 items (addition: 1)
+-> installed pkg-doc.1
+Done.
+### opam-cat OPAM/sw-doc/.opam-switch/install/pkg-doc.changes
+added: "doc/pkg-doc" {"D"}
+opam-version: "2.0"
+### ocaml cat.ml sw-doc pkg-doc
+==> No 'installed-file' found
+### OPAMDEBUG=-5 opam remove pkg-doc
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-doc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-doc.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-doc.1: files doc/pkg-doc were already removed
+-> removed   pkg-doc.1
+ACTION                          Cleaning up artefacts of pkg-doc.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-doc/.opam-switch/install/pkg-doc.changes
+# OPAM/sw-doc/.opam-switch/install/pkg-doc.changes not found
+### ocaml cat.ml sw-doc pkg-doc
+==> No 'installed-file' found
+### :VII:4: Non existing filename
+### <pkg:pkg-doc.1>
+opam-version: "2.0"
+### <pkg:pkg-doc.1:pkg-doc.install>
+doc: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-doc
+The following actions will be performed:
+=== install 1 package
+  - install pkg-doc 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-doc.1
+ACTION                          prepare_package_source: pkg-doc.1 at ${BASEDIR}/OPAM/sw-doc/.opam-switch/build/pkg-doc.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-doc.1.
+
+ACTION                          creating ${BASEDIR}/OPAM/sw-doc/doc/pkg-doc
+[ERROR] Installation of pkg-doc.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-doc/.opam-switch/install/pkg-doc.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-doc/.opam-switch/build/pkg-doc.1/finst to ${BASEDIR}/OPAM/sw-doc/doc/pkg-doc
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-doc 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-doc/.opam-switch/install/pkg-doc.changes
+# OPAM/sw-doc/.opam-switch/install/pkg-doc.changes not found
+### ocaml cat.ml sw-doc pkg-doc
+==> No 'installed-file' found
+### ::::::::::::::::
+### :VIII: Field 'man'
+### ::::::::::::::::
+### # special case for this test, man file to install need to be an archive with a number
+### <pkg:pkg-man.1:installed-file.1.gz>
+i'm a fake archive. youhou, i'm installed!
+### opam switch create sw-man --empty
+### :VIII:1: No defined destination path
+### <pkg:pkg-man.1>
+opam-version: "2.0"
+### <pkg:pkg-man.1:pkg-man.install>
+man: [ "installed-file.1.gz" ]
+### OPAMDEBUG=-5 opam install pkg-man
+The following actions will be performed:
+=== install 1 package
+  - install pkg-man 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-man.1
+ACTION                          prepare_package_source: pkg-man.1 at ${BASEDIR}/OPAM/sw-man/.opam-switch/build/pkg-man.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-man.1.
+
+TRACK                           after install: 3 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-man.1: 1 items (addition: 1)
+-> installed pkg-man.1
+Done.
+### opam-cat OPAM/sw-man/.opam-switch/install/pkg-man.changes
+added: "man/man1/installed-file.1.gz" {"F:29a37105d05441eb9a8c11dd6c060a4f"}
+opam-version: "2.0"
+### ocaml cat.ml sw-man pkg-man
+==> ${BASEDIR}/OPAM/sw-man/man/man1/installed-file.1.gz
+### OPAMDEBUG=-5 opam remove pkg-man
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-man 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-man.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-man.1: files man/man1/installed-file.1.gz were already removed
+-> removed   pkg-man.1
+ACTION                          Cleaning up artefacts of pkg-man.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-man/.opam-switch/install/pkg-man.changes
+# OPAM/sw-man/.opam-switch/install/pkg-man.changes not found
+### ocaml cat.ml sw-man pkg-man
+==> No 'installed-file' found
+### :VIII:2: Specify destination path
+### <pkg:pkg-man.1>
+opam-version: "2.0"
+### <pkg:pkg-man.1:pkg-man.install>
+man: [ "installed-file.1.gz" {"installed-file.1.gz.man"} ]
+### OPAMDEBUG=-5 opam install pkg-man
+The following actions will be performed:
+=== install 1 package
+  - install pkg-man 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-man.1
+ACTION                          prepare_package_source: pkg-man.1 at ${BASEDIR}/OPAM/sw-man/.opam-switch/build/pkg-man.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-man.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-man.1: 1 items (addition: 1)
+-> installed pkg-man.1
+Done.
+### opam-cat OPAM/sw-man/.opam-switch/install/pkg-man.changes
+added: "man/installed-file.1.gz.man" {"F:29a37105d05441eb9a8c11dd6c060a4f"}
+opam-version: "2.0"
+### ocaml cat.ml sw-man pkg-man
+==> ${BASEDIR}/OPAM/sw-man/man/installed-file.1.gz.man
+### OPAMDEBUG=-5 opam remove pkg-man
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-man 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-man.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-man.1: files man/installed-file.1.gz.man were already removed
+-> removed   pkg-man.1
+ACTION                          Cleaning up artefacts of pkg-man.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-man/.opam-switch/install/pkg-man.changes
+# OPAM/sw-man/.opam-switch/install/pkg-man.changes not found
+### ocaml cat.ml sw-man pkg-man
+==> No 'installed-file' found
+### :VIII:3: Non existing filename, with optional argument
+### <pkg:pkg-man.1>
+opam-version: "2.0"
+### <pkg:pkg-man.1:pkg-man.install>
+man: [ "?finst.1.gz" ]
+### OPAMDEBUG=-5 opam install pkg-man
+The following actions will be performed:
+=== install 1 package
+  - install pkg-man 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-man.1
+ACTION                          prepare_package_source: pkg-man.1 at ${BASEDIR}/OPAM/sw-man/.opam-switch/build/pkg-man.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-man.1.
+
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-man/.opam-switch/build/pkg-man.1/finst.1.gz is not present and optional.
+TRACK                           after install: 2 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-man.1: 0 items
+-> installed pkg-man.1
+Done.
+### opam-cat OPAM/sw-man/.opam-switch/install/pkg-man.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-man pkg-man
+==> No 'installed-file' found
+### OPAMDEBUG=-5 opam remove pkg-man
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-man 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-man.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-man.1
+ACTION                          Cleaning up artefacts of pkg-man.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-man/.opam-switch/install/pkg-man.changes
+# OPAM/sw-man/.opam-switch/install/pkg-man.changes not found
+### ocaml cat.ml sw-man pkg-man
+==> No 'installed-file' found
+### :VIII:4: Non existing filename
+### <pkg:pkg-man.1>
+opam-version: "2.0"
+### <pkg:pkg-man.1:pkg-man.install>
+man: [ "finsti.1.gz" ]
+### OPAMDEBUG=-5 opam install pkg-man
+The following actions will be performed:
+=== install 1 package
+  - install pkg-man 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-man.1
+ACTION                          prepare_package_source: pkg-man.1 at ${BASEDIR}/OPAM/sw-man/.opam-switch/build/pkg-man.1
+TRACK                           before install: 2 elements scanned in 0.000s
+ACTION                          Installing pkg-man.1.
+
+[ERROR] Installation of pkg-man.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-man/.opam-switch/install/pkg-man.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-man/.opam-switch/build/pkg-man.1/finsti.1.gz to ${BASEDIR}/OPAM/sw-man/man
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-man 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-man/.opam-switch/install/pkg-man.changes
+# OPAM/sw-man/.opam-switch/install/pkg-man.changes not found
+### ocaml cat.ml sw-man pkg-man
+==> No 'installed-file' found
+### :VIII:5: Wrongly-formed filename, no destination specified
+### # ERROR: this error should be better handled
+### <pkg:pkg-man.1>
+opam-version: "2.0"
+### mkdir -p REPO/packages/pkg-man/pkg-man.1/files
+### cp installed-file REPO/packages/pkg-man/pkg-man.1/files/installed-file
+### <pkg:pkg-man.1:pkg-man.install>
+man: [ "installed-file" ]
+### OPAMDEBUG=-5 opam install pkg-man
+The following actions will be performed:
+=== install 1 package
+  - install pkg-man 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-man.1
+ACTION                          prepare_package_source: pkg-man.1 at ${BASEDIR}/OPAM/sw-man/.opam-switch/build/pkg-man.1
+[ERROR] In ${BASEDIR}/OPAM/sw-man/.opam-switch/build/pkg-man.1/pkg-man.install:
+        Not_found
+[ERROR] Strict mode: aborting
+
+OpamStd.OpamSys.Exit(30)
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-man 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-man/.opam-switch/install/pkg-man.changes
+# OPAM/sw-man/.opam-switch/install/pkg-man.changes not found
+### ocaml cat.ml sw-man pkg-man
+==> No 'installed-file' found
+### :VIII:6: Wrongly-formed filename, with good format destination specified
+### # ERROR: this error should be better handled
+### <pkg:pkg-man.1>
+opam-version: "2.0"
+### mkdir -p REPO/packages/pkg-man/pkg-man.1/files
+### cp installed-file REPO/packages/pkg-man/pkg-man.1/files/installed-file
+### <pkg:pkg-man.1:pkg-man.install>
+man: [ "installed-file" "installed-file.1.gz"]
+### OPAMDEBUG=-5 opam install pkg-man
+The following actions will be performed:
+=== install 1 package
+  - install pkg-man 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-man.1
+ACTION                          prepare_package_source: pkg-man.1 at ${BASEDIR}/OPAM/sw-man/.opam-switch/build/pkg-man.1
+[ERROR] In ${BASEDIR}/OPAM/sw-man/.opam-switch/build/pkg-man.1/pkg-man.install:
+        Not_found
+[ERROR] Strict mode: aborting
+
+OpamStd.OpamSys.Exit(30)
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-man 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-man/.opam-switch/install/pkg-man.changes
+# OPAM/sw-man/.opam-switch/install/pkg-man.changes not found
+### ocaml cat.ml sw-man pkg-man
+==> No 'installed-file' found
+### :::::::::::::::::::::::
+### :VIII: Field 'lib_root'
+### :::::::::::::::::::::::
+### mkdir -p REPO/packages/pkg-lib_root/pkg-lib_root.1/files
+### cp installed-file REPO/packages/pkg-lib_root/pkg-lib_root.1/files/installed-file
+### opam switch create sw-lib_root --empty
+### :VIII:1: No defined destination path
+### <pkg:pkg-lib_root.1>
+opam-version: "2.0"
+### <pkg:pkg-lib_root.1:pkg-lib_root.install>
+lib_root: [ "installed-file" ]
+### OPAMDEBUG=-5 opam install pkg-lib_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-lib_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-lib_root.1
+ACTION                          prepare_package_source: pkg-lib_root.1 at ${BASEDIR}/OPAM/sw-lib_root/.opam-switch/build/pkg-lib_root.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-lib_root.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-lib_root.1: 1 items (addition: 1)
+-> installed pkg-lib_root.1
+Done.
+### opam-cat OPAM/sw-lib_root/.opam-switch/install/pkg-lib_root.changes
+added: "lib/installed-file" {"F:a611026bf7b99362c57473c4e1ef30a0"}
+opam-version: "2.0"
+### ocaml cat.ml sw-lib_root pkg-lib_root
+==> ${BASEDIR}/OPAM/sw-lib_root/lib/installed-file
+### OPAMDEBUG=-5 opam remove pkg-lib_root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-lib_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-lib_root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-lib_root.1
+ACTION                          Cleaning up artefacts of pkg-lib_root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-lib_root/.opam-switch/install/pkg-lib_root.changes
+# OPAM/sw-lib_root/.opam-switch/install/pkg-lib_root.changes not found
+### ocaml cat.ml sw-lib_root pkg-lib_root
+==> No 'installed-file' found
+### :VIII:2: Specify destination path
+### <pkg:pkg-lib_root.1>
+opam-version: "2.0"
+### <pkg:pkg-lib_root.1:pkg-lib_root.install>
+lib_root: [ "installed-file" {"installed-file.lib_root"} ]
+### OPAMDEBUG=-5 opam install pkg-lib_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-lib_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-lib_root.1
+ACTION                          prepare_package_source: pkg-lib_root.1 at ${BASEDIR}/OPAM/sw-lib_root/.opam-switch/build/pkg-lib_root.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-lib_root.1.
+
+TRACK                           after install: 2 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-lib_root.1: 1 items (addition: 1)
+-> installed pkg-lib_root.1
+Done.
+### opam-cat OPAM/sw-lib_root/.opam-switch/install/pkg-lib_root.changes
+added: "lib/installed-file.lib_root" {"F:a611026bf7b99362c57473c4e1ef30a0"}
+opam-version: "2.0"
+### ocaml cat.ml sw-lib_root pkg-lib_root
+==> ${BASEDIR}/OPAM/sw-lib_root/lib/installed-file.lib_root
+### OPAMDEBUG=-5 opam remove pkg-lib_root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-lib_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-lib_root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-lib_root.1
+ACTION                          Cleaning up artefacts of pkg-lib_root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-lib_root/.opam-switch/install/pkg-lib_root.changes
+# OPAM/sw-lib_root/.opam-switch/install/pkg-lib_root.changes not found
+### ocaml cat.ml sw-lib_root pkg-lib_root
+==> No 'installed-file' found
+### :VIII:3: Non existing filename, with optional argument
+### <pkg:pkg-lib_root.1>
+opam-version: "2.0"
+### <pkg:pkg-lib_root.1:pkg-lib_root.install>
+lib_root: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-lib_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-lib_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-lib_root.1
+ACTION                          prepare_package_source: pkg-lib_root.1 at ${BASEDIR}/OPAM/sw-lib_root/.opam-switch/build/pkg-lib_root.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-lib_root.1.
+
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-lib_root/.opam-switch/build/pkg-lib_root.1/finst is not present and optional.
+TRACK                           after install: 1 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-lib_root.1: 0 items
+-> installed pkg-lib_root.1
+Done.
+### opam-cat OPAM/sw-lib_root/.opam-switch/install/pkg-lib_root.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-lib_root pkg-lib_root
+==> No 'installed-file' found
+### OPAMDEBUG=-5 opam remove pkg-lib_root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-lib_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-lib_root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-lib_root.1
+ACTION                          Cleaning up artefacts of pkg-lib_root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-lib_root/.opam-switch/install/pkg-lib_root.changes
+# OPAM/sw-lib_root/.opam-switch/install/pkg-lib_root.changes not found
+### ocaml cat.ml sw-lib_root pkg-lib_root
+==> No 'installed-file' found
+### :VIII:4: Non existing filename
+### <pkg:pkg-lib_root.1>
+opam-version: "2.0"
+### <pkg:pkg-lib_root.1:pkg-lib_root.install>
+lib_root: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-lib_root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-lib_root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-lib_root.1
+ACTION                          prepare_package_source: pkg-lib_root.1 at ${BASEDIR}/OPAM/sw-lib_root/.opam-switch/build/pkg-lib_root.1
+TRACK                           before install: 1 elements scanned in 0.000s
+ACTION                          Installing pkg-lib_root.1.
+
+[ERROR] Installation of pkg-lib_root.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-lib_root/.opam-switch/install/pkg-lib_root.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-lib_root/.opam-switch/build/pkg-lib_root.1/finst to ${BASEDIR}/OPAM/sw-lib_root/lib
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-lib_root 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-lib_root/.opam-switch/install/pkg-lib_root.changes
+# OPAM/sw-lib_root/.opam-switch/install/pkg-lib_root.changes not found
+### ocaml cat.ml sw-lib_root pkg-lib_root
+==> No 'installed-file' found

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -546,6 +546,69 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:deps-only.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-dot-install-exe-fields.unix)
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (action
+  (diff dot-install-exe-fields.unix.test dot-install-exe-fields.unix.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (deps (alias reftest-dot-install-exe-fields.unix)))
+
+(rule
+ (targets dot-install-exe-fields.unix.out)
+ (deps root-N0REP0)
+ (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:dot-install-exe-fields.unix.test} %{read-lines:testing-env}))))
+
+(rule
+ (alias reftest-dot-install-exe-fields.win32)
+ (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (action
+  (diff dot-install-exe-fields.win32.test dot-install-exe-fields.win32.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (deps (alias reftest-dot-install-exe-fields.win32)))
+
+(rule
+ (targets dot-install-exe-fields.win32.out)
+ (deps root-N0REP0)
+ (enabled_if (and (= %{os_type} "Win32") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:dot-install-exe-fields.win32.test} %{read-lines:testing-env}))))
+
+(rule
+ (alias reftest-dot-install-non-exe-fields)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (action
+  (diff dot-install-non-exe-fields.test dot-install-non-exe-fields.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (deps (alias reftest-dot-install-non-exe-fields)))
+
+(rule
+ (targets dot-install-non-exe-fields.out)
+ (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:dot-install-non-exe-fields.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-dot-install)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -651,6 +651,10 @@ let common_filters ?opam dir =
     seq [ char '.'; set "/\\"; str f ],
     Sed ("./"^f);
   in
+  let extra_dotinstall_dirs d =
+    seq [ str " "; str d; set "/\\" ],
+    Sed (" "^d^"/");
+  in
   [
     seq [ bol;
           alt [ str "#=== ERROR";
@@ -678,6 +682,14 @@ let common_filters ?opam dir =
     extra_packages_dirs "pkg";
     extra_packages_dirs "root-no-nv";
     extra_standalone_file "repo";
+    (* dot-install-*-fields tests *)
+    extra_dotinstall_dirs "lib";
+    extra_dotinstall_dirs "bin";
+    extra_dotinstall_dirs "doc";
+    extra_dotinstall_dirs "etc";
+    extra_dotinstall_dirs "man";
+    extra_dotinstall_dirs "sbin";
+    extra_dotinstall_dirs "share";
     seq [
       str "state-";
       repn digit 14 (Some 14);


### PR DESCRIPTION
#6938 add new field to `.install` files, there was no exhaustive test.
The tests are 3 files:
- a cross platform test for non executable fields
- 2 per platform tests for executable fields (it differs from win to nux)
Note: the windows test highlights some bugs, issues will be opened