### PR TITLE
'OpamFilename.open_in' no longer opens directory on Unix

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -311,3 +311,5 @@ users)
   * `OpamCompat.Seq`: add `to_dispenser` [#6945 @kit-ty-kate]
   * `OpamSystem.directories_with_links`, `OpamSystem.rec_files`, `OpamFilename.rec_files`: add optional `?except_vcs` that default to false to exclude VCS directories [#6945 @kit-ty-kate @rjbou]
   * `OpamFilename.make_tar_gz{_job}`: rename `make_tar_gz_job` into `make_tar_gz` as it no longer need an external process call [#6945 @kit-ty-kate]
+  * `OpamSystem`: add `open_in` and `open_in_bin` that checks is the file is a directory and raise `Sys_error` in that case [#6996 @rjbou - fix #6997]
+  * `OpamFilename.{open_in,open_in_bin}`: now errors when the filename is a directory, in all platforms [#6996 @rjbou - fix #6997]

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -210,11 +210,11 @@ let read filename =
   OpamSystem.read (to_string filename)
 
 let open_in filename =
-  try open_in (to_string filename)
+  try OpamSystem.open_in (to_string filename)
   with Sys_error _ -> raise (OpamSystem.File_not_found (to_string filename))
 
 let open_in_bin filename =
-  try open_in_bin (to_string filename)
+  try OpamSystem.open_in_bin (to_string filename)
   with Sys_error _ -> raise (OpamSystem.File_not_found (to_string filename))
 
 let open_out filename =

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -261,6 +261,15 @@ let string_of_channel ic =
   iter ic b s;
   Buffer.contents b
 
+let open_in_t fopen filename =
+  if Sys.is_directory filename then
+    raise (Sys_error "Is a directory")
+  else
+    fopen filename
+
+let open_in filename = open_in_t open_in filename
+let open_in_bin filename = open_in_t open_in_bin filename
+
 let read file =
   log ~level:5 "read %s" file;
   let ic =

--- a/src/core/opamSystem.mli
+++ b/src/core/opamSystem.mli
@@ -124,6 +124,12 @@ val string_of_channel: in_channel -> string
     bad permissions, etc.) *)
 exception File_not_found of string
 
+(** [open_in filename] is like {!Stdlib.open_in} but have an additional check
+    if the given filename is a directory, and raise {!Sys_error} in that case.
+*)
+val open_in: string -> in_channel
+val open_in_bin: string -> in_channel
+
 (** [read filename] returns the contents of [filename] (while taking an advisory
     read lock to prevent concurrent writes) *)
 val read: string -> string


### PR DESCRIPTION
It is an error on Windows, and it errors afterwards anyway as no reading is possible, via Stdlib and core functions

fixes #6997 