### PR TITLE
Re-allow .install files containing '..'

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -97,7 +97,7 @@ users)
 
 ## Opamfile
   * The `url` file now only supports the legacy opam 1.2 fields [#6827 @kit-ty-kate]
-  * Filter fields in .install files containing destinations with `..` or absolute filepaths as parse errors [#6897 @kit-ty-kate]
+  * Warn on fields in .install files containing destinations with `..` and filter absolute filepaths as parse errors [#6897 #7008 @kit-ty-kate]
 
 ## External dependencies
   * Restore the distribution detection on Gentoo [#6886 @kit-ty-kate - fix #6887]
@@ -290,7 +290,7 @@ users)
   * Update the Install page with the new opam 2.5.2 release [#7018 @kit-ty-kate]
 
 ## Security fixes
-  * Invalidate .install fields containing destination filepath trying to escape their scope [#6897 @kit-ty-kate]
+  * Invalidate .install fields containing absolute destination filepath except when in the `misc` field [#6897 #7008 @kit-ty-kate]
   * Fix a bug that allowed a package to install files anywhere on the system using a symlink to an external directory without warning the user and asking for their permission: CVE-2026-57825. [#7005 @NathanReb]
 
 # API updates

--- a/master_changes.md
+++ b/master_changes.md
@@ -207,7 +207,7 @@ users)
   * Add more tests for depexts behaviour with unknown family types [#6489 @arozovyk]
   * Add disabled depexts tests [#6489 @rjbou]
   * Add depexts tests with debug section that demostrate system availability polling [#6489 @arozovyk]
-  * Add a test showing the behaviour of .install files containing destination filepath trying to escape their scope [#6897 @rjbou @kit-ty-kate]
+  * Add a test showing the behaviour of .install files containing destination filepath trying to escape their scope [#6897 #7008 @rjbou @kit-ty-kate]
   * Add a test showing that `opam install ./` will leave packages pinned if
     aborted or failed [#6922 @NathanReb]
   * Add test for update in repository that changes directories to files and vice versa [#6915 @rjbou]

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -32,14 +32,15 @@ module Pp = struct
   module V = OpamFormat.V
   module I = OpamFormat.I
 
-  let warn ?pos ?(strict=OpamFormatConfig.(!r.strict)) ?exn fmt =
+  let warn ?pos ?(show=OpamConsole.verbose ())
+      ?(strict=OpamFormatConfig.(!r.strict)) ?exn fmt =
     if strict then
       match exn with
       | Some e -> raise e
       | None -> bad_format ?pos fmt
     else
       Printf.ksprintf (fun s ->
-          if OpamConsole.verbose () then
+          if show then
             match exn with
             | None ->
               OpamConsole.warning "%s"

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3870,11 +3870,14 @@ module Dot_installSyntax = struct
     let raise_with_file file ?pos message =
       Pp.bad_format ?pos ("%s " ^^ message) file
     in
-    let pp_check_parent_dir =
-      Pp.check ~name:"rel-filename"
-        ~raise:raise_with_file
-        ~errmsg:"references its parent directory."
-        (Fun.negate @@ OpamFilename.might_escape ~sep:`Unspecified)
+    let pp_warn_parent_dir =
+      Pp.pp ~name:"rel-filename"
+        (fun ~pos x ->
+           if OpamFilename.might_escape ~sep:`Unspecified x then
+             Pp.warn ~show:true ~pos
+               "Path '%s' contains '..', its use is discouraged" x;
+           x)
+        (fun x -> x)
     in
     let pp_check_not_absolute =
       Pp.check ~name:"rel-filename"
@@ -3887,7 +3890,7 @@ module Dot_installSyntax = struct
         (Pp.V.string -| pp_optional)
         (Pp.opt @@
          Pp.singleton -| Pp.V.string
-         -| pp_check_parent_dir
+         -| pp_warn_parent_dir
          -| pp_check_not_absolute
          -| Pp.of_module "file" (module OpamFilename.Base))
     in
@@ -3896,7 +3899,7 @@ module Dot_installSyntax = struct
         (Pp.V.string -| pp_optional)
         (Pp.opt @@
          Pp.singleton -| Pp.V.string
-         -| pp_check_parent_dir
+         -| pp_warn_parent_dir
          -| pp_check_not_absolute
          -| Pp.check ~name:"rel-filename"
            ~raise:raise_with_file

--- a/tests/reftests/dot-install.test
+++ b/tests/reftests/dot-install.test
@@ -370,30 +370,35 @@ lib: [
   "a-file"  { "../../a-file" }
   "fichier" { "/ab/so/lute/path/fichier" }
   "dosiero" { "/tmp/../middle/dosiero" }
+  "dosiero" { "tmp/../../../../middle/dosiero" }
   "good"    { "good" }
   ]
 bin: [
   "a-file"  { "../../a-file" }
   "fichier" { "/ab/so/lute/path/fichier" }
   "dosiero" { "/tmp/../middle/dosiero" }
+  "dosiero" { "tmp/../../../../middle/dosiero" }
   "good"    { "good" }
   ]
 etc: [
   "a-file"  { "../../a-file" }
   "fichier" { "/ab/so/lute/path/fichier" }
   "dosiero" { "/tmp/../middle/dosiero" }
+  "dosiero" { "tmp/../../../../middle/dosiero" }
   "good"    { "good" }
   ]
 share: [
   "a-file"  { "../../a-file" }
   "fichier" { "/ab/so/lute/path/fichier" }
   "dosiero" { "/tmp/../middle/dosiero" }
+  "dosiero" { "tmp/../../../../middle/dosiero" }
   "good"    { "good" }
   ]
 misc: [
   "a-file"  { "../../a-file" }
   "fichier" { "/ab/so/lute/path/fichier" }
   "dosiero" { "/tmp/../middle/dosiero" }
+  "dosiero" { "tmp/../../../../middle/dosiero" }
   "good"    { "good" }
   ]
 root: [
@@ -444,17 +449,17 @@ SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/good
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/good
 [WARNING] Errors in ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install, some fields have been ignored:
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:34:15-34:29::
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:39:15-39:29::
               ../../a-file references its parent directory.
             - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:2:14-2:28::
               ../../a-file references its parent directory.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:8:14-8:28::
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:9:14-9:28::
               ../../a-file references its parent directory.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:26:14-26:28::
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:30:14-30:28::
               ../../a-file is not an absolute filename.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:20:14-20:28::
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:23:14-23:28::
               ../../a-file references its parent directory.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:14:14-14:28::
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:16:14-16:28::
               ../../a-file references its parent directory.
 
 -> installed eskape.1

--- a/tests/reftests/dot-install.test
+++ b/tests/reftests/dot-install.test
@@ -362,6 +362,7 @@ OPAM/rem-dir/lib/toplevel
 ### OPAMDEBUG=0
 ### unset OPAMDEBUGSECTIONS
 ### : Escapability
+### OPAMSTRICT=0
 ### <pkg:eskape.1>
 opam-version: "2.0"
 install: [ "echo" "hellow" ]
@@ -448,19 +449,29 @@ SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskap
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/dosiero
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/good
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/good
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:39:15-39:29::
+          Path '../../a-file' contains '..', its use is discouraged
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:2:14-2:28::
+          Path '../../a-file' contains '..', its use is discouraged
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:9:14-9:28::
+          Path '../../a-file' contains '..', its use is discouraged
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:23:14-23:28::
+          Path '../../a-file' contains '..', its use is discouraged
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:16:14-16:28::
+          Path '../../a-file' contains '..', its use is discouraged
 [WARNING] Errors in ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install, some fields have been ignored:
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:39:15-39:29::
-              ../../a-file references its parent directory.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:2:14-2:28::
-              ../../a-file references its parent directory.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:9:14-9:28::
-              ../../a-file references its parent directory.
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:40:15-40:41::
+              /ab/so/lute/path/fichier is an absolute filename.
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:3:14-3:40::
+              /ab/so/lute/path/fichier is an absolute filename.
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:10:14-10:40::
+              /ab/so/lute/path/fichier is an absolute filename.
             - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:30:14-30:28::
               ../../a-file is not an absolute filename.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:23:14-23:28::
-              ../../a-file references its parent directory.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:16:14-16:28::
-              ../../a-file references its parent directory.
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:24:14-24:40::
+              /ab/so/lute/path/fichier is an absolute filename.
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:17:14-17:40::
+              /ab/so/lute/path/fichier is an absolute filename.
 
 -> installed eskape.1
 SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache
@@ -488,6 +499,85 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
 Not found: ${BASEDIR}/OPAM/escapability/share/eskape/a-file
 ==> eskape changes
 opam-version: "2.0"
+### : Testing escapability with strict mode
+### opam remove eskape --debug-level=0
+The following actions will be performed:
+=== remove 1 package
+  - remove eskape 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   eskape.1
+Done.
+### opam install eskape --strict | unordered
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/lock (none => write)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (none => write)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (write => none)
+The following actions will be performed:
+=== install 1 package
+  - install eskape 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1
+SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install
+SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/a-file
+SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/fichier
+SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/dosiero
+SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/good
+SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1
+SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/eskape.install
+SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install
+SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/a-file
+SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/a-file
+SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/fichier
+SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/fichier
+SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/dosiero
+SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/dosiero
+SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/good
+SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/good
+[WARNING] Errors in ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install, some fields have been ignored:
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:39:15-39:29::
+              Path '../../a-file' contains '..', its use is discouraged
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:2:14-2:28::
+              Path '../../a-file' contains '..', its use is discouraged
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:9:14-9:28::
+              Path '../../a-file' contains '..', its use is discouraged
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:30:14-30:28::
+              ../../a-file is not an absolute filename.
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:23:14-23:28::
+              Path '../../a-file' contains '..', its use is discouraged
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:16:14-16:28::
+              Path '../../a-file' contains '..', its use is discouraged
+
+-> installed eskape.1
+SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache
+SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/.opam-switch/packages/eskape.1
+SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/.opam-switch/packages/eskape.1/files
+SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/eskape.install
+SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/packages/eskape.1/files/eskape.install
+SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/a-file
+SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/packages/eskape.1/files/a-file
+SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/fichier
+SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/packages/eskape.1/files/fichier
+SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/dosiero
+SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/packages/eskape.1/files/dosiero
+SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/good
+SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/packages/eskape.1/files/good
+SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (none => write)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (write => none)
+Done.
+SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/lock (write => none)
+SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/backup/state-today.export
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
+### ocaml cat.ml escapibility eskape
+==> eskape installed file
+Not found: ${BASEDIR}/OPAM/escapibility/share/eskape/a-file
+==> eskape changes
+Not found: ${BASEDIR}/OPAM/escapibility/.opam-switch/install/eskape.changes
 ### : Testing escapability with a relative path containing '..' that does exist and doesn't escape
 ### <pkg:eskape-rel-dotdot-exists.1>
 opam-version: "2.0"
@@ -527,15 +617,23 @@ SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskap
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1/eskape-rel-dotdot-exists.install
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape-rel-dotdot-exists/eskape-rel-dotdot-exists.1/files/a-file
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1/a-file
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1/eskape-rel-dotdot-exists.install:2:14-2:28::
+          Path '../../a-file' contains '..', its use is discouraged
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1/eskape-rel-dotdot-exists.install:8:14-8:28::
+          Path '../../a-file' contains '..', its use is discouraged
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1/eskape-rel-dotdot-exists.install:5:14-5:28::
+          Path '../../a-file' contains '..', its use is discouraged
 [WARNING] Errors in ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1/eskape-rel-dotdot-exists.install, some fields have been ignored:
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1/eskape-rel-dotdot-exists.install:2:14-2:28::
-              ../../a-file references its parent directory.
+SYSTEM                          install ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1/a-file -> ${BASEDIR}/OPAM/escapability/a-file (644)
+SYSTEM                          install ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1/a-file -> ${BASEDIR}/OPAM/escapability/a-file (644)
+SYSTEM                          install ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1/a-file -> ${BASEDIR}/OPAM/escapability/a-file (644)
             - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1/eskape-rel-dotdot-exists.install:11:14-11:28::
               ../../a-file is not an absolute filename.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1/eskape-rel-dotdot-exists.install:8:14-8:28::
-              ../../a-file references its parent directory.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1/eskape-rel-dotdot-exists.install:5:14-5:28::
-              ../../a-file references its parent directory.
+SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/lib/eskape-rel-dotdot-exists
+SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/share
+SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/share/eskape-rel-dotdot-exists
+SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/etc
+SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/etc/eskape-rel-dotdot-exists
 
 -> installed eskape-rel-dotdot-exists.1
 SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache
@@ -557,6 +655,14 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
 Not found: ${BASEDIR}/OPAM/escapability/share/eskape-rel-dotdot-exists/a-file
 ==> eskape-rel-dotdot-exists changes
 opam-version: "2.0"
+added: [
+  "etc" {"D"}
+  "etc|eskape-rel-dotdot-exists" {"D"}
+  "lib|eskape-rel-dotdot-exists" {"D"}
+  "share" {"D"}
+  "share|eskape-rel-dotdot-exists" {"D"}
+]
+contents-changed: "a-file" {"F:12fc204edeae5b57713c5ad7dcb97d39"}
 ### : Testing escapability with a relative path containing '..' in the middle, that does not exist and doesn't escape
 ### <pkg:eskape-rel-middotdot-notexists.1>
 opam-version: "2.0"
@@ -598,17 +704,28 @@ SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskap
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/eskape-rel-middotdot-notexists.install
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape-rel-middotdot-notexists/eskape-rel-middotdot-notexists.1/files/a-file
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/a-file
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/eskape-rel-middotdot-notexists.install:2:13-2:35::
+          Path 'tmp/../middle/a-file' contains '..', its use is discouraged
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/eskape-rel-middotdot-notexists.install:5:13-5:35::
+          Path 'tmp/../middle/a-file' contains '..', its use is discouraged
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/eskape-rel-middotdot-notexists.install:11:13-11:35::
+          Path 'tmp/../middle/a-file' contains '..', its use is discouraged
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/eskape-rel-middotdot-notexists.install:8:13-8:35::
+          Path 'tmp/../middle/a-file' contains '..', its use is discouraged
 [WARNING] Errors in ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/eskape-rel-middotdot-notexists.install, some fields have been ignored:
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/eskape-rel-middotdot-notexists.install:2:13-2:35::
-              tmp/../middle/a-file references its parent directory.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/eskape-rel-middotdot-notexists.install:5:13-5:35::
-              tmp/../middle/a-file references its parent directory.
+SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/bin/middle
+SYSTEM                          install ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/a-file -> ${BASEDIR}/OPAM/escapability/bin/middle/a-file (755)
+SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/lib/eskape-rel-middotdot-notexists/middle
+SYSTEM                          install ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/a-file -> ${BASEDIR}/OPAM/escapability/lib/eskape-rel-middotdot-notexists/middle/a-file (644)
+SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/share/eskape-rel-middotdot-notexists/middle
+SYSTEM                          install ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/a-file -> ${BASEDIR}/OPAM/escapability/share/eskape-rel-middotdot-notexists/middle/a-file (644)
+SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/etc/eskape-rel-middotdot-notexists/middle
+SYSTEM                          install ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/a-file -> ${BASEDIR}/OPAM/escapability/etc/eskape-rel-middotdot-notexists/middle/a-file (644)
+SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/lib/eskape-rel-middotdot-notexists
+SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/share/eskape-rel-middotdot-notexists
+SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/etc/eskape-rel-middotdot-notexists
             - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/eskape-rel-middotdot-notexists.install:14:13-14:35::
               tmp/../middle/a-file is not an absolute filename.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/eskape-rel-middotdot-notexists.install:11:13-11:35::
-              tmp/../middle/a-file references its parent directory.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/eskape-rel-middotdot-notexists.install:8:13-8:35::
-              tmp/../middle/a-file references its parent directory.
 
 -> installed eskape-rel-middotdot-notexists.1
 SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache
@@ -630,6 +747,22 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
 Not found: ${BASEDIR}/OPAM/escapability/share/eskape-rel-middotdot-notexists/a-file
 ==> eskape-rel-middotdot-notexists changes
 opam-version: "2.0"
+added: [
+  "bin|middle" {"D"}
+  "bin|middle|a-file" {"F:12fc204edeae5b57713c5ad7dcb97d39"}
+  "etc|eskape-rel-middotdot-notexists" {"D"}
+  "etc|eskape-rel-middotdot-notexists|middle" {"D"}
+  "etc|eskape-rel-middotdot-notexists|middle|a-file"
+    {"F:12fc204edeae5b57713c5ad7dcb97d39"}
+  "lib|eskape-rel-middotdot-notexists" {"D"}
+  "lib|eskape-rel-middotdot-notexists|middle" {"D"}
+  "lib|eskape-rel-middotdot-notexists|middle|a-file"
+    {"F:12fc204edeae5b57713c5ad7dcb97d39"}
+  "share|eskape-rel-middotdot-notexists" {"D"}
+  "share|eskape-rel-middotdot-notexists|middle" {"D"}
+  "share|eskape-rel-middotdot-notexists|middle|a-file"
+    {"F:12fc204edeae5b57713c5ad7dcb97d39"}
+]
 ### : Testing escapability with a relative path containing '..' in the middle, that does not exist and does escape
 ### <pkg:realeskape-rel-middotdot-notexists.1>
 opam-version: "2.0"
@@ -671,38 +804,54 @@ SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/reale
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/realeskape-rel-middotdot-notexists.1/realeskape-rel-middotdot-notexists.install
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/realeskape-rel-middotdot-notexists/realeskape-rel-middotdot-notexists.1/files/a-file
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/realeskape-rel-middotdot-notexists.1/a-file
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/realeskape-rel-middotdot-notexists.1/realeskape-rel-middotdot-notexists.install:2:13-2:44::
+          Path 'tmp/../../../../middle/a-file' contains '..', its use is discouraged
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/realeskape-rel-middotdot-notexists.1/realeskape-rel-middotdot-notexists.install:5:13-5:41::
+          Path 'tmp/../../../middle/a-file' contains '..', its use is discouraged
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/realeskape-rel-middotdot-notexists.1/realeskape-rel-middotdot-notexists.install:11:13-11:44::
+          Path 'tmp/../../../../middle/a-file' contains '..', its use is discouraged
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/build/realeskape-rel-middotdot-notexists.1/realeskape-rel-middotdot-notexists.install:8:13-8:44::
+          Path 'tmp/../../../../middle/a-file' contains '..', its use is discouraged
 [WARNING] Errors in ${BASEDIR}/OPAM/escapability/.opam-switch/build/realeskape-rel-middotdot-notexists.1/realeskape-rel-middotdot-notexists.install, some fields have been ignored:
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/realeskape-rel-middotdot-notexists.1/realeskape-rel-middotdot-notexists.install:2:13-2:44::
-              tmp/../../../../middle/a-file references its parent directory.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/realeskape-rel-middotdot-notexists.1/realeskape-rel-middotdot-notexists.install:5:13-5:41::
-              tmp/../../../middle/a-file references its parent directory.
+[ERROR] package realeskape-rel-middotdot-notexists attempted to install a file outside allowed destination directories: ${BASEDIR}/OPAM/escapability/bin/tmp/../../../middle/a-file -> ${BASEDIR}/OPAM/middle/a-file.
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/install/realeskape-rel-middotdot-notexists.install:2:15-2:46::
+          Path 'tmp/../../../../middle/a-file' contains '..', its use is discouraged
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/install/realeskape-rel-middotdot-notexists.install:3:15-3:43::
+          Path 'tmp/../../../middle/a-file' contains '..', its use is discouraged
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/install/realeskape-rel-middotdot-notexists.install:4:17-4:48::
+          Path 'tmp/../../../../middle/a-file' contains '..', its use is discouraged
+[WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/install/realeskape-rel-middotdot-notexists.install:5:15-5:46::
+          Path 'tmp/../../../../middle/a-file' contains '..', its use is discouraged
+SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/lib/realeskape-rel-middotdot-notexists
+SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/lib/realeskape-rel-middotdot-notexists
+SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/share/realeskape-rel-middotdot-notexists
+SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/etc/realeskape-rel-middotdot-notexists
+SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/doc/realeskape-rel-middotdot-notexists
+SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/install/realeskape-rel-middotdot-notexists.install
+
+.install file escaping allowed directories
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install realeskape-rel-middotdot-notexists 1
++- 
+- No changes have been performed
             - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/realeskape-rel-middotdot-notexists.1/realeskape-rel-middotdot-notexists.install:14:13-14:44::
               tmp/../../../../middle/a-file is not an absolute filename.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/realeskape-rel-middotdot-notexists.1/realeskape-rel-middotdot-notexists.install:11:13-11:44::
-              tmp/../../../../middle/a-file references its parent directory.
-            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/realeskape-rel-middotdot-notexists.1/realeskape-rel-middotdot-notexists.install:8:13-8:44::
-              tmp/../../../../middle/a-file references its parent directory.
 
--> installed realeskape-rel-middotdot-notexists.1
-SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache
-SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/.opam-switch/packages/realeskape-rel-middotdot-notexists.1
-SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/.opam-switch/packages/realeskape-rel-middotdot-notexists.1/files
-SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/realeskape-rel-middotdot-notexists/realeskape-rel-middotdot-notexists.1/files/realeskape-rel-middotdot-notexists.install
-SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/packages/realeskape-rel-middotdot-notexists.1/files/realeskape-rel-middotdot-notexists.install
-SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/realeskape-rel-middotdot-notexists/realeskape-rel-middotdot-notexists.1/files/a-file
-SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/packages/realeskape-rel-middotdot-notexists.1/files/a-file
-Done.
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (write => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/lock (write => none)
 SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/backup/state-today.export
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
+# Return code 31 #
 ### ocaml cat.ml escapability realeskape-rel-middotdot-notexists
 ==> realeskape-rel-middotdot-notexists installed file
 Not found: ${BASEDIR}/OPAM/escapability/share/realeskape-rel-middotdot-notexists/a-file
 ==> realeskape-rel-middotdot-notexists changes
-opam-version: "2.0"
+Not found: ${BASEDIR}/OPAM/escapability/.opam-switch/install/realeskape-rel-middotdot-notexists.changes
 ### : Testing escapability with an absolute path
 ### <pkg:eskape-abs.1>
 opam-version: "2.0"


### PR DESCRIPTION
Partially reverts https://github.com/ocaml/opam/commit/ae877c0f74f696e05c2d524913c682c8aeaad918 (from #6879)

This check is no longer necessary since https://github.com/ocaml/opam/commit/d7f7d8e39afcf8ade6b560224e5b084a924f2b15 (#7005) and broke opam repositories providing cross-compiled packages as such format is used by `dune` (see https://github.com/ocaml/dune/issues/14393)

See https://ocaml.zulipchat.com/#narrow/channel/527832-opam/topic/Cross.20compilation.20with.20opam.202.2E5.2E1/with/592359165

Backported to 2.5 in #7009 