### PR TITLE
Keep the switch description empty upon switch creation instead of guessing one

### DIFF
--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -3099,12 +3099,11 @@ let switch cli =
       in
       if is_new_switch then
         with_repos_rt gt cli repos @@ fun (repos, rt) ->
-        let synopsis = "Import from " ^ Filename.basename filename in
         let (), gt =
           OpamGlobalState.with_write_lock gt @@ fun gt ->
           let gt, st =
             OpamSwitchCommand.create gt ~rt
-              ~synopsis ?repos ~invariant:OpamFormula.Empty
+              ?repos ~invariant:OpamFormula.Empty
               ~update_config:(not no_switch)
               switch
             @@ fun st ->

--- a/src/client/opamSwitchCommand.ml
+++ b/src/client/opamSwitchCommand.ml
@@ -242,23 +242,6 @@ let install_compiler
       "No invariant was set, you may want to use `opam switch set-invariant' \
        to keep a stable compiler version on upgrades.";
   let t =
-    if t.switch_config.OpamFile.Switch_config.synopsis = "" then
-      let synopsis =
-        if invariant = OpamFormula.Empty then
-          OpamSwitch.to_string t.switch
-        else
-          OpamFormula.to_string invariant
-      in
-      let switch_config =
-        { t.switch_config with OpamFile.Switch_config.synopsis }
-      in
-      if not (OpamStateConfig.(!r.dryrun) || OpamClientConfig.(!r.show)) then
-        OpamSwitchAction.install_switch_config t.switch_global.root t.switch
-          switch_config;
-      { t with switch_config }
-    else t
-  in
-  let t =
     let base_comp =
       OpamSwitchState.compute_invariant_packages
         { t with installed = t.installed


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/7061

TODO:
- [ ] add some tests