### PR TITLE
GHA: Fix Cygwin build

### DIFF
--- a/.github/scripts/cygwin.cmd
+++ b/.github/scripts/cygwin.cmd
@@ -92,7 +92,7 @@ if "%1" equ "x86_64-pc-cygwin" (
 
 :: libicu-devel is needed until an alternative to the uconv call in MungeSymlinks
 :: is found
-set CYGWIN_PACKAGES=make,patch,curl,diffutils,tar,unzip,git,gcc-g++,libicu-devel%CYGWIN_PACKAGES%
+set CYGWIN_PACKAGES=make,patch,curl,diffutils,tar,unzip,git,gcc-g++=13.4.0-1,libicu-devel%CYGWIN_PACKAGES%
 :: xxd is needed for reftests
 set CYGWIN_PACKAGES=xxd,%CYGWIN_PACKAGES%
 

--- a/.github/scripts/cygwin.cmd
+++ b/.github/scripts/cygwin.cmd
@@ -84,16 +84,15 @@ md %CYGWIN_ROOT%
 :: installed with Cygwin64.
 if "%1" equ "x86_64-pc-cygwin" (
   curl -fsSLo %CYGWIN_ROOT%\setup.exe https://cygwin.com/setup-x86_64.exe
-  set CYGWIN_PACKAGES=,mingw64-i686-gcc-core=14.3.0-0.1,mingw64-x86_64-gcc-core=14.3.0-0.1,mingw64-i686-gcc-g++=14.3.0-0.1,mingw64-x86_64-gcc-g++=14.3.0-0.1
+  set CYGWIN_PACKAGES=,mingw64-i686-gcc-core,mingw64-x86_64-gcc-core,mingw64-i686-gcc-g++,mingw64-x86_64-gcc-g++
 ) else (
   curl -fsSLo %CYGWIN_ROOT%\setup.exe https://cygwin.com/setup-x86.exe
   set CYGWIN_PACKAGES=
 )
 
-:: TODO: Remove the explicit version set for diffutils when https://debbugs.gnu.org/cgi/bugreport.cgi?bug=76452 is fixed
 :: libicu-devel is needed until an alternative to the uconv call in MungeSymlinks
 :: is found
-set CYGWIN_PACKAGES=make,patch,curl,diffutils=3.10-1,tar,unzip,git,gcc-g++,libicu-devel%CYGWIN_PACKAGES%
+set CYGWIN_PACKAGES=make,patch,curl,diffutils,tar,unzip,git,gcc-g++,libicu-devel%CYGWIN_PACKAGES%
 :: xxd is needed for reftests
 set CYGWIN_PACKAGES=xxd,%CYGWIN_PACKAGES%
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -221,6 +221,7 @@ users)
   * Bump `actions/cache` to version 6 [#6983 @kit-ty-kate]
   * Fix Doc & Depends jobs when a opam root format upgrade is needed [#6998 #7002 @rjbou]
   * Upgrade the CI to OCaml 5.5 and 4.14.4 [#6988 @kit-ty-kate]
+  * Fix the Cygwin 5.5 build by requiring cygwin gcc 13.4 as 14.4 breaks C++ support [#7007 @kit-ty-kate]
 
 ## Doc
   * Update the packaging page to recommend using static archives for releases [#6973 @mseri]


### PR DESCRIPTION
~Could this be enough to f.i.x https://github.com/ocaml/ocaml/issues/14911?~

The original gcc package constraints were from https://github.com/ocaml/opam/pull/6624