### PR TITLE
Make git calls more deterministic regardless of the global or system config

### DIFF
--- a/.github/scripts/main/preamble.sh
+++ b/.github/scripts/main/preamble.sh
@@ -35,7 +35,6 @@ git config --global user.email "gha@example.com"
 git config --global user.name "Github Actions CI"
 git config --global gc.autoDetach false
 git config --global init.defaultBranch thisShouldNotHappen
-git config --global protocol.file.allow always
 
 if [ -d ~/opam-repository ]; then
   OPAM_REPO_CACHE=file://$HOME/opam-repository

--- a/master_changes.md
+++ b/master_changes.md
@@ -210,6 +210,7 @@ users)
   * Add 2.6 root test cases in opamroot-versions [#6625 @rjbou]
   * Add tests for `.install` fields handling [#6956 #67026 @rjbou]
   * Add a test showing opam pin list not working when the source git directory is missing [#6597 @kit-ty-kate]
+  * Add a test making sure the global or system `git` config doesn't change the behaviour of opam [#6992 @kit-ty-kate]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -30,6 +30,7 @@ users)
   * Remove the build directory as soon as possible when installing a package [#6906 @kit-ty-kate - fix #5884]
 
 ## Build (package)
+  * When fetching a git repository, the resulting git branch is now deterministically named `main` instead of taking the system's `init.defaultBranch` [#6992 @kit-ty-kate]
 
 ## Remove
 
@@ -67,6 +68,7 @@ users)
 ## Exec
 
 ## Source
+  * When fetching a git repository (i.e. `--dev-repo` or a package with git url), the resulting git branch is now deterministically named `main` instead of taking the system's `init.defaultBranch` [#6992 @kit-ty-kate]
 
 ## Lint
 
@@ -74,6 +76,7 @@ users)
   * No longer call tar tool to create archives, use tar library instead [#6945 @kit-ty-kate]
   * [BUG] Do not fail on directories named `opam` when scanning the `packages` directory of a repository during `opam repo add` or `opam init` (worked on subsequent `opam update`) [#6941 @kit-ty-kate @rjbou]
   * Speedup repository operations on certain file-systems (e.g. NTFS on Windows or IO constrained machines) by changing its storage in the opam root from plain directory to archive, for HTTP repositories, or non-VCS one if `OPAMREPOSITORYTARRING` is enabled [#6625 @rjbou @kit-ty-kate @arozovyk - fix #5346 #5741 #5648 #5484 #5559 #3050 #6974]
+  * When fetching a git repository, the resulting git branch is now deterministically named `main` instead of taking the system's `init.defaultBranch` [#6992 @kit-ty-kate]
 
 ## Lock
   * [BUG] Fix `undefined variable` error when a lock file filter contains an undefined variables: fail gracefully with strict mode, continue and default the variable to false on normal mode [#6947 @rjbou - fix #6946]

--- a/master_changes.md
+++ b/master_changes.md
@@ -105,6 +105,7 @@ users)
 
 ## VCS
   * Darcs no longer fall back to “Num Patches” as “Weak Hash” has been supported since 2016 [#6866 @toastal]
+  * Make `git` calls more deterministic regardless of the global or system config [#6992 @kit-ty-kate - fix #6937]
 
 ## Build
   * Fix Windows build on MSYS2 [#6862 @Firobe]
@@ -279,6 +280,8 @@ users)
   * `OpamConfigCommand.subst` now takes a `filename` instead of a `basename` [#6936 @NathanReb]
 
 ## opam-repository
+  * `OpamGit.env` was added [#6992 @kit-ty-kate]
+  * `OpamGit`: git is now always called with the `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` environment variables set to `/dev/null` [#6992 @kit-ty-kate]
   * `OpamRepositoryPath` was moved to `opam-format` [#6917 @rjbou]
   * `OpamRepositoryRoot` was added [#6680 @kit-ty-kate @rjbou]
   * `OpamTar`: add module to manipulate tar gz archive. It handles only files, not directories [#6945 @kit-ty-kate @rjbou]
@@ -355,7 +358,9 @@ users)
   * `OpamCompat.Sys.sigwinch` was added [#6933 @kit-ty-kate]
   * `OpamSystem`: add `is_dir_read_only` [#6489 @rjbou]
   * `OpamSystem.*patch` were moved to `OpamPatch` [#6934 @rjbou]
+  * `OpamFilename.env_of_list` was removed [#6992 @kit-ty-kate]
   * `OpamFilename`: add `is_dir_read_only` [#6489 @rjbou]
+  * `OpamFilename.exec`: change the type of `?env` to `string array` [#6992 @kit-ty-kate]
   * `OpamFilename.might_escape`: ensure / is detected as a file separator when called with `~sep:Unspecified` on Windows [#6897 @kit-ty-kate]
   * `OpamFilename.Unix` was added abstracting over `/` separated paths regardless of the current system [#6914 @rjbou @kit-ty-kate]
   * `OpamFilename.in_dir`: removed [#6910 @NathanReb]

--- a/master_changes.md
+++ b/master_changes.md
@@ -211,6 +211,7 @@ users)
   * Add tests for `.install` fields handling [#6956 #67026 @rjbou]
   * Add a test showing opam pin list not working when the source git directory is missing [#6597 @kit-ty-kate]
   * Add a test making sure the global or system `git` config doesn't change the behaviour of opam [#6992 @kit-ty-kate]
+  * Add a test showing the remote and branch names of a git repository extracted by `opam source` [#6992 @kit-ty-kate]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -219,6 +219,7 @@ users)
   * Add to automatic path substitutions lines that contains switch installation paths [#6956 @rjbou]
   * Fix the port number range on Windows [#7029 @kit-ty-kate]
   * Wait for background processes to end before removing its working directory [#7030 @kit-ty-kate]
+  * Set the `protocol.file.allow=always` git config while running the reftests regardless of `GIT_CONFIG_GLOBAL` [#6992 @kit-ty-kate]
 
 ## Github Actions
   * Add OCaml 5.4 to the test matrix [#6732 @kit-ty-kate]

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -4400,7 +4400,8 @@ let clean cli =
        List.iter (fun dir ->
            match OpamFilename.(Base.to_string (basename_dir dir)) with
            | "git" ->
-             (try OpamFilename.exec dir ~name:"git gc" [["git"; "gc"]]
+             let env = OpamGit.env () in
+             (try OpamFilename.exec ~env dir ~name:"git gc" [["git"; "gc"]]
               with e -> OpamStd.Exn.fatal e)
            | _ -> cleandir dir
          )

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -109,12 +109,7 @@ let dir_is_empty d =
 let is_dir_read_only dirname =
   OpamSystem.is_dir_read_only (Dir.to_string dirname)
 
-let env_of_list l = Array.of_list (List.rev_map (fun (k,v) -> k^"="^v) l)
-
 let exec dir ?env ?name ?metadata ?keep_going cmds =
-  let env = match env with
-    | None   -> None
-    | Some l -> Some (env_of_list l) in
   OpamSystem.commands ~dir ?env ?name ?metadata ?keep_going cmds
 
 let move_dir ~src ~dst =

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -60,11 +60,8 @@ val is_dir_read_only: Dir.t -> bool
 (** List the sub-directory (do not recurse) *)
 val dirs: Dir.t -> Dir.t list
 
-(** Turns an assoc list into an array suitable to be provided as environment *)
-val env_of_list: (string * string) list -> string array
-
 (** Execute a list of commands in a given directory *)
-val exec: Dir.t -> ?env:(string * string) list -> ?name:string ->
+val exec: Dir.t -> ?env:string array -> ?name:string ->
   ?metadata:(string * string) list -> ?keep_going:bool -> string list list -> unit
 
 (** Move a directory *)

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -14,6 +14,14 @@ open OpamProcess.Job.Op
 
 (* let log fmt = OpamConsole.log "GIT" fmt *)
 
+let git_env = [|
+  "GIT_CONFIG_GLOBAL="^Filename.null;
+  "GIT_CONFIG_SYSTEM="^Filename.null;
+|]
+
+let env () =
+  Array.append git_env (OpamProcess.default_env ())
+
 module VCS : OpamVCS.VCS = struct
 
   let name = `git
@@ -30,7 +38,8 @@ module VCS : OpamVCS.VCS = struct
        of git will need to change, as altering PATH could select a different
        Git *)
     fun ?verbose ?stdout args ->
-      OpamSystem.make_command ?verbose ?stdout "git" ("-C"::dir::args)
+      let env = env () in
+      OpamSystem.make_command ~env ?verbose ?stdout "git" ("-C"::dir::args)
 
   let init repo_root repo_url =
     OpamFilename.mkdir repo_root;

--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -35,7 +35,7 @@ module VCS : OpamVCS.VCS = struct
   let init repo_root repo_url =
     OpamFilename.mkdir repo_root;
     OpamProcess.Job.of_list [
-      git repo_root [ "init" ];
+      git repo_root [ "init"; "--initial-branch=main" ];
       (* Enforce this option, it can break our use of git if set *)
       git repo_root [ "config" ; "--local" ; "fetch.prune"; "false"];
       (* We reset diff.noprefix to ensure we get a `-p1` patch and avoid <https://github.com/ocaml/opam/issues/3627>. *)

--- a/src/repository/opamGit.mli
+++ b/src/repository/opamGit.mli
@@ -11,6 +11,12 @@
 
 (** Git repository backend (based on {!OpamVCS}) *)
 
+(** Returns [OpamProcess.default_env] + some git specific environment variables
+    used to make git calls more reproducible.
+    Note however that it cannot be used if you need values from the global git
+    configs (e.g. /etc/gitconfig or ~/.gitconfig) *)
+val env : unit -> string array
+
 module VCS: OpamVCS.VCS
 
 module B: OpamRepositoryBackend.S

--- a/tests/lib/patchDiff.ml
+++ b/tests/lib/patchDiff.ml
@@ -330,7 +330,12 @@ let write_setup ?(only_fst=false) dir content =
 let git_cmds ~dir repo_root commands error_msg =
   let commands =
     List.map (fun args ->
-        OpamSystem.make_command "git"
+        let args =
+          "-c"::"user.email=you@example.com"::
+          "-c"::"user.name=Your Name"::
+          args
+        in
+        OpamSystem.make_command ~env:(OpamGit.env ()) "git"
           ("-C"::(OpamFilename.Dir.to_string repo_root)::args))
       commands
   in
@@ -346,7 +351,7 @@ let git_cmds ~dir repo_root commands error_msg =
 let make_git_repo dir =
   let first_root = dir / first in
   let commands = [
-    [ "init"];
+    [ "init"; "--initial-branch=main" ];
     [ "add"; "--all" ];
     [ "commit"; "-qm"; "first" ];
   ] in

--- a/tests/reftests/action-disk.test
+++ b/tests/reftests/action-disk.test
@@ -1290,7 +1290,7 @@ SYSTEM                          mkdir ${OPAMTMP}
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin
 Processing  1/1: [main-gpin: git]
-+ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "init"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "init" "--initial-branch=main"
 - Initialized empty Git repository in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/.git/
 + git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "config" "--local" "fetch.prune" "false"
 + git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "config" "--local" "diff.noprefix" "false"
@@ -1650,7 +1650,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.o
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config atomically in 0.000s
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 + git "-C" "${BASEDIR}/main-gpin" "symbolic-ref" "--quiet" "--short" "HEAD"
-+ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "init"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "init" "--initial-branch=main"
 + git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "config" "--local" "fetch.prune" "false"
 + git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "config" "--local" "diff.noprefix" "false"
 + git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "config" "--local" "core.autocrlf" "false"
@@ -1865,7 +1865,7 @@ The following actions will be performed:
 SYSTEM                          mkdir ${OPAMTMP}
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev
 Processing  1/2: [main-gpin.dev: git]
-+ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "init"
++ git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "init" "--initial-branch=main"
 + git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "config" "--local" "fetch.prune" "false"
 + git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "config" "--local" "diff.noprefix" "false"
 + git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin.dev" "config" "--local" "core.autocrlf" "false"

--- a/tests/reftests/download.test
+++ b/tests/reftests/download.test
@@ -236,7 +236,7 @@ The following actions will be performed:
 SYSTEM                          mkdir ${OPAMTMP}
 SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1
 Processing  1/1: [bar.1: git]
-+ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "init"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "init" "--initial-branch=main"
 + git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "config" "--local" "fetch.prune" "false"
 + git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "config" "--local" "diff.noprefix" "false"
 + git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/bar.1" "config" "--local" "core.autocrlf" "false"
@@ -295,7 +295,7 @@ The following actions will be performed:
 SYSTEM                          mkdir ${OPAMTMP}
 SYSTEM                          mkdir ${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1
 Processing  1/1: [qux.1: git]
-+ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "init"
++ git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "init" "--initial-branch=main"
 + git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "config" "--local" "fetch.prune" "false"
 + git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "config" "--local" "diff.noprefix" "false"
 + git "-C" "${BASEDIR}/OPAM/download/.opam-switch/sources/qux.1" "config" "--local" "core.autocrlf" "false"

--- a/tests/reftests/fetch-package.test
+++ b/tests/reftests/fetch-package.test
@@ -107,7 +107,7 @@ Done.
 files
 opam
 root.ml
-### opam pin foo-git-pin ./a-dev -y
+### opam pin foo-git-pin ./a-dev -yb
 [NOTE] Package foo-git-pin does not exist in opam repositories registered in the current switch.
 [foo-git-pin.dev] synchronised (git+file://${BASEDIR}/a-dev#master)
 foo-git-pin is now pinned to git+file://${BASEDIR}/a-dev#master (version dev)
@@ -125,9 +125,15 @@ opam
 root.ml
 ### cat OPAM/downloads-pin/lib/foo-git-pin-hist
 2
+### git -C OPAM/downloads-pin/.opam-switch/build/foo-git-pin.dev branch -avv | ' [a-f0-9]+ ' -> ' +hash+ '
+* main                    +hash+ i'm empty
+  remotes/opam-ref-master +hash+ i'm empty
+### git -C OPAM/downloads-pin/.opam-switch/build/foo-git-pin.dev remote -v
+origin	file://${BASEDIR}/a-dev (fetch)
+origin	file://${BASEDIR}/a-dev (push)
 ### :: dev-repo
 ### opam switch create downloads-devrepo --empty
-### opam pin foo-git --dev-repo -y
+### opam pin foo-git --dev-repo -yb
 [foo-git.1] synchronised (git+file://${BASEDIR}/a-dev)
 foo-git is now pinned to git+file://${BASEDIR}/a-dev (version 1)
 
@@ -144,3 +150,9 @@ opam
 root.ml
 ### cat OPAM/downloads-devrepo/lib/foo-git-hist
 2
+### git -C OPAM/downloads-devrepo/.opam-switch/build/foo-git.1 branch -avv | ' [a-f0-9]+ ' -> ' +hash+ '
+* main             +hash+ i'm empty
+  remotes/opam-ref +hash+ i'm empty
+### git -C OPAM/downloads-devrepo/.opam-switch/build/foo-git.1 remote -v
+origin	file://${BASEDIR}/a-dev (fetch)
+origin	file://${BASEDIR}/a-dev (push)

--- a/tests/reftests/git.test
+++ b/tests/reftests/git.test
@@ -142,3 +142,83 @@ Done.
 [WARNING] Dependency dep-nip.dev is pinned to local target git+file://${BASEDIR}/dep-nip#master, skipping
 Generated lock files for:
   - nip.dev: ${BASEDIR}/nip.opam.locked
+### : Make sure the global or system git config doesn't change the behaviour of opam
+### opam switch create dup --empty
+### <mygitconfig>
+[diff]
+	renames = copies
+### <GIT_REPO_DUP/repo>
+opam-version: "2.0"
+### : NOTE: This file is large to make sure git doesn't suddenly decide
+### : that having 'copy from' in the diff isn't worth it.
+### <GIT_REPO_DUP/packages/duplicate/duplicate.1/opam>
+opam-version: "2.0"
+post-messages: """
+aaa
+bbb
+ccc
+ddd
+eee
+fff
+ggg
+hhh
+iii
+jjj
+kkk
+lll
+mmm
+nnn
+ooo
+ppp
+qqq
+rrr
+sss
+ttt
+uuu
+vvv
+www
+xxx
+yyy
+zzz
+"""
+### git -C GIT_REPO_DUP init -q --initial-branch=master
+### git -C GIT_REPO_DUP config core.autocrlf false
+### git -C GIT_REPO_DUP add *
+### git -C GIT_REPO_DUP commit -qm init
+### opam repo add dup ./GIT_REPO_DUP --this-switch
+[dup] Initialised
+### mkdir GIT_REPO_DUP/packages/duplicate/duplicate.2
+### cp GIT_REPO_DUP/packages/duplicate/duplicate.1/opam GIT_REPO_DUP/packages/duplicate/duplicate.2/opam
+### sed -i.bak 's/aaa/ααα/' GIT_REPO_DUP/packages/duplicate/duplicate.1/opam
+### rm GIT_REPO_DUP/packages/duplicate/duplicate.1/opam.bak
+### git -C GIT_REPO_DUP add *
+### git -C GIT_REPO_DUP commit -qm dup
+### GIT_CONFIG_GLOBAL=${BASEDIR}/mygitconfig GIT_CONFIG_SYSTEM=/dev/null
+### git config --get --global diff.renames
+copies
+### opam update -vv dup | sed-cmd git | grep -v "^- index "
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+Processing  1/1: [dup: git]
++ git "-C" "${BASEDIR}/OPAM/repo/dup" "remote" "set-url" "origin" "file://${BASEDIR}/GIT_REPO_DUP"
++ git "-C" "${BASEDIR}/OPAM/repo/dup" "fetch" "-q" "file://${BASEDIR}/GIT_REPO_DUP" "--update-shallow" "--depth=1" "+HEAD:refs/remotes/opam-ref"
++ git "-C" "${BASEDIR}/OPAM/repo/dup" "add" "."
++ git "-C" "${BASEDIR}/OPAM/repo/dup" "-c" "diff.noprefix=false" "diff" "--text" "--no-ext-diff" "-R" "-p" "refs/remotes/opam-ref" "--"
+- diff --git b/packages/duplicate/duplicate.1/opam a/packages/duplicate/duplicate.1/opam
+- --- b/packages/duplicate/duplicate.1/opam
+- +++ a/packages/duplicate/duplicate.1/opam
+- @@ -1,6 +1,6 @@
+-  opam-version: "2.0"
+-  post-messages: """
+- -aaa
+- +ααα
+-  bbb
+-  ccc
+-  ddd
+- diff --git b/packages/duplicate/duplicate.1/opam a/packages/duplicate/duplicate.2/opam
+- similarity index 100%
+- copy from packages/duplicate/duplicate.1/opam
+- copy to packages/duplicate/duplicate.2/opam
+[dup] synchronised from git+file://${BASEDIR}/GIT_REPO_DUP
+Processing: [dup: loading data]
+### unset GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM

--- a/tests/reftests/git.test
+++ b/tests/reftests/git.test
@@ -9,9 +9,6 @@ N0REP0
 ### mkdir use-submodule
 ### git -C ./use-submodule init -q
 ### git -C ./use-submodule config core.autocrlf false
-### ### This test may fail locally depending on your git version
-### ### File protocol is removed locally since git 2.38,
-### ### to fix a CVE: https://www.cve.org/CVERecord?id=CVE-2022-39253
 ### git -C ./use-submodule submodule add ../submodule ./vendor
 Cloning into '${BASEDIR}/use-submodule/vendor'...
 done.

--- a/tests/reftests/git.test
+++ b/tests/reftests/git.test
@@ -212,10 +212,41 @@ Processing  1/1: [dup: git]
 -  bbb
 -  ccc
 -  ddd
-- diff --git b/packages/duplicate/duplicate.1/opam a/packages/duplicate/duplicate.2/opam
-- similarity index 100%
-- copy from packages/duplicate/duplicate.1/opam
-- copy to packages/duplicate/duplicate.2/opam
+- diff --git b/packages/duplicate/duplicate.2/opam a/packages/duplicate/duplicate.2/opam
+- new file mode 100644
+- --- /dev/null
+- +++ a/packages/duplicate/duplicate.2/opam
+- @@ -0,0 +1,29 @@
+- +opam-version: "2.0"
+- +post-messages: """
+- +aaa
+- +bbb
+- +ccc
+- +ddd
+- +eee
+- +fff
+- +ggg
+- +hhh
+- +iii
+- +jjj
+- +kkk
+- +lll
+- +mmm
+- +nnn
+- +ooo
+- +ppp
+- +qqq
+- +rrr
+- +sss
+- +ttt
+- +uuu
+- +vvv
+- +www
+- +xxx
+- +yyy
+- +zzz
+- +"""
 [dup] synchronised from git+file://${BASEDIR}/GIT_REPO_DUP
 Processing: [dup: loading data]
+Now run 'opam upgrade' to apply any package updates.
 ### unset GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -1058,7 +1058,7 @@ RSTATE                          Cache found
 REPOSITORY                      repository-set-url
 REPOSITORY                      update changes from git+file://${BASEDIR}/CHG
 Processing  1/1: [changes: git]
-+ git "-C" "${BASEDIR}/OPAM/repo/changes" "init"
++ git "-C" "${BASEDIR}/OPAM/repo/changes" "init" "--initial-branch=main"
 - Initialized empty Git repository in ${BASEDIR}/OPAM/repo/changes/.git/
 + git "-C" "${BASEDIR}/OPAM/repo/changes" "config" "--local" "fetch.prune" "false"
 + git "-C" "${BASEDIR}/OPAM/repo/changes" "config" "--local" "diff.noprefix" "false"
@@ -1112,7 +1112,7 @@ Processing  1/1:
 + tar "xfz" "${BASEDIR}/OPAM/repo/changes.tar.gz" "-C" "${BASEDIR}/OPAM/repo/changes"
 REPOSITORY                      update changes from git+file://${BASEDIR}/CHG
 Processing  1/1: [changes: git]
-+ git "-C" "${BASEDIR}/OPAM/repo/changes" "init"
++ git "-C" "${BASEDIR}/OPAM/repo/changes" "init" "--initial-branch=main"
 - Initialized empty Git repository in ${BASEDIR}/OPAM/repo/changes/.git/
 + git "-C" "${BASEDIR}/OPAM/repo/changes" "config" "--local" "fetch.prune" "false"
 + git "-C" "${BASEDIR}/OPAM/repo/changes" "config" "--local" "diff.noprefix" "false"
@@ -1234,7 +1234,7 @@ RSTATE                          Cache found
 REPOSITORY                      repository-set-url
 REPOSITORY                      update changes from git+file://${BASEDIR}/CHG
 Processing  1/1: [changes: git]
-+ git "-C" "${BASEDIR}/OPAM/repo/changes" "init"
++ git "-C" "${BASEDIR}/OPAM/repo/changes" "init" "--initial-branch=main"
 - Initialized empty Git repository in ${BASEDIR}/OPAM/repo/changes/.git/
 + git "-C" "${BASEDIR}/OPAM/repo/changes" "config" "--local" "fetch.prune" "false"
 + git "-C" "${BASEDIR}/OPAM/repo/changes" "config" "--local" "diff.noprefix" "false"
@@ -1285,7 +1285,7 @@ RSTATE                          Cache found
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 REPOSITORY                      update changes from git+file://${BASEDIR}/CHG
 Processing  1/1: [changes: git]
-+ git "-C" "${BASEDIR}/OPAM/repo/changes" "init"
++ git "-C" "${BASEDIR}/OPAM/repo/changes" "init" "--initial-branch=main"
 - Initialized empty Git repository in ${BASEDIR}/OPAM/repo/changes/.git/
 + git "-C" "${BASEDIR}/OPAM/repo/changes" "config" "--local" "fetch.prune" "false"
 + git "-C" "${BASEDIR}/OPAM/repo/changes" "config" "--local" "diff.noprefix" "false"

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -86,6 +86,10 @@ let base_env =
     "OPAMNOENVNOTICE", "1";
     "OPAMNODEPEXTS", "1";
     "OPAMDOWNLOADJOBS", "1";
+
+    "GIT_CONFIG_COUNT", "1";
+    "GIT_CONFIG_KEY_0", "protocol.file.allow";
+    "GIT_CONFIG_VALUE_0", "always";
   ]
 
 (* See [opamprocess.safe_wait] *)

--- a/tests/reftests/source.test
+++ b/tests/reftests/source.test
@@ -141,3 +141,9 @@ Successfully extracted to ${BASEDIR}/pandore5
 Successfully fetched pandore development repo to ${BASEDIR}/pandore6
 ### git -C pandore6 rev-list --all --count
 2
+### git -C pandore6 branch -avv | ' [a-f0-9]+ ' -> ' +hash+ '
+* main             +hash+ second empty commit
+  remotes/opam-ref +hash+ second empty commit
+### git -C pandore6 remote -v
+origin	file://${BASEDIR}/pandev (fetch)
+origin	file://${BASEDIR}/pandev (push)


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/6937

* Set the protocol.file.allow=always git config while running the reftests regardless of GIT_CONFIG_GLOBAL
* When fetching a git repository, the resulting git branch is now deterministically named main instead of taking the system's init.defaultBranch
* Make git calls more deterministic regardless of the global or system config
git calls made in opam had a non-deterministic behaviour based on the
user's local git configuration. Setting GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM
to /dev/null fixes this problem.