### PR TITLE
reftests: wait for background processes to end before removing its working directory

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -216,6 +216,7 @@ users)
   * Add to automatic path subsitutions lines that contains `packages` [#6625 @rjbou]
   * Add to automatic path substitutions lines that contains switch installation paths [#6956 @rjbou]
   * Fix the port number range on Windows [#7029 @kit-ty-kate]
+  * Wait for background processes to end before removing its working directory [#7030 @kit-ty-kate]
 
 ## Github Actions
   * Add OCaml 5.4 to the test matrix [#6732 @kit-ty-kate]

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -113,8 +113,12 @@ let clean_background_processes () =
   Hashtbl.iter (fun (pid, ic) cmd ->
       Printf.printf "[[[Killing %s]]]\n" cmd;
       close_in ic;
-      try Unix.kill pid Sys.sigkill
-      with Unix.Unix_error (ESRCH, "kill", _) -> ()
+      (try Unix.kill pid Sys.sigkill
+       with Unix.Unix_error (ESRCH, "kill", _) -> ());
+      let _ : int * Unix.process_status = Unix.waitpid [] pid in
+      (* we need to ensure the process has ended
+         before removing the test directory on Windows *)
+      ()
     ) background_pids;
   Hashtbl.clear background_pids
 


### PR DESCRIPTION
```
Fatal error: exception Unix.Unix_error(Unix.EACCES, "rmdir", "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\build_6f8884_dune\\opam-reftest-277ccd")
Raised by primitive operation at Dune__exe__Run.rm_rf.erase in file "tests/reftests/run.ml", line 274, characters 6-21
Called from Dune__exe__Run.rm_rf in file "tests/reftests/run.ml", line 277, characters 35-45
Called from Dune__exe__Run.finally in file "tests/reftests/run.ml", line 245, characters 9-13
Called from Dune__exe__Run in file "tests/reftests/run.ml", line 1334, characters 4-43
```