### PR TITLE
reftests: Stop transforming / into \ in command lines on Windows

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -242,6 +242,7 @@ users)
   * Fix the port number range on Windows [#7029 @kit-ty-kate]
   * Wait for background processes to end before removing its working directory [#7030 @kit-ty-kate]
   * Set the `protocol.file.allow=always` git config while running the reftests regardless of `GIT_CONFIG_GLOBAL` [#6992 @kit-ty-kate]
+  * Stop transforming `/` into `\` in command lines on Windows [#7044 @kit-ty-kate]
 
 ## Github Actions
   * Add OCaml 5.4 to the test matrix [#6732 @kit-ty-kate]

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -142,7 +142,7 @@ let escape_regexps s =
     ) s;
   Buffer.contents buf
 
-let str_replace_path ?escape whichway filters s =
+let str_replace_path ?escape ?(wrap_whole_path=true) whichway filters s =
   let s =
     match escape with
     | Some `Unescape -> Re.(replace_string (compile @@ str "\\\\") ~by:"\\" s)
@@ -160,13 +160,17 @@ let str_replace_path ?escape whichway filters s =
     | Some `Unescape | None -> fun s -> s
   in
   List.fold_left (fun s (re, by) ->
-      let re_path = Re.(
-          seq [re; group (rep (diff any (alt [set ":;$\"'"; space])))]
-        ) in
       match by with
       | Sed by ->
-        Re.replace (Re.compile re_path) s ~f:(fun g ->
-            escape_regexps by ^ escape_backslashes (whichway (Re.Group.(get g (nb_groups g - 1)))))
+        if wrap_whole_path then
+          let re_path = Re.(
+              seq [re; group (rep (diff any (alt [set ":;$\"'"; space])))]
+            ) in
+          Re.replace (Re.compile re_path) s ~f:(fun g ->
+              escape_regexps by ^
+              escape_backslashes (whichway (Re.Group.(get g (nb_groups g - 1)))))
+        else
+          Re.replace_string (Re.compile re) s ~by:(escape_regexps by)
       | Grep | GrepV ->
         if (by = Grep) = Re.execp (Re.compile re) s then s else "\\c")
     s filters
@@ -766,7 +770,7 @@ let run_cmd ~opam ~dir ?(vars=[]) ?(filter=[]) ?(silent=false) ?(sort=false) cmd
           if a <> "" && a.[0] = '\'' then a
           else
             str_replace_path ~escape:`Backslashes OpamSystem.forward_to_back
-              var_filters a
+              ~wrap_whole_path:false var_filters a
         in
         Parse.get_str expanded)
       args


### PR DESCRIPTION
Turns out the error shown in #7029 wasn't due to the port number at all but https://github.com/curl/curl/issues/22337 because patterns such as `${VAR}/x/y` would be rewritten `<content of var>\x\y` even in the command line itself (as opposed to the result).