### PR TITLE
Fix and enhance some cache handling in restest engine

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -113,6 +113,7 @@ users)
 ### Tests
   * Add a test showing `opam init --reinit` upgrading from pre opam 2.6 `OPAMREPOTARRING=1` (aka. opam 2.1's default) [#7058 @kit-ty-kate]
   * Add `opam init --reinit` regenerating cache & fixing switch test [#7068 @rjbou]
+  * Update reftest test for cache [#7092 @rjbou]
 
 ### Engine
   * Stop the testsuite from generating files containing CRLF [#7071 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -116,6 +116,7 @@ users)
 
 ### Engine
   * Stop the testsuite from generating files containing CRLF [#7071 @kit-ty-kate]
+  * Add an automatic replace for opam magic version, and an environment variable `$MAGICV` to refer to it [#7092 @rjbou]
 
 ## Github Actions
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -120,6 +120,7 @@ users)
   * Add an automatic replace for opam magic version, and an environment variable `$MAGICV` to refer to it [#7092 @rjbou]
   * When printing caches, differentiate file not found & invalid cache printing [#7092 @rjbou]
   * When printing caches, add a printing when packages selection is empty [#7092 @rjbou]
+  * When printing caches, ensure that the operation is a no-op on cache file [#7092 @rjbou]
 
 ## Github Actions
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -118,6 +118,7 @@ users)
 ### Engine
   * Stop the testsuite from generating files containing CRLF [#7071 @kit-ty-kate]
   * Add an automatic replace for opam magic version, and an environment variable `$MAGICV` to refer to it [#7092 @rjbou]
+  * When printing caches, differentiate file not found & invalid cache printing [#7092 @rjbou]
 
 ## Github Actions
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -119,6 +119,7 @@ users)
   * Stop the testsuite from generating files containing CRLF [#7071 @kit-ty-kate]
   * Add an automatic replace for opam magic version, and an environment variable `$MAGICV` to refer to it [#7092 @rjbou]
   * When printing caches, differentiate file not found & invalid cache printing [#7092 @rjbou]
+  * When printing caches, add a printing when packages selection is empty [#7092 @rjbou]
 
 ## Github Actions
 

--- a/tests/reftests/action-disk.test
+++ b/tests/reftests/action-disk.test
@@ -58,9 +58,9 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => write)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => write)
 
@@ -117,11 +117,11 @@ SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-
 FILE(opam)                      Read packages/main-repo/main-repo.2/opam (out of ${BASEDIR}/OPAM/repo/default) in 0.000s
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files/x-file.main-repo.2
 FILE(repos-config)              Wrote ${BASEDIR}/OPAM/repo/repos-config atomically in 0.000s
-SYSTEM                          rm ${BASEDIR}/OPAM/repo/state-magicv.cache
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => write)
-CACHE(repository)               Writing the repository cache to ${BASEDIR}/OPAM/repo/state-magicv.cache ...
-CACHE(repository)               ${BASEDIR}/OPAM/repo/state-magicv.cache written in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (write => none)
+SYSTEM                          rm ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => write)
+CACHE(repository)               Writing the repository cache to ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache ...
+CACHE(repository)               ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache written in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (write => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (write => none)
 SYSTEM                          LOCK  (none => none)
 Now run 'opam upgrade' to apply any package updates.
@@ -134,9 +134,9 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => write)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/lib
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/lib/stublibs
@@ -187,9 +187,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-repo/.opam-switch/switch-config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache (none => read)
@@ -271,9 +271,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-repo/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-repo/.opam-switch/switch-state in 0.000s
@@ -361,9 +361,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-repo/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-repo/.opam-switch/switch-state in 0.000s
@@ -463,9 +463,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-repo/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-repo/.opam-switch/switch-state in 0.000s
@@ -547,9 +547,9 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => write)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-path-pin-all
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-path-pin-all/lib
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-path-pin-all/lib/stublibs
@@ -599,9 +599,9 @@ FILE(opam)                      Read ${BASEDIR}/main-ppin/main-ppin.opam in 0.00
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (none => read)
@@ -638,9 +638,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
@@ -718,9 +718,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
@@ -818,9 +818,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
@@ -884,9 +884,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
@@ -918,9 +918,9 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => write)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 [ERROR] No compiler matching `install-from-path-pin-combined--empty' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (write => none)
@@ -931,9 +931,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
@@ -1006,9 +1006,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
@@ -1105,9 +1105,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
@@ -1200,9 +1200,9 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => write)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/lib
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/lib/stublibs
@@ -1254,9 +1254,9 @@ FILE(opam)                      Read ${BASEDIR}/main-gpin/main-gpin.opam in 0.00
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (none => read)
@@ -1303,9 +1303,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
@@ -1389,9 +1389,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
@@ -1502,9 +1502,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
@@ -1572,9 +1572,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
@@ -1606,9 +1606,9 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => write)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 [ERROR] No compiler matching `install-from-git-pin-combined--empty' found, use `opam switch list-available' to see what is available, or use `--packages' to select packages explicitly.
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (write => none)
@@ -1619,9 +1619,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
@@ -1706,9 +1706,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
@@ -1818,9 +1818,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
@@ -1911,9 +1911,9 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => write)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-version-pin
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-version-pin/lib
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-version-pin/lib/stublibs
@@ -1962,9 +1962,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache (none => read)
@@ -1986,9 +1986,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-state in 0.000s
@@ -2055,9 +2055,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-state in 0.000s
@@ -2153,9 +2153,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-state in 0.000s
@@ -2226,9 +2226,9 @@ FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-state in 0.000s
@@ -2264,9 +2264,9 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => write)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          mkdir ${BASEDIR}/OPAM/package-switch
 SYSTEM                          mkdir ${BASEDIR}/OPAM/package-switch/lib
 SYSTEM                          mkdir ${BASEDIR}/OPAM/package-switch/lib/stublibs
@@ -2363,9 +2363,9 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => write)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          mkdir ${BASEDIR}/void
 SYSTEM                          mkdir ${BASEDIR}/void/_opam
 SYSTEM                          mkdir ${BASEDIR}/void/_opam/lib
@@ -2413,9 +2413,9 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => write)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          mkdir ${BASEDIR}/main-ppin/_opam
 SYSTEM                          mkdir ${BASEDIR}/main-ppin/_opam/lib
 SYSTEM                          mkdir ${BASEDIR}/main-ppin/_opam/lib/stublibs

--- a/tests/reftests/dot-install.test
+++ b/tests/reftests/dot-install.test
@@ -252,8 +252,8 @@ touch
 ### opam install no-specified-dir | '[0-9]{14}' -> "now"
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/rem-dir/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/rem-dir/.opam-switch/packages/cache (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/rem-dir/.opam-switch/packages/cache (read => none)
@@ -311,8 +311,8 @@ added: [
 ### opam remove  no-specified-dir | '[0-9]{14}' -> "now" | grep -v "were already removed" | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/rem-dir/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/rem-dir/.opam-switch/packages/cache (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/rem-dir/.opam-switch/packages/cache (read => none)
@@ -426,8 +426,8 @@ hallo
 ### opam install eskape
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (read => none)
@@ -511,8 +511,8 @@ Done.
 ### opam install eskape --strict | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (write => none)
@@ -601,8 +601,8 @@ hellow
 ### opam install eskape-rel-dotdot-exists | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (read => none)
@@ -688,8 +688,8 @@ hellow
 ### opam install eskape-rel-middotdot-notexists | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (read => none)
@@ -788,8 +788,8 @@ hellow
 ### opam install realeskape-rel-middotdot-notexists | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (read => none)
@@ -874,8 +874,8 @@ hellow
 ### opam install eskape-abs | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (none => read)
-SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-magicv.cache (read => none)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => read)
+SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (read => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (read => none)

--- a/tests/reftests/no-depexts-sandboxed.unix.test
+++ b/tests/reftests/no-depexts-sandboxed.unix.test
@@ -80,7 +80,7 @@ Processing  2/3: [foo: sh build.sh]
 - CLI                             Parsing CLI version 2.0
 - GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 - RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
-- CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
+- CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
 - RSTATE                          Cache found
 - STATE                           LOAD-SWITCH-STATE @ internals-debian
 - CACHE(installed)                Loaded ${BASEDIR}/OPAM/internals-debian/.opam-switch/packages/cache in 0.000s
@@ -133,7 +133,7 @@ Processing  2/3: [foo: sh build.sh]
 - CLI                             Parsing CLI version 2.0
 - GSTATE                          LOAD-GLOBAL-STATE @ ${BASEDIR}/OPAM
 - RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
-- CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
+- CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
 - RSTATE                          Cache found
 - STATE                           LOAD-SWITCH-STATE @ internals-suse
 - CACHE(installed)                Loaded ${BASEDIR}/OPAM/internals-suse/.opam-switch/packages/cache in 0.000s

--- a/tests/reftests/reftests.test
+++ b/tests/reftests/reftests.test
@@ -973,6 +973,7 @@ opam-version: "2.0"
 name: "foo"
 version: "2"
 ### opam-cache installed cache inexistent
+Empty selection
 ### opam switch create cache2 --empty
 ### opam-cache installed cache2
 Empty cache
@@ -1049,6 +1050,7 @@ name: "baz"
 version: "1"
 extra-files: ["xf-baz" "md5=9ac116bceba2bdf45065df19d26a6b64"]
 ### opam-cache repo inexistent
+Empty selection
 ### :V:3:c: Invalid installed cache
 ### opam switch create cache4 --empty
 ### opam install foo

--- a/tests/reftests/reftests.test
+++ b/tests/reftests/reftests.test
@@ -1067,13 +1067,13 @@ version: "1"
 extra-files: ["xfile" "md5=f343d90d29f2632b7e5fcf8ee249d1b5"]
 ### sh -c 'echo XXX > OPAM/cache4/.opam-switch/packages/cache'
 ### opam-cache installed cache4
-No cache
+Invalid cache
 ### opam-cache installed cache4
 No cache
 ### :V:3:d: Invalid repo cache
 ### sh -c 'echo XXX > OPAM/repo/state-${MAGICV}.cache'
 ### opam-cache repo un
-No cache
+Invalid cache
 ### opam-cache repo un
 No cache
 ### :V:4: unset

--- a/tests/reftests/reftests.test
+++ b/tests/reftests/reftests.test
@@ -1071,13 +1071,13 @@ extra-files: ["xfile" "md5=f343d90d29f2632b7e5fcf8ee249d1b5"]
 ### opam-cache installed cache4
 Invalid cache
 ### opam-cache installed cache4
-No cache
+Invalid cache
 ### :V:3:d: Invalid repo cache
 ### sh -c 'echo XXX > OPAM/repo/state-${MAGICV}.cache'
 ### opam-cache repo un
 Invalid cache
 ### opam-cache repo un
-No cache
+Invalid cache
 ### :V:4: unset
 ### env | grep REFTEST_UNSET
 ### REFTEST_UNSET=test

--- a/tests/reftests/reftests.test
+++ b/tests/reftests/reftests.test
@@ -934,7 +934,7 @@ The following actions will be performed:
 -> installed foo.2
 -> installed un.2
 Done.
-### :V:3: installed packages cache
+### :V:3:a: installed packages cache
 ### opam-cache installed cache
 => un.2 <=
 opam-version: "2.0"
@@ -1049,6 +1049,33 @@ name: "baz"
 version: "1"
 extra-files: ["xf-baz" "md5=9ac116bceba2bdf45065df19d26a6b64"]
 ### opam-cache repo inexistent
+### :V:3:c: Invalid installed cache
+### opam switch create cache4 --empty
+### opam install foo
+The following actions will be performed:
+=== install 1 package
+  - install foo 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed foo.1
+Done.
+### opam-cache installed cache4
+=> foo.1 <=
+opam-version: "2.0"
+name: "foo"
+version: "1"
+extra-files: ["xfile" "md5=f343d90d29f2632b7e5fcf8ee249d1b5"]
+### sh -c 'echo XXX > OPAM/cache4/.opam-switch/packages/cache'
+### opam-cache installed cache4
+No cache
+### opam-cache installed cache4
+No cache
+### :V:3:d: Invalid repo cache
+### sh -c 'echo XXX > OPAM/repo/state-${MAGICV}.cache'
+### opam-cache repo un
+No cache
+### opam-cache repo un
+No cache
 ### :V:4: unset
 ### env | grep REFTEST_UNSET
 ### REFTEST_UNSET=test

--- a/tests/reftests/repository-http.test
+++ b/tests/reftests/repository-http.test
@@ -228,7 +228,7 @@ OPAM/repo
 OPAM/repo/http-repo.tar.gz
 OPAM/repo/lock
 OPAM/repo/repos-config
-OPAM/repo/state-magicv.cache
+OPAM/repo/state-${MAGICV}.cache
 ### mkdir OPAM/repo/http-repo
 ### tar xf OPAM/repo/http-repo.tar.gz -C OPAM/repo/http-repo
 ### rm OPAM/repo/http-repo.tar.gz

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -19,10 +19,11 @@ some content
 ### : Internal repository storage as archive or plain directory :
 ### opam switch create tarring --empty
 ### opam update -vv | grep '^\+'
-### ls $OPAMROOT/repo | grep -v "cache"
+### ls $OPAMROOT/repo
 default
 lock
 repos-config
+state-${MAGICV}.cache
 ### opam install foo.1 -vv | grep '^\+' | sed-cmd test
 + test "-f" "bar" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.1)
 ### opam repository add plain ./REPO --this-switch
@@ -38,11 +39,12 @@ some content
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS=TAR opam update default | grep TAR
 TAR                             creating archive ${BASEDIR}/OPAM/repo/default.tar.gz from ${BASEDIR}/OPAM/repo/default
 TAR                             creating archive ${BASEDIR}/OPAM/repo/default.tar.gz.new from ${BASEDIR}/REPO
-### ls $OPAMROOT/repo | grep -v "cache"
+### ls $OPAMROOT/repo
 default.tar.gz
 lock
 plain
 repos-config
+state-${MAGICV}.cache
 ### opam install foo.2 -vv | grep '^\+' | sed-cmd test tar
 + test "-f" "baz" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.2)
 ### opam repository remove default --all
@@ -56,10 +58,11 @@ some content
 ### opam repository add tarred ./REPO --this-switch
 [tarred] Initialised
 ### : New tarred repositories does not change already unchanged existing ones
-### ls $OPAMROOT/repo | grep -v "cache"
+### ls $OPAMROOT/repo
 lock
 plain
 repos-config
+state-${MAGICV}.cache
 tarred.tar.gz
 ### opam install foo.3 -vv | grep '^\+' | sed-cmd test
 + test "-f" "baz" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.3)
@@ -78,9 +81,10 @@ TAR                             creating archive ${BASEDIR}/OPAM/repo/tarred.tar
 ### mkdir tarred-ext
 ### tar xf OPAM/repo/tarred.tar.gz -C tarred-ext
 ### diff -ru ./tarred-ext REPO
-### ls $OPAMROOT/repo | grep -v "cache"
+### ls $OPAMROOT/repo
 lock
 repos-config
+state-${MAGICV}.cache
 tarred.tar.gz
 ### : From tarred repo to plain repo (tarred)
 ### OPAMREPOSITORYTARRING=0
@@ -94,9 +98,10 @@ some content
 + tar "xfz" "${BASEDIR}/OPAM/repo/tarred.tar.gz" "-C" "${BASEDIR}/OPAM/repo/tarred"
 ### opam install foo.5 -vv | grep '^\+' | sed-cmd test
 + test "-f" "quux" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.5)
-### ls $OPAMROOT/repo | grep -v "cache"
+### ls $OPAMROOT/repo
 lock
 repos-config
+state-${MAGICV}.cache
 tarred
 ### ls $OPAMROOT/repo/tarred
 packages
@@ -113,7 +118,7 @@ some content
 ### opam update --debug-level=-3 | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/tarring/.opam-switch/packages/foo.5/opam in 0.000s
 
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
@@ -121,8 +126,8 @@ FILE(opam)                      Read ${BASEDIR}/OPAM/tarring/.opam-switch/packag
 FILE(repo)                      Read ${BASEDIR}/OPAM/repo/tarred/repo in 0.000s
 FILE(opam)                      Read packages/foo/foo.4/opam (out of ${BASEDIR}/OPAM/repo/tarred) in 0.000s
 FILE(repos-config)              Wrote ${BASEDIR}/OPAM/repo/repos-config atomically in 0.000s
-CACHE(repository)               Writing the repository cache to ${BASEDIR}/OPAM/repo/state-magicv.cache ...
-CACHE(repository)               ${BASEDIR}/OPAM/repo/state-magicv.cache written in 0.000s
+CACHE(repository)               Writing the repository cache to ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache ...
+CACHE(repository)               ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache written in 0.000s
 Now run 'opam upgrade' to apply any package updates.
 ### opam install foo.4
 The following actions will be performed:
@@ -133,10 +138,10 @@ The following actions will be performed:
 -> removed   foo.5
 -> installed foo.4
 Done.
-### opam update --debug-level=-3 | "state-[0-9A-Z]{8}" -> "state-magicv"
+### opam update --debug-level=-3
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/tarring/.opam-switch/packages/foo.4/opam in 0.000s
 
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
@@ -169,10 +174,10 @@ some content
 ### sh hash.sh REPO2 bar.1
 ### opam repository add repo2 ./REPO2 --this-switch
 [repo2] Initialised
-### opam update --debug-level=-3 | "state-[0-9A-Z]{8}" -> "state-magicv"
+### opam update --debug-level=-3
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/tarring/.opam-switch/packages/foo.1/opam in 0.000s
 
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
@@ -195,7 +200,7 @@ some content
 ### opam update --debug-level=-3 | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
 
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
 [repo2] synchronised from file://${BASEDIR}/REPO2
@@ -203,8 +208,8 @@ FILE(repo)                      Read ${BASEDIR}/OPAM/repo/repo2/repo in 0.000s
 FILE(opam)                      Read packages/bar/bar.2/opam (out of ${BASEDIR}/OPAM/repo/repo2) in 0.000s
 [tarred] no changes from file://${BASEDIR}/REPO
 FILE(repos-config)              Wrote ${BASEDIR}/OPAM/repo/repos-config atomically in 0.000s
-CACHE(repository)               Writing the repository cache to ${BASEDIR}/OPAM/repo/state-magicv.cache ...
-CACHE(repository)               ${BASEDIR}/OPAM/repo/state-magicv.cache written in 0.000s
+CACHE(repository)               Writing the repository cache to ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache ...
+CACHE(repository)               ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache written in 0.000s
 Now run 'opam upgrade' to apply any package updates.
 ### opam install bar.2
 The following actions will be performed:
@@ -230,7 +235,7 @@ some content
 ### opam update --debug-level=-3 | unordered
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
 FILE(repos-config)              Read ${BASEDIR}/OPAM/repo/repos-config in 0.000s
-CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-magicv.cache in 0.000s
+CACHE(repository)               Loaded ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/tarring/.opam-switch/packages/bar.2/opam in 0.000s
 FILE(opam)                      Read ${BASEDIR}/OPAM/tarring/.opam-switch/packages/foo.1/opam in 0.000s
 
@@ -242,8 +247,8 @@ FILE(opam)                      Read packages/foo/foo.6/opam (out of ${BASEDIR}/
 [tarred] synchronised from file://${BASEDIR}/REPO
 FILE(repo)                      Read ${BASEDIR}/OPAM/repo/tarred/repo in 0.000s
 FILE(repos-config)              Wrote ${BASEDIR}/OPAM/repo/repos-config atomically in 0.000s
-CACHE(repository)               Writing the repository cache to ${BASEDIR}/OPAM/repo/state-magicv.cache ...
-CACHE(repository)               ${BASEDIR}/OPAM/repo/state-magicv.cache written in 0.000s
+CACHE(repository)               Writing the repository cache to ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache ...
+CACHE(repository)               ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache written in 0.000s
 Now run 'opam upgrade' to apply any package updates.
 ### opam install bar.3 foo.6 | unordered
 The following actions will be performed:

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -1220,71 +1220,80 @@ let run_test ?(vars=[]) ~opam t =
           in
           (match kind with
            | `installed ->
-             (let cache =
-                OpamSwitchState.Installed_cache.load
-                  (OpamPath.Switch.installed_opams_cache
-                     (OpamFilename.Dir.of_string opamroot)
-                     (OpamSwitch.of_string switch))
-              in
-              match cache with
-              | None -> print_string "No cache\n"
-              | Some cache when OpamPackage.Map.is_empty cache ->
-                print_string "Empty cache\n"
-              | Some cache ->
-                let cache =
-                  if OpamPackage.Name.Map.is_empty nvs then cache else
-                    OpamPackage.Map.filter (fun nv _ ->
-                        let n = OpamPackage.name nv in
-                        match OpamPackage.Name.Map.find_opt n nvs with
-                        | Some vs ->
-                          OpamPackage.Version.Set.is_empty vs
-                          || OpamPackage.Version.Set.mem
-                            (OpamPackage.version nv) vs
-                        | None -> false)
-                      cache
-                in
-                let files =
-                  OpamPackage.Map.fold (fun pkg opam files ->
-                      let name = OpamPackage.to_string pkg in
-                      let content = OpamFile.OPAM.write_to_string opam in
-                      (name, content)::files)
-                    cache []
-                in
-                print_file ~filters:(filter @ common_filters dir) files)
-           | `repo ->
-             (let cache =
-                OpamRepositoryState.Cache.load
+             (let cachefile =
+                OpamPath.Switch.installed_opams_cache
                   (OpamFilename.Dir.of_string opamroot)
+                  (OpamSwitch.of_string switch)
               in
-              match cache with
-              | None -> print_string "No cache\n"
-              | Some (_, cache, _) when OpamRepositoryName.Map.is_empty cache ->
-                print_string "Empty cache\n"
-              | Some (_, cache, _) ->
+              if not (OpamFilename.exists cachefile) then
+                print_string "No cache\n"
+              else
                 let cache =
-                  if OpamPackage.Name.Map.is_empty nvs then cache else
-                    OpamRepositoryName.Map.map
-                      (OpamPackage.Map.filter (fun nv _ ->
-                           let n = OpamPackage.name nv in
-                           match OpamPackage.Name.Map.find_opt n nvs with
-                           | Some vs ->
-                             OpamPackage.Version.Set.is_empty vs
-                             || OpamPackage.Version.Set.mem
-                               (OpamPackage.version nv) vs
-                           | None -> false))
-                      cache
+                  OpamSwitchState.Installed_cache.load cachefile
                 in
-                let files =
-                  OpamRepositoryName.Map.fold (fun reponame pkgmap files->
-                      let pre = OpamRepositoryName.to_string reponame in
-                      OpamPackage.Map.fold (fun pkg opam files ->
-                          let name = pre ^ ":" ^ OpamPackage.to_string pkg in
-                          let content = OpamFile.OPAM.write_to_string opam in
-                          (name, content)::files)
-                        pkgmap files)
-                    cache []
+                match cache with
+                | None -> print_string "Invalid cache\n"
+                | Some cache when OpamPackage.Map.is_empty cache ->
+                  print_string "Empty cache\n"
+                | Some cache ->
+                  let cache =
+                    if OpamPackage.Name.Map.is_empty nvs then cache else
+                      OpamPackage.Map.filter (fun nv _ ->
+                          let n = OpamPackage.name nv in
+                          match OpamPackage.Name.Map.find_opt n nvs with
+                          | Some vs ->
+                            OpamPackage.Version.Set.is_empty vs
+                            || OpamPackage.Version.Set.mem
+                              (OpamPackage.version nv) vs
+                          | None -> false)
+                        cache
+                  in
+                  let files =
+                    OpamPackage.Map.fold (fun pkg opam files ->
+                        let name = OpamPackage.to_string pkg in
+                        let content = OpamFile.OPAM.write_to_string opam in
+                        (name, content)::files)
+                      cache []
+                  in
+                  print_file ~filters:(filter @ common_filters dir) files)
+           | `repo ->
+             (let root = OpamFilename.Dir.of_string opamroot in
+              let cachefile = OpamPath.state_cache root in
+              if not (OpamFilename.exists cachefile) then
+                print_string "No cache\n"
+              else
+                let cache =
+                  OpamRepositoryState.Cache.load root
                 in
-                print_file ~filters:(filter @ common_filters dir) files));
+                match cache with
+                | None -> print_string "Invalid cache\n"
+                | Some (_, cache, _) when OpamRepositoryName.Map.is_empty cache ->
+                  print_string "Empty cache\n"
+                | Some (_, cache, _) ->
+                  let cache =
+                    if OpamPackage.Name.Map.is_empty nvs then cache else
+                      OpamRepositoryName.Map.map
+                        (OpamPackage.Map.filter (fun nv _ ->
+                             let n = OpamPackage.name nv in
+                             match OpamPackage.Name.Map.find_opt n nvs with
+                             | Some vs ->
+                               OpamPackage.Version.Set.is_empty vs
+                               || OpamPackage.Version.Set.mem
+                                 (OpamPackage.version nv) vs
+                             | None -> false))
+                        cache
+                  in
+                  let files =
+                    OpamRepositoryName.Map.fold (fun reponame pkgmap files->
+                        let pre = OpamRepositoryName.to_string reponame in
+                        OpamPackage.Map.fold (fun pkg opam files ->
+                            let name = pre ^ ":" ^ OpamPackage.to_string pkg in
+                            let content = OpamFile.OPAM.write_to_string opam in
+                            (name, content)::files)
+                          pkgmap files)
+                      cache []
+                  in
+                  print_file ~filters:(filter @ common_filters dir) files));
           vars
         | Run {env; cmd; args; filter; output; unordered; sort} ->
           let silent = output <> None || unordered in

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -1218,6 +1218,14 @@ let run_test ?(vars=[]) ~opam t =
                     nvs)
               OpamPackage.Name.Map.empty nvs
           in
+          let save_and_restore file k =
+            let tmpdir = OpamFilename.mk_tmp_dir () in
+            let backup = OpamFilename.Op.(tmpdir // "cache-backup") in
+            OpamFilename.copy ~src:file ~dst:backup;
+            k ();
+            OpamFilename.copy ~src:backup ~dst:file;
+            OpamFilename.rmdir tmpdir
+          in
           (match kind with
            | `installed ->
              (let cachefile =
@@ -1228,6 +1236,7 @@ let run_test ?(vars=[]) ~opam t =
               if not (OpamFilename.exists cachefile) then
                 print_string "No cache\n"
               else
+                save_and_restore cachefile @@ fun () ->
                 let cache =
                   OpamSwitchState.Installed_cache.load cachefile
                 in
@@ -1265,6 +1274,7 @@ let run_test ?(vars=[]) ~opam t =
               if not (OpamFilename.exists cachefile) then
                 print_string "No cache\n"
               else
+                save_and_restore cachefile @@ fun () ->
                 let cache =
                   OpamRepositoryState.Cache.load root
                 in

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -92,6 +92,8 @@ let base_env =
     "GIT_CONFIG_VALUE_0", "always";
   ]
 
+let opam_magicv = OpamVersion.magic ()
+
 (* See [opamprocess.safe_wait] *)
 let rec waitpid pid =
   match Unix.waitpid [] pid with
@@ -688,6 +690,8 @@ let common_filters ?opam dir =
       str "opam-";
       rep1 (alt [xdigit; char '-'])],
     Sed "${OPAMTMP}";
+    str opam_magicv,
+    Sed "${MAGICV}";
     (* We need this sed to ensure that the line containing 'packages' is
        rewritten with the good dir sep replacements *)
     extra_packages_dirs "packages";
@@ -709,12 +713,6 @@ let common_filters ?opam dir =
       str ".export";
     ],
     Sed "state-today.export";
-    seq [
-      str "state-";
-      repn xdigit 8 (Some 8);
-      str ".cache";
-    ],
-    Sed "state-magicv.cache";
     with_hexa_twice "log",
     Sed "log-xxx";
     with_hexa_twice "patch",
@@ -990,6 +988,7 @@ let run_test ?(vars=[]) ~opam t =
     "OPAMROOT", opamroot;
     "BASEDIR", dir;
     "PATH", Sys.getenv "PATH";
+    "MAGICV", opam_magicv;
   ] @ vars
   in
   if t.repo_hash = no_opam_repo then

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -1248,14 +1248,17 @@ let run_test ?(vars=[]) ~opam t =
                           | None -> false)
                         cache
                   in
-                  let files =
-                    OpamPackage.Map.fold (fun pkg opam files ->
-                        let name = OpamPackage.to_string pkg in
-                        let content = OpamFile.OPAM.write_to_string opam in
-                        (name, content)::files)
-                      cache []
-                  in
-                  print_file ~filters:(filter @ common_filters dir) files)
+                  if OpamPackage.Map.is_empty cache then
+                    print_string "Empty selection\n"
+                  else
+                    let files =
+                      OpamPackage.Map.fold (fun pkg opam files ->
+                          let name = OpamPackage.to_string pkg in
+                          let content = OpamFile.OPAM.write_to_string opam in
+                          (name, content)::files)
+                        cache []
+                    in
+                    print_file ~filters:(filter @ common_filters dir) files)
            | `repo ->
              (let root = OpamFilename.Dir.of_string opamroot in
               let cachefile = OpamPath.state_cache root in
@@ -1282,18 +1285,23 @@ let run_test ?(vars=[]) ~opam t =
                                  (OpamPackage.version nv) vs
                              | None -> false))
                         cache
+                      |> OpamRepositoryName.Map.filter (fun _ nvs ->
+                          not (OpamPackage.Map.is_empty nvs))
                   in
-                  let files =
-                    OpamRepositoryName.Map.fold (fun reponame pkgmap files->
-                        let pre = OpamRepositoryName.to_string reponame in
-                        OpamPackage.Map.fold (fun pkg opam files ->
-                            let name = pre ^ ":" ^ OpamPackage.to_string pkg in
-                            let content = OpamFile.OPAM.write_to_string opam in
-                            (name, content)::files)
-                          pkgmap files)
-                      cache []
-                  in
-                  print_file ~filters:(filter @ common_filters dir) files));
+                  if OpamRepositoryName.Map.is_empty cache then
+                    print_string "Empty selection\n"
+                  else
+                    let files =
+                      OpamRepositoryName.Map.fold (fun reponame pkgmap files->
+                          let pre = OpamRepositoryName.to_string reponame in
+                          OpamPackage.Map.fold (fun pkg opam files ->
+                              let name = pre ^ ":" ^ OpamPackage.to_string pkg in
+                              let content = OpamFile.OPAM.write_to_string opam in
+                              (name, content)::files)
+                            pkgmap files)
+                        cache []
+                    in
+                    print_file ~filters:(filter @ common_filters dir) files));
           vars
         | Run {env; cmd; args; filter; output; unordered; sort} ->
           let silent = output <> None || unordered in


### PR DESCRIPTION
While reviewing #7067, i found some missing features and a bug:
* when we print a cache, we load it via opam code, that can do operations on cache. It is now a no-op
* more specific cache status:
  * dissociate no cache file and invalid cache
  * print a message when the package selection is empty instead of no printing
  * handle the opam magic number, as it is used in `state-xxx.cache` file (now we can name it in a test), and like that it will automatically replace all magic number automatically (they can appear on debug log, like invalid cache).