### PR TITLE
reftest: Fix the regexp matching on temporary files

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -122,6 +122,7 @@ users)
   * When printing caches, differentiate file not found & invalid cache printing [#7092 @rjbou]
   * When printing caches, add a printing when packages selection is empty [#7092 @rjbou]
   * When printing caches, ensure that the operation is a no-op on cache file [#7092 @rjbou]
+  * Fix the regexp matching on temporary files [#7094 @kit-ty-kate]
 
 ## Github Actions
 

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -74,6 +74,7 @@ let rec real_path p =
     | x -> real_path dirname / x
 
 let temp_basename prefix =
+  (* Sync with tests/reftests/run.ml *)
   Printf.sprintf "%s-%d-%06x" prefix (OpamStubs.getpid ()) (Random.int 0xFFFFFF)
 
 let temp_name ?dir ?(prefix="opam") () =

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -648,13 +648,14 @@ let common_filters ?opam dir =
       [str dir; str (OpamSystem.back_to_forward dir); str (OpamSystem.apply_cygpath dir)]
     else
       [str dir] in
-  let with_hexa_twice prefix =
+  let opam_temp_basename prefix =
+    (* Sync with OpamSystem.temp_basename *)
     seq [
       str prefix;
       char '-';
-      repn xdigit 3 (Some 9);
+      repn digit 1 (Some 19); (* 19 is max number of digit from Int.max_int *)
       char '-';
-      repn xdigit 3 (Some 9);
+      repn xdigit 6 (Some 6);
     ]
   in
   let extra_packages_dirs d =
@@ -713,9 +714,9 @@ let common_filters ?opam dir =
       str ".export";
     ],
     Sed "state-today.export";
-    with_hexa_twice "log",
+    opam_temp_basename "log",
     Sed "log-xxx";
-    with_hexa_twice "patch",
+    opam_temp_basename "patch",
     Sed "patch-xxx";
     (* rsync output
        Linux


### PR DESCRIPTION
Noticed in https://github.com/ocaml/opam/pull/7067:
```diff
diff --git a/_build/default/tests/reftests/action-disk.test b/_build/default/tests/reftests/action-disk.out
index 1e7d673..ec5c857 100644
--- a/_build/default/tests/reftests/action-disk.test
+++ b/_build/default/tests/reftests/action-disk.out
@@ -92,7 +92,7 @@ SYSTEM                          read ${BASEDIR}/OPAM/repo/default.new/packages/m
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/opam
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default.new/packages/main-repo/main-repo.1/opam
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default.new/packages/main-repo/main-repo.1/files/x-file.main-repo.1
-SYSTEM                          write ${BASEDIR}/OPAM/log/patch-xxx
+SYSTEM                          write ${BASEDIR}/OPAM/log/patch-96-7ec154
 SYSTEM                          rmdir ${BASEDIR}/OPAM/repo/default.new
 SYSTEM                          rm ${BASEDIR}/OPAM/repo/default.new/packages/main-repo/main-repo.1/opam
 SYSTEM                          rm ${BASEDIR}/OPAM/repo/default.new/packages/main-repo/main-repo.1/files/x-file.main-repo.1
```