### PR TITLE
bugfix: avoid compiler setup for opam init --bare

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -218,6 +218,7 @@ users)
   * Add a test making sure the global or system `git` config doesn't change the behaviour of opam [#6992 @kit-ty-kate]
   * Add a test showing the remote and branch names of a git repository extracted by `opam source` [#6992 @kit-ty-kate]
   * Add a test showing the order of install actions for each relevant commands [#6864 @kit-ty-kate]
+  * Add a test showing some of the internal steps of `opam init` [#6957 @kit-ty-kate]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -21,6 +21,7 @@ users)
 
 ## Init
   * ✘ Display an appropriate error message when the file given to `opam init --config` does not exist or is in a VCS. This changes the behaviour for VCS local urls that was previously retrieved. [#5979 @kit-ty-kate - fix #5971]
+  * Improve the performance of `opam init --bare` by no longer computing the default compiler in that case [#6957 @tuesdayjz @kit-ty-kate - fix #5815]
 
 ## Config report
 
@@ -276,6 +277,7 @@ users)
 ## opam-client
   * `OpamArg`: add `build_options_no_depexts` getter to retrieve the value of the given flag  [#6489 @rjbou]
   * `OpamArg{,Tools}.cli2_6` was added [#6978 @kit-ty-kate]
+  * `OpamClient.init`: a new `?no_compiler` argument was added to not compute the default compiler and the list of atom returned is now an option to separate empty invariant from no switch [#6957 @kit-ty-kate]
   * `OpamClientConfig.opam_init`: replace `no_depexts` argument by `depexts` [#6489 @rjbou]
   * `OpamSolution` remove the heuristic of recomputing depexts of additional (pinned) packages. [#6489 @arozovyk]
   * `OpamClient` update the system package status check for dependencies during `opam install --deps-only`, including support for pinned packages; also update this in `OpamAuxCommands.autopin` [#6489 @arozovyk]

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1802,6 +1802,7 @@ let init
     ?dot_profile ?update_config ?env_hook ?(completion=true)
     ?(check_sandbox=true)
     ?cygwin_setup ?git_location
+    ?(no_compiler=false)
     shell =
   log "INIT %a"
     (slog @@ OpamStd.Option.to_string OpamRepositoryBackend.to_string) repo;
@@ -1840,7 +1841,7 @@ let init
         OpamConsole.msg
           "... but you have no switches installed, use `opam switch \
            create <compiler-or-version>' to get started.";
-      gt, OpamRepositoryState.load `Lock_none gt, []
+      gt, OpamRepositoryState.load `Lock_none gt, None
     ) else (
       if not root_empty then (
         OpamConsole.warning "%s exists and is not empty"
@@ -1917,31 +1918,33 @@ let init
            OpamConsole.error_and_exit `Sync_error
              "Initial download of repository failed.");
         let default_compiler =
-          if dontswitch then [] else
-          let chrono = OpamConsole.timer () in
-          let alternatives =
-            OpamFormula.to_dnf
-              (OpamFile.InitConfig.default_compiler init_config)
-          in
-          let invariant = OpamFile.InitConfig.default_invariant init_config in
-          let virt_st =
-            OpamSwitchState.load_virtual ~avail_default:false gt rt
-          in
-          let univ =
-            OpamSwitchState.universe virt_st
-              ~requested:OpamPackage.Set.empty Query
-          in
-          let univ = { univ with u_invariant = invariant } in
-          let default_compiler =
-            List.find_opt
-              (OpamSolver.atom_coinstallability_check univ)
-            alternatives
-            |> OpamStd.Option.default []
-          in
-          log "Selected default compiler %s in %0.3fs"
-            (OpamFormula.string_of_atoms default_compiler)
-            (chrono ());
-          default_compiler
+          if dontswitch then Some []
+          else if no_compiler then None
+          else
+            let chrono = OpamConsole.timer () in
+            let alternatives =
+              OpamFormula.to_dnf
+                (OpamFile.InitConfig.default_compiler init_config)
+            in
+            let invariant = OpamFile.InitConfig.default_invariant init_config in
+            let virt_st =
+              OpamSwitchState.load_virtual ~avail_default:false gt rt
+            in
+            let univ =
+              OpamSwitchState.universe virt_st
+                ~requested:OpamPackage.Set.empty Query
+            in
+            let univ = { univ with u_invariant = invariant } in
+            let default_compiler =
+              List.find_opt
+                (OpamSolver.atom_coinstallability_check univ)
+                alternatives
+              |> OpamStd.Option.default []
+            in
+            log "Selected default compiler %s in %0.3fs"
+              (OpamFormula.string_of_atoms default_compiler)
+              (chrono ());
+            Some default_compiler
         in
         gt, OpamRepositoryState.unlock ~cleanup:false rt, default_compiler
       with e ->

--- a/src/client/opamClient.mli
+++ b/src/client/opamClient.mli
@@ -30,8 +30,9 @@ val init:
   ?check_sandbox:bool ->
   ?cygwin_setup: [ `internal of OpamSysPkg.t list | `default_location | `location of dirname | `no ] ->
   ?git_location:(dirname, unit) either ->
+  ?no_compiler:bool ->
   shell ->
-  rw global_state * unlocked repos_state * atom list
+  rw global_state * unlocked repos_state * atom list option
 
 (* (\** Gets the initial config (opamrc) to be used *\)
  * val get_init_config:

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -507,46 +507,49 @@ let init cli =
         ?update_config ?env_hook ?completion
         ~check_sandbox:(not no_sandboxing)
         ?cygwin_setup ?git_location
+        ~no_compiler
         shell
     in
     OpamStd.Exn.finally (fun () -> OpamRepositoryState.drop rt)
     @@ fun () ->
-    if no_compiler then () else
-    let invariant, default_compiler, name =
-      match compiler with
-      | Some comp when String.length comp > 0 ->
-        OpamSwitchCommand.guess_compiler_invariant rt [comp],
-        [],
-        comp
-      | _ ->
-        OpamFile.Config.default_invariant gt.config,
-        default_compiler, "default"
-    in
-    OpamConsole.header_msg "Creating initial switch '%s' (invariant %s%s)"
-      name
-      (match invariant with
-       | OpamFormula.Empty -> "empty"
-       | c -> OpamFileTools.dep_formula_to_string c)
-      (match default_compiler with
-       | [] -> ""
-       | comp -> " - initially with "^ (OpamFormula.string_of_atoms comp));
-    let (), st =
-      try
-        OpamSwitchCommand.create
-          gt ~rt ~invariant ~update_config:true (OpamSwitch.of_string name) @@
-        (fun st ->
-           (),
-           OpamSwitchCommand.install_compiler st
-             ~ask:false
-             ~additional_installs:default_compiler)
-      with e ->
-        OpamStd.Exn.finalise e @@ fun () ->
-        OpamConsole.note
-          "Opam has been initialised, but the initial switch creation \
-           failed.\n\
-           Use 'opam switch create <compiler>' to get started."
-    in
-    OpamSwitchState.drop st
+    match default_compiler with
+    | None -> ()
+    | Some default_compiler ->
+      let invariant, default_compiler, name =
+        match compiler with
+        | Some comp when String.length comp > 0 ->
+          OpamSwitchCommand.guess_compiler_invariant rt [comp],
+          [],
+          comp
+        | _ ->
+          OpamFile.Config.default_invariant gt.config,
+          default_compiler, "default"
+      in
+      OpamConsole.header_msg "Creating initial switch '%s' (invariant %s%s)"
+        name
+        (match invariant with
+         | OpamFormula.Empty -> "empty"
+         | c -> OpamFileTools.dep_formula_to_string c)
+        (match default_compiler with
+         | [] -> ""
+         | comp -> " - initially with "^ (OpamFormula.string_of_atoms comp));
+      let (), st =
+        try
+          OpamSwitchCommand.create
+            gt ~rt ~invariant ~update_config:true (OpamSwitch.of_string name) @@
+          (fun st ->
+             (),
+             OpamSwitchCommand.install_compiler st
+               ~ask:false
+               ~additional_installs:default_compiler)
+        with e ->
+          OpamStd.Exn.finalise e @@ fun () ->
+          OpamConsole.note
+            "Opam has been initialised, but the initial switch creation \
+             failed.\n\
+             Use 'opam switch create <compiler>' to get started."
+      in
+      OpamSwitchState.drop st
   in
   mk_command  ~cli cli_original "init" ~doc ~man
     Term.(const init

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -402,3 +402,17 @@ this is not the content of a config file
 ### opam init --bypass-checks --bare --no-setup --config wrong-config --config non-existant --config $BASEDIR/config-files/config
 [ERROR] File does not exist: ${BASEDIR}/non-existant
 # Return code 2 #
+### :III: Debug logs
+### :III:1: CLIENT actions during --bare (detects if the default compiler was computed or not)
+### ::::::: See https://github.com/ocaml/opam/issues/5815
+### rm -rf $OPAMROOT
+### <opamrc>
+opam-version: "2.0"
+### OPAMDEBUGSECTIONS=CLIENT OPAMDEBUG=-5 opam init --bypass-checks --bare --no-setup --config opamrc REPO/ | grep -v Cygwin | grep -v git-location
+Configuring from ${BASEDIR}/opamrc and then from built-in defaults.
+CLIENT                          INIT default from file://${BASEDIR}/REPO
+CLIENT                          updating repository state
+
+<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+[default] Initialised
+CLIENT                          Selected default compiler ocaml-base-compiler in 0.000s

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -415,4 +415,3 @@ CLIENT                          updating repository state
 
 <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
 [default] Initialised
-CLIENT                          Selected default compiler ocaml-base-compiler in 0.000s


### PR DESCRIPTION
Fixes #5815 - `opam init --bare` was spending a few seconds selecting a default compiler, which is inappropriate for `--bare` that don't need a compiler environment.

Changes:
- Added a new ?no_compiler:bool parameter to OpamClient
- Added logic to skip compiler setup when no_compiler=true
- Updated init function to pass the no_compiler flag from the CLI

verification:
- before
```log
...
00:05.622  CACHE(repository)      Writing the repository cache to ~/.opam/repo/state-3DDC2EF7.cache ...
00:05.796  CACHE(repository)      ~/.opam/repo/state-3DDC2EF7.cache written in 0.174s
00:08.265  CLIENT                 Selected default compiler ocaml-base-compiler in 2.469s
```

- after
```log
...
00:06.044  CACHE(repository)      Writing the repository cache to ~/.opam/repo/state-3DDC2EF7.cache ...
00:06.213  CACHE(repository)      ~/.opam/repo/state-3DDC2EF7.cache written in 0.169s
```
