### PR TITLE
OpamFile: when printing format error, add repository information if available

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -35,6 +35,7 @@ users)
 ## UI
   * Read full lines when asking for user input when `TERM=dumb` [#6829 @arvidj - fix #6828]
   * Fix a typo in the note telling users about new a depexts bypass [#6489 @rjbou @kit-ty-kate]
+  * Opam files parsing error now prints the origin repository of the failing opam file if relevant [#6971 @rjbou]
 
 ## Switch
 
@@ -256,6 +257,7 @@ users)
   * `OpamRepositoryPath` was moved from `opam-repository` [#6917 @rjbou]
   * `OpamRepositoryPath.{root,repo,packages_dir,packages,opam,files,descr,url}: have been moved to a new `OpamRepositoryPath.Make` functor [#6680 @rjbou @kit-ty-kate]
   * `OpamFilter.expand_interpolations_in_file`: changed argument type from `basename` to `filename` [#6910 @NathanReb]
+  * `OpamFile.OPAM.print_errors`: now prints the repository if the informations is available [#6971 @rjbou]
 
 ## opam-core
   * `OpamCmdliner` was added. It is accessible through a new `opam-core.cmdliner` sub-library [#6755 @kit-ty-kate]

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3692,9 +3692,17 @@ module OPAM = struct
       OpamConsole.error "In the opam file%s:\n%s\
                          %s %s been %s."
         (match o.name, o.version, file, o.metadata_dir with
+         | Some n, Some v, _, (Some (Some repo, _)) ->
+           Printf.sprintf " for %s from repository %s"
+             (OpamPackage.to_string (OpamPackage.create n v))
+             (OpamRepositoryName.to_string repo)
          | Some n, Some v, _, _ ->
            Printf.sprintf " for %s"
              (OpamPackage.to_string (OpamPackage.create n v))
+         | _, _, Some f, (Some (Some repo, _)) ->
+           Printf.sprintf " at %s from repository %s"
+             (to_string f)
+             (OpamRepositoryName.to_string repo)
          | _, _, Some f, _ ->
            Printf.sprintf " at %s" (to_string f)
          | _, _, _, Some (None, dir) ->

--- a/tests/reftests/extrafile.test
+++ b/tests/reftests/extrafile.test
@@ -381,7 +381,7 @@ Clearing cache of downloaded files
 # Return code 1 #
 ### # extra files is added with its checksum at repo loading
 ### opam install no-checksum
-[ERROR] In the opam file for no-checksum.1:
+[ERROR] In the opam file for no-checksum.1 from repository default:
           - At ${BASEDIR}/OPAM/repo/default/packages/no-checksum/no-checksum.1/opam:11:2-11:13::
             expected [file checksum]
         'extra-files' has been ignored.
@@ -406,7 +406,7 @@ The following actions will be performed:
 
 Nothing to do.
 ### opam install no-checksum --require-checksums
-[ERROR] In the opam file for no-checksum.1:
+[ERROR] In the opam file for no-checksum.1 from repository default:
           - At ${BASEDIR}/OPAM/repo/default/packages/no-checksum/no-checksum.1/opam:11:2-11:13::
             expected [file checksum]
         'extra-files' has been ignored.

--- a/tests/reftests/extrasource.test
+++ b/tests/reftests/extrasource.test
@@ -1093,7 +1093,7 @@ Successfully extracted to ${BASEDIR}/not-mentioned.1
              error  3: File format error in 'extra-source': Duplicate section extra-source
 # Return code 1 #
 ### opam install multiple
-[ERROR] In the opam file for multiple.1:
+[ERROR] In the opam file for multiple.1 from repository default:
           - In ${BASEDIR}/OPAM/repo/default/packages/multiple/multiple.1/opam:
             Duplicate section extra-source
         'extra-source' has been ignored.
@@ -1106,7 +1106,7 @@ The following actions will be performed:
 -> installed multiple.1
 Done.
 ### opam remove multiple
-[ERROR] In the opam file for multiple.1:
+[ERROR] In the opam file for multiple.1 from repository default:
           - In ${BASEDIR}/OPAM/repo/default/packages/multiple/multiple.1/opam:
             Duplicate section extra-source
         'extra-source' has been ignored.
@@ -1118,7 +1118,7 @@ The following actions will be performed:
 -> removed   multiple.1
 Done.
 ### opam install multiple --require-checksums
-[ERROR] In the opam file for multiple.1:
+[ERROR] In the opam file for multiple.1 from repository default:
           - In ${BASEDIR}/OPAM/repo/default/packages/multiple/multiple.1/opam:
             Duplicate section extra-source
         'extra-source' has been ignored.


### PR DESCRIPTION
For #6625, we no longer always have the full paths of opam files from repository, so we want to print the repository information, if available.
This PR adds for another parse error the repository information if available, for homogeneity

in the story of #6625