### PR TITLE
Use /dev/null on both Unix and Windows when setting GIT_CONFIG_*

### DIFF
--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -15,8 +15,8 @@ open OpamProcess.Job.Op
 (* let log fmt = OpamConsole.log "GIT" fmt *)
 
 let git_env = [|
-  "GIT_CONFIG_GLOBAL="^Filename.null;
-  "GIT_CONFIG_SYSTEM="^Filename.null;
+  "GIT_CONFIG_GLOBAL=/dev/null";
+  "GIT_CONFIG_SYSTEM=/dev/null";
 |]
 
 let env () =


### PR DESCRIPTION
Extracted from https://github.com/ocaml/opam/pull/7073
Not sure if `/dev/null` is better than `NUL` on Windows. Technically it should be equivalent since git does special cases `/dev/null` on Windows, but since only `/dev/null` is mentioned in the manual maybe this one should be used.