### PR TITLE
[2.5] Fix OpamFilename startswith functions

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -100,6 +100,7 @@ users)
 
 ## Test
   * Add `opamUnit` as a basic unit test framework [#6953 @NathanReb]
+  * Add unit tests for `OpamFilename.starts_with` and `dir_starts_with` in `tests/lib/core` [#6953 @NathanReb]
 
 ## Benchmarks
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -99,6 +99,7 @@ users)
 ## Internal: Windows
 
 ## Test
+  * Add `opamUnit` as a basic unit test framework [#6953 @NathanReb]
 
 ## Benchmarks
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -127,3 +127,6 @@ users)
 ## opam-format
 
 ## opam-core
+  * `OpamFilename.{,dir_}starts_with`: Fix a bug where `foo/bar` would be considered a prefix of `foo/bar-baz` [#6953 @NathanReb - fix #6948]
+  * `OpamFilename.{,dir_}starts_with`: `/` and `\` are now equivalent on Windows [#6953 @NathanReb]
+  * `OpamFilename.starts_with`: `starts_with "a/b" "a/b"` no longer returns `true` [#6953 @NathanReb]

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -344,11 +344,23 @@ let is_exec file =
   with Unix.Unix_error _ ->
     OpamSystem.internal_error "%s does not exist." (to_string file)
 
-let starts_with dirname filename =
-  OpamCompat.String.starts_with ~prefix:(Dir.to_string dirname) (to_string filename)
+let cmpable_dir_string dir =
+  match OpamSystem.forward_to_back (Dir.to_string dir) with
+  | "" -> ""
+  | d -> Filename.concat d ""
 
-let dir_starts_with pfx dir =
-  OpamCompat.String.starts_with ~prefix:(Dir.to_string pfx) (Dir.to_string dir)
+let cmpable_file_string file =
+  OpamSystem.forward_to_back (to_string file)
+
+let starts_with prefix filename =
+  let prefix = cmpable_dir_string prefix in
+  let dir = cmpable_file_string filename in
+  OpamCompat.String.starts_with ~prefix dir
+
+let dir_starts_with prefix dir =
+  let prefix = cmpable_dir_string prefix in
+  let dir = cmpable_dir_string dir in
+  OpamCompat.String.starts_with ~prefix dir
 
 let remove_prefix prefix filename =
   let prefix =

--- a/tests/lib/core/dune
+++ b/tests/lib/core/dune
@@ -1,0 +1,4 @@
+(test
+ (name testOpamCore)
+ (package opam-core)
+ (libraries opam-core opamUnit))

--- a/tests/lib/core/testOpamCore.ml
+++ b/tests/lib/core/testOpamCore.ml
@@ -1,0 +1,14 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2026 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+let () =
+  OpamUnit.run_tests
+    (fun ctxt ->
+       TestOpamFilename.test ~ctxt ())

--- a/tests/lib/core/testOpamFilename.ml
+++ b/tests/lib/core/testOpamFilename.ml
@@ -1,0 +1,151 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2026 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+let test_starts_with ~ctxt () =
+  let fun_name = "OpamFilename.starts_with" in
+  let test ~on ~prefix_dir ~file ~expected =
+    let test_name = Printf.sprintf "(%s, %s)" prefix_dir file in
+    if List.exists (String.equal Sys.os_type) on then
+      (let prefix_dir' = OpamFilename.raw_dir prefix_dir in
+       let file' = OpamFilename.raw file in
+       let got = OpamFilename.starts_with prefix_dir' file' in
+       if Bool.equal expected got then
+         OpamUnit.success ~ctxt ~fun_name ~test_name ()
+       else
+         let expected = Bool.to_string expected in
+         let got = Bool.to_string got in
+         OpamUnit.failure ~ctxt ~fun_name ~test_name ~expected ~got ())
+    else
+      let reason = Printf.sprintf "Test does not run on %s" Sys.os_type in
+      OpamUnit.skip ~ctxt ~fun_name ~test_name ~reason ()
+  in
+  List.iter
+    (fun (on, prefix_dir, file, expected) ->
+       test ~on ~prefix_dir ~file ~expected)
+    [
+      (* absolute path without parent dirname *)
+      ["Unix"; "Cygwin"], "/no/match", "/foo/bar/file", false;
+      ["Unix"; "Cygwin"], "/foo/bar", "/foo/bar/file", true;
+      ["Unix"; "Cygwin"], "/foo/bar", "/foo/bar/baz/file", true;
+      ["Unix"; "Cygwin"], "/foo/bar", "/foo/bar-baz/file", false;
+      ["Unix"; "Cygwin"], "/foo/bar/", "/foo/bar-baz/file", false;
+      ["Unix"; "Cygwin"], "/foo/bar/file", "/foo/bar/file", false;
+      ["Cygwin"], "/cygdrive/c/foo/bar", "/cygdrive/c/foo/bar/file", true;
+      ["Cygwin"], "/cygdrive/c/foo/bar", "/cygdrive/d/foo/bar/file", false;
+      ["Win32"], {|C:\no\match|}, {|C:\foo\bar\file|}, false;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\bar\file|}, true;
+      ["Win32"], {|C:\foo\bar|}, {|D:\foo\bar\file|}, false;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\bar\baz\file|}, true;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\bar-baz\file|}, false;
+      ["Win32"], {|C:\foo\bar\|}, {|C:\foo\bar-baz\file|}, false;
+      ["Win32"], {|C:\foo\bar\file|}, {|C:\foo\bar\file|}, false;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\bar/file|}, true;
+      (* from current directory *)
+      (* Note that those tests exhibit how starts_with behaves with [.]
+         and [..] when constructed with OpamFilename.raw rather than specify
+         what the ideal behaviour is. *)
+      ["Unix"; "Cygwin"], "/no/match", "./foo/bar/file", false;
+      ["Unix"; "Cygwin"], "/foo/bar", "./foo/bar/file", false;
+      ["Unix"; "Cygwin"], "./foo/bar", "./foo/bar/file", true;
+      ["Win32"], {|C:\no\match|}, {|.\foo\bar\file|}, false;
+      ["Win32"], {|C:\foo\bar|}, {|.\foo\bar\file|}, false;
+      ["Win32"], {|.\foo\bar|}, {|.\foo\bar\file|}, true;
+      (* current directory in the middle *)
+      ["Unix"; "Cygwin"], "/foo/bar", "/foo/./bar/file", false;
+      ["Unix"; "Cygwin"], "/foo/bar", "/foo/bar/./file", true;
+      ["Unix"; "Cygwin"], "/foo/./bar", "/foo/./bar/file", true;
+      ["Unix"; "Cygwin"], "/foo/./bar", "/foo/./bar/./file", true;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\.\bar\file|}, false;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\bar\.\file|}, true;
+      ["Win32"], {|C:\foo\.\bar|}, {|C:\foo\.\bar\file|}, true;
+      ["Win32"], {|C:\foo\.\bar|}, {|C:\foo\.\bar\.\file|}, true;
+      (* absolute path with parent dirname *)
+      ["Unix"; "Cygwin"], "/foo/bar", "/foo/../bar/file", false;
+      ["Unix"; "Cygwin"], "/foo/bar", "/foo/bar/../file", true;
+      ["Unix"; "Cygwin"], "/foo/../bar", "/foo/../bar/file", true;
+      ["Unix"; "Cygwin"], "/foo/../bar", "/foo/../bar/../file", true;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\..\bar\file|}, false;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\bar\..\file|}, true;
+      ["Win32"], {|C:\foo\..\bar|}, {|C:\foo\..\bar\file|}, true;
+      ["Win32"], {|C:\foo\..\bar|}, {|C:\foo\..\bar\..\file|}, true;
+    ]
+
+let test_dir_starts_with ~ctxt () =
+  let fun_name = "OpamFilename.dir_starts_with" in
+  let test ~on ~prefix_dir ~dir ~expected =
+    let test_name = Printf.sprintf "(%s, %s)" prefix_dir dir in
+    if List.exists (String.equal Sys.os_type) on then
+      (let prefix_dir' = OpamFilename.raw_dir prefix_dir in
+       let dir' = OpamFilename.raw_dir dir in
+       let got = OpamFilename.dir_starts_with prefix_dir' dir' in
+       if Bool.equal expected got then
+         OpamUnit.success ~ctxt ~fun_name ~test_name ()
+       else
+         let expected = Bool.to_string expected in
+         let got = Bool.to_string got in
+         OpamUnit.failure ~ctxt ~fun_name ~test_name ~expected ~got ())
+    else
+      let reason = Printf.sprintf "Test does not run on %s" Sys.os_type in
+      OpamUnit.skip ~ctxt ~fun_name ~test_name ~reason ()
+  in
+  List.iter
+    (fun (on, prefix_dir, dir, expected) ->
+       test ~on ~prefix_dir ~dir ~expected)
+    [
+      (* absolute path without parent dirname *)
+      ["Unix"; "Cygwin"], "/no/match", "/foo/bar/dir", false;
+      ["Unix"; "Cygwin"], "/foo/bar", "/foo/bar/dir", true;
+      ["Unix"; "Cygwin"], "/foo/bar", "/foo/bar/baz/dir", true;
+      ["Unix"; "Cygwin"], "/foo/bar", "/foo/bar-baz/dir", false;
+      ["Unix"; "Cygwin"], "/foo/bar/", "/foo/bar-baz/dir", false;
+      ["Unix"; "Cygwin"], "/foo/bar/dir", "/foo/bar/dir", true;
+      ["Cygwin"], "/cygdrive/c/foo/bar", "/cygdrive/c/foo/bar/dir", true;
+      ["Cygwin"], "/cygdrive/c/foo/bar", "/cygdrive/d/foo/bar/dir", false;
+      ["Win32"], {|C:\no\match|}, {|C:\foo\bar\dir|}, false;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\bar\dir|}, true;
+      ["Win32"], {|C:\foo\bar|}, {|D:\foo\bar\dir|}, false;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\bar\baz\dir|}, true;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\bar-baz\dir|}, false;
+      ["Win32"], {|C:\foo\bar\|}, {|C:\foo\bar-baz\dir|}, false;
+      ["Win32"], {|C:\foo\bar\dir|}, {|C:\foo\bar\dir|}, true;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\bar/dir|}, true;
+      (* from current directory *)
+      (* Note that those tests exhibit how dir_starts_with behaves with [.]
+         and [..] when constructed with OpamFilename.raw rather than specify
+         what the ideal behaviour is. *)
+      ["Unix"; "Cygwin"], "/no/match", "./foo/bar/dir", false;
+      ["Unix"; "Cygwin"], "/foo/bar", "./foo/bar/dir", false;
+      ["Unix"; "Cygwin"], "./foo/bar", "./foo/bar/dir", true;
+      ["Win32"], {|C:\no\match|}, {|.\foo\bar\dir|}, false;
+      ["Win32"], {|C:\foo\bar|}, {|.\foo\bar\dir|}, false;
+      ["Win32"], {|.\foo\bar|}, {|.\foo\bar\dir|}, true;
+      (* current directory in the middle *)
+      ["Unix"; "Cygwin"], "/foo/bar", "/foo/./bar/dir", false;
+      ["Unix"; "Cygwin"], "/foo/bar", "/foo/bar/./dir", true;
+      ["Unix"; "Cygwin"], "/foo/./bar", "/foo/./bar/dir", true;
+      ["Unix"; "Cygwin"], "/foo/./bar", "/foo/./bar/./dir", true;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\.\bar\dir|}, false;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\bar\.\dir|}, true;
+      ["Win32"], {|C:\foo\.\bar|}, {|C:\foo\.\bar\dir|}, true;
+      ["Win32"], {|C:\foo\.\bar|}, {|C:\foo\.\bar\.\dir|}, true;
+      (* absolute path with parent dirname *)
+      ["Unix"; "Cygwin"], "/foo/bar", "/foo/../bar/dir", false;
+      ["Unix"; "Cygwin"], "/foo/bar", "/foo/bar/../dir", true;
+      ["Unix"; "Cygwin"], "/foo/../bar", "/foo/../bar/dir", true;
+      ["Unix"; "Cygwin"], "/foo/../bar", "/foo/../bar/../dir", true;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\..\bar\dir|}, false;
+      ["Win32"], {|C:\foo\bar|}, {|C:\foo\bar\..\dir|}, true;
+      ["Win32"], {|C:\foo\..\bar|}, {|C:\foo\..\bar\dir|}, true;
+      ["Win32"], {|C:\foo\..\bar|}, {|C:\foo\..\bar\..\dir|}, true;
+    ]
+
+let test ~ctxt () =
+  test_starts_with ~ctxt ();
+  test_dir_starts_with ~ctxt ()

--- a/tests/lib/core/testOpamFilename.mli
+++ b/tests/lib/core/testOpamFilename.mli
@@ -1,0 +1,11 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2026 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+val test : ctxt: OpamUnit.ctxt -> unit -> unit

--- a/tests/opam-unit/dune
+++ b/tests/opam-unit/dune
@@ -1,0 +1,2 @@
+(library
+ (name opamUnit))

--- a/tests/opam-unit/opamUnit.ml
+++ b/tests/opam-unit/opamUnit.ml
@@ -1,0 +1,101 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2026 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+type test = {
+  fun_name : string;
+  name : string;
+}
+
+let pp_test fmt {fun_name; name} =
+  Format.fprintf fmt "%s.%s" fun_name name
+
+type result =
+  | Failure of {expected : string; got : string}
+  | Skip of {reason : string}
+  | Success
+
+type test_result = {
+  test : test;
+  result : result;
+}
+
+type ctxt = {
+  mutable results : test_result list;
+  mutable failures : int;
+}
+
+let failure ~ctxt ~fun_name ~test_name ~expected ~got () =
+  let test = {fun_name; name = test_name} in
+  ctxt.results <- {test; result = Failure {expected; got}}::ctxt.results;
+  ctxt.failures <- ctxt.failures + 1
+
+let success ~ctxt ~fun_name ~test_name () =
+  let test = {fun_name; name = test_name} in
+  ctxt.results <- {test; result = Success}::ctxt.results
+
+let skip ~ctxt ~fun_name ~test_name ~reason () =
+  let test = {fun_name; name = test_name} in
+  ctxt.results <- {test; result = Skip {reason}}::ctxt.results
+
+let print_failure ~test ~expected ~got =
+  Format.printf "[31m[FAILED][0m  %a: expected %s but got %s\n"
+    pp_test test expected got
+
+let print_skip ~test ~reason =
+  Format.printf "[33m[SKIPPED][0m %a: %s\n" pp_test test reason
+
+let print_success ~test =
+  Format.printf "[32m[OK][0m      %a\n" pp_test test
+
+let print_report ~show_failures ~show_skipped ~show_success ctxt =
+  List.iter
+    (function
+      | {test; result = Failure {expected; got}} ->
+        if show_failures then print_failure ~test ~expected ~got
+      | {test; result = Skip {reason}} ->
+        if show_skipped then print_skip ~test ~reason
+      | {test; result = Success} ->
+        if show_success then print_success ~test)
+    ctxt.results
+
+module Args = struct
+  let show_skipped = ref false
+  let show_success= ref false
+  let hide_failures = ref false
+
+  let specs = [
+    ("--show-skipped", Arg.Set show_skipped , "Show skipped tests in report");
+    ("--show-success", Arg.Set show_success , "Show succesful tests in report");
+    ("--hide-failure", Arg.Set hide_failures, "Do not show failed tests in report");
+  ]
+
+  let usage_msg =
+    let exe_name = Filename.basename Sys.executable_name in
+    Printf.sprintf "%s [options]" exe_name
+
+  let handle_pos_arg s =
+    raise (Arg.Bad (Printf.sprintf "No positional arguments accepted: %s" s))
+
+  let parse () = Arg.parse specs handle_pos_arg usage_msg
+end
+
+let run_tests f =
+  Args.parse ();
+  let ctxt = {failures = 0; results = []} in
+  f ctxt;
+  ctxt.results <- List.rev ctxt.results;
+  print_report
+    ~show_failures:(not !Args.hide_failures)
+    ~show_skipped:!Args.show_skipped
+    ~show_success:!Args.show_success
+    ctxt;
+  match ctxt.failures with
+  | 0 -> exit 0
+  | _ -> exit 1

--- a/tests/opam-unit/opamUnit.mli
+++ b/tests/opam-unit/opamUnit.mli
@@ -1,0 +1,33 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2026 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+type ctxt
+
+val failure :
+  ctxt: ctxt ->
+  fun_name: string ->
+  test_name: string ->
+  expected: string ->
+  got: string ->
+  unit ->
+  unit
+
+val success :
+  ctxt: ctxt -> fun_name: string -> test_name: string -> unit -> unit
+
+val skip :
+  ctxt: ctxt ->
+  fun_name: string ->
+  test_name: string ->
+  reason: string ->
+  unit ->
+  unit
+
+val run_tests : (ctxt -> unit) -> unit


### PR DESCRIPTION
Backport of https://github.com/ocaml/opam/pull/6953 on 2.5