### PR TITLE
Packaging.md: add a paragraph explaining that static archives are preferrable when manually releasing packages

### DIFF
--- a/doc/pages/Packaging.md
+++ b/doc/pages/Packaging.md
@@ -114,6 +114,11 @@ url {
 }
 ```
 
+It is recommended to use a static archive for the `src:`. Any change in the
+archive (such as those that can happen when using archives generated
+by git forges such as GitHub) can lead to changes in the checksums and
+consequently break the package on opam-repository.
+
 Then get to https://github.com/ocaml/opam-repository and select `Fork` on the
 top-right. Clone the resulting repository, add your package definition, and
 push back, as such:

--- a/master_changes.md
+++ b/master_changes.md
@@ -214,6 +214,7 @@ users)
   * Bump `actions/cache` to version 6 [#6983 @kit-ty-kate]
 
 ## Doc
+  * Update the packaging page to recommend using static archives for releases [#6973 @mseri]
   * Add spacing between two words in `--locked` man section [#6806 @yosefAlsuhaibani]
   * Update the Install page with the new opam 2.5.0 release [#6821 @kit-ty-kate]
   * Mention more explicitely that raw fields are an option [@raphael-proust]


### PR DESCRIPTION
See: https://github.com/ocaml/opam-repository/issues/30089#issuecomment-4801321415

Not sure if it is worth having this in the master_changes file
