### PR TITLE
Disable git's fsmonitor on repositories managed by opam

### DIFF
--- a/src/repository/opamGit.ml
+++ b/src/repository/opamGit.ml
@@ -22,6 +22,7 @@ let git_env = [
 let git_config = [
   "gc.autoDetach", "false";
   "maintenance.autoDetach", "false";
+  "core.fsmonitor", "false";
 ]
 
 let env =


### PR DESCRIPTION
Fixes #7054 
As mentioned in this ticket this is barely worth doing as one would need to set an undocumented environment variable to trigger the issue but i guess it's best to make sure it never happens and we already have the code for it anyway.