### PR TITLE
Silence warnings raised by OCaml 5.6

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -113,6 +113,7 @@ users)
   * Require `spdx_licenses` >= 1.4.0 to ensure compatibility with SPDX v3 syntax [#6878 @kit-ty-kate]
   * Remove support for building opam with OCaml 4.08, 4.09 and 4.10 [#6879 @kit-ty-kate]
   * Upgrade to ocaml-tar.3.5.0 [#6976 @kit-ty-kate]
+  * Silence warnings raised by OCaml 5.6 [#6987 @kit-ty-kate]
 
 ## Infrastructure
 

--- a/src/client/opamClientConfig.ml
+++ b/src/client/opamClientConfig.ml
@@ -122,7 +122,7 @@ type 'a options_fun =
   ?verbose_on:OpamTypes.name_set ->
   'a
 
-let setk k t
+let[@ocaml.warning "-unerasable-optional-argument"] setk k t
     ?pin_kind_auto
     ?autoremove
     ?editor

--- a/src/core/opamCoreConfig.ml
+++ b/src/core/opamCoreConfig.ml
@@ -118,7 +118,7 @@ let default = {
   in_opam = false;
 }
 
-let setk k t
+let[@ocaml.warning "-unerasable-optional-argument"] setk k t
     ?auto_answer
     ?debug_level
     ?debug_sections

--- a/src/format/opamFormatConfig.ml
+++ b/src/format/opamFormatConfig.ml
@@ -40,7 +40,7 @@ let default = {
   all_parens = false;
 }
 
-let setk k t
+let[@ocaml.warning "-unerasable-optional-argument"] setk k t
     ?strict
     ?skip_version_checks
     ?all_parens

--- a/src/format/opamLineLexer.mll
+++ b/src/format/opamLineLexer.mll
@@ -34,6 +34,7 @@ rule main = parse
                { Buffer.reset word ; Buffer.add_string word w; escaped lexbuf }
 | (normalchar+ as w)
                { WORD w }
+| '\r'         { raise (Failure "lexing: empty token") }
 | eof          { EOF }
 
 and escaped = parse
@@ -41,6 +42,7 @@ and escaped = parse
                { Buffer.add_string word w; escaped lexbuf }
 | (_ normalchar*) as w
                { Buffer.add_string word w; WORD (Buffer.contents word) }
+| ""           { raise (Failure "lexing: empty token") }
 
 {
 

--- a/src/repository/opamRepositoryConfig.ml
+++ b/src/repository/opamRepositoryConfig.ml
@@ -85,7 +85,7 @@ let default = {
   repo_tarring = false;
 }
 
-let setk k t
+let[@ocaml.warning "-unerasable-optional-argument"] setk k t
     ?download_tool
     ?validation_hook
     ?retries

--- a/src/solver/opamSolverConfig.ml
+++ b/src/solver/opamSolverConfig.ml
@@ -107,7 +107,7 @@ let default =
     version_lag_power = 1;
   }
 
-let setk k t
+let[@ocaml.warning "-unerasable-optional-argument"] setk k t
     ?cudf_file
     ?solver
     ?best_effort

--- a/src/state/opamStateConfig.ml
+++ b/src/state/opamStateConfig.ml
@@ -137,7 +137,7 @@ type 'a options_fun =
   ?depexts: bool ->
   'a
 
-let setk k t
+let[@ocaml.warning "-unerasable-optional-argument"] setk k t
     ?root_dir
     ?original_root_dir
     ?root_from


### PR DESCRIPTION
Noticed in the trunk CI. All of these seem correct, however we cannot properly fix the warnings in `setk` due to how the type of the function has to be to be composable across our multiple `*Config` modules