### PR TITLE
Stop the opam 1.2 to 2.0 repository upgrade process from downloading packages without checksums to add a non-trusted md5

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -86,6 +86,7 @@ users)
 ## Format upgrade
   * Fix switch and repo format upgrade on Windows. A block occurred because the global lock fd was reopened instead of using the one already opened.  [#6839 @rjbou]
   * Add opam root format upgrade conditional mechanism for hard upgrades [#6949 @rjbou]
+  * Stop the opam 1.2 to 2.0 repository upgrade process from downloading packages without checksums to add a non-trusted md5 [#6978 @kit-ty-kate]
 
 ## Sandbox
   * Allow the macOS sandbox to write in the `/var/folders/` and `/var/db/mds/` directories as it is required by some of macOS core tools [#4797 @kit-ty-kate - fix #4389 #6460]
@@ -125,6 +126,7 @@ users)
   * Fix the AppArmor support when installing in `/usr/bin` [#6823 @kit-ty-kate - fix #6820]
 
 ## Admin
+ * `opam admin upgrade --clear-cache` is now a no-op as it is no longer needed [#6978 @kit-ty-kate]
 
 ## Opam installer
 
@@ -202,6 +204,7 @@ users)
   * Bump the opam-repository commits sha [#6976 @kit-ty-kate]
   * Fix the archlinux depexts run [#6976 @kit-ty-kate]
   * Fix the cygwin backend basic tests [#6979 @kit-ty-kate]
+  * Fix undeterministic tests [#6978 @kit-ty-kate]
 
 ## Doc
   * Add spacing between two words in `--locked` man section [#6806 @yosefAlsuhaibani]
@@ -218,6 +221,7 @@ users)
 # API updates
 ## opam-client
   * `OpamArg`: add `build_options_no_depexts` getter to retrieve the value of the given flag  [#6489 @rjbou]
+  * `OpamArg{,Tools}.cli2_6` was added [#6978 @kit-ty-kate]
   * `OpamClientConfig.opam_init`: replace `no_depexts` argument by `depexts` [#6489 @rjbou]
   * `OpamSolution` remove the heuristic of recomputing depexts of additional (pinned) packages. [#6489 @arozovyk]
   * `OpamClient` update the system package status check for dependencies during `opam install --deps-only`, including support for pinned packages; also update this in `OpamAuxCommands.autopin` [#6489 @arozovyk]

--- a/src/client/opamAdminCommand.ml
+++ b/src/client/opamAdminCommand.ml
@@ -781,11 +781,8 @@ let upgrade_command cli =
   ]
   in
   let clear_cache_arg =
-    OpamArg.mk_flag ~cli OpamArg.cli_original ["clear-cache"]
-      (Printf.sprintf
-         "Instead of running the upgrade, clear the cache of archive hashes (held \
-          in ~%s.cache), that is used to avoid re-downloading files to obtain \
-          their hashes at every run." OpamArg.dir_sep)
+    OpamArg.mk_flag ~cli OpamArg.(cli_between cli2_0 cli2_6) ["clear-cache"]
+      "Deprecated"
   in
   let create_mirror_arg =
     OpamArg.mk_opt ~cli OpamArg.cli_original ["m"; "mirror"] "URL"
@@ -795,22 +792,20 @@ let upgrade_command cli =
        of opam don't understand relative redirects)."
       Arg.(some OpamArg.url) None
   in
-  let cmd global_options clear_cache create_mirror () =
+  let cmd global_options _clear_cache create_mirror () =
     OpamArg.apply_global_options cli global_options;
-    if clear_cache then OpamAdminRepoUpgrade.clear_cache ()
-    else
-      let repo_root = checked_repo_root ~check:false () in
-      match create_mirror with
-      | None ->
-        OpamAdminRepoUpgrade.do_upgrade repo_root;
-        if OpamFilename.exists (OpamFilename.of_string "index.tar.gz") ||
-           OpamFilename.exists (OpamFilename.of_string "urls.txt")
-        then
-          OpamConsole.note
-            "Indexes need updating: you should now run:\n\
-             \n\
-            \  opam admin index"
-      | Some m -> OpamAdminRepoUpgrade.do_upgrade_mirror repo_root m
+    let repo_root = checked_repo_root ~check:false () in
+    match create_mirror with
+    | None ->
+      OpamAdminRepoUpgrade.do_upgrade repo_root;
+      if OpamFilename.exists (OpamFilename.of_string "index.tar.gz") ||
+         OpamFilename.exists (OpamFilename.of_string "urls.txt")
+      then
+        OpamConsole.note
+          "Indexes need updating: you should now run:\n\
+           \n\
+          \  opam admin index"
+    | Some m -> OpamAdminRepoUpgrade.do_upgrade_mirror repo_root m
   in
   OpamArg.mk_command  ~cli OpamArg.cli_original command ~doc ~man
     Term.(const cmd $ global_options cli $

--- a/src/client/opamAdminRepoUpgrade.ml
+++ b/src/client/opamAdminRepoUpgrade.ml
@@ -9,7 +9,6 @@
 (**************************************************************************)
 
 open OpamTypes
-open OpamProcess.Job.Op
 open OpamStd.Option.Op
 
 module O = OpamFile.OPAM
@@ -146,10 +145,6 @@ let all_base_packages =
       "base-unix";
     ])
 
-let cache_file : string list list OpamFile.t =
-  OpamFile.make @@
-  OpamFilename.of_string "~/.cache/opam-compilers-to-packages/url-hashes"
-
 let do_upgrade repo_root =
   let write_opam ?(add_files=[]) opam =
     let nv = O.package opam in
@@ -175,44 +170,6 @@ let do_upgrade repo_root =
       OpamStd.String.Map.empty
   in
 
-  let get_url_md5, save_cache =
-    let url_md5 = Hashtbl.create 187 in
-    let () =
-      OpamFile.Lines.read_opt cache_file +! [] |> List.iter @@ function
-      | [url; md5] ->
-        Stdlib.Option.iter
-          (fun url -> Hashtbl.add url_md5 url (OpamHash.of_string md5))
-          (OpamUrl.parse_opt ~handle_suffix:false url)
-      | _ -> failwith "Bad cache, run 'opam admin upgrade --clear-cache'"
-    in
-    (fun url ->
-       try Done (Some (Hashtbl.find url_md5 url))
-       with Not_found ->
-         OpamFilename.with_tmp_dir_job @@ fun dir ->
-         OpamProcess.Job.ignore_errors ~default:None
-           (fun () ->
-                (* Download to package.patch, rather than allowing the name to be
-                   guessed since, on Windows, some of the characters which are
-                   valid in URLs are not valid in filenames *)
-              let f =
-                let base = OpamFilename.Base.of_string "package.patch" in
-                OpamFilename.create dir base
-              in
-              OpamDownload.download_as ~overwrite:false url f @@| fun () ->
-              let hash = OpamHash.compute (OpamFilename.to_string f) in
-              Hashtbl.add url_md5 url hash;
-              Some hash)),
-    (fun () ->
-       Hashtbl.fold
-         (fun url hash l -> [OpamUrl.to_string url; OpamHash.to_string hash]::l)
-         url_md5 [] |> fun lines ->
-       try OpamFile.Lines.write cache_file lines with e ->
-         OpamStd.Exn.fatal e;
-         OpamConsole.log "REPO_UPGRADE"
-           "Could not write archive hash cache to %s, skipping (%s)"
-           (OpamFile.to_string cache_file)
-           (Printexc.to_string e))
-  in
   let ocaml_versions =
     OpamStd.String.Map.fold (fun c comp_file ocaml_versions ->
       let comp = OpamFile.Comp.read (OpamFile.make comp_file) in
@@ -244,56 +201,17 @@ let do_upgrade repo_root =
 
       let opam = OpamFormatUpgrade.comp_file ~package:nv ?descr comp in
       let opam = O.with_conflict_class [ocaml_conflict_class] opam in
-      let opam =
-        match OpamFile.OPAM.url opam with
-        | Some urlf when OpamFile.URL.checksum urlf = [] ->
-          let url = OpamFile.URL.url urlf in
-          (match url.OpamUrl.backend with
-           | #OpamUrl.version_control -> Some opam
-           | `rsync when OpamUrl.local_dir url <> None -> Some opam
-           | _ ->
-             (match OpamProcess.Job.run (get_url_md5 url) with
-              | None -> None
-              | Some hash ->
-                Some
-                  (OpamFile.OPAM.with_url (OpamFile.URL.with_checksum [hash] urlf)
-                     opam)))
-        | _ -> Some opam
-      in
-      match opam with
-      | None ->
-        OpamConsole.error
-          "Could not get the archive of %s, skipping"
-          (OpamPackage.to_string nv);
-        ocaml_versions
-      | Some opam ->
       let patches = OpamFile.Comp.patches comp in
       if patches <> [] then
         OpamConsole.msg "Fetching patches of %s to check their hashes...\n"
           (OpamPackage.to_string nv);
-      let extra_sources =
-        (* Download them just to get their MD5 *)
-        OpamParallel.map
-          ~jobs:3
-          ~command:(fun url ->
-              get_url_md5 url @@| function
-              | Some md5 -> Some (url, md5, None)
-              | None ->
-                OpamConsole.error
-                  "Could not get patch file for %s from %s, skipping"
-                  (OpamPackage.to_string nv) (OpamUrl.to_string url);
-                None)
-          (OpamFile.Comp.patches comp)
-      in
-      if List.mem None extra_sources then ocaml_versions
-      else
       let opam =
         opam |>
         OpamFile.OPAM.with_extra_sources
-          (List.map (fun (url, hash, _) ->
+          (List.map (fun url ->
                OpamFilename.Base.of_string (OpamUrl.basename url),
-               OpamFile.URL.create ~checksum:[hash] url)
-              (OpamStd.List.filter_some extra_sources))
+               OpamFile.URL.create url)
+              (OpamFile.Comp.patches comp))
       in
       write_opam opam;
 
@@ -344,7 +262,6 @@ let do_upgrade repo_root =
     compilers OpamStd.String.Set.empty
   in
   OpamConsole.clear_status ();
-  save_cache ();
 
   (* Generate "ocaml" package wrappers depending on one of the implementations
      at the appropriate version *)
@@ -448,9 +365,6 @@ let do_upgrade repo_root =
   OpamFile.Repo.write repo_file
     (OpamFile.Repo.with_opam_version upgradeto_version
        (OpamFile.Repo.safe_read repo_file))
-
-let clear_cache () =
-  OpamFilename.remove (OpamFile.filename cache_file)
 
 let do_upgrade_mirror repo_root base_url =
   OpamRepositoryRoot.Dir.with_tmp @@ fun tmp_mirror_dir ->

--- a/src/client/opamAdminRepoUpgrade.mli
+++ b/src/client/opamAdminRepoUpgrade.mli
@@ -8,8 +8,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val clear_cache: unit -> unit
-
 val upgradeto_version: OpamVersion.t
 val upgradefrom_version: OpamVersion.t
 

--- a/src/client/opamArg.mli
+++ b/src/client/opamArg.mli
@@ -27,6 +27,7 @@ val cli2_2: OpamCLIVersion.t
 val cli2_3: OpamCLIVersion.t
 val cli2_4: OpamCLIVersion.t
 val cli2_5: OpamCLIVersion.t
+val cli2_6: OpamCLIVersion.t
 
 (* [cli_from ?platform ?experimental since] validity flag since [since], and no
    removal version. If [experimental] is true, it is marked as is (warning and

--- a/src/client/opamArgTools.ml
+++ b/src/client/opamArgTools.ml
@@ -18,6 +18,7 @@ let cli2_2 = OpamCLIVersion.of_string "2.2"
 let cli2_3 = OpamCLIVersion.of_string "2.3"
 let cli2_4 = OpamCLIVersion.of_string "2.4"
 let cli2_5 = OpamCLIVersion.of_string "2.5"
+let cli2_6 = OpamCLIVersion.of_string "2.6"
 
 type subplatform = [ `windows | `unix ]
 type platform = [ `all | subplatform ]

--- a/src/client/opamArgTools.mli
+++ b/src/client/opamArgTools.mli
@@ -31,6 +31,7 @@ val cli2_2: OpamCLIVersion.t
 val cli2_3: OpamCLIVersion.t
 val cli2_4: OpamCLIVersion.t
 val cli2_5: OpamCLIVersion.t
+val cli2_6: OpamCLIVersion.t
 
 val mk_flag:
   cli:OpamCLIVersion.Sourced.t -> validity -> section:string -> string list ->

--- a/tests/reftests/admin.test
+++ b/tests/reftests/admin.test
@@ -88,7 +88,7 @@ packages/ocaml-system/ocaml-system.1.2/files/gen_ocaml_config.ml.in
 depends: ["ocaml"]
 opam-version: "2.0"
 synopsis: "base package"
-### opam-cat packages/ocaml-base-compiler/ocaml-base-compiler.1.2/opam | '=[0-9a-f]{32}"' -> =HASH
+### opam-cat packages/ocaml-base-compiler/ocaml-base-compiler.1.2/opam
 conflict-class: "ocaml-core-compiler"
 depends: ["ocaml" {= "1.2" & post} "base-comp" {post}]
 flags: compiler
@@ -98,7 +98,6 @@ opam-version: "2.0"
 synopsis: "1.2+1 compiler release"
 url {
 src: "file://${BASEDIR}/old-comp.1.2.tgz"
-checksum: "md5=HASH
 }
 ### opam-cat packages/ocaml/ocaml.1.2/opam
 build: ["ocaml" "-I" "+unix" "unix.cma" "gen_ocaml_config.ml"]
@@ -162,7 +161,7 @@ let () =
   p "  compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{ocaml-variants:version}%\"";
   p "}";
   close_out oc
-### opam-cat packages/ocaml-variants/ocaml-variants.1.2+1/opam | '=[0-9a-f]{32}"' -> =HASH
+### opam-cat packages/ocaml-variants/ocaml-variants.1.2+1/opam
 conflict-class: "ocaml-core-compiler"
 depends: ["ocaml" {= "1.2" & post} "base-comp" {post}]
 flags: compiler
@@ -171,7 +170,6 @@ maintainer: "platform@lists.ocaml.org"
 opam-version: "2.0"
 url {
 src: "file://${BASEDIR}/old-comp.1.2+1.tgz"
-checksum: "md5=HASH
 }
 ### opam-cat packages/ocaml-system/ocaml-system.1.2/opam
 available: sys-ocaml-version = "1.2"
@@ -451,6 +449,10 @@ repo
 ### opam admin lint
 In base-comp.base:
            warning 47: Synopsis should start with a capital and not end with a dot
+In ocaml-base-compiler.1.2:
+           warning 59: url doesn't contain a checksum
+In ocaml-variants.1.2+1:
+           warning 59: url doesn't contain a checksum
 In risus.1:
              error 23: Missing field 'maintainer'
            warning 25: Missing field 'authors'


### PR DESCRIPTION
This made the result of `opamrt-big-upgrade.test` depend on whether or not `caml.inria.fr` is down or not.