### PR TITLE
OpamFilename.parse_patch: change labelled argument name and type

### DIFF
--- a/src/core/opamFilename.ml
+++ b/src/core/opamFilename.ml
@@ -469,8 +469,10 @@ let link ?(relative=false) ~target ~link =
   OpamSystem.link target (to_string link)
 [@@ocaml.warning "-16"]
 
-let parse_patch ~dir patch_file =
-  OpamPatch.parse_patch ~translate:(Some (Dir.to_string dir)) (to_string patch_file)
+let parse_patch ~translate patch_file =
+  OpamPatch.parse_patch
+    ~translate:(Option.map Dir.to_string translate)
+    (to_string patch_file)
 
 module PatchFS = struct
   type root = string

--- a/src/core/opamFilename.mli
+++ b/src/core/opamFilename.mli
@@ -293,10 +293,13 @@ val patch: allow_unclean:bool ->
   [`Patch_file of t | `Patch_diffs of Patch.t list ] -> Dir.t ->
   (Patch.operation list, exn) result
 
-(** [parse_patch ~dir patch_file] processes and parses a patch file.
+(** [parse_patch ~translate patch_file] parses a patch file.
     Returns the parsed patch diffs or raises an exception if the patch file
-    doesn't exist or can't be parsed. *)
-val parse_patch : dir:Dir.t -> t -> Patch.t list
+    doesn't exist or can't be parsed.
+
+    @param translate is the target base directory used for the optional
+    CRLF processing (see {!OpamPatch.translate_patch}). *)
+val parse_patch : translate:Dir.t option -> t -> Patch.t list
 
 (** Create an empty file *)
 val touch: t -> unit

--- a/src/repository/opamVCS.ml
+++ b/src/repository/opamVCS.ml
@@ -58,7 +58,7 @@ module Make (VCS: VCS) = struct
         | Some patch_file ->
           try
             let diffs =
-              OpamFilename.parse_patch ~dir:repo_root_dir patch_file
+              OpamFilename.parse_patch ~translate:(Some repo_root_dir) patch_file
             in
             OpamRepositoryBackend.Update_patch (patch_file, diffs)
           with exn -> Update_err exn


### PR DESCRIPTION
97be5526b8e1255f6c3d4907a0c67d499aa08142 introduced `OpamFilename.parse_patch` as an abstraction over `OpamSystem.parse_patch` (now `OpamPatch.parse_patch`) but in the process changed its type and name from `translate:_ option` to `dir:_`. As translation is an optional component of parsing it should be kept as-is, so this PR changes that.