### PR TITLE
Fix the filename check used when parsing arguments to allow '/' to be recognised as a directory separator on Windows

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -17,6 +17,7 @@ users)
   * Update Kate's email address [#6808 @kit-ty-kate]
   * Remove unnecessary uses of `chdir` [#6910 @NathanReb]
   * Added `--ignore-available-on` option to allow ignoring the `available:` section of certain packages. [#6836 @WardBrian - fix #5283]
+  * Fix the filename check used when parsing arguments to allow `/` to be recognised as a directory separator on Windows [#6981 @kit-ty-kate - fix #6940]
 
 ## Plugins
 
@@ -385,6 +386,7 @@ users)
   * `OpamFilename.might_escape`: ensure / is detected as a file separator when called with `~sep:Unspecified` on Windows [#6897 @kit-ty-kate]
   * `OpamFilename.Unix` was added abstracting over `/` separated paths regardless of the current system [#6914 @rjbou @kit-ty-kate]
   * `OpamFilename.in_dir`: removed [#6910 @NathanReb]
+  * `OpamFilename.{is_dir_sep,is_rel_seg}` were added [#6981 @kit-ty-kate]
   * `OpamSystem.in_tmp_dir`: removed [#6910 @NathanReb]
   * `OpamSystem.in_dir`: removed [#6910 @NathanReb]
   * `OpamSystem.chdir`: removed [#6910 @NathanReb]

--- a/master_changes.md
+++ b/master_changes.md
@@ -229,6 +229,7 @@ users)
   * Add tests for `.install` `root` and `rootexec` fields [#6938 @rjbou]
   * Test the new `--ignore-available-on` argument and `OPAMIGNOREAVAILABLE` environment variable [#6836 @WardBrian @kit-ty-kate]
   * Add a test showing the behaviour of `opam init` when the default compiler failed to build [#6851 @kit-ty-kate]
+  * Add a test ensuring `/` can be used as directory separator on Windows when referring to a path to a local repository [#6981 @kit-ty-kate]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -230,6 +230,7 @@ users)
   * Test the new `--ignore-available-on` argument and `OPAMIGNOREAVAILABLE` environment variable [#6836 @WardBrian @kit-ty-kate]
   * Add a test showing the behaviour of `opam init` when the default compiler failed to build [#6851 @kit-ty-kate]
   * Add a test ensuring `/` can be used as directory separator on Windows when referring to a path to a local repository [#6981 @kit-ty-kate]
+  * Add a test showing when opam creates a local switch vs. global [#6981 @kit-ty-kate]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -872,8 +872,8 @@ let atom =
 
 let atom_or_local =
   let parse str =
-    if OpamStd.String.contains ~sub:Filename.dir_sep str ||
-       OpamCompat.String.starts_with ~prefix:"." str
+    if OpamFilename.is_rel_seg str ||
+       OpamCompat.String.exists OpamFilename.is_dir_sep str
     then
       if OpamFilename.(exists (of_string str)) then
         Ok (`Filename (OpamFilename.of_string str))

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -26,6 +26,16 @@ let might_escape ~sep path =
   List.exists (String.equal Filename.parent_dir_name)
     (split ~sep path)
 
+let is_dir_sep =
+  if Sys.win32 then
+    function '/' | '\\' -> true | _ -> false
+  else
+    function '/' -> true | _ -> false
+
+let is_rel_seg = function
+  | "." | ".." -> true
+  | _ -> false
+
 module Base = struct
   include OpamStd.AbstractString
 

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -12,11 +12,17 @@
 (** Higher level file and directory name manipulation AND file operations,
     wrappers on OpamSystem using the filename type *)
 
-(* Returns [true] if string contains '..' between directory separators *)
+(** Returns [true] if string contains '..' between directory separators *)
 val might_escape: sep:[`Unix | `Windows | `Unspecified ] -> string -> bool
 
 (* Returns a list of elements between directory separators *)
 val split: sep:[`Unix | `Windows | `Unspecified ] -> string -> string list
+
+(** Returns [true] if the character is a directory separator *)
+val is_dir_sep: char -> bool
+
+(** Returns [true] if the string is [".."] or ["."] (relative segment) *)
+val is_rel_seg: string -> bool
 
 (** Basenames *)
 module Base: sig

--- a/src/format/opamSwitch.ml
+++ b/src/format/opamSwitch.ml
@@ -14,8 +14,8 @@ include OpamStd.AbstractString
 let unset = of_string "#unset#"
 
 let is_external s =
-  OpamCompat.String.starts_with ~prefix:"." s ||
-  OpamStd.String.contains ~sub:Filename.dir_sep s
+  OpamFilename.is_rel_seg s ||
+  OpamCompat.String.exists OpamFilename.is_dir_sep s
 
 let external_dirname = "_opam"
 

--- a/tests/reftests/autopin.test
+++ b/tests/reftests/autopin.test
@@ -460,3 +460,10 @@ Proceed with 2 installations? [Y/n] n
 # Return code 10 #
 ### opam pin list
 abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (error while fetching current revision)
+### : Ensure the dir/*.opam pattern works on all platform (see https://github.com/ocaml/opam/issues/6940)
+### opam install abort-install/abort-install.opam --no
+opam: PACKAGES… arguments: Invalid character '/' in package name
+      "abort-install/abort-install"
+Usage: opam install [OPTION]… [PACKAGES]…
+Try 'opam install --help' or 'opam --help' for more information.
+# Return code 2 #

--- a/tests/reftests/autopin.test
+++ b/tests/reftests/autopin.test
@@ -462,8 +462,11 @@ Proceed with 2 installations? [Y/n] n
 abort-install.dev  (uninstalled)  git  git+file://${BASEDIR}/abort-install#master  (error while fetching current revision)
 ### : Ensure the dir/*.opam pattern works on all platform (see https://github.com/ocaml/opam/issues/6940)
 ### opam install abort-install/abort-install.opam --no
-opam: PACKAGES… arguments: Invalid character '/' in package name
-      "abort-install/abort-install"
-Usage: opam install [OPTION]… [PACKAGES]…
-Try 'opam install --help' or 'opam --help' for more information.
-# Return code 2 #
+[abort-install.dev] synchronised (git+file://${BASEDIR}/abort-install#master)
+The following actions will be performed:
+=== install 2 packages
+  - install abort-install dev (pinned)
+  - install dep-lib       1            [required by abort-install]
+
+Proceed with 2 installations? [Y/n] n
+# Return code 10 #

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1512,6 +1512,27 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:list.unix.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-local-switch)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (action
+  (diff local-switch.test local-switch.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (deps (alias reftest-local-switch)))
+
+(rule
+ (targets local-switch.out)
+ (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:local-switch.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-lock)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action

--- a/tests/reftests/local-switch.test
+++ b/tests/reftests/local-switch.test
@@ -8,22 +8,22 @@ N0REP0
 ### opam switch show --switch=global-1
 global-1
 ### opam switch show --switch=.global-2
-${BASEDIR}/.global-2
+.global-2
 ### opam switch show --switch=./local-1
 ${BASEDIR}/local-1
 ### opam switch show --switch=local-2/
-local-2/
+${BASEDIR}/local-2
 ### opam switch show --switch=local-3/inner
-local-3/inner
+${BASEDIR}/local-3/inner
 ### ls -a OPAM | sort | grep -v log
 .
 ..
+.global-2
 config
 config.lock
 global-1
-local-2
-local-3
 lock
 opam-init
 repo
 ### test -d OPAM/local-3/inner
+# Return code 1 #

--- a/tests/reftests/local-switch.test
+++ b/tests/reftests/local-switch.test
@@ -1,0 +1,29 @@
+N0REP0
+### OPAMYES=1
+### opam switch create global-1 --empty
+### opam switch create .global-2 --empty
+### opam switch create ./local-1 --empty
+### opam switch create local-2/ --empty
+### opam switch create local-3/inner --empty
+### opam switch show --switch=global-1
+global-1
+### opam switch show --switch=.global-2
+${BASEDIR}/.global-2
+### opam switch show --switch=./local-1
+${BASEDIR}/local-1
+### opam switch show --switch=local-2/
+local-2/
+### opam switch show --switch=local-3/inner
+local-3/inner
+### ls -a OPAM | sort | grep -v log
+.
+..
+config
+config.lock
+global-1
+local-2
+local-3
+lock
+opam-init
+repo
+### test -d OPAM/local-3/inner


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/6940

The only reason this half worked before is because of the `String.starts_with ~prefix:"." s` which should instead have been `s = "." || s = ".."`, else `.pkg` is wrongly detected as a valid filename instead of an invalid package name.

Also for some reason the testsuite always use `./` as a prefix when using directory names etc, so it was never detected.