### PR TITLE
reftest: fix repository http test

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -168,7 +168,7 @@ users)
   * Add a test showing that `opam install ./` will leave packages pinned if
     aborted or failed [#6922 @NathanReb]
   * Add test for update in repository that changes directories to files and vice versa [#6915 @rjbou]
-  * Add an http repository test [#6939 @rjbou]
+  * Add an http repository test [#6939 #6961 @rjbou]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/tests/reftests/repository-http.test
+++ b/tests/reftests/repository-http.test
@@ -18,11 +18,22 @@ opam-version:"2.0"
 opam-version:"2.0"
 ### <packages/empat/empat.4/opam>
 opam-version:"2.0"
+### # We need this script to remove automatically embed timestamp in repo file
+### # by 'opam admin index'
+### <remove-timestamp.sh>
+set -eu
+cat > repo << EOF
+opam-version:"2.0"
+EOF
+gzip -d index.tar.gz
+tar rf index.tar repo
+gzip index.tar
 ### : Creation of the archive to serve
 ### opam admin index
 Generating urls.txt...
 Generating index.tar.gz...
 Done.
+### sh remove-timestamp.sh
 ### : Clean the already default repository
 ### opam repo remove --all default
 ### opam repo --all | grep -v '^#'
@@ -64,6 +75,7 @@ opam-version:"2.0"
 Generating urls.txt...
 Generating index.tar.gz...
 Done.
+### sh remove-timestamp.sh
 ### OPAMDEBUGSECTIONS="RSTATE REPOSITORY REPO_BACKEND UPDATE" OPAMDEBUG=-3 OPAMVERBOSE=2
 ### opam update http-repo | sed-cmd tar | grep -v "^+-" | ".*\(curl\|wget\).* \"--\"" -> 'curl-or-wget --' | "${HTTPSERVERPORT}" -> "port"
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -101,6 +113,7 @@ tujuh  --
 Generating urls.txt...
 Generating index.tar.gz...
 Done.
+### sh remove-timestamp.sh
 ### OPAMDEBUGSECTIONS="RSTATE REPOSITORY REPO_BACKEND UPDATE" OPAMDEBUG=-3 OPAMVERBOSE=2
 ### opam update http-repo | sed-cmd tar | grep -v "^+-" | ".*\(curl\|wget\).* \"--\"" -> 'curl-or-wget --' | "${HTTPSERVERPORT}" -> "port"
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -140,6 +153,7 @@ synopsis: "A tautological synopsis."
 Generating urls.txt...
 Generating index.tar.gz...
 Done.
+### sh remove-timestamp.sh
 ### OPAMDEBUGSECTIONS="RSTATE REPOSITORY REPO_BACKEND UPDATE" OPAMDEBUG=-3 OPAMVERBOSE=2
 ### opam update http-repo | sed-cmd tar | grep -v "^+-" | ".*\(curl\|wget\).* \"--\"" -> 'curl-or-wget --' | "${HTTPSERVERPORT}" -> "port"
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s


### PR DESCRIPTION
Timestamps are added in repo file by 'opam admin index', which made the test non reproducible.

It was unnoticed in #6939. It can be seen only on some windows jobs (with a cache), because of some latency, and only when the minute changes between the beginning & the end of the test.

For the moment, to unlock CI, the test is updated. In the future, maybe we want some option to 'opam admin index' to not embed timestamp, or even an environment variable for tests that disables it.