### PR TITLE
Add some checks on `.install` `root` and `rootexec` fields

### DIFF
--- a/doc/pages/Manual.md
+++ b/doc/pages/Manual.md
@@ -1399,6 +1399,11 @@ allowed.
   installs to `<prefix>/doc/<pkgname>/`
 - <a id="installfield-stublibs">`stublibs:`</a>
   installs to `<prefix>/lib/stublibs/`, with the `exec` bit set
+- <a id="installfield-root">`root:`</a>
+  installs to `<prefix>/` (since opam 2.6.0)
+- <a id="installfield-rootexec">`rootexec:`</a>
+  installs to `<prefix>/`, but the `exec` bit is set (since
+  opam 2.6.0)
 
 The following are treated slightly differently:
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -349,6 +349,7 @@ users)
   * `OpamFile.*.read_from_string`: add optional `?loc` string argument to propagate location information when available (path on disk, archive, etc.), and add logging with level 3 that displays it [#6625 @rjbou]
   * `OpamFile.*`: add `safe_read_from_string` [#6625 @rjbou]
   * `OpamRepositoryPath.tar`: renamed to `repo_tarring`, deprecated, no longer used [#6625 @rjbou]
+  * `OpamPathName`: add `opam_switch_d` for `.opam-switch` [#6938 @WardBrian]
 
 ## opam-core
   * `OpamCmdliner` was added. It is accessible through a new `opam-core.cmdliner` sub-library [#6755 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -393,3 +393,4 @@ users)
   * `OpamPatch.patch`: no longer patch a file on disk, but take as argument a filesystem abstraction `FS_ABSTR` that delivers the needed functions [#6625 @rjbou]
   * `OpamPatch.parse_patch`: no longer take `~dir` the directory to translate the patch in as argument, it now takes `~translate` argument that is a string option (directory option), if we want to perform a translation in that directory [#6625 @rjbou]
   * `OpamSystem.real_path`: fix a bug where paths after a non existent directory where not resolve [#7011 @kit-ty-kate - fix #7010]
+  * `OpamFilename`: add `split` function that returns the list of paths elements, not platform dependent [#6938 @WardBrian]

--- a/master_changes.md
+++ b/master_changes.md
@@ -221,6 +221,7 @@ users)
   * Add a test showing the remote and branch names of a git repository extracted by `opam source` [#6992 @kit-ty-kate]
   * Add a test showing the order of install actions for each relevant commands [#6864 @kit-ty-kate]
   * Add a test showing some of the internal steps of `opam init` [#6957 @kit-ty-kate]
+  * Add tests for `.install` `root` and `rootexec` fields [#6938 @rjbou]
 
 ### Engine
   * Add `http-server` to launch a minimal http server [#6939 @rjbou]

--- a/master_changes.md
+++ b/master_changes.md
@@ -30,6 +30,7 @@ users)
 
 ## Install
   * Remove the build directory as soon as possible when installing a package [#6906 @kit-ty-kate - fix #5884]
+  * Add `root` and `rootexec` sections to `.install` files to install files from prefix root [#6938 @WardBrian @rjbou - fix #6919]
 
 ## Build (package)
   * When fetching a git repository, the resulting git branch is now deterministically named `main` instead of taking the system's `init.defaultBranch` [#6992 @kit-ty-kate]
@@ -350,6 +351,8 @@ users)
   * `OpamFile.*`: add `safe_read_from_string` [#6625 @rjbou]
   * `OpamRepositoryPath.tar`: renamed to `repo_tarring`, deprecated, no longer used [#6625 @rjbou]
   * `OpamPathName`: add `opam_switch_d` for `.opam-switch` [#6938 @WardBrian]
+  * `OpamFile.Dot_install`: add fields `root` and `rootexec` to type record `t` [#6938 @WardBrian]
+  * `OpamFile.Dot_install`: add `root`, `rootexec`, `with_root`, and `with_rootexec` functions [#6938 @WardBrian]
 
 ## opam-core
   * `OpamCmdliner` was added. It is accessible through a new `opam-core.cmdliner` sub-library [#6755 @kit-ty-kate]

--- a/src/client/opamAction.ml
+++ b/src/client/opamAction.ml
@@ -155,6 +155,10 @@ let preprocess_dot_install_t st nv build_dir =
     false, (instdir_gen P.lib_dir), I.lib_root;
     true, (instdir_gen P.lib_dir), I.libexec_root;
 
+    (* prefix files *)
+    false, (fun r s _ -> P.root r s), I.root;
+    true, (fun r s _ -> P.root r s), I.rootexec;
+
     (* toplevel *)
     false, (instdir_gen P.toplevel), I.toplevel;
 
@@ -827,6 +831,8 @@ let remove_package_aux
     remove_files OpamPath.Switch.share_dir OpamFile.Dot_install.share_root;
     remove_files_and_dir OpamPath.Switch.etc OpamFile.Dot_install.etc;
     remove_files (OpamPath.Switch.man_dir ?num:None) OpamFile.Dot_install.man;
+    remove_files ((fun r s _ -> OpamPath.Switch.root r s)) OpamFile.Dot_install.root;
+    remove_files ((fun r s _ -> OpamPath.Switch.root r s)) OpamFile.Dot_install.rootexec;
     remove_files_and_dir OpamPath.Switch.doc OpamFile.Dot_install.doc;
 
     (* Remove the misc files *)

--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -9,7 +9,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let might_escape ~sep path =
+let split ~sep path =
   let sep =
     let real_sep = function
       | `Unix -> Re.char '/'
@@ -20,8 +20,11 @@ let might_escape ~sep path =
     | `Unspecified -> real_sep `Unix
     | `Unix | `Windows as sep -> real_sep sep
   in
+  Re.(split (compile sep) path)
+
+let might_escape ~sep path =
   List.exists (String.equal Filename.parent_dir_name)
-    Re.(split (compile sep) path)
+    (split ~sep path)
 
 module Base = struct
   include OpamStd.AbstractString

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -15,6 +15,9 @@
 (* Returns [true] if string contains '..' between directory separators *)
 val might_escape: sep:[`Unix | `Windows | `Unspecified ] -> string -> bool
 
+(* Returns a list of elements between directory separators *)
+val split: sep:[`Unix | `Windows | `Unspecified ] -> string -> string list
+
 (** Basenames *)
 module Base: sig
   include OpamStd.ABSTRACT

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3751,6 +3751,8 @@ module Dot_installSyntax = struct
   let format_version = OpamVersion.of_string "2.0"
 
   type t =  {
+    root    : (basename optional * basename option) list;
+    rootexec  : (basename optional * basename option) list;
     bin     : (basename optional * basename option) list;
     sbin    : (basename optional * basename option) list;
     lib     : (basename optional * basename option) list;
@@ -3768,6 +3770,8 @@ module Dot_installSyntax = struct
   }
 
   let empty = {
+    root     = [];
+    rootexec = [];
     lib      = [];
     bin      = [];
     sbin     = [];
@@ -3784,6 +3788,8 @@ module Dot_installSyntax = struct
     doc      = [];
   }
 
+  let root t = t.root
+  let rootexec t = t.rootexec
   let bin t = t.bin
   let sbin t = t.sbin
   let lib t = t.lib
@@ -3799,6 +3805,8 @@ module Dot_installSyntax = struct
   let lib_root t = t.lib_root
   let libexec_root t = t.libexec_root
 
+  let with_root root t = { t with root }
+  let with_rootexec rootexec t = { t with rootexec }
   let with_bin bin t = { t with bin }
   let with_sbin sbin t = { t with sbin }
   let with_lib lib t = { t with lib }
@@ -3858,31 +3866,59 @@ module Dot_installSyntax = struct
          else OpamFilename.Base.to_string op.c)
 
   let fields =
+    let raise_with_file file ?pos message =
+      Pp.bad_format ?pos ("%s " ^^ message) file
+    in
+    let pp_check_parent_dir =
+      Pp.check ~name:"rel-filename"
+        ~raise:raise_with_file
+        ~errmsg:"references its parent directory."
+        (Fun.negate @@ OpamFilename.might_escape ~sep:`Unspecified)
+    in
+    let pp_check_not_absolute =
+      Pp.check ~name:"rel-filename"
+        ~raise:raise_with_file
+        ~errmsg:"is an absolute filename."
+        Filename.is_relative
+    in
     let pp_field =
       Pp.V.map_list ~depth:1 @@ Pp.V.map_option
         (Pp.V.string -| pp_optional)
         (Pp.opt @@
-         Pp.singleton -| Pp.V.string -| Pp.pp ~name:"rel-filename"
-           (fun ~pos s ->
-              if OpamFilename.might_escape ~sep:`Unspecified s then
-                Pp.bad_format ~pos "%s references its parent directory." s
-              else if Filename.is_relative s then
-                OpamFilename.Base.of_string s
-              else
-                Pp.bad_format ~pos "%s is an absolute filename." s)
-           OpamFilename.Base.to_string)
+         Pp.singleton -| Pp.V.string
+         -| pp_check_parent_dir
+         -| pp_check_not_absolute
+         -| Pp.of_module "file" (module OpamFilename.Base))
+    in
+    let pp_root =
+      Pp.V.map_list ~depth:1 @@ Pp.V.map_option
+        (Pp.V.string -| pp_optional)
+        (Pp.opt @@
+         Pp.singleton -| Pp.V.string
+         -| pp_check_parent_dir
+         -| pp_check_not_absolute
+         -| Pp.check ~name:"rel-filename"
+           ~raise:raise_with_file
+           ~errmsg:"tries to overwrite opam internal files."
+           (fun s ->
+              match OpamFilename.split ~sep:`Unspecified s with
+              | root::_::_ -> (root : string) <> OpamPathName.opamswitch_d
+              | _ -> true)
+         -| Pp.of_module "file" (module OpamFilename.Base))
     in
     let pp_misc =
       Pp.V.map_list ~depth:1 @@ Pp.V.map_option
         (Pp.V.string -| pp_optional)
-        (Pp.singleton -| Pp.V.string -| Pp.pp ~name:"abs-filename"
-           (fun ~pos s ->
-              if not (Filename.is_relative s) then OpamFilename.of_string s
-              else Pp.bad_format ~pos
-                  "%s is not an absolute filename." s)
-           OpamFilename.to_string)
+        (Pp.singleton -| Pp.V.string
+         -| Pp.check ~name:"abs-filename"
+           ~raise:raise_with_file
+           ~errmsg:"is not an absolute filename."
+           (Fun.negate Filename.is_relative)
+         -| Pp.of_module "abs-filename" (module OpamFilename))
     in
     [
+      "root", Pp.ppacc with_root root pp_root;
+      "rootexec", Pp.ppacc with_rootexec rootexec pp_root;
       "lib", Pp.ppacc with_lib lib pp_field;
       "bin", Pp.ppacc with_bin bin pp_field;
       "sbin", Pp.ppacc with_sbin sbin pp_field;

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3881,6 +3881,23 @@ module Dot_installSyntax = struct
         ~errmsg:"is an absolute filename."
         Filename.is_relative
     in
+    let pp_warn_std_paths =
+      Pp.pp ~name:"std-paths"
+        (fun ~pos str ->
+           let paths = OpamTypesBase.all_std_paths in
+           let paths = List.filter (fun x -> x <> Prefix) paths in
+           let paths = List.map OpamTypesBase.string_of_std_path paths in
+           (match OpamFilename.split ~sep:`Unspecified str with
+            | root::_::_ ->
+              if OpamStd.List.mem String.equal root paths then
+                Pp.warn ~pos
+                  "Path '%s' begins with %s directory in 'root' field. \
+                   Use '%s' field instead."
+                  str root root
+            | _ -> ());
+           str)
+        Fun.id
+    in
     let pp_field =
       Pp.V.map_list ~depth:1 @@ Pp.V.map_option
         (Pp.V.string -| pp_optional)
@@ -3897,6 +3914,7 @@ module Dot_installSyntax = struct
          Pp.singleton -| Pp.V.string
          -| pp_check_parent_dir
          -| pp_check_not_absolute
+         -| pp_warn_std_paths
          -| Pp.check ~name:"rel-filename"
            ~raise:raise_with_file
            ~errmsg:"tries to overwrite opam internal files."

--- a/src/format/opamFile.mli
+++ b/src/format/opamFile.mli
@@ -936,6 +936,12 @@ module Dot_install: sig
 
   include IO_FILE
 
+  (** List of files to install directly under the switch root. *)
+  val root: t -> (basename optional * basename option) list
+
+  (** List of files to install directly under the switch root, with +x set. *)
+  val rootexec: t -> (basename optional * basename option) list
+
   (** List of files to install in $bin/ *)
   val bin:  t -> (basename optional * basename option) list
 
@@ -977,6 +983,12 @@ module Dot_install: sig
 
   (** List of other files to install *)
   val misc: t -> (basename optional * filename) list
+
+  (** List of files to install directly under the switch root. *)
+  val with_root: (basename optional * basename option) list -> t -> t
+
+  (** List of files to install directly under the switch root, with +x set. *)
+  val with_rootexec: (basename optional * basename option) list -> t -> t
 
   (** List of files to install in $bin/ *)
   val with_bin : (basename optional * basename option) list -> t -> t

--- a/src/format/opamPathName.ml
+++ b/src/format/opamPathName.ml
@@ -22,6 +22,7 @@ let reinstall_d = "reinstall"
 let remove_d = "remove"
 let sources_d = "sources"
 let opam_d = "opam"
+let opamswitch_d = ".opam-switch"
 
 let config_f = "config"
 let opam_f = OpamRepositoryPathName.opam_f

--- a/src/format/opamPathName.mli
+++ b/src/format/opamPathName.mli
@@ -25,6 +25,7 @@ val reinstall_d: string
 val remove_d: string
 val sources_d: string
 val opam_d: string
+val opamswitch_d: string
 
 (** {2 Files} *)
 val config_f: string

--- a/src/tools/opam_installer.ml
+++ b/src/tools/opam_installer.ml
@@ -194,7 +194,9 @@ let iter_install f instfile o =
       dest_pkg                    D.share,    S.share instfile,      false;
       dest_global                 D.share_dir,S.share_root instfile, false;
       dest_pkg                    D.etc,      S.etc instfile,        false;
-      dest_pkg    ?fix:o.docdir   D.doc,      S.doc instfile,        false; ]
+      dest_pkg    ?fix:o.docdir   D.doc,      S.doc instfile,        false;
+      dest                        o.prefix,   S.root instfile,       false;
+      dest                        o.prefix,   S.rootexec instfile,   true;  ]
 
 let install options =
   let instfile = OpamFile.Dot_install.safe_read options.file in

--- a/tests/reftests/dot-install-exe-fields.unix.test
+++ b/tests/reftests/dot-install-exe-fields.unix.test
@@ -1211,3 +1211,223 @@ Done.
 # OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes not found
 ### ocaml cat.ml sw-libexec_root pkg-libexec_root
 ==> No 'installed-bin' found
+### ::::::::::::::::::::::::::
+### :VI: Field 'rootexec'
+### ::::::::::::::::::::::::::
+### mkdir -p REPO/packages/pkg-rootexec/pkg-rootexec.1/files
+### cp installed-bin REPO/packages/pkg-rootexec/pkg-rootexec.1/files/installed-bin
+### opam switch create sw-rootexec --empty
+### :VI:1: No defined destination path
+### <pkg:pkg-rootexec.1>
+opam-version: "2.0"
+### <pkg:pkg-rootexec.1:pkg-rootexec.install>
+rootexec: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-rootexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-rootexec.1
+ACTION                          prepare_package_source: pkg-rootexec.1 at ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/build/pkg-rootexec.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-rootexec.1.
+
+TRACK                           after install: 1 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-rootexec.1: 1 items (addition: 1)
+-> installed pkg-rootexec.1
+Done.
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes | sed-hash $BINMD5 hash
+added: "installed-bin" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> ${BASEDIR}/OPAM/sw-rootexec/installed-bin (+x)
+### OPAMDEBUG=-5 opam remove pkg-rootexec
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-rootexec.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-rootexec.1: files installed-bin were already removed
+-> removed   pkg-rootexec.1
+ACTION                          Cleaning up artefacts of pkg-rootexec.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes
+# OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes not found
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> No 'installed-bin' found
+### :VI:2: Specify destination path
+### <pkg:pkg-rootexec.1>
+opam-version: "2.0"
+### <pkg:pkg-rootexec.1:pkg-rootexec.install>
+rootexec: [ "installed-bin" {"installed-bin.rootexec"} ]
+### OPAMDEBUG=-5 opam install pkg-rootexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-rootexec.1
+ACTION                          prepare_package_source: pkg-rootexec.1 at ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/build/pkg-rootexec.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-rootexec.1.
+
+TRACK                           after install: 1 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-rootexec.1: 1 items (addition: 1)
+-> installed pkg-rootexec.1
+Done.
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes | sed-hash $BINMD5 hash
+added: "installed-bin.rootexec" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> ${BASEDIR}/OPAM/sw-rootexec/installed-bin.rootexec (+x)
+### OPAMDEBUG=-5 opam remove pkg-rootexec
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-rootexec.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-rootexec.1: files installed-bin.rootexec were already removed
+-> removed   pkg-rootexec.1
+ACTION                          Cleaning up artefacts of pkg-rootexec.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes
+# OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes not found
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> No 'installed-bin' found
+### :VI:3: Non existing filename, with optional argument
+### <pkg:pkg-rootexec.1>
+opam-version: "2.0"
+### <pkg:pkg-rootexec.1:pkg-rootexec.install>
+rootexec: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-rootexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-rootexec.1
+ACTION                          prepare_package_source: pkg-rootexec.1 at ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/build/pkg-rootexec.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-rootexec.1.
+
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/build/pkg-rootexec.1/finst is not present and optional.
+TRACK                           after install: 0 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-rootexec.1: 0 items
+-> installed pkg-rootexec.1
+Done.
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> No 'installed-bin' found
+### OPAMDEBUG=-5 opam remove pkg-rootexec
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-rootexec.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-rootexec.1
+ACTION                          Cleaning up artefacts of pkg-rootexec.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes
+# OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes not found
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> No 'installed-bin' found
+### :VI:4: Non existing filename
+### <pkg:pkg-rootexec.1>
+opam-version: "2.0"
+### <pkg:pkg-rootexec.1:pkg-rootexec.install>
+rootexec: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-rootexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-rootexec.1
+ACTION                          prepare_package_source: pkg-rootexec.1 at ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/build/pkg-rootexec.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-rootexec.1.
+
+[ERROR] Installation of pkg-rootexec.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/build/pkg-rootexec.1/finst to ${BASEDIR}/OPAM/sw-rootexec
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-rootexec 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes
+# OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes not found
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> No 'installed-bin' found
+### :VI:5: Default install with no executable bit
+### chmod -x REPO/packages/pkg-rootexec/pkg-rootexec.1/files/installed-bin
+### <pkg:pkg-rootexec.1>
+opam-version: "2.0"
+### <pkg:pkg-rootexec.1:pkg-rootexec.install>
+rootexec: [ "installed-bin" ]
+### OPAMDEBUG=-5 opam install pkg-rootexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-rootexec.1
+ACTION                          prepare_package_source: pkg-rootexec.1 at ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/build/pkg-rootexec.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-rootexec.1.
+
+TRACK                           after install: 1 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-rootexec.1: 1 items (addition: 1)
+-> installed pkg-rootexec.1
+Done.
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes | sed-hash $BINMD5 hash
+added: "installed-bin" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> ${BASEDIR}/OPAM/sw-rootexec/installed-bin (+x)
+### OPAMDEBUG=-5 opam remove pkg-rootexec
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-rootexec.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-rootexec.1: files installed-bin were already removed
+-> removed   pkg-rootexec.1
+ACTION                          Cleaning up artefacts of pkg-rootexec.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes
+# OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes not found
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> No 'installed-bin' found

--- a/tests/reftests/dot-install-exe-fields.win32.test
+++ b/tests/reftests/dot-install-exe-fields.win32.test
@@ -1200,3 +1200,220 @@ Done.
 # OPAM/sw-libexec_root/.opam-switch/install/pkg-libexec_root.changes not found
 ### ocaml cat.ml sw-libexec_root pkg-libexec_root
 ==> ${BASEDIR}/OPAM/sw-libexec_root/lib/installed-bin.exe (+x)
+### :::::::::::::::::::::
+### :VI: Field 'rootexec'
+### :::::::::::::::::::::
+### mkdir -p REPO/packages/pkg-rootexec/pkg-rootexec.1/files
+### cp installed-bin.exe REPO/packages/pkg-rootexec/pkg-rootexec.1/files/installed-bin.exe
+### opam switch create sw-rootexec --empty
+### :VI:1: No defined destination path
+### <pkg:pkg-rootexec.1>
+opam-version: "2.0"
+### <pkg:pkg-rootexec.1:pkg-rootexec.install>
+rootexec: [ "installed-bin.exe" ]
+### OPAMDEBUG=-5 opam install pkg-rootexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-rootexec.1
+ACTION                          prepare_package_source: pkg-rootexec.1 at ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/build/pkg-rootexec.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-rootexec.1.
+
+TRACK                           after install: 1 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-rootexec.1: 1 items (addition: 1)
+-> installed pkg-rootexec.1
+Done.
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes | sed-hash $BINMD5 hash
+added: "installed-bin.exe" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> ${BASEDIR}/OPAM/sw-rootexec/installed-bin.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-rootexec
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-rootexec.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-rootexec.1: files installed-bin.exe were already removed
+-> removed   pkg-rootexec.1
+ACTION                          Cleaning up artefacts of pkg-rootexec.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes
+# OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes not found
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> No 'installed-bin*' found
+### :VI:2: Specify destination path
+### <pkg:pkg-rootexec.1>
+opam-version: "2.0"
+### <pkg:pkg-rootexec.1:pkg-rootexec.install>
+rootexec: [ "installed-bin.exe" {"installed-bin.rootexec.exe"} ]
+### OPAMDEBUG=-5 opam install pkg-rootexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-rootexec.1
+ACTION                          prepare_package_source: pkg-rootexec.1 at ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/build/pkg-rootexec.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-rootexec.1.
+
+TRACK                           after install: 1 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-rootexec.1: 1 items (addition: 1)
+-> installed pkg-rootexec.1
+Done.
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes | sed-hash $BINMD5 hash
+added: "installed-bin.rootexec.exe" {"F:+hash+"}
+opam-version: "2.0"
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> ${BASEDIR}/OPAM/sw-rootexec/installed-bin.rootexec.exe (+x)
+### OPAMDEBUG=-5 opam remove pkg-rootexec
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-rootexec.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-rootexec.1: files installed-bin.rootexec.exe were already removed
+-> removed   pkg-rootexec.1
+ACTION                          Cleaning up artefacts of pkg-rootexec.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes
+# OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes not found
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> No 'installed-bin*' found
+### :VI:3: Non existing filename, with optional argument
+### <pkg:pkg-rootexec.1>
+opam-version: "2.0"
+### <pkg:pkg-rootexec.1:pkg-rootexec.install>
+rootexec: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-rootexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-rootexec.1
+ACTION                          prepare_package_source: pkg-rootexec.1 at ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/build/pkg-rootexec.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-rootexec.1.
+
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/build/pkg-rootexec.1/finst is not present and optional.
+TRACK                           after install: 0 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-rootexec.1: 0 items
+-> installed pkg-rootexec.1
+Done.
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> No 'installed-bin*' found
+### OPAMDEBUG=-5 opam remove pkg-rootexec
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-rootexec.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-rootexec.1
+ACTION                          Cleaning up artefacts of pkg-rootexec.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes
+# OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes not found
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> No 'installed-bin*' found
+### :VI:4: Non existing filename
+### <pkg:pkg-rootexec.1>
+opam-version: "2.0"
+### <pkg:pkg-rootexec.1:pkg-rootexec.install>
+rootexec: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-rootexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-rootexec.1
+ACTION                          prepare_package_source: pkg-rootexec.1 at ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/build/pkg-rootexec.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-rootexec.1.
+
+[ERROR] Installation of pkg-rootexec.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/build/pkg-rootexec.1/finst to ${BASEDIR}/OPAM/sw-rootexec
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-rootexec 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes
+# OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes not found
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> No 'installed-bin*' found
+### :VI:5: Default install with no executable bit
+### mv REPO/packages/pkg-rootexec/pkg-rootexec.1/files/installed-bin.exe REPO/packages/pkg-rootexec/pkg-rootexec.1/files/installed-bin
+### <pkg:pkg-rootexec.1>
+opam-version: "2.0"
+### <pkg:pkg-rootexec.1:pkg-rootexec.install>
+rootexec: [ "installed-bin.exe" ]
+### OPAMDEBUG=-5 opam install pkg-rootexec
+The following actions will be performed:
+=== install 1 package
+  - install pkg-rootexec 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-rootexec.1
+ACTION                          prepare_package_source: pkg-rootexec.1 at ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/build/pkg-rootexec.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-rootexec.1.
+
+[ERROR] Installation of pkg-rootexec.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-rootexec/.opam-switch/build/pkg-rootexec.1/installed-bin.exe to ${BASEDIR}/OPAM/sw-rootexec
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-rootexec 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes
+# OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes not found
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> No 'installed-bin*' found
+### OPAMDEBUG=-5 opam remove pkg-rootexec
+[NOTE] pkg-rootexec is not installed.
+
+Nothing to do.
+### opam-cat OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes
+# OPAM/sw-rootexec/.opam-switch/install/pkg-rootexec.changes not found
+### ocaml cat.ml sw-rootexec pkg-rootexec
+==> No 'installed-bin*' found

--- a/tests/reftests/dot-install-non-exe-fields.test
+++ b/tests/reftests/dot-install-non-exe-fields.test
@@ -2188,26 +2188,21 @@ The following actions will be performed:
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 ACTION                          download_package: pkg-root.1
 ACTION                          prepare_package_source: pkg-root.1 at ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1
-TRACK                           before install: 7 elements scanned in 0.000s
+[WARNING] Errors in ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1/pkg-root.install, some fields have been ignored:
+            - At ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1/pkg-root.install:2:20-2:49::
+              Path 'lib/installed-file.lib.root' begins with lib directory in 'root' field. Use 'lib' field instead.
+
+TRACK                           before install: 0 elements scanned in 0.000s
 ACTION                          Installing pkg-root.1.
 
-TRACK                           after install: 18 elements, 11 added, scanned in 0.000s
-ACTION                          changes recorded for pkg-root.1: 11 items (addition: 11)
+TRACK                           after install: 0 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-root.1: 0 items
 -> installed pkg-root.1
 Done.
 ### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
-added: ["bin/installed-file.bin.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "doc/installed-file.doc.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "etc" {"D"} "etc/installed-file.etc.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "lib/installed-file.lib.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "lib/stublibs/installed-file.stublibs.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "lib/toplevel/installed-file.lib.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "man/installed-file.man.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "sbin/installed-file.sbin.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "share" {"D"} "share/installed-file.share.root" {"F:a611026bf7b99362c57473c4e1ef30a0"}]
 opam-version: "2.0"
 ### ocaml cat.ml sw-root pkg-root
-==> ${BASEDIR}/OPAM/sw-root/bin/installed-file.bin.root
-==> ${BASEDIR}/OPAM/sw-root/doc/installed-file.doc.root
-==> ${BASEDIR}/OPAM/sw-root/etc/installed-file.etc.root
-==> ${BASEDIR}/OPAM/sw-root/lib/installed-file.lib.root
-==> ${BASEDIR}/OPAM/sw-root/lib/stublibs/installed-file.stublibs.root
-==> ${BASEDIR}/OPAM/sw-root/lib/toplevel/installed-file.lib.root
-==> ${BASEDIR}/OPAM/sw-root/man/installed-file.man.root
-==> ${BASEDIR}/OPAM/sw-root/sbin/installed-file.sbin.root
-==> ${BASEDIR}/OPAM/sw-root/share/installed-file.share.root
+==> No 'installed-file' found
 ### OPAMDEBUG=-5 opam remove pkg-root
 The following actions will be performed:
 === remove 1 package
@@ -2218,7 +2213,6 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 ACTION                          Removing pkg-root.1
 ACTION                          Removing files from .install
 ACTION                          Removing the misc files
-TRACK                           While removing pkg-root.1: files share/installed-file.share.root, sbin/installed-file.sbin.root, man/installed-file.man.root, lib/toplevel/installed-file.lib.root, lib/stublibs/installed-file.stublibs.root, lib/installed-file.lib.root, etc/installed-file.etc.root, doc/installed-file.doc.root, bin/installed-file.bin.root were already removed
 -> removed   pkg-root.1
 ACTION                          Cleaning up artefacts of pkg-root.1
 ACTION                          Removing the local metadata
@@ -2254,15 +2248,14 @@ ACTION                          prepare_package_source: pkg-root.1 at ${BASEDIR}
 TRACK                           before install: 0 elements scanned in 0.000s
 ACTION                          Installing pkg-root.1.
 
-TRACK                           after install: 21 elements, 21 added, scanned in 0.000s
-ACTION                          changes recorded for pkg-root.1: 21 items (addition: 21)
+TRACK                           after install: 19 elements, 19 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-root.1: 19 items (addition: 19)
 -> installed pkg-root.1
 Done.
 ### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
-added: ["not-fst" {"D"} "not-fst/.opam-switch" {"D"} "not-fst/.opam-switch/installed-file.opam-switch.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/bin" {"D"} "not-fst/bin/installed-file.bin.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/doc" {"D"} "not-fst/doc/installed-file.doc.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/etc" {"D"} "not-fst/etc/installed-file.etc.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/lib" {"D"} "not-fst/lib/installed-file.lib.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/lib/stublibs" {"D"} "not-fst/lib/stublibs/installed-file.stublibs.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/lib/toplevel" {"D"} "not-fst/lib/toplevel/installed-file.lib.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/man" {"D"} "not-fst/man/installed-file.man.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/sbin" {"D"} "not-fst/sbin/installed-file.sbin.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/share" {"D"} "not-fst/share/installed-file.share.root" {"F:a611026bf7b99362c57473c4e1ef30a0"}]
+added: ["not-fst" {"D"} "not-fst/bin" {"D"} "not-fst/bin/installed-file.bin.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/doc" {"D"} "not-fst/doc/installed-file.doc.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/etc" {"D"} "not-fst/etc/installed-file.etc.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/lib" {"D"} "not-fst/lib/installed-file.lib.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/lib/stublibs" {"D"} "not-fst/lib/stublibs/installed-file.stublibs.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/lib/toplevel" {"D"} "not-fst/lib/toplevel/installed-file.lib.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/man" {"D"} "not-fst/man/installed-file.man.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/sbin" {"D"} "not-fst/sbin/installed-file.sbin.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/share" {"D"} "not-fst/share/installed-file.share.root" {"F:a611026bf7b99362c57473c4e1ef30a0"}]
 opam-version: "2.0"
 ### ocaml cat.ml sw-root pkg-root
-==> ${BASEDIR}/OPAM/sw-root/not-fst/.opam-switch/installed-file.opam-switch.root
 ==> ${BASEDIR}/OPAM/sw-root/not-fst/bin/installed-file.bin.root
 ==> ${BASEDIR}/OPAM/sw-root/not-fst/doc/installed-file.doc.root
 ==> ${BASEDIR}/OPAM/sw-root/not-fst/etc/installed-file.etc.root
@@ -2282,7 +2275,7 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 ACTION                          Removing pkg-root.1
 ACTION                          Removing files from .install
 ACTION                          Removing the misc files
-TRACK                           While removing pkg-root.1: files not-fst/share/installed-file.share.root, not-fst/sbin/installed-file.sbin.root, not-fst/man/installed-file.man.root, not-fst/lib/toplevel/installed-file.lib.root, not-fst/lib/stublibs/installed-file.stublibs.root, not-fst/lib/installed-file.lib.root, not-fst/etc/installed-file.etc.root, not-fst/doc/installed-file.doc.root, not-fst/bin/installed-file.bin.root, not-fst/.opam-switch/installed-file.opam-switch.root were already removed
+TRACK                           While removing pkg-root.1: files not-fst/share/installed-file.share.root, not-fst/sbin/installed-file.sbin.root, not-fst/man/installed-file.man.root, not-fst/lib/toplevel/installed-file.lib.root, not-fst/lib/stublibs/installed-file.stublibs.root, not-fst/lib/installed-file.lib.root, not-fst/etc/installed-file.etc.root, not-fst/doc/installed-file.doc.root, not-fst/bin/installed-file.bin.root were already removed
 -> removed   pkg-root.1
 ACTION                          Cleaning up artefacts of pkg-root.1
 ACTION                          Removing the local metadata

--- a/tests/reftests/dot-install-non-exe-fields.test
+++ b/tests/reftests/dot-install-non-exe-fields.test
@@ -2114,3 +2114,180 @@ Done.
 # OPAM/sw-root/.opam-switch/install/pkg-root.changes not found
 ### ocaml cat.ml sw-root pkg-root
 ==> No 'installed-file' found
+### :V:5:c: Begins with another field path
+### <pkg:pkg-root.1>
+opam-version: "2.0"
+### <pkg:pkg-root.1:pkg-root.install>
+root: [
+  "installed-file" {"lib/installed-file.lib.root"}
+  "installed-file" {"bin/installed-file.bin.root"}
+  "installed-file" {"sbin/installed-file.sbin.root"}
+  "installed-file" {"share/installed-file.share.root"}
+  "installed-file" {"doc/installed-file.doc.root"}
+  "installed-file" {"etc/installed-file.etc.root"}
+  "installed-file" {"man/installed-file.man.root"}
+  "installed-file" {"lib/toplevel/installed-file.lib.root"}
+  "installed-file" {"lib/stublibs/installed-file.stublibs.root"}
+  ]
+### :V:5:c:1: Begins with another field path, without strict mode
+### OPAMDEBUG=-5 opam install pkg-root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-root.1
+ACTION                          prepare_package_source: pkg-root.1 at ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1
+TRACK                           before install: 7 elements scanned in 0.000s
+ACTION                          Installing pkg-root.1.
+
+TRACK                           after install: 18 elements, 11 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-root.1: 11 items (addition: 11)
+-> installed pkg-root.1
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+added: ["bin/installed-file.bin.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "doc/installed-file.doc.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "etc" {"D"} "etc/installed-file.etc.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "lib/installed-file.lib.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "lib/stublibs/installed-file.stublibs.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "lib/toplevel/installed-file.lib.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "man/installed-file.man.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "sbin/installed-file.sbin.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "share" {"D"} "share/installed-file.share.root" {"F:a611026bf7b99362c57473c4e1ef30a0"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-root pkg-root
+==> ${BASEDIR}/OPAM/sw-root/bin/installed-file.bin.root
+==> ${BASEDIR}/OPAM/sw-root/doc/installed-file.doc.root
+==> ${BASEDIR}/OPAM/sw-root/etc/installed-file.etc.root
+==> ${BASEDIR}/OPAM/sw-root/lib/installed-file.lib.root
+==> ${BASEDIR}/OPAM/sw-root/lib/stublibs/installed-file.stublibs.root
+==> ${BASEDIR}/OPAM/sw-root/lib/toplevel/installed-file.lib.root
+==> ${BASEDIR}/OPAM/sw-root/man/installed-file.man.root
+==> ${BASEDIR}/OPAM/sw-root/sbin/installed-file.sbin.root
+==> ${BASEDIR}/OPAM/sw-root/share/installed-file.share.root
+### OPAMDEBUG=-5 opam remove pkg-root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-root.1: files share/installed-file.share.root, sbin/installed-file.sbin.root, man/installed-file.man.root, lib/toplevel/installed-file.lib.root, lib/stublibs/installed-file.stublibs.root, lib/installed-file.lib.root, etc/installed-file.etc.root, doc/installed-file.doc.root, bin/installed-file.bin.root were already removed
+-> removed   pkg-root.1
+ACTION                          Cleaning up artefacts of pkg-root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+# OPAM/sw-root/.opam-switch/install/pkg-root.changes not found
+### ocaml cat.ml sw-root pkg-root
+==> No 'installed-file' found
+### :V:5:c:2: Begins with another field path, with strict mode
+### OPAMDEBUG=-5 opam install pkg-root --strict
+The following actions will be performed:
+=== install 1 package
+  - install pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-root.1
+ACTION                          prepare_package_source: pkg-root.1 at ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1
+TRACK                           before install: 7 elements scanned in 0.000s
+ACTION                          Installing pkg-root.1.
+
+TRACK                           after install: 18 elements, 11 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-root.1: 11 items (addition: 11)
+-> installed pkg-root.1
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+added: ["bin/installed-file.bin.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "doc/installed-file.doc.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "etc" {"D"} "etc/installed-file.etc.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "lib/installed-file.lib.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "lib/stublibs/installed-file.stublibs.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "lib/toplevel/installed-file.lib.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "man/installed-file.man.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "sbin/installed-file.sbin.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "share" {"D"} "share/installed-file.share.root" {"F:a611026bf7b99362c57473c4e1ef30a0"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-root pkg-root
+==> ${BASEDIR}/OPAM/sw-root/bin/installed-file.bin.root
+==> ${BASEDIR}/OPAM/sw-root/doc/installed-file.doc.root
+==> ${BASEDIR}/OPAM/sw-root/etc/installed-file.etc.root
+==> ${BASEDIR}/OPAM/sw-root/lib/installed-file.lib.root
+==> ${BASEDIR}/OPAM/sw-root/lib/stublibs/installed-file.stublibs.root
+==> ${BASEDIR}/OPAM/sw-root/lib/toplevel/installed-file.lib.root
+==> ${BASEDIR}/OPAM/sw-root/man/installed-file.man.root
+==> ${BASEDIR}/OPAM/sw-root/sbin/installed-file.sbin.root
+==> ${BASEDIR}/OPAM/sw-root/share/installed-file.share.root
+### OPAMDEBUG=-5 opam remove pkg-root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-root.1: files share/installed-file.share.root, sbin/installed-file.sbin.root, man/installed-file.man.root, lib/toplevel/installed-file.lib.root, lib/stublibs/installed-file.stublibs.root, lib/installed-file.lib.root, etc/installed-file.etc.root, doc/installed-file.doc.root, bin/installed-file.bin.root were already removed
+-> removed   pkg-root.1
+ACTION                          Cleaning up artefacts of pkg-root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+# OPAM/sw-root/.opam-switch/install/pkg-root.changes not found
+### ocaml cat.ml sw-root pkg-root
+==> No 'installed-file' found
+### :V:5:d: Forbidden paths in another layer of path
+### <pkg:pkg-root.1>
+opam-version: "2.0"
+### <pkg:pkg-root.1:pkg-root.install>
+root: [
+  "installed-file" {"not-fst/lib/installed-file.lib.root"}
+  "installed-file" {"not-fst/bin/installed-file.bin.root"}
+  "installed-file" {"not-fst/sbin/installed-file.sbin.root"}
+  "installed-file" {"not-fst/share/installed-file.share.root"}
+  "installed-file" {"not-fst/doc/installed-file.doc.root"}
+  "installed-file" {"not-fst/etc/installed-file.etc.root"}
+  "installed-file" {"not-fst/man/installed-file.man.root"}
+  "installed-file" {"not-fst/lib/toplevel/installed-file.lib.root"}
+  "installed-file" {"not-fst/lib/stublibs/installed-file.stublibs.root"}
+  ]
+### OPAMDEBUG=-5 opam install pkg-root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-root.1
+ACTION                          prepare_package_source: pkg-root.1 at ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-root.1.
+
+TRACK                           after install: 21 elements, 21 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-root.1: 21 items (addition: 21)
+-> installed pkg-root.1
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+added: ["not-fst" {"D"} "not-fst/.opam-switch" {"D"} "not-fst/.opam-switch/installed-file.opam-switch.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/bin" {"D"} "not-fst/bin/installed-file.bin.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/doc" {"D"} "not-fst/doc/installed-file.doc.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/etc" {"D"} "not-fst/etc/installed-file.etc.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/lib" {"D"} "not-fst/lib/installed-file.lib.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/lib/stublibs" {"D"} "not-fst/lib/stublibs/installed-file.stublibs.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/lib/toplevel" {"D"} "not-fst/lib/toplevel/installed-file.lib.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/man" {"D"} "not-fst/man/installed-file.man.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/sbin" {"D"} "not-fst/sbin/installed-file.sbin.root" {"F:a611026bf7b99362c57473c4e1ef30a0"} "not-fst/share" {"D"} "not-fst/share/installed-file.share.root" {"F:a611026bf7b99362c57473c4e1ef30a0"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-root pkg-root
+==> ${BASEDIR}/OPAM/sw-root/not-fst/.opam-switch/installed-file.opam-switch.root
+==> ${BASEDIR}/OPAM/sw-root/not-fst/bin/installed-file.bin.root
+==> ${BASEDIR}/OPAM/sw-root/not-fst/doc/installed-file.doc.root
+==> ${BASEDIR}/OPAM/sw-root/not-fst/etc/installed-file.etc.root
+==> ${BASEDIR}/OPAM/sw-root/not-fst/lib/installed-file.lib.root
+==> ${BASEDIR}/OPAM/sw-root/not-fst/lib/stublibs/installed-file.stublibs.root
+==> ${BASEDIR}/OPAM/sw-root/not-fst/lib/toplevel/installed-file.lib.root
+==> ${BASEDIR}/OPAM/sw-root/not-fst/man/installed-file.man.root
+==> ${BASEDIR}/OPAM/sw-root/not-fst/sbin/installed-file.sbin.root
+==> ${BASEDIR}/OPAM/sw-root/not-fst/share/installed-file.share.root
+### OPAMDEBUG=-5 opam remove pkg-root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-root.1: files not-fst/share/installed-file.share.root, not-fst/sbin/installed-file.sbin.root, not-fst/man/installed-file.man.root, not-fst/lib/toplevel/installed-file.lib.root, not-fst/lib/stublibs/installed-file.stublibs.root, not-fst/lib/installed-file.lib.root, not-fst/etc/installed-file.etc.root, not-fst/doc/installed-file.doc.root, not-fst/bin/installed-file.bin.root, not-fst/.opam-switch/installed-file.opam-switch.root were already removed
+-> removed   pkg-root.1
+ACTION                          Cleaning up artefacts of pkg-root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+# OPAM/sw-root/.opam-switch/install/pkg-root.changes not found
+### ocaml cat.ml sw-root pkg-root
+==> No 'installed-file' found

--- a/tests/reftests/dot-install-non-exe-fields.test
+++ b/tests/reftests/dot-install-non-exe-fields.test
@@ -1835,3 +1835,282 @@ Some files in ${BASEDIR}/OPAM/sw-lib_root/.opam-switch/install/pkg-lib_root.inst
 # OPAM/sw-lib_root/.opam-switch/install/pkg-lib_root.changes not found
 ### ocaml cat.ml sw-lib_root pkg-lib_root
 ==> No 'installed-file' found
+### :::::::::::::::::::::::::
+### :V: Field 'root'
+### :::::::::::::::::::::::::
+### mkdir -p REPO/packages/pkg-root/pkg-root.1/files
+### cp installed-file REPO/packages/pkg-root/pkg-root.1/files/installed-file
+### opam switch create sw-root --empty
+### :V:1: No defined destination path
+### <pkg:pkg-root.1>
+opam-version: "2.0"
+### <pkg:pkg-root.1:pkg-root.install>
+root: [ "installed-file" ]
+### OPAMDEBUG=-5 opam install pkg-root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-root.1
+ACTION                          prepare_package_source: pkg-root.1 at ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-root.1.
+
+TRACK                           after install: 1 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-root.1: 1 items (addition: 1)
+-> installed pkg-root.1
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+added: "installed-file" {"F:a611026bf7b99362c57473c4e1ef30a0"}
+opam-version: "2.0"
+### ocaml cat.ml sw-root pkg-root
+==> ${BASEDIR}/OPAM/sw-root/installed-file
+### OPAMDEBUG=-5 opam remove pkg-root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-root.1: files installed-file were already removed
+-> removed   pkg-root.1
+ACTION                          Cleaning up artefacts of pkg-root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+# OPAM/sw-root/.opam-switch/install/pkg-root.changes not found
+### ocaml cat.ml sw-root pkg-root
+==> No 'installed-file' found
+### :V:2: Specify destination path
+### <pkg:pkg-root.1>
+opam-version: "2.0"
+### <pkg:pkg-root.1:pkg-root.install>
+root: [ "installed-file" {"installed-file.root"} ]
+### OPAMDEBUG=-5 opam install pkg-root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-root.1
+ACTION                          prepare_package_source: pkg-root.1 at ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-root.1.
+
+TRACK                           after install: 1 elements, 1 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-root.1: 1 items (addition: 1)
+-> installed pkg-root.1
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+added: "installed-file.root" {"F:a611026bf7b99362c57473c4e1ef30a0"}
+opam-version: "2.0"
+### ocaml cat.ml sw-root pkg-root
+==> ${BASEDIR}/OPAM/sw-root/installed-file.root
+### OPAMDEBUG=-5 opam remove pkg-root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-root.1: files installed-file.root were already removed
+-> removed   pkg-root.1
+ACTION                          Cleaning up artefacts of pkg-root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+# OPAM/sw-root/.opam-switch/install/pkg-root.changes not found
+### ocaml cat.ml sw-root pkg-root
+==> No 'installed-file' found
+### :V:3: Non existing filename, with optional argument
+### <pkg:pkg-root.1>
+opam-version: "2.0"
+### <pkg:pkg-root.1:pkg-root.install>
+root: [ "?finst" ]
+### OPAMDEBUG=-5 opam install pkg-root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-root.1
+ACTION                          prepare_package_source: pkg-root.1 at ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-root.1.
+
+ACTION                          Not installing ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1/finst is not present and optional.
+TRACK                           after install: 0 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-root.1: 0 items
+-> installed pkg-root.1
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-root pkg-root
+==> No 'installed-file' found
+### OPAMDEBUG=-5 opam remove pkg-root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-root.1
+ACTION                          Cleaning up artefacts of pkg-root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+# OPAM/sw-root/.opam-switch/install/pkg-root.changes not found
+### ocaml cat.ml sw-root pkg-root
+==> No 'installed-file' found
+### :V:4: Non existing filename
+### <pkg:pkg-root.1>
+opam-version: "2.0"
+### <pkg:pkg-root.1:pkg-root.install>
+root: [ "finst" ]
+### OPAMDEBUG=-5 opam install pkg-root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-root.1
+ACTION                          prepare_package_source: pkg-root.1 at ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-root.1.
+
+[ERROR] Installation of pkg-root.1 failed
+
+Some files in ${BASEDIR}/OPAM/sw-root/.opam-switch/install/pkg-root.install couldn't be installed:
+  - ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1/finst to ${BASEDIR}/OPAM/sw-root
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - install pkg-root 1
++- 
+- No changes have been performed
+# Return code 31 #
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+# OPAM/sw-root/.opam-switch/install/pkg-root.changes not found
+### ocaml cat.ml sw-root pkg-root
+==> No 'installed-file' found
+### OPAMDEBUG=-5 opam remove pkg-root
+[NOTE] pkg-root is not installed.
+
+Nothing to do.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+# OPAM/sw-root/.opam-switch/install/pkg-root.changes not found
+### ocaml cat.ml sw-root pkg-root
+==> No 'installed-file' found
+### :V:5: Target path is checked
+### :V:5:a: Begins with '.opam-switch'
+### <pkg:pkg-root.1>
+opam-version: "2.0"
+### <pkg:pkg-root.1:pkg-root.install>
+root: [
+  "installed-file" {".opam-switch/installed-file.opam-switch.root"}
+  ]
+### OPAMDEBUG=-5 opam install pkg-root --strict
+The following actions will be performed:
+=== install 1 package
+  - install pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-root.1
+ACTION                          prepare_package_source: pkg-root.1 at ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1
+[WARNING] Errors in ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1/pkg-root.install, some fields have been ignored:
+            - At ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1/pkg-root.install:2:20-2:66::
+              .opam-switch/installed-file.opam-switch.root tries to overwrite opam internal files.
+
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-root.1.
+
+TRACK                           after install: 0 elements, 0 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-root.1: 0 items
+-> installed pkg-root.1
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+opam-version: "2.0"
+### ocaml cat.ml sw-root pkg-root
+==> No 'installed-file' found
+### OPAMDEBUG=-5 opam remove pkg-root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+-> removed   pkg-root.1
+ACTION                          Cleaning up artefacts of pkg-root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+# OPAM/sw-root/.opam-switch/install/pkg-root.changes not found
+### ocaml cat.ml sw-root pkg-root
+==> No 'installed-file' found
+### :V:5:b: Forbidden '.opam-switch' in another layer of path
+### <pkg:pkg-root.1>
+opam-version: "2.0"
+### <pkg:pkg-root.1:pkg-root.install>
+root: [
+  "installed-file" {"not-fst/.opam-switch/installed-file.opam-switch.root"}
+  ]
+### OPAMDEBUG=-5 opam install pkg-root
+The following actions will be performed:
+=== install 1 package
+  - install pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          download_package: pkg-root.1
+ACTION                          prepare_package_source: pkg-root.1 at ${BASEDIR}/OPAM/sw-root/.opam-switch/build/pkg-root.1
+TRACK                           before install: 0 elements scanned in 0.000s
+ACTION                          Installing pkg-root.1.
+
+TRACK                           after install: 3 elements, 3 added, scanned in 0.000s
+ACTION                          changes recorded for pkg-root.1: 3 items (addition: 3)
+-> installed pkg-root.1
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+added: ["not-fst" {"D"} "not-fst/.opam-switch" {"D"} "not-fst/.opam-switch/installed-file.opam-switch.root" {"F:a611026bf7b99362c57473c4e1ef30a0"}]
+opam-version: "2.0"
+### ocaml cat.ml sw-root pkg-root
+==> ${BASEDIR}/OPAM/sw-root/not-fst/.opam-switch/installed-file.opam-switch.root
+### OPAMDEBUG=-5 opam remove pkg-root
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg-root 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+ACTION                          Removing pkg-root.1
+ACTION                          Removing files from .install
+ACTION                          Removing the misc files
+TRACK                           While removing pkg-root.1: files not-fst/.opam-switch/installed-file.opam-switch.root were already removed
+-> removed   pkg-root.1
+ACTION                          Cleaning up artefacts of pkg-root.1
+ACTION                          Removing the local metadata
+Done.
+### opam-cat OPAM/sw-root/.opam-switch/install/pkg-root.changes
+# OPAM/sw-root/.opam-switch/install/pkg-root.changes not found
+### ocaml cat.ml sw-root pkg-root
+==> No 'installed-file' found

--- a/tests/reftests/dot-install.test
+++ b/tests/reftests/dot-install.test
@@ -396,6 +396,13 @@ misc: [
   "dosiero" { "/tmp/../middle/dosiero" }
   "good"    { "good" }
   ]
+root: [
+  "good"     { "windows-sysroot/good" }
+  "internal" { "././.opam-switch/switch-state" }
+  "a-file"   { "../../a-file" }
+  "fichier"  { "/ab/so/lute/path/fichier" }
+  "dosiero"  { "/tmp/../middle/dosiero" }
+  ]
 ### <pkg:eskape.1:a-file>
 hellow
 ### <pkg:eskape.1:fichier>
@@ -437,6 +444,8 @@ SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/good
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/good
 [WARNING] Errors in ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install, some fields have been ignored:
+            - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:34:15-34:29::
+              ../../a-file references its parent directory.
             - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:2:14-2:28::
               ../../a-file references its parent directory.
             - At ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install:8:14-8:28::


### PR DESCRIPTION
This PR adds some checks on the target optional field : it shouldn't begin with another field prefix. There a warning when it is the case (and failure on strict mode)
From https://github.com/ocaml/opam/pull/6938#discussion_r3570687952

Todo :
* [ ] update `Pp.warn`with an optional argument to not display warning only on verbose mode
* [ ] fix toplevel & stublibs paths
* [ ] queued on #6938
