### PR TITLE
Some reftest fixes

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -169,6 +169,7 @@ users)
     aborted or failed [#6922 @NathanReb]
   * Add test for update in repository that changes directories to files and vice versa [#6915 @rjbou]
   * Add an http repository test [#6939 #6961 @rjbou]
+  * Fix `extrafile` test : remove trailing mkdir, the error was fixed in #6679 [#6970 rjbou]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -171,6 +171,7 @@ users)
   * Add an http repository test [#6939 #6961 @rjbou]
   * Fix `extrafile` test : remove trailing mkdir, the error was fixed in #6679 [#6970 rjbou]
   * Fix trailing full path for `tar` call in `no-depexts-sandboxed.unix.test` [#6970 @rjbou]
+  * Fix some forgotten sed in `extrasource` and `update` tests in #6734 [#6970 @rjbou]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -170,6 +170,7 @@ users)
   * Add test for update in repository that changes directories to files and vice versa [#6915 @rjbou]
   * Add an http repository test [#6939 #6961 @rjbou]
   * Fix `extrafile` test : remove trailing mkdir, the error was fixed in #6679 [#6970 rjbou]
+  * Fix trailing full path for `tar` call in `no-depexts-sandboxed.unix.test` [#6970 @rjbou]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/tests/reftests/extrafile.test
+++ b/tests/reftests/extrafile.test
@@ -618,11 +618,6 @@ Clearing cache of downloaded files
              error 53: Mismatching 'extra-files:' field: "../../../no-checksum/no-checksum.1/files/p.patch"
              error 73: Field 'extra-files' contains path with '..': "../../../no-checksum/no-checksum.1/files/p.patch"
 # Return code 1 #
-### # ERROR it copies it to build dir ^ relative path -> escape!!!!
-### # currently writing in /tmp as a common it copies in
-### # /tmp/build_d2b6ce_dune/opam-reftest-8f9413/escape-good-md5.1/../../../no-checksum/no-checksum.1/files
-### # This is needed for test portability, windows doesn't check path before resolving it
-### mkdir ${BASEDIR}/OPAM/repo/default/packages/escape-good-md5/escape-good-md5.1/files
 ### opam install escape-good-md5
 The following actions will be performed:
 === install 1 package

--- a/tests/reftests/extrasource.test
+++ b/tests/reftests/extrasource.test
@@ -811,18 +811,18 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam source good-md5-bad-sha256
+### opam source good-md5-bad-sha256 | sed-hash $PATCH_SHA256 patch-sha256
 [ERROR] good-md5-bad-sha256.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
           expected sha256=0000000000000000000000000000000000000000000000000000000000000000
-          got      sha256=c00eac22da21925d2077b66a29dc911cddc739b1b0d0909a6cb192344fba55ab
+          got      sha256=+patch-sha256+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f good-md5-bad-sha256.1/i-am-a-patch
 # Return code 1 #
-### opam source good-md5-bad-sha256 --require-checksums
+### opam source good-md5-bad-sha256 --require-checksums | sed-hash $PATCH_SHA256 patch-sha256
 [ERROR] good-md5-bad-sha256.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
           expected sha256=0000000000000000000000000000000000000000000000000000000000000000
-          got      sha256=c00eac22da21925d2077b66a29dc911cddc739b1b0d0909a6cb192344fba55ab
+          got      sha256=+patch-sha256+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f good-md5-bad-sha256.1/i-am-a-patch
@@ -854,7 +854,7 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam install good-sha256-bad-md5 --require-checksums
+### opam install good-sha256-bad-md5 --require-checksums | sed-hash $PATCH_MD5 patch-md5
 The following actions will be performed:
 === install 1 package
   - install good-sha256-bad-md5 1
@@ -862,7 +862,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [ERROR] good-sha256-bad-md5.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
           expected md5=00000000000000000000000000000000
-          got      md5=cf8c4c20658f6c3efea4eb2c6b1b34d7
+          got      md5=+patch-md5+
 [ERROR] Failed to get extra source "i-am-a-patch" of good-sha256-bad-md5.1: Checksum mismatch
 
 OpamSolution.Fetch_fail("Checksum mismatch")
@@ -874,18 +874,18 @@ OpamSolution.Fetch_fail("Checksum mismatch")
 +- 
 - No changes have been performed
 # Return code 40 #
-### opam source good-sha256-bad-md5
+### opam source good-sha256-bad-md5 | sed-hash $PATCH_MD5 patch-md5
 [ERROR] good-sha256-bad-md5.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
           expected md5=00000000000000000000000000000000
-          got      md5=cf8c4c20658f6c3efea4eb2c6b1b34d7
+          got      md5=+patch-md5+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f good-sha256-bad-md5.1/i-am-a-patch
 # Return code 1 #
-### opam source good-sha256-bad-md5 --require-checksums
+### opam source good-sha256-bad-md5 --require-checksums | sed-hash $PATCH_MD5 patch-md5
 [ERROR] good-sha256-bad-md5.1/i-am-a-patch: Checksum mismatch for file://${BASEDIR}/p.patch:
           expected md5=00000000000000000000000000000000
-          got      md5=cf8c4c20658f6c3efea4eb2c6b1b34d7
+          got      md5=+patch-md5+
 [ERROR] Download failed: Checksum mismatch
 # Return code 40 #
 ### test -f good-sha256-bad-md5.1/i-am-a-patch

--- a/tests/reftests/no-depexts-sandboxed.unix.test
+++ b/tests/reftests/no-depexts-sandboxed.unix.test
@@ -52,7 +52,7 @@ Done.
 Added '[os-family "debian" "Set through 'opam var'"]' to field global-variables in global configuration
 ### sh -c "rm OPAM/repo/state-*.cache"
 ### OPAMVERBOSE=2 OPAMNODEPEXTS=1 OPAMDEBUG=-1 OPAMDEBUGSECTIONS="XSYS RSTATE"
-### opam install foo | sed-cmd rsync
+### opam install foo | sed-cmd rsync tar
 RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          No cache found
 Processing: [default: loading data]
@@ -67,7 +67,7 @@ Processing  1/3: [foo.1: rsync]
 - foo.tgz
 - 
 Processing  1/3: [foo.1: extract]
-+ /usr/bin/tar "xfz" "${OPAMTMP}/foo.tgz" "-C" "${OPAMTMP}"
++ tar "xfz" "${OPAMTMP}/foo.tgz" "-C" "${OPAMTMP}"
 -> retrieved foo.1  (file://${BASEDIR}/foo.tgz)
 Processing  2/3: [foo: sh build.sh]
 + ${BASEDIR}/OPAM/opam-init/hooks/sandbox.sh "build" "sh" "build.sh" (CWD=${BASEDIR}/OPAM/internals-debian/.opam-switch/build/foo.1)

--- a/tests/reftests/update.test
+++ b/tests/reftests/update.test
@@ -607,8 +607,8 @@ REPO_BACKEND                    Internal diff (non-empty, 2 changed files) done 
 [incremental] synchronised from file://${BASEDIR}/INCR_REPO
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/incremental/packages/eta/eta.1/opam in 0.000s
 Now run 'opam upgrade' to apply any package updates.
-### opam show eta --field extra-files:
-"eta.installl" "md5=d9b673248d119b87a2e1f9766e543aa3"
+### opam show eta --field extra-files: | sed-hash $INSTALL_MD5 install-md5
+"eta.installl" "md5=+install-md5+"
 ### opam install eta
 The following actions will be performed:
 === install 1 package
@@ -727,8 +727,8 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/incremental/packages/eta/eta.1/opam in 0.000s
 opam-file                       Mismatching extra-files at ${BASEDIR}/OPAM/repo/incremental/packages/eta/eta.1: wrong checksum (1)
 Now run 'opam upgrade' to apply any package updates.
-### opam show eta --field extra-files:
-"eta.installl" "md5=d9b673248d119b87a2e1f9766e543aa3"
+### opam show eta --field extra-files: | sed-hash $INSTALL_MD5 install-md5
+"eta.installl" "md5=+install-md5+"
 ### opam install eta
 The following actions will be performed:
 === install 1 package
@@ -763,8 +763,8 @@ REPO_BACKEND                    Internal diff (non-empty, 1 changed files) done 
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/repo/incremental/packages/eta/eta.1/opam in 0.000s
 opam-file                       Missing expected extra files eta.installl at ${BASEDIR}/OPAM/repo/incremental/packages/eta/eta.1/files
-### opam show eta --field extra-files:
-"eta.installl" "md5=d9b673248d119b87a2e1f9766e543aa3"
+### opam show eta --field extra-files: | sed-hash $INSTALL_MD5 install-md5
+"eta.installl" "md5=+install-md5+"
 ### opam install eta
 The following actions will be performed:
 === install 1 package


### PR DESCRIPTION

  * Fix `extrafile` test : remove trailing mkdir, the error was fixed in #6679
  * Fix trailing full path for `tar` call in `no-depexts-sandboxed.unix.test`
  * Fix some forgotten sed in `extrrasource` and `update` tests in #6734 