### PR TITLE
Fix generated PowerShell init script

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -389,9 +389,9 @@ let main_test_job ~analyse_job ~build_linux_job ~build_windows_job:_ ~build_macO
   job ~oc ~workflow ?section ~runs_on:(Runner [runner])
     ~env:[("OPAM_TEST", "1"); ("GITHUB_PR_USER", "${{ github.event.pull_request.user.login }}")]
     ~matrix ~needs ("Test-" ^ name_of_platform platform)
-    ++ only_on MacOS (install_sys_packages ["coreutils"; "gpatch"; "rsync"] ~descr:"Install gnu coreutils" [MacOS])
+    ++ only_on MacOS (install_sys_packages ["coreutils"; "fish"; "gpatch"; "rsync"; "tcsh"; "zsh"] ~descr:"Install test dependencies" [MacOS])
     ++ checkout ()
-    ++ only_on Linux (run "Install bubblewrap" ["sudo apt install bubblewrap"])
+    ++ only_on Linux (install_sys_packages ["bubblewrap"; "fish"; "tcsh"; "zsh"] ~descr:"Install test dependencies" [Linux])
     ++ only_on Linux (run "Disable AppArmor" ["echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns"])
     ++ cache Archives
     ++ cache OCaml platform ocamlv host

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -370,7 +370,7 @@ let main_build_job ~analyse_job ~cygwin_job ?section runner start_version ~oc ~w
            {|opam list|};
            {|opam config report|};
           ]))
-    ++ only_on Windows (run "Test (reftests)" ["bash -exu .github/scripts/main/reftests.sh ${{ matrix.host }}"])
+    ++ only_on Windows (run "Test (reftests)" ["PATH='/cygdrive/c/Program Files/PowerShell/7':$PATH bash -exu .github/scripts/main/reftests.sh ${{ matrix.host }}"])
     ++ end_job f
 
 let main_test_job ~analyse_job ~build_linux_job ~build_windows_job:_ ~build_macOS_job:_ ?section runner ~oc ~workflow f =

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -245,7 +245,7 @@ jobs:
         opam list || exit /b 1
         opam config report || exit /b 1
     - name: Test (reftests)
-      run: bash -exu .github/scripts/main/reftests.sh ${{ matrix.host }}
+      run: PATH='/cygdrive/c/Program Files/PowerShell/7':$PATH bash -exu .github/scripts/main/reftests.sh ${{ matrix.host }}
 
   Build-macOS:
     runs-on: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -302,8 +302,8 @@ jobs:
     steps:
     - name: Checkout tree
       uses: actions/checkout@v7
-    - name: Install bubblewrap
-      run: sudo apt install bubblewrap
+    - name: Install test dependencies
+      run: sudo apt install bubblewrap fish tcsh zsh
     - name: Disable AppArmor
       run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
     - name: src_ext/archives and opam-repository Cache
@@ -357,8 +357,8 @@ jobs:
       OPAM_TEST: 1
       GITHUB_PR_USER: ${{ github.event.pull_request.user.login }}
     steps:
-    - name: Install gnu coreutils
-      run: brew install coreutils gpatch rsync
+    - name: Install test dependencies
+      run: brew install coreutils fish gpatch rsync tcsh zsh
     - name: Checkout tree
       uses: actions/checkout@v7
     - name: src_ext/archives and opam-repository Cache

--- a/master_changes.md
+++ b/master_changes.md
@@ -17,6 +17,7 @@ users)
 ## Plugins
 
 ## Init
+  * [BUG] Fix invalid PowerShell syntax in generated init scripts [@flandia]
 
 ## Config report
 

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -1073,7 +1073,7 @@ let source root shell f =
   | SH_cmd ->
     Printf.sprintf "if exist \"%s\" call \"%s\" >NUL 2>NUL\n" fname fname
   | SH_pwsh _ ->
-    Printf.sprintf "if Test-Path \"%s\" { . \"%s\" *> $null }\n" fname fname
+    Printf.sprintf "if (Test-Path \"%s\") { . \"%s\" *> $null }\n" fname fname
 
 let if_interactive_script shell t e =
   let ielse else_opt = match else_opt with

--- a/tests/reftests/init-scripts.unix.test
+++ b/tests/reftests/init-scripts.unix.test
@@ -35,6 +35,7 @@ if [ -t 0 ]; then
 fi
 
 test -r '${BASEDIR}/root/opam-init/variables.sh' && . '${BASEDIR}/root/opam-init/variables.sh' > /dev/null 2> /dev/null || true
+### sh -n root/opam-init/init.sh
 ### cat root/opam-init/init.zsh
 if [[ -o interactive ]]; then
   [[ ! -r '${BASEDIR}/root/opam-init/complete.zsh' ]] || source '${BASEDIR}/root/opam-init/complete.zsh' > /dev/null 2> /dev/null; true
@@ -43,18 +44,21 @@ if [[ -o interactive ]]; then
 fi
 
 [[ ! -r '${BASEDIR}/root/opam-init/variables.sh' ]] || source '${BASEDIR}/root/opam-init/variables.sh' > /dev/null 2> /dev/null; true
+### zsh -f -n root/opam-init/init.zsh
 ### cat root/opam-init/init.fish
 if status is-interactive
   test -r '${BASEDIR}/root/opam-init/env_hook.fish' && source '${BASEDIR}/root/opam-init/env_hook.fish' > /dev/null 2> /dev/null; or true
 end
 
 test -r '${BASEDIR}/root/opam-init/variables.fish' && source '${BASEDIR}/root/opam-init/variables.fish' > /dev/null 2> /dev/null; or true
+### fish --no-config --no-execute root/opam-init/init.fish
 ### cat root/opam-init/init.csh
 if ( $?prompt ) then
   if ( -f '${BASEDIR}/root/opam-init/env_hook.csh' ) source '${BASEDIR}/root/opam-init/env_hook.csh' >& /dev/null
 endif
 
 if ( -f '${BASEDIR}/root/opam-init/variables.csh' ) source '${BASEDIR}/root/opam-init/variables.csh' >& /dev/null
+### tcsh -f -n root/opam-init/init.csh
 ### cat root/opam-init/init.cmd
 if exist "${BASEDIR}/root/opam-init/variables.cmd" call "${BASEDIR}/root/opam-init/variables.cmd" >NUL 2>NUL
 ### cat root/opam-init/init.ps1

--- a/tests/reftests/init-scripts.unix.test
+++ b/tests/reftests/init-scripts.unix.test
@@ -58,7 +58,7 @@ if ( -f '${BASEDIR}/root/opam-init/variables.csh' ) source '${BASEDIR}/root/opam
 ### cat root/opam-init/init.cmd
 if exist "${BASEDIR}/root/opam-init/variables.cmd" call "${BASEDIR}/root/opam-init/variables.cmd" >NUL 2>NUL
 ### cat root/opam-init/init.ps1
-if Test-Path "${BASEDIR}/root/opam-init/variables.ps1" { . "${BASEDIR}/root/opam-init/variables.ps1" *> $null }
+if (Test-Path "${BASEDIR}/root/opam-init/variables.ps1") { . "${BASEDIR}/root/opam-init/variables.ps1" *> $null }
 ### : Variables scripts :
 ### cat root/opam-init/variables.sh | grep -v man | grep -v MANPATH
 test -z "${OPAM_SWITCH_PREFIX:+x}" || return 0

--- a/tests/reftests/init-scripts.unix.test
+++ b/tests/reftests/init-scripts.unix.test
@@ -63,7 +63,6 @@ if ( -f '${BASEDIR}/root/opam-init/variables.csh' ) source '${BASEDIR}/root/opam
 if exist "${BASEDIR}/root/opam-init/variables.cmd" call "${BASEDIR}/root/opam-init/variables.cmd" >NUL 2>NUL
 ### cat root/opam-init/init.ps1
 if (Test-Path "${BASEDIR}/root/opam-init/variables.ps1") { . "${BASEDIR}/root/opam-init/variables.ps1" *> $null }
-### pwsh -NoLogo -NoProfile -NonInteractive -File root/opam-init/init.ps1
 ### : Variables scripts :
 ### cat root/opam-init/variables.sh | grep -v man | grep -v MANPATH
 test -z "${OPAM_SWITCH_PREFIX:+x}" || return 0

--- a/tests/reftests/init-scripts.unix.test
+++ b/tests/reftests/init-scripts.unix.test
@@ -58,7 +58,7 @@ if ( $?prompt ) then
 endif
 
 if ( -f '${BASEDIR}/root/opam-init/variables.csh' ) source '${BASEDIR}/root/opam-init/variables.csh' >& /dev/null
-### tcsh -f -n root/opam-init/init.csh
+### tcsh -f -c 'source root/opam-init/init.csh'
 ### cat root/opam-init/init.cmd
 if exist "${BASEDIR}/root/opam-init/variables.cmd" call "${BASEDIR}/root/opam-init/variables.cmd" >NUL 2>NUL
 ### cat root/opam-init/init.ps1

--- a/tests/reftests/init-scripts.unix.test
+++ b/tests/reftests/init-scripts.unix.test
@@ -63,6 +63,7 @@ if ( -f '${BASEDIR}/root/opam-init/variables.csh' ) source '${BASEDIR}/root/opam
 if exist "${BASEDIR}/root/opam-init/variables.cmd" call "${BASEDIR}/root/opam-init/variables.cmd" >NUL 2>NUL
 ### cat root/opam-init/init.ps1
 if (Test-Path "${BASEDIR}/root/opam-init/variables.ps1") { . "${BASEDIR}/root/opam-init/variables.ps1" *> $null }
+### pwsh -NoLogo -NoProfile -NonInteractive -File root/opam-init/init.ps1
 ### : Variables scripts :
 ### cat root/opam-init/variables.sh | grep -v man | grep -v MANPATH
 test -z "${OPAM_SWITCH_PREFIX:+x}" || return 0

--- a/tests/reftests/init-scripts.win32.test
+++ b/tests/reftests/init-scripts.win32.test
@@ -57,7 +57,8 @@ if ( -f '${BASEDIR}/root/opam-init/variables.csh' ) source '${BASEDIR}/root/opam
 ### cat root/opam-init/init.cmd
 if exist "${BASEDIR}/root/opam-init/variables.cmd" call "${BASEDIR}/root/opam-init/variables.cmd" >NUL 2>NUL
 ### cat root/opam-init/init.ps1
-if Test-Path "${BASEDIR}/root/opam-init/variables.ps1" { . "${BASEDIR}/root/opam-init/variables.ps1" *> $null }
+if (Test-Path "${BASEDIR}/root/opam-init/variables.ps1") { . "${BASEDIR}/root/opam-init/variables.ps1" *> $null }
+### powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File root/opam-init/init.ps1
 ### : Variables scripts :
 ### cat root/opam-init/variables.sh | grep -v man | grep -v MANPATH
 test -z "${OPAM_SWITCH_PREFIX:+x}" || return 0

--- a/tests/reftests/init-scripts.win32.test
+++ b/tests/reftests/init-scripts.win32.test
@@ -60,6 +60,7 @@ if exist "${BASEDIR}/root/opam-init/variables.cmd" call "${BASEDIR}/root/opam-in
 ### cat root/opam-init/init.ps1
 if (Test-Path "${BASEDIR}/root/opam-init/variables.ps1") { . "${BASEDIR}/root/opam-init/variables.ps1" *> $null }
 ### powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File root/opam-init/init.ps1
+### pwsh.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File root/opam-init/init.ps1
 ### : Variables scripts :
 ### cat root/opam-init/variables.sh | grep -v man | grep -v MANPATH
 test -z "${OPAM_SWITCH_PREFIX:+x}" || return 0

--- a/tests/reftests/init-scripts.win32.test
+++ b/tests/reftests/init-scripts.win32.test
@@ -56,6 +56,7 @@ endif
 if ( -f '${BASEDIR}/root/opam-init/variables.csh' ) source '${BASEDIR}/root/opam-init/variables.csh' >& /dev/null
 ### cat root/opam-init/init.cmd
 if exist "${BASEDIR}/root/opam-init/variables.cmd" call "${BASEDIR}/root/opam-init/variables.cmd" >NUL 2>NUL
+### cmd.exe /D /Q /C call root\\opam-init\\init.cmd
 ### cat root/opam-init/init.ps1
 if (Test-Path "${BASEDIR}/root/opam-init/variables.ps1") { . "${BASEDIR}/root/opam-init/variables.ps1" *> $null }
 ### powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File root/opam-init/init.ps1


### PR DESCRIPTION
## Problem

Since #5864, opam has generated the following PowerShell:

```powershell
if Test-Path "...\variables.ps1" { ... }
```

PowerShell requires parentheses around an `if` condition and rejects this
script with:

```text
Missing '(' after 'if' in if statement.
```

## Fix

Generate valid PowerShell syntax:

```powershell
if (Test-Path "...\variables.ps1") { ... }
```

The Windows reftest now executes the generated script using Windows
PowerShell, ensuring future syntax errors fail the test.

## Testing

```powershell
dune build --profile=release --root . '@reftest-init-scripts.win32' --force
```

The generated script was also executed successfully with Windows PowerShell
5.1 and PowerShell 7.