### PR TITLE
reftests: Fix the port number range on Windows

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -208,6 +208,7 @@ users)
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]
   * Add to automatic path subsitutions lines that contains `packages` [#6625 @rjbou]
   * Add to automatic path substitutions lines that contains switch installation paths [#6956 @rjbou]
+  * Fix the port number range on Windows [#7029 @kit-ty-kate]
 
 ## Github Actions
   * Add OCaml 5.4 to the test matrix [#6732 @kit-ty-kate]

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -777,11 +777,7 @@ let rec list_remove x = function
 
 let run_http_server dir () =
   let port =
-    let rec aux p =
-      if p < 1030 then aux (Random.int 49000)
-      else p
-    in
-    aux (Random.int 49000)
+    Random.int (65535 - 1030) + 1030
   in
   let cmd = "micro_httpd" in
   let args = ["-p"; string_of_int port; dir] in


### PR DESCRIPTION
```
diff --git a/_build/default/tests/reftests/pin.test b/_build/default/tests/reftests/pin.out
index 753fe47..cddb9e4 100644
--- a/_build/default/tests/reftests/pin.test
+++ b/_build/default/tests/reftests/pin.out
@@ -1671,15 +1671,6 @@ name: "http-archive-test"
 build: ["cat" "file"]
 ### tar czf http-archive.tar.gz http-archive
 ### opam pin add http://localhost:$HTTPSERVERPORT/http-archive.tar.gz | "${HTTPSERVERPORT}" -> "port"
-[NOTE] Package http-archive-test does not exist in opam repositories registered in the current switch.
-http-archive-test is now pinned to http://localhost:port/http-archive.tar.gz (version dev)
-
-The following actions will be performed:
-=== install 1 package
-  - install http-archive-test dev (pinned)
-
-<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
--> retrieved http-archive-test.dev  (http://localhost:port/http-archive.tar.gz)
--> installed http-archive-test.dev
-Done.
+[ERROR] Could not retrieve http://localhost:port/http-archive.tar.gz (curl failed: "D:\cygwin\bin\curl.exe --write-out %{http_code}\n --retry 3 --retry-delay 2 --user-agent opam/2.6.0~alpha1~dev -L -o ${OPAMTMP}/localhost_port_http-archive.tar.gz.part -- http://localhost:port/http-archive.tar.gz" exited with code 3 "curl: (3) URL rejected: Port number was not a decimal number between 0 and 65535")
+# Return code 40 #
 [[[Killing micro_httpd]]]
```