### PR TITLE
Stop the testsuite from generating files containing CRLF

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -109,6 +109,7 @@ users)
 ### Tests
 
 ### Engine
+  * Stop the testsuite from generating files containing CRLF [#7071 @kit-ty-kate]
 
 ## Github Actions
 

--- a/tests/reftests/init-ocaml-eval-variables.unix.test
+++ b/tests/reftests/init-ocaml-eval-variables.unix.test
@@ -31,7 +31,7 @@ let _ =
   in
   let name = Filename.concat opamroot "config" in
   let content = get_files Sys.argv.(1) in
-  let fd = open_out name in
+  let fd = open_out_bin name in
   List.iter (fun l -> output_string fd (l^"\n")) content;
   close_out fd
 ### rm -rf "$OPAMROOT"

--- a/tests/reftests/init-ocaml-eval-variables.win32.test
+++ b/tests/reftests/init-ocaml-eval-variables.win32.test
@@ -31,7 +31,7 @@ let _ =
   in
   let name = Filename.concat opamroot "config" in
   let content = get_files Sys.argv.(1) in
-  let fd = open_out name in
+  let fd = open_out_bin name in
   List.iter (fun l -> output_string fd (l^"\n")) content;
   close_out fd
 ### rm -rf "$OPAMROOT"

--- a/tests/reftests/opamroot-versions.test
+++ b/tests/reftests/opamroot-versions.test
@@ -42,7 +42,7 @@ let _ =
        ])
   in
   List.iter (fun (name, content) ->
-      let fd = open_out name in
+      let fd = open_out_bin name in
       List.iter (fun l -> output_string fd (l^"\n")) content;
       close_out fd)
     (files @ errs)
@@ -490,7 +490,7 @@ let files = [
 ]
 let _ =
   List.iter (fun (name, content) ->
-      let fd = open_out name in
+      let fd = open_out_bin name in
       List.iter (fun l -> output_string fd (l^"\n")) content;
       close_out fd)
     (List.map (fun (n,c) -> "default/"^n, c) files)
@@ -665,7 +665,7 @@ let _ =
   let write dir (name, content) =
     let name = Filename.concat dir name in
     mkdir_p (Filename.dirname name);
-    let fd = open_out name in
+    let fd = open_out_bin name in
     List.iter (fun l -> output_string fd (l^"\n")) content;
     close_out fd
   in


### PR DESCRIPTION
Detected in https://github.com/ocaml/opam/pull/7058