### PR TITLE
Fix package name inference from project directory names

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -23,6 +23,7 @@ users)
 ## Actions
 
 ## Install
+  * [BUG] Fix package name inference from a local project directory name: the name is everything up to the first dot, and directory names starting with a dot no longer infer a mangled name (`opam install ./.foo` used to infer, pin and install a package named `oo`) [#XXXX @MavenRain - fix #7043]
 
 ## Build (package)
 
@@ -105,6 +106,7 @@ users)
 
 ## Reftests
 ### Tests
+  * Add a test covering package name inference from local project directory names [#XXXX @MavenRain]
 
 ### Engine
 

--- a/src/client/opamAuxCommands.ml
+++ b/src/client/opamAuxCommands.ml
@@ -78,11 +78,16 @@ let remove_files_from_destdir st pfx packages =
       end
   | _ -> ()
 
+(* Guesses a package name from a project directory name: everything up
+   to the first dot, mirroring the name/version split of package
+   strings (e.g. "foo.2.0" gives "foo"). Directory names starting with
+   a dot yield no name (see #7043). *)
 let name_from_project_dirname d =
-  try
-    Some (OpamFilename.(Base.to_string (basename_dir d)) |>
-          Re.(replace_string (compile (seq [char '.'; any]))) ~by:"" |>
-          OpamPackage.Name.of_string)
+  let base = OpamFilename.(Base.to_string (basename_dir d)) in
+  let name =
+    OpamStd.Option.map_default fst base (OpamStd.String.cut_at base '.')
+  in
+  try Some (OpamPackage.Name.of_string name)
   with Failure _ -> None
 
 let url_with_local_branch = function

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1554,6 +1554,27 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:lock.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-name-inference-7043)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (action
+  (diff name-inference-7043.test name-inference-7043.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (deps (alias reftest-name-inference-7043)))
+
+(rule
+ (targets name-inference-7043.out)
+ (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:name-inference-7043.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-no-depexts-sandboxed.unix)
  (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action

--- a/tests/reftests/name-inference-7043.test
+++ b/tests/reftests/name-inference-7043.test
@@ -1,0 +1,49 @@
+N0REP0
+### opam switch create infer --empty
+### :::No package name is inferred from a dot-directory (#7043):::
+### <pin:.foo/opam>
+opam-version: "2.0"
+### opam install ./.foo
+[WARNING] Ignoring file at ${BASEDIR}/.foo/opam: could not infer package name
+[WARNING] No package definitions found at ${BASEDIR}/.foo
+Nothing to do
+### opam install .foo/opam
+[ERROR] Could not infer package name from package definition file ${BASEDIR}/.foo/opam
+# Return code 5 #
+### :::A name.version directory name still infers the name:::
+### <pin:proj.2.0/opam>
+opam-version: "2.0"
+### opam install ./proj.2.0 --show
+The following actions would be performed:
+=== install 1 package
+  - install proj 2.0 (pinned)
+### :::Multi-segment versions still infer via the opam file reader:::
+### <pin:proj2.12.3/opam>
+opam-version: "2.0"
+### opam install ./proj2.12.3 --show
+The following actions would be performed:
+=== install 1 package
+  - install proj2 12.3 (pinned)
+### :::File-form installs infer from the enclosing directory too:::
+### opam install proj.2.0/opam --show
+The following actions would be performed:
+=== install 1 package
+  - install proj 2.0 (pinned)
+### opam install proj2.12.3/opam --show
+The following actions would be performed:
+=== install 1 package
+  - install proj2 12.3 (pinned)
+### :::A dotted name whose stem is not a valid package name declines inference:::
+### <pin:2024.report/opam>
+opam-version: "2.0"
+### opam install ./2024.report
+[WARNING] Ignoring file at ${BASEDIR}/2024.report/opam: could not infer package name
+[WARNING] No package definitions found at ${BASEDIR}/2024.report
+Nothing to do
+### :::A dotted name with an unparseable version part infers the stem:::
+### <pin:foo.1@2/opam>
+opam-version: "2.0"
+### opam install ./foo.1@2 --show
+The following actions would be performed:
+=== install 1 package
+  - install foo dev (pinned)


### PR DESCRIPTION
Fixes #7043.

`name_from_project_dirname` (src/client/opamAuxCommands.ml) inferred a package name from a project directory name by deleting every `.` *plus the character following it* (`Re.replace_string` over the pattern `'.' + any`).  For a hidden directory `.foo` it inferred the name `oo`, which `opam install ./.foo` then happily pinned and installed.

This replaces the deletion with a cut at the **first** dot, the same name/version split `OpamPackage.of_string` uses, and infers no name at all when the basename starts with a dot (empty name part), so those directories fall into the existing "could not infer package name" warning path instead of guessing a mangled name.

| argument | before | after |
|---|---|---|
| `opam install ./.foo` | pins and installs `oo` | warning, no inference |
| `opam install .foo/opam` | pins and installs `oo` | "could not infer package name" error |
| `opam install ./2024.report` | pins and installs `2024eport` | "could not infer package name" warning |
| `opam install ./foo.1@2` | warning, no inference | pins `foo` (dev) |
| `opam install ./proj.2.0` | `proj` 2.0 | `proj` 2.0 (unchanged) |
| `opam install ./proj2.12.3` | `proj2` 12.3 | `proj2` 12.3 (unchanged) |

Notes:

* The old pattern also mangled `name.version`-style basenames at the function level (`proj2.12.3` gave `proj22`), but that never surfaced at the CLI: both call sites consult `OpamFile.OPAM.name_opt` first, and reading a bare `opam` file stamps name and version from the enclosing directory via `OpamPackage.of_filename` (the `pp`/`with_nv` hook in opamFile.ml), which already cuts at the first dot.  `name_from_project_dirname` is only consulted when that parse yields no name, i.e. an undotted basename (unchanged by this PR) or one whose name or version part is invalid, of which the leading dot is the practical case.  Cutting at the first dot keeps the fallback consistent with the reader's split instead of leaving a second, disagreeing parser.  The full set of behaviour flips on that fallback path: a leading-dot basename now declines inference (the #7043 fix);  a dotted basename with an unparseable version part, e.g. `foo.1@2`, previously declined and now infers `foo`;  a dotted basename whose stem is not a valid package name, e.g. `2024.report`, previously inferred the mangled `2024eport` and now declines;  a trailing-dot basename such as `foo.` previously declined and now infers `foo` (not in the reftest because Windows strips trailing dots from file names).
* The issue transcript uses a bare `opam install .foo`;  since #6981, `.foo` without a separator is parsed as a package atom and rejected by the CLI, so the reftest uses `./.foo` (directory form) and `.foo/opam` (file form, which exercises the `name_and_dir_of_opam_file` call site).
* The thread converged on the diagnosis but left open whether `.foo` should infer `foo` or decline inference;  this PR declines, on the grounds that a name opam cannot round-trip from the directory name is better asked of the user explicitly.  Happy to switch to stripping the leading dots if you prefer that UX.

Testing: new reftest `tests/reftests/name-inference-7043.test` covering the dot-directory through both call sites (`./.foo` and `.foo/opam`), the other two fallback flips (`2024.report` declines, `foo.1@2` infers `foo`), and `name.version` directories in both directory and file form, whose behaviour is unchanged.  Reverting the src change flips all three fallback cases (`oo` and `2024eport` pinned and installed, `foo.1@2` declining inference), so the test pins the fix.

<sub>Drafted with AI assistance;  root-caused, reviewed and tested by me.</sub>
