### PR TITLE
Workaround symlinks in local opam repositories

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -67,6 +67,7 @@ users)
 
 ## Repository
   * No longer call tar tool to create archives, use tar library instead [#6945 @kit-ty-kate]
+  * Synchronisation now always ignores `_opam`, `_build` and editor lock files (`.#*`) (rsync previously did this, but not local) [#6977 @dra27]
 
 ## Lock
 
@@ -268,6 +269,7 @@ users)
   * `OpamFile.OPAM.print_errors`: now prints the repository if the informations is available [#6971 @rjbou]
 
 ## opam-core
+  * `OpamSystem.{get_files_except_vcs,copy_dir_except_vcs}` (and `OpamFilename.copy_dir_except_vcs`) now also skip `_opam`, `_build` and editor lock files (`.#*`) [#6977 @dra27]
   * `OpamCmdliner` was added. It is accessible through a new `opam-core.cmdliner` sub-library [#6755 @kit-ty-kate]
   * `OpamUrl`: rename and expose `local_path` as `looks_like_local_path` [#5979 @kit-ty-kate]
   * `OpamCompat.Gc.ramp_up`: was added [#6515 @dra27]

--- a/master_changes.md
+++ b/master_changes.md
@@ -168,6 +168,7 @@ users)
   * Add disabled depexts tests [#6489 @rjbou]
   * Add depexts tests with debug section that demostrate system availability polling [#6489 @arozovyk]
   * Add a test showing the behaviour of .install files containing destination filepath trying to escape their scope [#6897 @rjbou @kit-ty-kate]
+  * Add `repository-symlink.test` showing that a local repository containing temporary files can be updated incrementally [#6977 @dra27]
   * Add a test showing that `opam install ./` will leave packages pinned if
     aborted or failed [#6922 @NathanReb]
   * Add test for update in repository that changes directories to files and vice versa [#6915 @rjbou]

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -75,7 +75,8 @@ val move_dir: src:Dir.t -> dst:Dir.t -> unit
 val copy_dir: src:Dir.t -> dst:Dir.t -> unit
 
 (** Same as [copy_dir] except it avoids copying VCS directories
-    ([.git], [.hg], [_darcs]) *)
+    ([.git], [.hg], [_darcs]), opam switches ([_opam*]), [_build]
+    and editor lock files ([.#]) *)
 val copy_dir_except_vcs : src:Dir.t -> dst:Dir.t -> unit
 
 (** Link a directory *)

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -123,8 +123,13 @@ let get_files_t ~except_vcs dirname =
   let rec aux files =
     match Unix.readdir dir with
     | "." | ".." -> aux files
-    | ".git" | ".hg" | "_darcs" when except_vcs -> aux files
-    | file -> aux (file :: files)
+    | ".git" | ".hg" | "_darcs" | "_build" when except_vcs -> aux files
+    | file ->
+      let has_prefix prefix = OpamCompat.String.starts_with ~prefix file in
+      if except_vcs && (has_prefix "_opam" || has_prefix ".#") then
+        aux files
+      else
+        aux (file :: files)
     | exception End_of_file -> files
   in
   let files = aux [] in

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -77,7 +77,8 @@ val copy_file: string -> string -> unit
 val copy_dir: string -> string -> unit
 
 (** Same as [copy_dir] except it avoids copying VCS directories
-    ([.git], [.hg], [_darcs]) *)
+    ([.git], [.hg], [_darcs]), opam switches ([_opam*]), [_build]
+    and editor lock files ([.#]) *)
 val copy_dir_except_vcs : string -> string -> unit
 
 val mv: string -> string -> unit
@@ -137,7 +138,8 @@ val write: string -> string -> unit
 val get_files : string -> string list
 
 (** Same as [get_files] except it avoids copying VCS directories
-    ([.git], [.hg], [_darcs]) *)
+    ([.git], [.hg], [_darcs]), opam switches ([_opam*]), [_build]
+    and editor lock files ([.#]) *)
 val get_files_except_vcs : string -> string list
 
 (** [remove filename] removes [filename]. Works whether [filename] is

--- a/src/repository/opamRepositoryRoot.mli
+++ b/src/repository/opamRepositoryRoot.mli
@@ -36,6 +36,7 @@ module Dir : sig
   val remove : t -> unit
   val move : src:t -> dst:t -> unit
   val copy : src:t -> dst:t -> unit
+
   val copy_except_vcs : src:t -> dst:t -> unit
   val make_empty : t -> unit
   val dirs : t -> dirname list

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1911,6 +1911,27 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:repository-patchdiff.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-repository-symlink)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (action
+  (diff repository-symlink.test repository-symlink.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (deps (alias reftest-repository-symlink)))
+
+(rule
+ (targets repository-symlink.out)
+ (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:repository-symlink.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-repository)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action

--- a/tests/reftests/repository-symlink.test
+++ b/tests/reftests/repository-symlink.test
@@ -1,0 +1,43 @@
+N0REP0
+### <REPO/packages/foo/foo.1/opam>
+opam-version: "2.0"
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### <REPO/packages/foo/foo.1/files/data.txt>
+hello
+### <REPO/.#repo>
+This file is locked by emacs
+### <REPO/_build/install/default/doc/README.txt>
+This file gets copied
+### <REPO/_opam/bin/ocamlopt.opt>
+dummy
+### <REPO/packages/foo/foo.2/opam>
+opam-version: "2.0"
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### find OPAM/repo/default | sort | grep -v .git
+OPAM/repo/default
+OPAM/repo/default/.#repo
+OPAM/repo/default/_build
+OPAM/repo/default/_build/install
+OPAM/repo/default/_build/install/default
+OPAM/repo/default/_build/install/default/doc
+OPAM/repo/default/_build/install/default/doc/README.txt
+OPAM/repo/default/_opam
+OPAM/repo/default/_opam/bin
+OPAM/repo/default/_opam/bin/ocamlopt.opt
+OPAM/repo/default/packages
+OPAM/repo/default/packages/foo
+OPAM/repo/default/packages/foo/foo.1
+OPAM/repo/default/packages/foo/foo.1/files
+OPAM/repo/default/packages/foo/foo.1/files/data.txt
+OPAM/repo/default/packages/foo/foo.1/opam
+OPAM/repo/default/packages/foo/foo.2
+OPAM/repo/default/packages/foo/foo.2/opam
+OPAM/repo/default/repo

--- a/tests/reftests/repository-symlink.test
+++ b/tests/reftests/repository-symlink.test
@@ -23,15 +23,6 @@ opam-version: "2.0"
 Now run 'opam upgrade' to apply any package updates.
 ### find OPAM/repo/default | sort | grep -v .git
 OPAM/repo/default
-OPAM/repo/default/.#repo
-OPAM/repo/default/_build
-OPAM/repo/default/_build/install
-OPAM/repo/default/_build/install/default
-OPAM/repo/default/_build/install/default/doc
-OPAM/repo/default/_build/install/default/doc/README.txt
-OPAM/repo/default/_opam
-OPAM/repo/default/_opam/bin
-OPAM/repo/default/_opam/bin/ocamlopt.opt
 OPAM/repo/default/packages
 OPAM/repo/default/packages/foo
 OPAM/repo/default/packages/foo/foo.1


### PR DESCRIPTION
We got caught out by a caching problem in the CI for [oxcaml/opam-repository](https://github.com/oxcaml/opam-repository) because it creates an opam local switch in the checkout for testing. First time round it all worked, but if the cache was restored then the repo being added in setup-ocaml failed because of the symlinks in `_opam`.

This PR presents a few ideas: the simplest one is first which is to extend `rsync`'s ignoring of `_opam*`, `.#*` and `_build`. I also added two possible ideas, given that it's for repos only, either dereferencing or just ignoring the symlinks... I'm not totally convinced by either, though.