### PR TITLE
Always print empty lists when printing bindings

### DIFF
--- a/src/format/opamFormat.ml
+++ b/src/format/opamFormat.ml
@@ -808,8 +808,7 @@ module I = struct
       List.filter_map
         (fun (field,ppa) ->
            match snd (ppa.print acc) with
-           | None | Some ({ pelem = List { pelem = []; _}; _}
-                         | { pelem = Group { pelem = []; _}; _}) -> None
+           | None -> None
            | Some value ->
              Some (nullify_pos @@ Variable (nullify_pos field, value)))
         ppas


### PR DESCRIPTION
Requires https://github.com/ocaml/opam-file-format/pull/66
Currently the all the tests fail in a spectacular manner for some unknown reason.