### PR TITLE
opam init --reinit now regenerate the list of valid switches and their associated metadata

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -32,6 +32,7 @@ users)
 ## UI
 
 ## Switch
+  * Add debug log when switch list is fixed [#7068 @rjbou]
 
 ## Config
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -109,6 +109,7 @@ users)
 ## Reftests
 ### Tests
   * Add a test showing `opam init --reinit` upgrading from pre opam 2.6 `OPAMREPOTARRING=1` (aka. opam 2.1's default) [#7058 @kit-ty-kate]
+  * Add `opam init --reinit` regenerating cache & fixing switch test [#7068 @rjbou]
 
 ### Engine
   * Stop the testsuite from generating files containing CRLF [#7071 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -18,6 +18,7 @@ users)
 
 ## Init
   * Do not make `opam init --reinit` ask to retry the command when upgrading from a 2.1 root [#7058 @kit-ty-kate - fix #7057]
+  * `opam init --reinit` now regenerate the list of valid switches, fix switch internal data (cache, config, packages) [#7068 @kit-ty-kate - fix #7066]
 
 ## Config report
 

--- a/src/client/opamClient.ml
+++ b/src/client/opamClient.ml
@@ -1674,6 +1674,13 @@ let reinit ?(init_config=OpamInitDefaults.init_config()) ~interactive
     OpamRepositoryCommand.update_with_auto_upgrade rt
       (OpamRepositoryName.Map.keys rt.repos_definitions)
   in
+  (* Sanitize switch list *)
+  let gt = OpamGlobalState.fix_switch_list gt in
+  (* Load each switch to make sure their cache and switch config
+     are up-to-date *)
+  List.iter (fun sw ->
+      OpamSwitchState.drop (OpamSwitchState.load `Lock_write gt rt sw))
+    (OpamFile.Config.installed_switches gt.config);
   OpamRepositoryState.drop rt
 
 let has_space s = String.contains s ' '

--- a/src/state/opamGlobalState.ml
+++ b/src/state/opamGlobalState.ml
@@ -14,7 +14,7 @@ open OpamFilename.Op
 
 open OpamStateTypes
 
-let log fmt = OpamConsole.log "GSTATE" fmt
+let log ?level fmt = OpamConsole.log ?level "GSTATE" fmt
 let slog = OpamConsole.slog
 
 let load_config lock_kind global_lock root =
@@ -53,6 +53,10 @@ let load_config lock_kind global_lock root =
   config
 
 let inferred_from_system = "Inferred from system"
+let string_of_removed_switches ~orig:switches0 switches =
+  OpamStd.Format.pretty_list (List.filter_map (fun sw ->
+      if OpamStd.List.mem OpamSwitch.equal sw switches then None
+      else Some (OpamSwitch.to_string sw)) switches0)
 
 let load lock_kind =
   let root = OpamStateConfig.(!r.root_dir) in
@@ -83,13 +87,22 @@ let load lock_kind =
          load with best-effort (read-only)"
       (OpamVersion.to_string (OpamFile.Config.opam_root_version config))
       (OpamVersion.to_string (OpamFile.Config.root_version));
+  let switches0 = OpamFile.Config.installed_switches config in
   let switches =
     List.filter
-      (fun sw -> not (OpamSwitch.is_external sw) ||
-                 OpamFilename.exists_dir (OpamSwitch.get_root root sw))
-      (OpamFile.Config.installed_switches config)
+      (fun sw ->
+         not (OpamSwitch.is_external sw) ||
+         OpamFilename.exists_dir (OpamSwitch.get_root root sw))
+      switches0
   in
-  let config = OpamFile.Config.with_installed_switches switches config in
+  let config =
+    if OpamCompat.List.equal OpamSwitch.equal switches0 switches then
+      config
+    else
+      (log ~level:4 "Cleaning switch list: removed %a"
+         (slog (string_of_removed_switches ~orig:switches0)) switches;
+       OpamFile.Config.with_installed_switches switches config)
+  in
   let global_variables =
     List.fold_left (fun acc (v,value) ->
         OpamVariable.Map.add v
@@ -217,18 +230,22 @@ let fix_switch_list gt =
       else sw::known_switches0
   in
   let known_switches = List.filter (switch_exists gt) known_switches in
-  if known_switches = known_switches0 then gt else
-  let config =
-    OpamFile.Config.with_installed_switches known_switches gt.config
-  in
-  let gt = { gt with config } in
-  if not OpamCoreConfig.(!r.safe_mode)
-  && OpamSystem.get_lock_flag gt.global_lock = `Lock_write then
-    try
-      snd @@ with_write_lock ~dontblock:true gt @@ fun gt ->
-      write gt, gt
-    with OpamSystem.Locked -> gt
-  else gt
+  if OpamCompat.List.equal OpamSwitch.equal known_switches known_switches0 then
+    gt
+  else
+    (log ~level:4 "Fixing switch list: removed %a"
+       (slog (string_of_removed_switches ~orig:known_switches0)) known_switches;
+     let config =
+       OpamFile.Config.with_installed_switches known_switches gt.config
+     in
+     let gt = { gt with config } in
+     if not OpamCoreConfig.(!r.safe_mode)
+     && OpamSystem.get_lock_flag gt.global_lock = `Lock_write then
+       try
+         snd @@ with_write_lock ~dontblock:true gt @@ fun gt ->
+         write gt, gt
+       with OpamSystem.Locked -> gt
+     else gt)
 
 let is_root_read_only gt =
   OpamFilename.is_dir_read_only gt.root

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -566,6 +566,7 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(config)                    Wrote ${BASEDIR}/OPAM/config atomically in 0.000s
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+GSTATE                          Cleaning switch list: removed /void/woosh
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/REPO

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -508,3 +508,82 @@ Switch initialisation failed: clean up? ('n' will leave the switch partially ins
 [NOTE] Opam has been initialised, but the initial switch creation failed.
        Use opam switch create default --formula '["fail-compiler" {= "1"} | "ocaml" {>= "4.10"}]' to get started.
 # Return code 31 #
+### :V: Reinit fixing switches list, and internal state of switch
+### rm -rf $OPAMROOT
+### <pkg:pina.1>
+opam-version: "2.0"
+### <pkg:ta.1>
+opam-version: "2.0"
+### opam init --no-setup --bypass-checks default REPO/ --bare | grep -v Cygwin
+No configuration file found, using built-in defaults.
+
+<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+[default] Initialised
+### # create some switches
+### opam switch create normal --empty
+### opam switch create ./real-local --empty
+### opam switch create corrupted --empty
+### opam install pina ta
+The following actions will be performed:
+=== install 2 packages
+  - install pina 1
+  - install ta   1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed pina.1
+-> installed ta.1
+Done.
+### opam sw normal
+### # corrupt installed opams cache
+### cp REPO/repo OPAM/corrupted/.opam-switch/packages/cache
+### # add in config file non existing local switches
+### mkdir -p empty-dir/_opam
+### <new-config.sh>
+basedir=$(printf '%s' "$BASEDIR" | sed 's/\\/\\\\/g')
+cat > OPAM/config << EOF
+opam-version: "2.0"
+opam-root-version: "2.6~alpha"
+repositories: "default"
+installed-switches: [
+  "normal"
+  "corrupted"
+  "${basedir}/real-local"
+  "${basedir}/woosh"
+  "${basedir}/empty-dir"
+]
+switch: "normal"
+EOF
+### sh new-config.sh
+### # corrupt switch-config by removing synopsis
+### sed -i.bak '/synopsis/d' OPAM/corrupted/.opam-switch/switch-config
+### # remove ta.1 definition from switch
+### rm -r OPAM/corrupted/.opam-switch/packages/ta.1
+### OPAMDEBUG=-5 OPAMDEBUGSECTIONS="CACHE(installed) FILE(switch-config) STATE GSTATE FILE(config)"
+### opam init --reinit --no-setup --bypass-checks | 'Bad installed cache: .*' -> 'Bad installed cache: ...'
+No configuration file found, using built-in defaults.
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+FILE(config)                    Wrote ${BASEDIR}/OPAM/config atomically in 0.000s
+GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+
+<><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+[default] no changes from file://${BASEDIR}/REPO
+### # check that everything was fixed
+### head OPAM/config
+opam-version: "2.0"
+opam-root-version: "2.6~alpha"
+repositories: "default"
+installed-switches: [
+  "normal"
+  "corrupted"
+  "${BASEDIR}/real-local"
+  "${BASEDIR}/woosh"
+  "${BASEDIR}/empty-dir"
+]
+### grep synopsis OPAM/corrupted/.opam-switch/switch-config
+# Return code 1 #
+### test -f OPAM/corrupted/.opam-switch/packages/ta.1/opam
+# Return code 1 #
+### opam-cache installed corrupted
+No cache

--- a/tests/reftests/init.test
+++ b/tests/reftests/init.test
@@ -566,10 +566,40 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(config)                    Wrote ${BASEDIR}/OPAM/config atomically in 0.000s
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
-GSTATE                          Cleaning switch list: removed /void/woosh
+GSTATE                          Cleaning switch list: removed ${BASEDIR}/woosh
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/REPO
+FILE(switch-config)             Read ${BASEDIR}/real-local/_opam/.opam-switch/switch-config in 0.000s
+GSTATE                          Fixing switch list: removed ${BASEDIR}/empty-dir
+FILE(config)                    Wrote ${BASEDIR}/OPAM/config atomically in 0.000s
+STATE                           LOAD-SWITCH-STATE @ normal
+FILE(switch-config)             Read ${BASEDIR}/real-local/_opam/.opam-switch/switch-config in 0.000s
+FILE(switch-config)             Read ${BASEDIR}/OPAM/normal/.opam-switch/switch-config in 0.000s
+CACHE(installed)                Loaded ${BASEDIR}/OPAM/normal/.opam-switch/packages/cache in 0.000s
+STATE                           Inferred invariant: from base packages {}, (roots {}) => []
+FILE(switch-config)             Wrote ${BASEDIR}/OPAM/normal/.opam-switch/switch-config atomically in 0.000s
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ corrupted
+FILE(switch-config)             Read ${BASEDIR}/real-local/_opam/.opam-switch/switch-config in 0.000s
+FILE(switch-config)             Read ${BASEDIR}/OPAM/corrupted/.opam-switch/switch-config in 0.000s
+CACHE(installed)                Bad installed cache: ...
+CACHE(installed)                Invalid installed cache, removing
+CACHE(installed)                Writing the installed cache to ${BASEDIR}/OPAM/corrupted/.opam-switch/packages/cache ...
+CACHE(installed)                ${BASEDIR}/OPAM/corrupted/.opam-switch/packages/cache written in 0.000s
+STATE                           Definition missing for installed package ta.1, copying from repo
+STATE                           Inferred invariant: from base packages {}, (roots {}) => []
+FILE(switch-config)             Wrote ${BASEDIR}/OPAM/corrupted/.opam-switch/switch-config atomically in 0.000s
+FILE(switch-config)             Wrote ${BASEDIR}/OPAM/corrupted/.opam-switch/switch-config atomically in 0.000s
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}/real-local
+FILE(switch-config)             Read ${BASEDIR}/real-local/_opam/.opam-switch/switch-config in 0.000s
+FILE(switch-config)             Read ${BASEDIR}/real-local/_opam/.opam-switch/switch-config in 0.000s
+FILE(switch-config)             Read ${BASEDIR}/real-local/_opam/.opam-switch/switch-config in 0.000s
+CACHE(installed)                Loaded ${BASEDIR}/real-local/_opam/.opam-switch/packages/cache in 0.000s
+STATE                           Inferred invariant: from base packages {}, (roots {}) => []
+FILE(switch-config)             Wrote ${BASEDIR}/real-local/_opam/.opam-switch/switch-config atomically in 0.000s
+STATE                           Switch state loaded in 0.000s
 ### # check that everything was fixed
 ### head OPAM/config
 opam-version: "2.0"
@@ -579,12 +609,14 @@ installed-switches: [
   "normal"
   "corrupted"
   "${BASEDIR}/real-local"
-  "${BASEDIR}/woosh"
-  "${BASEDIR}/empty-dir"
 ]
+switch: "normal"
+download-jobs: 3
 ### grep synopsis OPAM/corrupted/.opam-switch/switch-config
-# Return code 1 #
+synopsis: "corrupted"
 ### test -f OPAM/corrupted/.opam-switch/packages/ta.1/opam
-# Return code 1 #
 ### opam-cache installed corrupted
-No cache
+=> pina.1 <=
+opam-version: "2.0"
+name: "pina"
+version: "1"

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -1019,6 +1019,21 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.1 }, (roots { i-am-sys-compiler.1 }) => ["i-am-sys-compiler"]
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Inferred invariant: from base packages { i-am-compiler.2 }, (roots { i-am-compiler.2 }) => ["i-am-compiler" {>= "2"}]
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Inferred invariant: from base packages { i-am-sys-compiler.2 }, (roots { i-am-sys-compiler.2 }) => ["i-am-sys-compiler"]
+STATE                           Switch state loaded in 0.000s
 ### opam switch --short
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 ${BASEDIR}
@@ -1042,7 +1057,7 @@ depext: true
 depext-cannot-install: false
 depext-run-installs: true
 download-jobs: 3
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+installed-switches: ["${BASEDIR}" "sw-sys-comp" "sw-comp" "default"]
 opam-root-version: current
 opam-version: "2.0"
 repositories: "default"
@@ -1074,6 +1089,16 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
 Update done, please now retry your command.
 # Return code 10 #
 ### # ro global state, ro repo state, ro switch state
@@ -1165,6 +1190,19 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
 Update done, please now retry your command.
 # Return code 10 #
 ### # ro global state, ro repo state, rw switch state
@@ -1240,6 +1278,16 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
 Update done, please now retry your command.
 # Return code 10 #
 ### # ro global state, ro repo state, rw switch state
@@ -1382,6 +1430,18 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
 Update done.
 ### opam switch --short
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
@@ -1406,7 +1466,7 @@ depext: true
 depext-cannot-install: false
 depext-run-installs: true
 download-jobs: 3
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+installed-switches: ["${BASEDIR}" "sw-sys-comp" "sw-comp" "default"]
 opam-root-version: current
 opam-version: "2.0"
 repositories: "default"
@@ -1441,6 +1501,16 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
 Update done, please now retry your command.
 # Return code 10 #
 ### # ro global state, ro repo state, ro switch state
@@ -1534,6 +1604,19 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
 Update done, please now retry your command.
 # Return code 10 #
 ### # ro global state, ro repo state, rw switch state
@@ -1611,6 +1694,16 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
 Update done, please now retry your command.
 # Return code 10 #
 ### # ro global state, ro repo state, rw switch state
@@ -1754,6 +1847,18 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
 Update done.
 ### opam switch --short
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
@@ -1778,7 +1883,7 @@ depext: true
 depext-cannot-install: false
 depext-run-installs: true
 download-jobs: 3
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+installed-switches: ["${BASEDIR}" "sw-sys-comp" "sw-comp" "default"]
 opam-root-version: current
 opam-version: "2.0"
 repositories: "default"
@@ -2095,6 +2200,18 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
 ### opam switch --short
 GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 ${BASEDIR}
@@ -2118,7 +2235,7 @@ depext: true
 depext-cannot-install: false
 depext-run-installs: true
 download-jobs: 3
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+installed-switches: ["${BASEDIR}" "sw-sys-comp" "sw-comp" "default"]
 opam-root-version: current
 opam-version: "2.0"
 repositories: "default"
@@ -2456,6 +2573,18 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables | grep -v eval-variables:
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
@@ -2463,7 +2592,7 @@ depext: true
 depext-cannot-install: false
 depext-run-installs: true
 download-jobs: 3
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+installed-switches: ["${BASEDIR}" "sw-sys-comp" "sw-comp" "default"]
 opam-root-version: current
 opam-version: "2.0"
 repositories: "default"
@@ -2821,6 +2950,18 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
@@ -2829,7 +2970,7 @@ depext-cannot-install: false
 depext-run-installs: true
 download-jobs: 3
 eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+installed-switches: ["${BASEDIR}" "sw-sys-comp" "sw-comp" "default"]
 opam-root-version: current
 opam-version: "2.0"
 repositories: "default"
@@ -3177,6 +3318,18 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
@@ -3185,7 +3338,7 @@ depext-cannot-install: false
 depext-run-installs: true
 download-jobs: 3
 eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+installed-switches: ["${BASEDIR}" "sw-sys-comp" "sw-comp" "default"]
 opam-root-version: current
 opam-version: "2.0"
 repositories: "default"
@@ -3533,6 +3686,18 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
@@ -3541,7 +3706,7 @@ depext-cannot-install: false
 depext-run-installs: true
 download-jobs: 3
 eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
-installed-switches: ["sw-sys-comp" "sw-comp" "default"]
+installed-switches: ["${BASEDIR}" "sw-sys-comp" "sw-comp" "default"]
 opam-root-version: current
 opam-version: "2.0"
 repositories: "default"
@@ -3591,6 +3756,16 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
 Update done.
 ### test -f OPAM/repo/default.tar.gz
 # Return code 1 #
@@ -3863,6 +4038,22 @@ RSTATE                          loaded opam files from repo default in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 [default] no changes from file://${BASEDIR}/default
+STATE                           LOAD-SWITCH-STATE @ ${BASEDIR}
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-sys-comp
+STATE                           Definition missing for installed package i-am-another-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-package.2, copying from repo
+STATE                           Definition missing for installed package i-am-sys-compiler.1, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ sw-comp
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ default
+STATE                           Definition missing for installed package i-am-sys-compiler.2, copying from repo
+STATE                           Switch state loaded in 0.000s
+STATE                           LOAD-SWITCH-STATE @ this-internal-error
+[ERROR] No config file found for switch this-internal-error. Switch broken?
+STATE                           Inferred invariant: from base packages {}, (roots {}) => []
+STATE                           Switch state loaded in 0.000s
 ### opam-cat $OPAMROOT/config | '"${OPAMROOTVERSION}"' -> "current" | grep -v sys-pkg-manager-cmd | grep -v global-variables
 default-compiler: ["i-am-sys-compiler" "i-am-compiler"]
 default-invariant: ["i-am-sys-compiler"]
@@ -3871,7 +4062,7 @@ depext-cannot-install: false
 depext-run-installs: true
 download-jobs: 3
 eval-variables: [sys-comp-version ["sh" "-c" "echo $OPAMSYSCOMP"] "comp version"]
-installed-switches: ["sw-sys-comp" "sw-comp" "default" "${BASEDIR}/why-did-you-delete-me" "this-internal-error"]
+installed-switches: ["${BASEDIR}" "sw-sys-comp" "sw-comp" "default" "this-internal-error"]
 opam-root-version: current
 opam-version: "2.0"
 repositories: "default"


### PR DESCRIPTION
Fixes #7066 

This also changes the behaviour of `opam init --reinit` slightly in more subtle manner but consistent with regular handling of switches:
- `$PWD` is added to the list of switches if `$PWD/_opam` is a valid switch
- invalid switches are removed from the list
- fix corrupted switch config files