### PR TITLE
GHA: Ensure a better availability of the micro_httpd dependency

### DIFF
--- a/.github/scripts/main/preamble.sh
+++ b/.github/scripts/main/preamble.sh
@@ -84,7 +84,7 @@ EOF
     fi
 
     if [ "$OPAM_TEST" = "1" ]; then
-      opam pin git+https://codeberg.org/kit-ty-kate/micro_httpd
+      opam install micro_httpd
     fi
 
     rm -f "$OPAMBSROOT"/log/*

--- a/.github/scripts/main/preamble.sh
+++ b/.github/scripts/main/preamble.sh
@@ -83,7 +83,7 @@ EOF
     fi
 
     if [ "$OPAM_TEST" = "1" ]; then
-      opam pin git+https://codeberg.org/kit-ty-kate/micro_httpd
+      opam install micro_httpd
     fi
 
     rm -f "$OPAMBSROOT"/log/*

--- a/.github/scripts/main/reftests.sh
+++ b/.github/scripts/main/reftests.sh
@@ -36,7 +36,14 @@ esac
 
 export PATH="$PREFIX/bin:$PATH"
 
-git clone https://codeberg.org/kit-ty-kate/micro_httpd
+# Fetch micro_httpd
+export OPAMROOT=$(pwd)/tmp-opamroot
+opam init -n --bypass-checks --bare "git+$OPAM_REPO_MAIN#$OPAM_REPO_SHA"
+opam source --no-switch --dir=micro_httpd micro_httpd
+rm -rf "$OPAMROOT"
+unset OPAMROOT
+
+# Build micro_httpd
 pushd micro_httpd
 dune build -p micro_httpd
 dune install --root . --prefix "$CONFIGURE_PREFIX"

--- a/.github/scripts/main/reftests.sh
+++ b/.github/scripts/main/reftests.sh
@@ -36,7 +36,16 @@ esac
 
 export PATH="$PREFIX/bin:$PATH"
 
-git clone https://codeberg.org/kit-ty-kate/micro_httpd
+# Fetch micro_httpd
+# NOTE: We need to fetch it because it is not present in vendored deps
+# and no opam switch is set at this point
+export OPAMROOT=$(pwd)/tmp-opamroot
+opam init -n --bypass-checks --bare "git+$OPAM_REPO_MAIN#$OPAM_REPO_SHA"
+opam source --no-switch --dir=micro_httpd micro_httpd
+rm -rf "$OPAMROOT"
+unset OPAMROOT
+
+# Build micro_httpd
 pushd micro_httpd
 dune build -p micro_httpd
 dune install --root . --prefix "$CONFIGURE_PREFIX"

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -551,8 +551,8 @@ let main oc : unit =
     ("OPAMBSROOT", "~/.cache/.opam.cached");
     ("OPAM12CACHE", "~/.cache/opam1.2/cache");
     ("OPAM_REPO", "https://github.com/ocaml/opam-repository.git");
-    ("OPAM_TEST_REPO_SHA", "ceed23f9d33677f323a62325ad42599d14f46b98");
-    ("OPAM_REPO_SHA", "ceed23f9d33677f323a62325ad42599d14f46b98");
+    ("OPAM_TEST_REPO_SHA", "e1203ec1b376758dce6b8a976ab672afb8c9252f");
+    ("OPAM_REPO_SHA", "e1203ec1b376758dce6b8a976ab672afb8c9252f");
     ("SOLVER", "");
     (* Cygwin configuration *)
     ("CYGWIN_MIRROR", "http://mirrors.kernel.org/sourceware/cygwin/");

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -551,8 +551,8 @@ let main oc : unit =
     ("OPAMBSROOT", "~/.cache/.opam.cached");
     ("OPAM12CACHE", "~/.cache/opam1.2/cache");
     ("OPAM_REPO", "https://github.com/ocaml/opam-repository.git");
-    ("OPAM_TEST_REPO_SHA", "ceed23f9d33677f323a62325ad42599d14f46b98");
-    ("OPAM_REPO_SHA", "ceed23f9d33677f323a62325ad42599d14f46b98");
+    ("OPAM_TEST_REPO_SHA", "3c53726ac7d00556b0751d22e904b9153d9e7b89");
+    ("OPAM_REPO_SHA", "3c53726ac7d00556b0751d22e904b9153d9e7b89");
     ("SOLVER", "");
     (* Cygwin configuration *)
     ("CYGWIN_MIRROR", "http://mirrors.kernel.org/sourceware/cygwin/");

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,8 @@ env:
   OPAMBSROOT: ~/.cache/.opam.cached
   OPAM12CACHE: ~/.cache/opam1.2/cache
   OPAM_REPO: https://github.com/ocaml/opam-repository.git
-  OPAM_TEST_REPO_SHA: ceed23f9d33677f323a62325ad42599d14f46b98
-  OPAM_REPO_SHA: ceed23f9d33677f323a62325ad42599d14f46b98
+  OPAM_TEST_REPO_SHA: e1203ec1b376758dce6b8a976ab672afb8c9252f
+  OPAM_REPO_SHA: e1203ec1b376758dce6b8a976ab672afb8c9252f
   SOLVER:
   CYGWIN_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
   CYGWIN_ROOT: D:\cygwin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,8 @@ env:
   OPAMBSROOT: ~/.cache/.opam.cached
   OPAM12CACHE: ~/.cache/opam1.2/cache
   OPAM_REPO: https://github.com/ocaml/opam-repository.git
-  OPAM_TEST_REPO_SHA: ceed23f9d33677f323a62325ad42599d14f46b98
-  OPAM_REPO_SHA: ceed23f9d33677f323a62325ad42599d14f46b98
+  OPAM_TEST_REPO_SHA: 3c53726ac7d00556b0751d22e904b9153d9e7b89
+  OPAM_REPO_SHA: 3c53726ac7d00556b0751d22e904b9153d9e7b89
   SOLVER:
   CYGWIN_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
   CYGWIN_ROOT: D:\cygwin

--- a/master_changes.md
+++ b/master_changes.md
@@ -246,6 +246,7 @@ users)
   * Upgrade the CI to OCaml 5.5 and 4.14.4 [#6988 @kit-ty-kate]
   * Fix the Cygwin 5.5 build by requiring cygwin gcc 13.4 as 14.4 breaks C++ support [#7007 @kit-ty-kate]
   * Upgrade to use opam 2.5.2 [#7018 @kit-ty-kate]
+  * Ensure a better availability of the `micro_httpd` dependency [#7033 @kit-ty-kate]
 
 ## Doc
   * Update the packaging page to recommend using static archives for releases [#6973 @mseri]

--- a/master_changes.md
+++ b/master_changes.md
@@ -127,6 +127,7 @@ users)
   * Fix the regexp matching on temporary files [#7094 @kit-ty-kate]
 
 ## Github Actions
+  * Ensure a better availability of the `micro_httpd` dependency [#7033 @kit-ty-kate]
 
 ## Doc
 


### PR DESCRIPTION
Going through opam-repository instead of the git repository is faster and more consistent