### PR TITLE
Make OpamFilename.remove_prefix consistent with starts_with

### DIFF
--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -363,10 +363,8 @@ let dir_starts_with prefix dir =
   OpamCompat.String.starts_with ~prefix dir
 
 let remove_prefix prefix filename =
-  let prefix =
-    let str = Dir.to_string prefix in
-    if str = "" then "" else Filename.concat str "" in
-  let filename = to_string filename in
+  let prefix = cmpable_dir_string prefix in
+  let filename = cmpable_file_string filename in
   OpamStd.String.remove_prefix ~prefix filename
 
 let remove_prefix_dir prefix dir =


### PR DESCRIPTION
Extracted from #6953 by @NathanReb
In my opinion the change is too impacting (e.g. #6625) and not as easy to check the correctness of. Also tests were missing and the original issue isn't present on `remove_prefix`.