### PR TITLE
Stop scanning opam projects recursively for nautht

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -129,3 +129,4 @@ users)
 ## opam-format
 
 ## opam-core
+  * `OpamSystem.{rec_,}{files,dirs}`: add some log in debug mode [#7101 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -23,6 +23,7 @@ users)
 ## Actions
 
 ## Install
+  * Fix a performance regression where opam project trees were scanned for nothing, when pinning them [#7101 @kit-ty-kate - fix #7098]
 
 ## Build (package)
 
@@ -108,6 +109,8 @@ users)
 
 ## Reftests
 ### Tests
+  * Add a new test showing opam's package format upgrade behaviours [#7101 @kit-ty-kate]
+  * Test the behaviour of `extra-files` when pinned from a local directory [#7101 @kit-ty-kate]
 
 ### Engine
 

--- a/src/core/opamSystem.ml
+++ b/src/core/opamSystem.ml
@@ -370,23 +370,27 @@ let directories_with_links ?(except_vcs=false) =
   if except_vcs && is_vcs (Filename.basename f) then false else
   try Sys.is_directory f with Sys_error _ -> false)
 
-let rec_files ?except_vcs dir =
+let rec_files ?(except_vcs=false) dir =
+  log ~level:4 "scan files recursively (except_vcs: %b) in %s" except_vcs dir;
   let rec aux accu dir =
-    let d = directories_with_links ?except_vcs dir in
+    let d = directories_with_links ~except_vcs dir in
     let f = files_with_links dir in
     List.fold_left aux (f @ accu) d in
   aux [] dir
 
 let files dir =
+  log ~level:4 "scan files in %s" dir;
   files_with_links dir
 
 let rec_dirs dir =
+  log ~level:4 "scan dirs recursively in %s" dir;
   let rec aux accu dir =
     let d = directories_with_links dir in
     List.fold_left aux (d @ accu) d in
   aux [] dir
 
 let dirs dir =
+  log ~level:4 "scan dirs in %s" dir;
   directories_with_links dir
 
 let dir_is_empty dir =

--- a/src/state/opamFileTools.ml
+++ b/src/state/opamFileTools.ml
@@ -1518,10 +1518,21 @@ let get_extrafiles ~repo_root dir =
         OpamRepositoryRoot.remove_prefix repo_root file
     | None -> OpamFilename.Unix.of_filename
   in
-  List.fold_left (fun map file ->
-      OpamFilename.Unix.Map.add (to_key file)
-        (lazy (OpamFilename.read file)) map)
-    OpamFilename.Unix.Map.empty (OpamFilename.rec_files dir)
+  let aux map file =
+    OpamFilename.Unix.Map.add (to_key file)
+      (lazy (OpamFilename.read file))
+      map
+  in
+  let add_file_if_exists map file =
+    if OpamFilename.exists file
+    then aux map file
+    else map
+  in
+  let map = OpamFilename.Unix.Map.empty in
+  let map = add_file_if_exists map OpamFilename.Op.(dir // "url") in
+  let map = add_file_if_exists map OpamFilename.Op.(dir // "descr") in
+  let files_dir = OpamFilename.Op.(dir / OpamPathName.files_d) in
+  List.fold_left aux map (OpamFilename.rec_files files_dir)
 
 let get_contents ~repo_root dir =
   let file = OpamFilename.Op.(dir // OpamPathName.opam_f) in

--- a/tests/reftests/action-disk.test
+++ b/tests/reftests/action-disk.test
@@ -110,11 +110,11 @@ SYSTEM                          mkdir ${BASEDIR}/OPAM/repo/default/packages/main
 SYSTEM                          mkdir ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files
 FILE(repo)                      Read ${BASEDIR}/OPAM/repo/default/repo in 0.000s
 Processing: [default: loading data]
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/opam
 FILE(opam)                      Read packages/main-repo/main-repo.2/opam (out of ${BASEDIR}/OPAM/repo/default) in 0.000s
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files/x-file.main-repo.2
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/opam
 FILE(opam)                      Read packages/main-repo/main-repo.1/opam (out of ${BASEDIR}/OPAM/repo/default) in 0.000s
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
@@ -682,8 +682,8 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin/files
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam in 0.000s
@@ -766,8 +766,8 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
@@ -875,7 +875,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/share/main-ppin
@@ -948,7 +948,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/files
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (none => write)
@@ -1008,7 +1008,7 @@ SYSTEM                          scan dirs in ${BASEDIR}/main-ppin/opam
 SYSTEM                          scan files in ${BASEDIR}/main-ppin
 SYSTEM                          scan dirs in ${BASEDIR}/main-ppin
 FILE(opam)                      Read ${BASEDIR}/main-ppin/main-ppin.opam in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/main-ppin/files
 [NOTE] Package main-ppin does not exist in opam repositories registered in the current switch.
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
 SYSTEM                          read ${BASEDIR}/main-ppin/main-ppin.opam
@@ -1078,8 +1078,8 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
@@ -1186,7 +1186,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/share/main-ppin
@@ -1397,8 +1397,8 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/files
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam in 0.000s
@@ -1487,8 +1487,8 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
@@ -1609,7 +1609,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/share/main-gpin
@@ -1686,7 +1686,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/files
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (none => write)
@@ -1761,7 +1761,7 @@ SYSTEM                          scan dirs in ${BASEDIR}/main-gpin/opam
 SYSTEM                          scan files in ${BASEDIR}/main-gpin
 SYSTEM                          scan dirs in ${BASEDIR}/main-gpin
 FILE(opam)                      Read ${BASEDIR}/main-gpin/main-gpin.opam in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/main-gpin/files
 [NOTE] Package main-gpin does not exist in opam repositories registered in the current switch.
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
 SYSTEM                          read ${BASEDIR}/main-gpin/main-gpin.opam
@@ -1828,8 +1828,8 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
@@ -1949,7 +1949,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/share/main-gpin
@@ -2126,7 +2126,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo/files
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo/opam
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache (none => read)
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache in 0.000s
@@ -2199,7 +2199,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/lib/main-repo
@@ -2307,7 +2307,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/lib/main-repo
 SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/lib/main-repo
@@ -2388,7 +2388,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-state in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo/files
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo/opam
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache (none => write)
 CACHE(installed)                Writing the installed cache to ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache ...
@@ -2623,7 +2623,7 @@ SYSTEM                          scan dirs in ${BASEDIR}/main-ppin/opam
 SYSTEM                          scan files in ${BASEDIR}/main-ppin
 SYSTEM                          scan dirs in ${BASEDIR}/main-ppin
 FILE(opam)                      Read ${BASEDIR}/main-ppin/main-ppin.opam in 0.000s
-SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/main-ppin/files
 [NOTE] Package main-ppin does not exist in opam repositories registered in the current switch.
 SYSTEM                          rmdir ${BASEDIR}/main-ppin/_opam/.opam-switch/overlay/main-ppin
 SYSTEM                          read ${BASEDIR}/main-ppin/main-ppin.opam

--- a/tests/reftests/action-disk.test
+++ b/tests/reftests/action-disk.test
@@ -110,13 +110,16 @@ SYSTEM                          mkdir ${BASEDIR}/OPAM/repo/default/packages/main
 SYSTEM                          mkdir ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files
 FILE(repo)                      Read ${BASEDIR}/OPAM/repo/default/repo in 0.000s
 Processing: [default: loading data]
-SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/opam
-FILE(opam)                      Read packages/main-repo/main-repo.1/opam (out of ${BASEDIR}/OPAM/repo/default) in 0.000s
-SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/opam
 FILE(opam)                      Read packages/main-repo/main-repo.2/opam (out of ${BASEDIR}/OPAM/repo/default) in 0.000s
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files/x-file.main-repo.2
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1
+SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/opam
+FILE(opam)                      Read packages/main-repo/main-repo.1/opam (out of ${BASEDIR}/OPAM/repo/default) in 0.000s
+SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
 FILE(repos-config)              Wrote ${BASEDIR}/OPAM/repo/repos-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/repo
 SYSTEM                          rm ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache (none => write)
 CACHE(repository)               Writing the repository cache to ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache ...
@@ -169,6 +172,7 @@ CACHE(installed)                ${BASEDIR}/OPAM/install-from-repo/.opam-switch/p
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache (write => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-switch/switch-config atomically in 0.000s
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-repo/.opam-switch/config
 FILE(environment)               Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-switch/environment atomically in 0.000s
 FILE(config)                    Wrote ${BASEDIR}/OPAM/config atomically in 0.000s
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.sh
@@ -196,6 +200,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-swi
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-repo/.opam-switch/config
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/backup
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-switch/backup/state-today.export atomically in 0.000s
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-repo/.opam-switch/reinstall
@@ -236,6 +241,7 @@ SYSTEM                          rm ${OPAMTMP}/x-source
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1
 SYSTEM                          mv ${BASEDIR}/OPAM/install-from-repo/.opam-switch/sources/main-repo.1 -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1
 SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/x-source.main-repo.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/x-file.main-repo.1
 Processing  2/3: [main-repo: touch build-file]
@@ -254,6 +260,7 @@ FILE(.config)                   Cannot find ${BASEDIR}/OPAM/install-from-repo/.o
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/main-repo.1
 FILE(opam)                      Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/main-repo.1/opam atomically in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/main-repo.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/main-repo.1/files/x-file.main-repo.1
@@ -281,6 +288,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-swi
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-repo/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-switch/backup/state-today.export atomically in 0.000s
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-repo/.opam-switch/reinstall
 The following actions will be performed:
@@ -303,6 +311,7 @@ SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switc
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/x-source.main-repo.1
 SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/x-source.main-repo.1
 SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1/x-source.main-repo.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.1/x-file.main-repo.1
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
@@ -318,11 +327,17 @@ Processing  2/4: [main-repo: touch build-file]
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
 Processing  3/4: [main-repo: touch removal-file]
 + touch "removal-file" (CWD=${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1)
 FILE(.install)                  Cannot find ${BASEDIR}/OPAM/install-from-repo/.opam-switch/install/main-repo.install
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-repo/lib/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-repo/lib/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-repo/share/main-repo
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/share/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-repo/etc/main-repo
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/etc/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-repo/doc/main-repo
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/doc/main-repo
 FILE(changes)                   Read ${BASEDIR}/OPAM/install-from-repo/.opam-switch/install/main-repo.changes in 0.000s
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/lib/main-repo/content
@@ -343,6 +358,7 @@ FILE(environment)               Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-sw
 FILE(.config)                   Cannot find ${BASEDIR}/OPAM/install-from-repo/.opam-switch/config/main-repo.config
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache
 FILE(opam)                      Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/main-repo.1/opam atomically in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache (none => write)
 CACHE(installed)                Writing the installed cache to ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache ...
 CACHE(installed)                ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache written in 0.000s
@@ -371,6 +387,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-swi
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-repo/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-switch/backup/state-today.export atomically in 0.000s
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-repo/.opam-switch/reinstall
 The following actions will be performed:
@@ -402,6 +419,7 @@ SYSTEM                          rm ${OPAMTMP}/content
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2
 SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2/x-source.main-repo.2
 SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1/x-source.main-repo.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files/x-file.main-repo.2
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2/x-file.main-repo.2
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
@@ -413,11 +431,17 @@ Processing  2/4: [main-repo: touch build-file]
 + touch "build-file" (CWD=${BASEDIR}/OPAM/install-from-repo/.opam-switch/build/main-repo.2)
 -> compiled  main-repo.2
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
 Processing  3/4: [main-repo: touch removal-file]
 + touch "removal-file" (CWD=${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.1)
 FILE(.install)                  Cannot find ${BASEDIR}/OPAM/install-from-repo/.opam-switch/install/main-repo.install
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-repo/lib/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-repo/lib/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-repo/share/main-repo
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/share/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-repo/etc/main-repo
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/etc/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-repo/doc/main-repo
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/doc/main-repo
 FILE(changes)                   Read ${BASEDIR}/OPAM/install-from-repo/.opam-switch/install/main-repo.changes in 0.000s
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/lib/main-repo/content
@@ -439,6 +463,7 @@ FILE(.config)                   Cannot find ${BASEDIR}/OPAM/install-from-repo/.o
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/main-repo.2
 FILE(opam)                      Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/main-repo.2/opam atomically in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/main-repo.2/files
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache (none => write)
 CACHE(installed)                Writing the installed cache to ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache ...
@@ -475,6 +500,7 @@ CACHE(installed)                Writing the installed cache to ${BASEDIR}/OPAM/i
 CACHE(installed)                ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache written in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-repo/.opam-switch/packages/cache (write => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-repo/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-repo/.opam-switch/backup/state-today.export atomically in 0.000s
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-repo/.opam-switch/reinstall
 The following actions will be performed:
@@ -495,14 +521,20 @@ SYSTEM                          rm ${OPAMTMP}/content
 -> retrieved main-repo.2  (cached)
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2
 SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2/x-source.main-repo.2
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files/x-file.main-repo.2
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2/x-file.main-repo.2
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2/x-source.main-repo.2
 Processing  2/2: [main-repo: touch removal-file]
 + touch "removal-file" (CWD=${BASEDIR}/OPAM/install-from-repo/.opam-switch/remove/main-repo.2)
 FILE(.install)                  Cannot find ${BASEDIR}/OPAM/install-from-repo/.opam-switch/install/main-repo.install
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-repo/lib/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-repo/lib/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-repo/share/main-repo
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/share/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-repo/etc/main-repo
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/etc/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-repo/doc/main-repo
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-repo/doc/main-repo
 FILE(changes)                   Read ${BASEDIR}/OPAM/install-from-repo/.opam-switch/install/main-repo.changes in 0.000s
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-repo/lib/main-repo/content
@@ -582,6 +614,7 @@ CACHE(installed)                ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (write => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config atomically in 0.000s
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/config
 FILE(environment)               Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/environment atomically in 0.000s
 FILE(config)                    Wrote ${BASEDIR}/OPAM/config atomically in 0.000s
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.sh
@@ -595,6 +628,10 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
 ### opam pin ./main-ppin -n | grep -v '^- ./$' | sed-cmd rsync
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/main-ppin/opam
+SYSTEM                          scan dirs in ${BASEDIR}/main-ppin/opam
+SYSTEM                          scan files in ${BASEDIR}/main-ppin
+SYSTEM                          scan dirs in ${BASEDIR}/main-ppin
 FILE(opam)                      Read ${BASEDIR}/main-ppin/main-ppin.opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -608,6 +645,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/config
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/backup
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 SYSTEM                          mkdir ${OPAMTMP}
@@ -644,12 +682,16 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin/files
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (none => read)
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
@@ -724,12 +766,21 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/share/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/etc/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/doc/main-ppin
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (none => read)
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
@@ -824,12 +875,19 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/share/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/etc/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/doc/main-ppin
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (none => read)
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/reinstall
 The following actions will be performed:
@@ -890,6 +948,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (none => write)
@@ -897,6 +956,7 @@ CACHE(installed)                Writing the installed cache to ${BASEDIR}/OPAM/i
 CACHE(installed)                ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache written in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (write => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin/content
@@ -941,8 +1001,14 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/main-ppin/opam
+SYSTEM                          scan dirs in ${BASEDIR}/main-ppin/opam
+SYSTEM                          scan files in ${BASEDIR}/main-ppin
+SYSTEM                          scan dirs in ${BASEDIR}/main-ppin
 FILE(opam)                      Read ${BASEDIR}/main-ppin/main-ppin.opam in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/main-ppin
 [NOTE] Package main-ppin does not exist in opam repositories registered in the current switch.
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
 SYSTEM                          read ${BASEDIR}/main-ppin/main-ppin.opam
@@ -1012,12 +1078,21 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/share/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/etc/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/doc/main-ppin
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (none => read)
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
@@ -1111,12 +1186,19 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/lib/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/share/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/etc/main-ppin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-path-pin-all/doc/main-ppin
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/overlay/main-ppin/opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (none => read)
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-path-pin-all/.opam-switch/sources/main-ppin/content
@@ -1235,6 +1317,7 @@ CACHE(installed)                ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (write => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config atomically in 0.000s
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/config
 FILE(environment)               Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/environment atomically in 0.000s
 FILE(config)                    Wrote ${BASEDIR}/OPAM/config atomically in 0.000s
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.sh
@@ -1250,6 +1333,10 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
 + git "-C" "${BASEDIR}/main-gpin" "symbolic-ref" "--quiet" "--short" "HEAD"
 - master
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/main-gpin/opam
+SYSTEM                          scan dirs in ${BASEDIR}/main-gpin/opam
+SYSTEM                          scan files in ${BASEDIR}/main-gpin
+SYSTEM                          scan dirs in ${BASEDIR}/main-gpin
 FILE(opam)                      Read ${BASEDIR}/main-gpin/main-gpin.opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/lock (none => read)
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -1263,6 +1350,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.o
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/config
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/backup
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 SYSTEM                          mkdir ${OPAMTMP}
@@ -1309,12 +1397,16 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/files
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (none => read)
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
@@ -1395,12 +1487,21 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/share/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/etc/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/doc/main-gpin
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (none => read)
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
@@ -1508,12 +1609,19 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/share/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/etc/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/doc/main-gpin
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (none => read)
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/reinstall
 The following actions will be performed:
@@ -1578,6 +1686,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (none => write)
@@ -1585,6 +1694,7 @@ CACHE(installed)                Writing the installed cache to ${BASEDIR}/OPAM/i
 CACHE(installed)                ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache written in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (write => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/content
@@ -1629,6 +1739,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.o
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 + git "-C" "${BASEDIR}/main-gpin" "symbolic-ref" "--quiet" "--short" "HEAD"
 + git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "init" "--initial-branch=main"
@@ -1645,7 +1756,12 @@ FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.
 + git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "reset" "--hard" "refs/remotes/opam-ref-master" "--"
 + git "-C" "${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin" "clean" "-fdx"
 - master
+SYSTEM                          scan files in ${BASEDIR}/main-gpin/opam
+SYSTEM                          scan dirs in ${BASEDIR}/main-gpin/opam
+SYSTEM                          scan files in ${BASEDIR}/main-gpin
+SYSTEM                          scan dirs in ${BASEDIR}/main-gpin
 FILE(opam)                      Read ${BASEDIR}/main-gpin/main-gpin.opam in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/main-gpin
 [NOTE] Package main-gpin does not exist in opam repositories registered in the current switch.
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
 SYSTEM                          read ${BASEDIR}/main-gpin/main-gpin.opam
@@ -1712,12 +1828,21 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/share/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/etc/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/doc/main-gpin
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (none => read)
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 
 <><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
@@ -1824,12 +1949,19 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/lib/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/share/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/etc/main-gpin
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-git-pin-all/doc/main-gpin
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam
 FILE(opam)                      Read ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/overlay/main-gpin/opam in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (none => read)
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/backup/state-today.export atomically in 0.000s
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-git-pin-all/.opam-switch/sources/main-gpin/content
@@ -1946,6 +2078,7 @@ CACHE(installed)                ${BASEDIR}/OPAM/install-from-version-pin/.opam-s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache (write => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config atomically in 0.000s
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/config
 FILE(environment)               Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/environment atomically in 0.000s
 FILE(config)                    Wrote ${BASEDIR}/OPAM/config atomically in 0.000s
 SYSTEM                          write ${BASEDIR}/OPAM/opam-init/variables.sh
@@ -1971,6 +2104,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.o
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/config
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/backup
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/backup/state-today.export atomically in 0.000s
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-state atomically in 0.000s
@@ -1992,11 +2126,13 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo/opam
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache (none => read)
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/backup/state-today.export atomically in 0.000s
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/reinstall
 The following actions will be performed:
@@ -2020,6 +2156,7 @@ SYSTEM                          copydir ${BASEDIR}/OPAM/install-from-version-pin
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1
 SYSTEM                          copy ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo/content -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1/content
 SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1/x-source.main-repo.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/build/main-repo.1/x-file.main-repo.1
 Processing  2/3: [main-repo: touch build-file]
@@ -2038,6 +2175,7 @@ FILE(.config)                   Cannot find ${BASEDIR}/OPAM/install-from-version
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/main-repo.1
 FILE(opam)                      Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/main-repo.1/opam atomically in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
 SYSTEM                          mkdir ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/main-repo.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files/x-file.main-repo.1
 SYSTEM                          write ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/main-repo.1/files/x-file.main-repo.1
@@ -2061,11 +2199,21 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/lib/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/lib/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/share/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/etc/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/doc/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo/opam
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache (none => read)
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/backup/state-today.export atomically in 0.000s
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/reinstall
 The following actions will be performed:
@@ -2159,11 +2307,19 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.1/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/lib/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/lib/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/share/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/etc/main-repo
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/doc/main-repo
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo/opam
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache (none => read)
 CACHE(installed)                Loaded ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache (read => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/backup/state-today.export atomically in 0.000s
 FILE(package-version-list)      Cannot find ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/reinstall
 The following actions will be performed:
@@ -2232,12 +2388,14 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/lock (none => write)
 FILE(switch-config)             Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config in 0.000s
 FILE(switch-state)              Read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-state in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo
 SYSTEM                          read ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/overlay/main-repo/opam
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache (none => write)
 CACHE(installed)                Writing the installed cache to ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache ...
 CACHE(installed)                ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache written in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/packages/cache (write => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/config
 FILE(switch-state)              Wrote ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/backup/state-today.export atomically in 0.000s
 SYSTEM                          rmdir ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo
 SYSTEM                          rm ${BASEDIR}/OPAM/install-from-version-pin/.opam-switch/sources/main-repo/content
@@ -2298,6 +2456,7 @@ CACHE(installed)                Writing the installed cache to ${BASEDIR}/OPAM/p
 CACHE(installed)                ${BASEDIR}/OPAM/package-switch/.opam-switch/packages/cache written in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/package-switch/.opam-switch/packages/cache (write => none)
 FILE(switch-config)             Wrote ${BASEDIR}/OPAM/package-switch/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/OPAM/package-switch/.opam-switch/config
 
 <><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
 Switch invariant: ["main-repo"]
@@ -2318,6 +2477,7 @@ SYSTEM                          rm ${OPAMTMP}/content
 SYSTEM                          rmdir ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2
 SYSTEM                          mv ${BASEDIR}/OPAM/package-switch/.opam-switch/sources/main-repo.2 -> ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2
 SYSTEM                          copy ${BASEDIR}/OPAM/download-cache/md5/pre/+xs-hash+ -> ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2/x-source.main-repo.2
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files/x-file.main-repo.2
 SYSTEM                          write ${BASEDIR}/OPAM/package-switch/.opam-switch/build/main-repo.2/x-file.main-repo.2
 Processing  2/3: [main-repo: touch build-file]
@@ -2336,6 +2496,7 @@ FILE(.config)                   Cannot find ${BASEDIR}/OPAM/package-switch/.opam
 SYSTEM                          rm ${BASEDIR}/OPAM/package-switch/.opam-switch/packages/cache
 SYSTEM                          mkdir ${BASEDIR}/OPAM/package-switch/.opam-switch/packages/main-repo.2
 FILE(opam)                      Wrote ${BASEDIR}/OPAM/package-switch/.opam-switch/packages/main-repo.2/opam atomically in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files
 SYSTEM                          mkdir ${BASEDIR}/OPAM/package-switch/.opam-switch/packages/main-repo.2/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/main-repo/main-repo.2/files/x-file.main-repo.2
 SYSTEM                          write ${BASEDIR}/OPAM/package-switch/.opam-switch/packages/main-repo.2/files/x-file.main-repo.2
@@ -2401,6 +2562,11 @@ CACHE(installed)                ${BASEDIR}/void/_opam/.opam-switch/packages/cach
 SYSTEM                          LOCK ${BASEDIR}/void/_opam/.opam-switch/packages/cache (write => none)
 FILE(switch-config)             Wrote ${BASEDIR}/void/_opam/.opam-switch/switch-config atomically in 0.000s
 FILE(switch-config)             Wrote ${BASEDIR}/void/_opam/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/void/_opam/.opam-switch/config
+SYSTEM                          scan files in ${BASEDIR}/void/opam
+SYSTEM                          scan dirs in ${BASEDIR}/void/opam
+SYSTEM                          scan files in ${BASEDIR}/void
+SYSTEM                          scan dirs in ${BASEDIR}/void
 FILE(environment)               Wrote ${BASEDIR}/void/_opam/.opam-switch/environment atomically in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (write => none)
 SYSTEM                          LOCK ${BASEDIR}/void/_opam/.opam-switch/lock (write => none)
@@ -2451,7 +2617,13 @@ CACHE(installed)                ${BASEDIR}/main-ppin/_opam/.opam-switch/packages
 SYSTEM                          LOCK ${BASEDIR}/main-ppin/_opam/.opam-switch/packages/cache (write => none)
 FILE(switch-config)             Wrote ${BASEDIR}/main-ppin/_opam/.opam-switch/switch-config atomically in 0.000s
 FILE(switch-config)             Wrote ${BASEDIR}/main-ppin/_opam/.opam-switch/switch-config atomically in 0.000s
+SYSTEM                          scan files in ${BASEDIR}/main-ppin/_opam/.opam-switch/config
+SYSTEM                          scan files in ${BASEDIR}/main-ppin/opam
+SYSTEM                          scan dirs in ${BASEDIR}/main-ppin/opam
+SYSTEM                          scan files in ${BASEDIR}/main-ppin
+SYSTEM                          scan dirs in ${BASEDIR}/main-ppin
 FILE(opam)                      Read ${BASEDIR}/main-ppin/main-ppin.opam in 0.000s
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/main-ppin
 [NOTE] Package main-ppin does not exist in opam repositories registered in the current switch.
 SYSTEM                          rmdir ${BASEDIR}/main-ppin/_opam/.opam-switch/overlay/main-ppin
 SYSTEM                          read ${BASEDIR}/main-ppin/main-ppin.opam

--- a/tests/reftests/cache.test
+++ b/tests/reftests/cache.test
@@ -360,6 +360,7 @@ CACHE(installed)                Bad installed cache: incompatible magic string "
 SYSTEM                          LOCK ${BASEDIR}/OPAM/safe-cache/.opam-switch/packages/cache (read => none)
 CACHE(installed)                Invalid installed cache, removing
 CACHE(installed)                Running in safe mode, not upgrading the installed cache
+SYSTEM                          scan files in ${BASEDIR}/OPAM/safe-cache/.opam-switch/config
 im-here
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)
@@ -399,6 +400,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/safe-cache/.opam-switch/pac
 CACHE(installed)                Writing the installed cache to ${BASEDIR}/OPAM/safe-cache/.opam-switch/packages/cache ...
 CACHE(installed)                ${BASEDIR}/OPAM/safe-cache/.opam-switch/packages/cache written in 0.000s
 SYSTEM                          LOCK ${BASEDIR}/OPAM/safe-cache/.opam-switch/packages/cache (write => none)
+SYSTEM                          scan files in ${BASEDIR}/OPAM/safe-cache/.opam-switch/config
 im-here
 SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/lock (none => none)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/config.lock (none => none)

--- a/tests/reftests/dot-install.test
+++ b/tests/reftests/dot-install.test
@@ -257,6 +257,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/rem-dir/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/rem-dir/.opam-switch/packages/cache (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/rem-dir/.opam-switch/packages/cache (read => none)
+SYSTEM                          scan files in ${BASEDIR}/OPAM/rem-dir/.opam-switch/config
 SYSTEM                          mkdir ${BASEDIR}/OPAM/rem-dir/.opam-switch/backup
 The following actions will be performed:
 === install 1 package
@@ -265,6 +266,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 SYSTEM                          rmdir ${BASEDIR}/OPAM/rem-dir/.opam-switch/build/no-specified-dir.1
 SYSTEM                          mkdir ${BASEDIR}/OPAM/rem-dir/.opam-switch/build/no-specified-dir.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/no-specified-dir/no-specified-dir.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/no-specified-dir/no-specified-dir.1/files/no-specified-dir.install
 SYSTEM                          write ${BASEDIR}/OPAM/rem-dir/.opam-switch/build/no-specified-dir.1/no-specified-dir.install
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/no-specified-dir/no-specified-dir.1/files/a-file
@@ -281,6 +283,7 @@ TRACK                           after install: 9 elements, 7 added, scanned in 0
 -> installed no-specified-dir.1
 SYSTEM                          rm ${BASEDIR}/OPAM/rem-dir/.opam-switch/packages/cache
 SYSTEM                          mkdir ${BASEDIR}/OPAM/rem-dir/.opam-switch/packages/no-specified-dir.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/no-specified-dir/no-specified-dir.1/files
 SYSTEM                          mkdir ${BASEDIR}/OPAM/rem-dir/.opam-switch/packages/no-specified-dir.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/no-specified-dir/no-specified-dir.1/files/no-specified-dir.install
 SYSTEM                          write ${BASEDIR}/OPAM/rem-dir/.opam-switch/packages/no-specified-dir.1/files/no-specified-dir.install
@@ -316,6 +319,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/rem-dir/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/rem-dir/.opam-switch/packages/cache (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/rem-dir/.opam-switch/packages/cache (read => none)
+SYSTEM                          scan files in ${BASEDIR}/OPAM/rem-dir/.opam-switch/config
 The following actions will be performed:
 === remove 1 package
   - remove no-specified-dir 1
@@ -323,6 +327,11 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 SYSTEM                          mkdir ${BASEDIR}/OPAM/rem-dir/.opam-switch/remove
 SYSTEM                          mkdir ${BASEDIR}/OPAM/rem-dir/.opam-switch/remove/no-specified-dir.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/rem-dir/lib/no-specified-dir
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/rem-dir/lib/no-specified-dir
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/rem-dir/share/no-specified-dir
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/rem-dir/etc/no-specified-dir
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/rem-dir/doc/no-specified-dir
 SYSTEM                          rmdir ${BASEDIR}/OPAM/rem-dir/lib/no-specified-dir
 SYSTEM                          rmdir ${BASEDIR}/OPAM/rem-dir/lib/no-specified-dir
 SYSTEM                          rm ${BASEDIR}/OPAM/rem-dir/share/no-specified-dir/a-file
@@ -431,6 +440,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (read => none)
+SYSTEM                          scan files in ${BASEDIR}/OPAM/escapability/.opam-switch/config
 SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/.opam-switch/backup
 The following actions will be performed:
 === install 1 package
@@ -439,6 +449,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1
 SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/eskape.install
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/a-file
@@ -476,6 +487,7 @@ SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/
 -> installed eskape.1
 SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache
 SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/.opam-switch/packages/eskape.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files
 SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/.opam-switch/packages/eskape.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/eskape.install
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/packages/eskape.1/files/eskape.install
@@ -516,6 +528,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (write => none)
+SYSTEM                          scan files in ${BASEDIR}/OPAM/escapability/.opam-switch/config
 The following actions will be performed:
 === install 1 package
   - install eskape 1
@@ -528,6 +541,8 @@ SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/bui
 SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/dosiero
 SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/good
 SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/eskape.install
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape.1/eskape.install
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape/eskape.1/files/a-file
@@ -606,6 +621,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (read => none)
+SYSTEM                          scan files in ${BASEDIR}/OPAM/escapability/.opam-switch/config
 The following actions will be performed:
 === install 1 package
   - install eskape-rel-dotdot-exists 1
@@ -613,6 +629,8 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1
 SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/eskape-rel-dotdot-exists/eskape-rel-dotdot-exists.1/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/eskape-rel-dotdot-exists/eskape-rel-dotdot-exists.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape-rel-dotdot-exists/eskape-rel-dotdot-exists.1/files/eskape-rel-dotdot-exists.install
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-dotdot-exists.1/eskape-rel-dotdot-exists.install
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape-rel-dotdot-exists/eskape-rel-dotdot-exists.1/files/a-file
@@ -693,6 +711,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (read => none)
+SYSTEM                          scan files in ${BASEDIR}/OPAM/escapability/.opam-switch/config
 The following actions will be performed:
 === install 1 package
   - install eskape-rel-middotdot-notexists 1
@@ -700,6 +719,8 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1
 SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/eskape-rel-middotdot-notexists/eskape-rel-middotdot-notexists.1/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/eskape-rel-middotdot-notexists/eskape-rel-middotdot-notexists.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape-rel-middotdot-notexists/eskape-rel-middotdot-notexists.1/files/eskape-rel-middotdot-notexists.install
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-rel-middotdot-notexists.1/eskape-rel-middotdot-notexists.install
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape-rel-middotdot-notexists/eskape-rel-middotdot-notexists.1/files/a-file
@@ -793,6 +814,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (read => none)
+SYSTEM                          scan files in ${BASEDIR}/OPAM/escapability/.opam-switch/config
 The following actions will be performed:
 === install 1 package
   - install realeskape-rel-middotdot-notexists 1
@@ -800,6 +822,7 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/.opam-switch/build/realeskape-rel-middotdot-notexists.1
 SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/.opam-switch/build/realeskape-rel-middotdot-notexists.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/realeskape-rel-middotdot-notexists/realeskape-rel-middotdot-notexists.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/realeskape-rel-middotdot-notexists/realeskape-rel-middotdot-notexists.1/files/realeskape-rel-middotdot-notexists.install
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/realeskape-rel-middotdot-notexists.1/realeskape-rel-middotdot-notexists.install
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/realeskape-rel-middotdot-notexists/realeskape-rel-middotdot-notexists.1/files/a-file
@@ -822,10 +845,15 @@ SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/
           Path 'tmp/../../../../middle/a-file' contains '..', its use is discouraged
 [WARNING] At ${BASEDIR}/OPAM/escapability/.opam-switch/install/realeskape-rel-middotdot-notexists.install:5:15-5:46::
           Path 'tmp/../../../../middle/a-file' contains '..', its use is discouraged
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/escapability/lib/realeskape-rel-middotdot-notexists
 SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/lib/realeskape-rel-middotdot-notexists
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/escapability/lib/realeskape-rel-middotdot-notexists
 SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/lib/realeskape-rel-middotdot-notexists
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/escapability/share/realeskape-rel-middotdot-notexists
 SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/share/realeskape-rel-middotdot-notexists
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/escapability/etc/realeskape-rel-middotdot-notexists
 SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/etc/realeskape-rel-middotdot-notexists
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/escapability/doc/realeskape-rel-middotdot-notexists
 SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/doc/realeskape-rel-middotdot-notexists
 SYSTEM                          rm ${BASEDIR}/OPAM/escapability/.opam-switch/install/realeskape-rel-middotdot-notexists.install
 
@@ -879,6 +907,7 @@ SYSTEM                          LOCK ${BASEDIR}/OPAM/repo/state-${MAGICV}.cache 
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/lock (none => write)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (none => read)
 SYSTEM                          LOCK ${BASEDIR}/OPAM/escapability/.opam-switch/packages/cache (read => none)
+SYSTEM                          scan files in ${BASEDIR}/OPAM/escapability/.opam-switch/config
 The following actions will be performed:
 === install 1 package
   - install eskape-abs 1
@@ -886,6 +915,8 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 SYSTEM                          rmdir ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-abs.1
 SYSTEM                          mkdir ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-abs.1
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/eskape-abs/eskape-abs.1/files
+SYSTEM                          scan files recursively (except_vcs: false) in ${BASEDIR}/OPAM/repo/default/packages/eskape-abs/eskape-abs.1/files
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape-abs/eskape-abs.1/files/eskape-abs.install
 SYSTEM                          write ${BASEDIR}/OPAM/escapability/.opam-switch/build/eskape-abs.1/eskape-abs.install
 SYSTEM                          read ${BASEDIR}/OPAM/repo/default/packages/eskape-abs/eskape-abs.1/files/a-file

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1743,6 +1743,27 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:orphans.test} %{read-lines:testing-env}))))
 
 (rule
+ (alias reftest-package-legacy-sidefiles)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (action
+  (diff package-legacy-sidefiles.test package-legacy-sidefiles.out)))
+
+(alias
+ (name reftest)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (deps (alias reftest-package-legacy-sidefiles)))
+
+(rule
+ (targets package-legacy-sidefiles.out)
+ (deps root-N0REP0)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (package opam)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:package-legacy-sidefiles.test} %{read-lines:testing-env}))))
+
+(rule
  (alias reftest-parallel)
  (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action

--- a/tests/reftests/extrafile.test
+++ b/tests/reftests/extrafile.test
@@ -700,3 +700,291 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 -> installed good-nested-md5.1
 Done.
+### ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+### : Make sure extra-files aren't scanned in any of the other special directories
+### : when pinned from a local directory
+### ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+### : with the opam file in the root directory of the project
+### opam switch create extra-files-location --empty
+### rm -rf local-pkg
+### <local-pkg/standalone-file>
+Some random unused file
+### <local-pkg/files/some-extrafile>
+here is an extra file
+### <local-pkg/files/dir/some-other-extrafile>
+here is another extra file
+### <local-pkg/opam/file-in-opam-dir>
+This shouldn't be an extrafile
+### <local-pkg/opam/files/file-in-opam-dir-slash-files>
+This shouldn't be an extrafile either
+### openssl md5 local-pkg/standalone-file | '.*= ' -> '' >$ STANDALONE_MD5
+### openssl md5 local-pkg/files/some-extrafile | '.*= ' -> '' >$ EXTRAFILE_MD5
+### openssl md5 local-pkg/files/dir/some-other-extrafile | '.*= ' -> '' >$ OTHEREXTRAFILE_MD5
+### openssl md5 local-pkg/opam/file-in-opam-dir | '.*= ' -> '' >$ FILEINOPAM_MD5
+### openssl md5 local-pkg/opam/files/file-in-opam-dir-slash-files | '.*= ' -> '' >$ FILEINOPAMSLASHFILES_MD5
+### <extrafiles.sh>
+#!/bin/sh
+
+set -eu
+
+cat > "$1" << EOF
+opam-version: "2.0"
+build: [
+  ["test" "-f" "standalone-file"]
+  ["test" "-f" "some-extrafile"]
+  ["test" "-f" "dir/some-other-extrafile"]
+  ["test" "!" "-f" "file-in-opam-dir"]
+  ["test" "!" "-f" "file-in-opam-dir-slash-files"]
+]
+extra-files: [
+  ["standalone-file" "md5=$STANDALONE_MD5"]
+  ["some-extrafile" "md5=$EXTRAFILE_MD5"]
+  ["dir/some-other-extrafile" "md5=$OTHEREXTRAFILE_MD5"]
+  ["file-in-opam-dir" "md5=$FILEINOPAM_MD5"]
+  ["file-in-opam-dir-slash-files" "md5=$FILEINOPAMSLASHFILES_MD5"]
+]
+EOF
+### sh extrafiles.sh local-pkg/local-pkg.opam
+### opam show --no-lint --raw -f name,version,build,extra-files,url.src,url.checksum local-pkg/local-pkg.opam
+name:         "local-pkg"
+version:      "dev"
+build:        ["test" "-f" "standalone-file"]
+              ["test" "-f" "some-extrafile"]
+              ["test" "-f" "dir/some-other-extrafile"]
+              ["test" "!" "-f" "file-in-opam-dir"]
+              ["test" "!" "-f" "file-in-opam-dir-slash-files"]
+extra-files:  ["standalone-file" "md5=d3f734eb19ab1034a28b6c6906a3abb4"]
+              ["some-extrafile" "md5=daa4f25318ffd269629acc4c5dd6af1f"]
+              ["dir/some-other-extrafile" "md5=83818bf129403aba49ac140d109c03d5"]
+              ["file-in-opam-dir" "md5=0e0423ece5bb01b9093d04ac41aab85c"]
+              ["file-in-opam-dir-slash-files" "md5=24065d44a4a481ec928dedd084541f1b"]
+url.src:
+url.checksum:
+### opam pin -n ./local-pkg
+[NOTE] Package local-pkg does not exist in opam repositories registered in the current switch.
+[WARNING] Overlay file of local-pkg standalone-file not found, ignoring
+[WARNING] Overlay file of local-pkg file-in-opam-dir not found, ignoring
+[WARNING] Overlay file of local-pkg file-in-opam-dir-slash-files not found, ignoring
+local-pkg is now pinned to file://${BASEDIR}/local-pkg (version dev)
+### opam show --no-lint --raw -f name,version,build,extra-files,url.src,url.checksum local-pkg.dev
+name:         "local-pkg"
+version:      "dev"
+build:        ["test" "-f" "standalone-file"]
+              ["test" "-f" "some-extrafile"]
+              ["test" "-f" "dir/some-other-extrafile"]
+              ["test" "!" "-f" "file-in-opam-dir"]
+              ["test" "!" "-f" "file-in-opam-dir-slash-files"]
+extra-files:  ["some-extrafile" "md5=daa4f25318ffd269629acc4c5dd6af1f"]
+              ["dir/some-other-extrafile" "md5=83818bf129403aba49ac140d109c03d5"]
+url.src:      "file://${BASEDIR}/local-pkg"
+url.checksum:
+### opam install --verbose-on local-pkg local-pkg | sed-cmd test
+
+<><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
+[local-pkg.dev] synchronised (no changes)
+
+The following actions will be performed:
+=== install 1 package
+  - install local-pkg dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved local-pkg.dev  (file://${BASEDIR}/local-pkg)
++ test "-f" "standalone-file" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "-f" "some-extrafile" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "-f" "dir/some-other-extrafile" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "file-in-opam-dir" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "file-in-opam-dir-slash-files" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
+-> compiled  local-pkg.dev
+-> installed local-pkg.dev
+Done.
+### opam unpin ./local-pkg
+Ok, local-pkg is no longer pinned to file://${BASEDIR}/local-pkg (version dev)
+The following actions will be performed:
+=== remove 1 package
+  - remove local-pkg dev
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   local-pkg.dev
+Done.
+### opam install --verbose-on local-pkg ./local-pkg | sed-cmd test
+[WARNING] Failed checks on local-pkg package definition from source at file://${BASEDIR}/local-pkg:
+             error 23: Missing field 'maintainer'
+           warning 25: Missing field 'authors'
+           warning 35: Missing field 'homepage'
+           warning 36: Missing field 'bug-reports'
+             error 57: Synopsis must not be empty
+           warning 68: Missing field 'license'
+[NOTE] Package local-pkg does not exist in opam repositories registered in the current switch.
+[WARNING] Overlay file of local-pkg standalone-file not found, ignoring
+[WARNING] Overlay file of local-pkg file-in-opam-dir not found, ignoring
+[WARNING] Overlay file of local-pkg file-in-opam-dir-slash-files not found, ignoring
+local-pkg is now pinned to file://${BASEDIR}/local-pkg (version dev)
+The following actions will be performed:
+=== install 1 package
+  - install local-pkg dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved local-pkg.dev  (file://${BASEDIR}/local-pkg)
++ test "-f" "standalone-file" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "-f" "some-extrafile" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "-f" "dir/some-other-extrafile" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "file-in-opam-dir" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "file-in-opam-dir-slash-files" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
+-> compiled  local-pkg.dev
+-> installed local-pkg.dev
+Done.
+### opam show --no-lint --raw -f name,version,build,extra-files,url.src,url.checksum local-pkg.dev
+name:         "local-pkg"
+version:      "dev"
+build:        ["test" "-f" "standalone-file"]
+              ["test" "-f" "some-extrafile"]
+              ["test" "-f" "dir/some-other-extrafile"]
+              ["test" "!" "-f" "file-in-opam-dir"]
+              ["test" "!" "-f" "file-in-opam-dir-slash-files"]
+extra-files:  ["some-extrafile" "md5=daa4f25318ffd269629acc4c5dd6af1f"]
+              ["dir/some-other-extrafile" "md5=83818bf129403aba49ac140d109c03d5"]
+url.src:      "file://${BASEDIR}/local-pkg"
+url.checksum:
+### opam unpin local-pkg
+Ok, local-pkg is no longer pinned to file://${BASEDIR}/local-pkg (version dev)
+The following actions will be performed:
+=== remove 1 package
+  - remove local-pkg dev
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   local-pkg.dev
+Done.
+### : with the opam file in the opam/ directory of the project
+### <extrafiles.sh>
+#!/bin/sh
+
+set -eu
+
+cat > "$1" << EOF
+opam-version: "2.0"
+build: [
+  ["test" "-f" "standalone-file"]
+  ["test" "!" "-f" "some-extrafile"]
+  ["test" "!" "-f" "dir/some-other-extrafile"]
+  ["test" "!" "-f" "file-in-opam-dir"]
+  ["test" "-f" "file-in-opam-dir-slash-files"]
+]
+extra-files: [
+  ["standalone-file" "md5=$STANDALONE_MD5"]
+  ["some-extrafile" "md5=$EXTRAFILE_MD5"]
+  ["dir/some-other-extrafile" "md5=$OTHEREXTRAFILE_MD5"]
+  ["file-in-opam-dir" "md5=$FILEINOPAM_MD5"]
+  ["file-in-opam-dir-slash-files" "md5=$FILEINOPAMSLASHFILES_MD5"]
+]
+EOF
+### rm local-pkg/local-pkg.opam
+### sh extrafiles.sh local-pkg/opam/opam
+### opam show --no-lint --raw -f name,version,build,extra-files,url.src,url.checksum local-pkg/
+name:         "local-pkg"
+version:      "dev"
+build:        ["test" "-f" "standalone-file"]
+              ["test" "!" "-f" "some-extrafile"]
+              ["test" "!" "-f" "dir/some-other-extrafile"]
+              ["test" "!" "-f" "file-in-opam-dir"]
+              ["test" "-f" "file-in-opam-dir-slash-files"]
+extra-files:  ["standalone-file" "md5=d3f734eb19ab1034a28b6c6906a3abb4"]
+              ["some-extrafile" "md5=daa4f25318ffd269629acc4c5dd6af1f"]
+              ["dir/some-other-extrafile" "md5=83818bf129403aba49ac140d109c03d5"]
+              ["file-in-opam-dir" "md5=0e0423ece5bb01b9093d04ac41aab85c"]
+              ["file-in-opam-dir-slash-files" "md5=24065d44a4a481ec928dedd084541f1b"]
+url.src:
+url.checksum:
+### opam pin -n ./local-pkg
+[NOTE] Package local-pkg does not exist in opam repositories registered in the current switch.
+[WARNING] Overlay file of local-pkg standalone-file not found, ignoring
+[WARNING] Overlay file of local-pkg some-extrafile not found, ignoring
+[WARNING] Overlay file of local-pkg dir/some-other-extrafile not found, ignoring
+[WARNING] Overlay file of local-pkg file-in-opam-dir not found, ignoring
+local-pkg is now pinned to file://${BASEDIR}/local-pkg (version dev)
+### opam show --no-lint --raw -f name,version,build,extra-files,url.src,url.checksum local-pkg.dev
+name:         "local-pkg"
+version:      "dev"
+build:        ["test" "-f" "standalone-file"]
+              ["test" "!" "-f" "some-extrafile"]
+              ["test" "!" "-f" "dir/some-other-extrafile"]
+              ["test" "!" "-f" "file-in-opam-dir"]
+              ["test" "-f" "file-in-opam-dir-slash-files"]
+extra-files:  "file-in-opam-dir-slash-files" "md5=24065d44a4a481ec928dedd084541f1b"
+url.src:      "file://${BASEDIR}/local-pkg"
+url.checksum:
+### opam install --verbose-on local-pkg local-pkg | sed-cmd test
+
+<><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
+[local-pkg.dev] synchronised (no changes)
+
+The following actions will be performed:
+=== install 1 package
+  - install local-pkg dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved local-pkg.dev  (file://${BASEDIR}/local-pkg)
++ test "-f" "standalone-file" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "some-extrafile" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "dir/some-other-extrafile" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "file-in-opam-dir" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "-f" "file-in-opam-dir-slash-files" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
+-> compiled  local-pkg.dev
+-> installed local-pkg.dev
+Done.
+### opam unpin ./local-pkg
+Ok, local-pkg is no longer pinned to file://${BASEDIR}/local-pkg (version dev)
+The following actions will be performed:
+=== remove 1 package
+  - remove local-pkg dev
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   local-pkg.dev
+Done.
+### opam install --verbose-on local-pkg ./local-pkg | sed-cmd test
+[WARNING] Failed checks on local-pkg package definition from source at file://${BASEDIR}/local-pkg:
+             error 23: Missing field 'maintainer'
+           warning 25: Missing field 'authors'
+           warning 35: Missing field 'homepage'
+           warning 36: Missing field 'bug-reports'
+             error 57: Synopsis must not be empty
+           warning 68: Missing field 'license'
+[NOTE] Package local-pkg does not exist in opam repositories registered in the current switch.
+[WARNING] Overlay file of local-pkg standalone-file not found, ignoring
+[WARNING] Overlay file of local-pkg some-extrafile not found, ignoring
+[WARNING] Overlay file of local-pkg dir/some-other-extrafile not found, ignoring
+[WARNING] Overlay file of local-pkg file-in-opam-dir not found, ignoring
+local-pkg is now pinned to file://${BASEDIR}/local-pkg (version dev)
+The following actions will be performed:
+=== install 1 package
+  - install local-pkg dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved local-pkg.dev  (file://${BASEDIR}/local-pkg)
++ test "-f" "standalone-file" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "some-extrafile" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "dir/some-other-extrafile" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "file-in-opam-dir" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
++ test "-f" "file-in-opam-dir-slash-files" (CWD=${BASEDIR}/OPAM/extra-files-location/.opam-switch/build/local-pkg.dev)
+-> compiled  local-pkg.dev
+-> installed local-pkg.dev
+Done.
+### opam show --no-lint --raw -f name,version,build,extra-files,url.src,url.checksum local-pkg.dev
+name:         "local-pkg"
+version:      "dev"
+build:        ["test" "-f" "standalone-file"]
+              ["test" "!" "-f" "some-extrafile"]
+              ["test" "!" "-f" "dir/some-other-extrafile"]
+              ["test" "!" "-f" "file-in-opam-dir"]
+              ["test" "-f" "file-in-opam-dir-slash-files"]
+extra-files:  "file-in-opam-dir-slash-files" "md5=24065d44a4a481ec928dedd084541f1b"
+url.src:      "file://${BASEDIR}/local-pkg"
+url.checksum:
+### opam unpin local-pkg
+Ok, local-pkg is no longer pinned to file://${BASEDIR}/local-pkg (version dev)
+The following actions will be performed:
+=== remove 1 package
+  - remove local-pkg dev
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   local-pkg.dev
+Done.

--- a/tests/reftests/package-legacy-sidefiles.test
+++ b/tests/reftests/package-legacy-sidefiles.test
@@ -1,0 +1,418 @@
+N0REP0
+### OPAMYES=1
+### mkdir dir
+### tar czf file.tar.gz dir
+### openssl md5 file.tar.gz | '.*= ' -> '' >$ ARCHIVE_MD5
+### <url.sh>
+#!/bin/sh
+
+set -eu
+
+basedir=$(printf '%s' "$BASEDIR" | sed 's/\\/\\\\/g')
+cat > "$1" << EOF
+src: "file://$basedir/file.tar.gz"
+checksum: "md5=$ARCHIVE_MD5"
+EOF
+### :I: with format upgrade from 1.2
+### opam switch create 1dot2-upgrade-sw --empty
+### :I:1: format upgrade a package in a repository
+### <REPO/repo>
+opam-version: "1.2"
+### <REPO/packages/ocaml/ocaml.1/opam>
+opam-version: "2.0"
+### <REPO/packages/pkg/pkg.1/opam>
+opam-version: "1.2"
+build: [
+  ["test" "!" "-f" "standalone-file"]
+  ["test" "-f" "some-extrafile"]
+  ["test" "-f" "dir/some-other-extrafile"]
+]
+### <REPO/packages/pkg/pkg.1/standalone-file>
+Some random unused file
+### <REPO/packages/pkg/pkg.1/files/some-extrafile>
+here is an extra file
+### <REPO/packages/pkg/pkg.1/files/dir/some-other-extrafile>
+here is another extra file
+### <REPO/packages/pkg/pkg.1/descr>
+Some descr
+More descr
+### sh url.sh REPO/packages/pkg/pkg.1/url
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+
+<><> Upgrading repositories from older opam format ><><><><><><><><><><><><><><>
+Upgrading repository "default"...
+Updated ${BASEDIR}/OPAM/repo/default/packages/pkg/pkg.1/opam
+Now run 'opam upgrade' to apply any package updates.
+### find REPO | sort
+REPO
+REPO/packages
+REPO/packages/ocaml
+REPO/packages/ocaml/ocaml.1
+REPO/packages/ocaml/ocaml.1/opam
+REPO/packages/pkg
+REPO/packages/pkg/pkg.1
+REPO/packages/pkg/pkg.1/descr
+REPO/packages/pkg/pkg.1/files
+REPO/packages/pkg/pkg.1/files/dir
+REPO/packages/pkg/pkg.1/files/dir/some-other-extrafile
+REPO/packages/pkg/pkg.1/files/some-extrafile
+REPO/packages/pkg/pkg.1/opam
+REPO/packages/pkg/pkg.1/standalone-file
+REPO/packages/pkg/pkg.1/url
+REPO/repo
+### opam show --no-lint --raw -f name,version,synopsis,description,build,extra-files,url.src,url.checksum pkg.1 | sed-hash $ARCHIVE_MD5 archive-md5
+name:         "pkg"
+version:      "1"
+synopsis:     "Some descr"
+description:  "More descr"
+build:        ["test" "!" "-f" "standalone-file"]
+              ["test" "-f" "some-extrafile"]
+              ["test" "-f" "dir/some-other-extrafile"]
+extra-files:  ["dir/some-other-extrafile" "md5=83818bf129403aba49ac140d109c03d5"]
+              ["some-extrafile" "md5=daa4f25318ffd269629acc4c5dd6af1f"]
+url.src:      "file://${BASEDIR}/file.tar.gz"
+url.checksum: "md5=+archive-md5+"
+### opam install --verbose-on pkg pkg | sed-cmd test
+The following actions will be performed:
+=== install 2 packages
+  - install ocaml 1 [required by pkg]
+  - install pkg   1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> installed ocaml.1
+-> retrieved pkg.1  (file://${BASEDIR}/file.tar.gz)
++ test "!" "-f" "standalone-file" (CWD=${BASEDIR}/OPAM/1dot2-upgrade-sw/.opam-switch/build/pkg.1)
++ test "-f" "some-extrafile" (CWD=${BASEDIR}/OPAM/1dot2-upgrade-sw/.opam-switch/build/pkg.1)
++ test "-f" "dir/some-other-extrafile" (CWD=${BASEDIR}/OPAM/1dot2-upgrade-sw/.opam-switch/build/pkg.1)
+-> compiled  pkg.1
+-> installed pkg.1
+Done.
+### opam remove pkg
+The following actions will be performed:
+=== remove 1 package
+  - remove pkg 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   pkg.1
+Done.
+### cat REPO/packages/pkg/pkg.1/opam
+opam-version: "1.2"
+build: [
+  ["test" "!" "-f" "standalone-file"]
+  ["test" "-f" "some-extrafile"]
+  ["test" "-f" "dir/some-other-extrafile"]
+]
+### :I:2: format upgrade a package in a local dir
+### <local-pkg/local-pkg.opam>
+opam-version: "1.2"
+build: [
+  ["test" "-f" "standalone-file"]
+  ["test" "!" "-f" "some-extrafile"]
+  ["test" "!" "-f" "dir/some-other-extrafile"]
+  ["test" "!" "-f" "file-in-opam-dir"]
+  ["test" "!" "-f" "file-in-opam-dir-slash-files"]
+]
+### <local-pkg/standalone-file>
+Some random unused file
+### <local-pkg/files/some-extrafile>
+here is an extra file
+### <local-pkg/files/dir/some-other-extrafile>
+here is another extra file
+### <local-pkg/descr>
+Some descr
+More descr
+### <local-pkg/opam/file-in-opam-dir>
+This shouldn't be an extrafile
+### <local-pkg/opam/files/file-in-opam-dir-slash-files>
+This shouldn't be an extrafile either
+### sh url.sh local-pkg/url
+### :I:2:a: via show
+### opam show --no-lint --raw -f name,version,synopsis,description,build,extra-files,url.src,url.checksum local-pkg/local-pkg.opam | sed-hash $ARCHIVE_MD5 archive-md5
+name:         "local-pkg"
+version:      "dev"
+synopsis:     "Some descr"
+description:  "More descr"
+build:        ["test" "-f" "standalone-file"]
+              ["test" "!" "-f" "some-extrafile"]
+              ["test" "!" "-f" "dir/some-other-extrafile"]
+              ["test" "!" "-f" "file-in-opam-dir"]
+              ["test" "!" "-f" "file-in-opam-dir-slash-files"]
+extra-files:
+url.src:      "file://${BASEDIR}/file.tar.gz"
+url.checksum: "md5=+archive-md5+"
+### :I:2:b: via pin
+### opam pin -n ./local-pkg
+[NOTE] Package local-pkg does not exist in opam repositories registered in the current switch.
+local-pkg is now pinned to file://${BASEDIR}/local-pkg (version dev)
+### opam show --no-lint --raw -f name,version,synopsis,description,build,extra-files,url.src,url.checksum local-pkg.dev
+name:         "local-pkg"
+version:      "dev"
+synopsis:
+description:
+build:        ["test" "-f" "standalone-file"]
+              ["test" "!" "-f" "some-extrafile"]
+              ["test" "!" "-f" "dir/some-other-extrafile"]
+              ["test" "!" "-f" "file-in-opam-dir"]
+              ["test" "!" "-f" "file-in-opam-dir-slash-files"]
+extra-files:
+url.src:      "file://${BASEDIR}/local-pkg"
+url.checksum:
+### opam install --verbose-on local-pkg local-pkg | sed-cmd test
+
+<><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
+[local-pkg.dev] synchronised (no changes)
+
+The following actions will be performed:
+=== install 1 package
+  - install local-pkg dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved local-pkg.dev  (file://${BASEDIR}/local-pkg)
++ test "-f" "standalone-file" (CWD=${BASEDIR}/OPAM/1dot2-upgrade-sw/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "some-extrafile" (CWD=${BASEDIR}/OPAM/1dot2-upgrade-sw/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "dir/some-other-extrafile" (CWD=${BASEDIR}/OPAM/1dot2-upgrade-sw/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "file-in-opam-dir" (CWD=${BASEDIR}/OPAM/1dot2-upgrade-sw/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "file-in-opam-dir-slash-files" (CWD=${BASEDIR}/OPAM/1dot2-upgrade-sw/.opam-switch/build/local-pkg.dev)
+-> compiled  local-pkg.dev
+-> installed local-pkg.dev
+Done.
+### opam unpin ./local-pkg
+Ok, local-pkg is no longer pinned to file://${BASEDIR}/local-pkg (version dev)
+The following actions will be performed:
+=== remove 1 package
+  - remove local-pkg dev
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   local-pkg.dev
+Done.
+### :I:2:c: via autopin
+### opam install --verbose-on local-pkg ./local-pkg | sed-cmd test
+[WARNING] Failed checks on local-pkg package definition from source at file://${BASEDIR}/local-pkg:
+             error 23: Missing field 'maintainer'
+           warning 25: Missing field 'authors'
+           warning 35: Missing field 'homepage'
+           warning 36: Missing field 'bug-reports'
+           warning 37: Missing field 'dev-repo'
+           warning 68: Missing field 'license'
+[NOTE] Package local-pkg does not exist in opam repositories registered in the current switch.
+local-pkg is now pinned to file://${BASEDIR}/local-pkg (version dev)
+The following actions will be performed:
+=== install 1 package
+  - install local-pkg dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved local-pkg.dev  (file://${BASEDIR}/local-pkg)
++ test "-f" "standalone-file" (CWD=${BASEDIR}/OPAM/1dot2-upgrade-sw/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "some-extrafile" (CWD=${BASEDIR}/OPAM/1dot2-upgrade-sw/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "dir/some-other-extrafile" (CWD=${BASEDIR}/OPAM/1dot2-upgrade-sw/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "file-in-opam-dir" (CWD=${BASEDIR}/OPAM/1dot2-upgrade-sw/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "file-in-opam-dir-slash-files" (CWD=${BASEDIR}/OPAM/1dot2-upgrade-sw/.opam-switch/build/local-pkg.dev)
+-> compiled  local-pkg.dev
+-> installed local-pkg.dev
+Done.
+### opam show --no-lint --raw -f name,version,synopsis,description,build,extra-files,url.src,url.checksum local-pkg.dev
+name:         "local-pkg"
+version:      "dev"
+synopsis:     "Some descr"
+description:  "More descr"
+build:        ["test" "-f" "standalone-file"]
+              ["test" "!" "-f" "some-extrafile"]
+              ["test" "!" "-f" "dir/some-other-extrafile"]
+              ["test" "!" "-f" "file-in-opam-dir"]
+              ["test" "!" "-f" "file-in-opam-dir-slash-files"]
+extra-files:
+url.src:      "file://${BASEDIR}/local-pkg"
+url.checksum:
+### opam unpin local-pkg
+Ok, local-pkg is no longer pinned to file://${BASEDIR}/local-pkg (version dev)
+The following actions will be performed:
+=== remove 1 package
+  - remove local-pkg dev
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   local-pkg.dev
+Done.
+### cat local-pkg/local-pkg.opam
+opam-version: "1.2"
+build: [
+  ["test" "-f" "standalone-file"]
+  ["test" "!" "-f" "some-extrafile"]
+  ["test" "!" "-f" "dir/some-other-extrafile"]
+  ["test" "!" "-f" "file-in-opam-dir"]
+  ["test" "!" "-f" "file-in-opam-dir-slash-files"]
+]
+### :II: with 2.0 format
+### opam switch create 2point0-upgrade-sw --empty
+### :II:1: package in a repository
+### rm -rf REPO
+### <REPO/repo>
+opam-version: "2.0"
+### <REPO/packages/pkg/pkg.1/opam>
+opam-version: "2.0"
+build: [
+  ["test" "!" "-f" "standalone-file"]
+  ["test" "!" "-f" "some-extrafile"]
+  ["test" "!" "-f" "dir/some-other-extrafile"]
+]
+### <REPO/packages/pkg/pkg.1/standalone-file>
+Some random unused file
+### <REPO/packages/pkg/pkg.1/files/some-extrafile>
+here is an extra file
+### <REPO/packages/pkg/pkg.1/files/dir/some-other-extrafile>
+here is another extra file
+### <REPO/packages/pkg/pkg.1/descr>
+Some descr
+More descr
+### sh url.sh REPO/packages/pkg/pkg.1/url
+### opam update
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[default] synchronised from file://${BASEDIR}/REPO
+Now run 'opam upgrade' to apply any package updates.
+### find REPO | sort
+REPO
+REPO/packages
+REPO/packages/pkg
+REPO/packages/pkg/pkg.1
+REPO/packages/pkg/pkg.1/descr
+REPO/packages/pkg/pkg.1/files
+REPO/packages/pkg/pkg.1/files/dir
+REPO/packages/pkg/pkg.1/files/dir/some-other-extrafile
+REPO/packages/pkg/pkg.1/files/some-extrafile
+REPO/packages/pkg/pkg.1/opam
+REPO/packages/pkg/pkg.1/standalone-file
+REPO/packages/pkg/pkg.1/url
+REPO/repo
+### opam show --no-lint --raw -f name,version,synopsis,description,build,extra-files,url.src,url.checksum pkg.1 | sed-hash $ARCHIVE_MD5 archive-md5
+name:         "pkg"
+version:      "1"
+synopsis:     "Some descr"
+description:  "More descr"
+build:        ["test" "!" "-f" "standalone-file"]
+              ["test" "!" "-f" "some-extrafile"]
+              ["test" "!" "-f" "dir/some-other-extrafile"]
+extra-files:
+url.src:      "file://${BASEDIR}/file.tar.gz"
+url.checksum: "md5=+archive-md5+"
+### opam install --verbose-on pkg pkg | sed-cmd test
+The following actions will be performed:
+=== install 1 package
+  - install pkg 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved pkg.1  (cached)
++ test "!" "-f" "standalone-file" (CWD=${BASEDIR}/OPAM/2point0-upgrade-sw/.opam-switch/build/pkg.1)
++ test "!" "-f" "some-extrafile" (CWD=${BASEDIR}/OPAM/2point0-upgrade-sw/.opam-switch/build/pkg.1)
++ test "!" "-f" "dir/some-other-extrafile" (CWD=${BASEDIR}/OPAM/2point0-upgrade-sw/.opam-switch/build/pkg.1)
+-> compiled  pkg.1
+-> installed pkg.1
+Done.
+### :II:2: package in a local dir
+### rm -rf local-pkg
+### <local-pkg/opam>
+opam-version: "2.0"
+build: [
+  ["test" "-f" "standalone-file"]
+  ["test" "!" "-f" "some-extrafile"]
+  ["test" "!" "-f" "dir/some-other-extrafile"]
+]
+### <local-pkg/standalone-file>
+Some random unused file
+### <local-pkg/files/some-extrafile>
+here is an extra file
+### <local-pkg/files/dir/some-other-extrafile>
+here is another extra file
+### <local-pkg/descr>
+Some descr
+More descr
+### sh url.sh local-pkg/url
+### :II:2:a: via show
+### opam show --no-lint --raw -f name,version,synopsis,description,build,extra-files,url.src,url.checksum local-pkg/opam | sed-hash $ARCHIVE_MD5 archive-md5
+name:         "local-pkg"
+version:      "dev"
+synopsis:     "Some descr"
+description:  "More descr"
+build:        ["test" "-f" "standalone-file"]
+              ["test" "!" "-f" "some-extrafile"]
+              ["test" "!" "-f" "dir/some-other-extrafile"]
+extra-files:
+url.src:      "file://${BASEDIR}/file.tar.gz"
+url.checksum: "md5=+archive-md5+"
+### :II:2:b: via pin
+### opam pin -n ./local-pkg
+[NOTE] Package local-pkg does not exist in opam repositories registered in the current switch.
+local-pkg is now pinned to file://${BASEDIR}/local-pkg (version dev)
+### opam show --no-lint --raw -f name,version,synopsis,description,build,extra-files,url.src,url.checksum local-pkg.dev
+name:         "local-pkg"
+version:      "dev"
+synopsis:
+description:
+build:        ["test" "-f" "standalone-file"]
+              ["test" "!" "-f" "some-extrafile"]
+              ["test" "!" "-f" "dir/some-other-extrafile"]
+extra-files:
+url.src:      "file://${BASEDIR}/local-pkg"
+url.checksum:
+### opam install --verbose-on local-pkg local-pkg | sed-cmd test
+
+<><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
+[local-pkg.dev] synchronised (no changes)
+
+The following actions will be performed:
+=== install 1 package
+  - install local-pkg dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved local-pkg.dev  (file://${BASEDIR}/local-pkg)
++ test "-f" "standalone-file" (CWD=${BASEDIR}/OPAM/2point0-upgrade-sw/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "some-extrafile" (CWD=${BASEDIR}/OPAM/2point0-upgrade-sw/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "dir/some-other-extrafile" (CWD=${BASEDIR}/OPAM/2point0-upgrade-sw/.opam-switch/build/local-pkg.dev)
+-> compiled  local-pkg.dev
+-> installed local-pkg.dev
+Done.
+### opam unpin local-pkg
+Ok, local-pkg is no longer pinned to file://${BASEDIR}/local-pkg (version dev)
+The following actions will be performed:
+=== remove 1 package
+  - remove local-pkg dev
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> removed   local-pkg.dev
+Done.
+### :II:2:c: via autopin
+### opam install --verbose-on local-pkg ./local-pkg | sed-cmd test
+[WARNING] Failed checks on local-pkg package definition from source at file://${BASEDIR}/local-pkg:
+             error 23: Missing field 'maintainer'
+           warning 25: Missing field 'authors'
+           warning 35: Missing field 'homepage'
+           warning 36: Missing field 'bug-reports'
+           warning 37: Missing field 'dev-repo'
+           warning 68: Missing field 'license'
+[NOTE] Package local-pkg does not exist in opam repositories registered in the current switch.
+local-pkg is now pinned to file://${BASEDIR}/local-pkg (version dev)
+The following actions will be performed:
+=== install 1 package
+  - install local-pkg dev (pinned)
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+-> retrieved local-pkg.dev  (file://${BASEDIR}/local-pkg)
++ test "-f" "standalone-file" (CWD=${BASEDIR}/OPAM/2point0-upgrade-sw/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "some-extrafile" (CWD=${BASEDIR}/OPAM/2point0-upgrade-sw/.opam-switch/build/local-pkg.dev)
++ test "!" "-f" "dir/some-other-extrafile" (CWD=${BASEDIR}/OPAM/2point0-upgrade-sw/.opam-switch/build/local-pkg.dev)
+-> compiled  local-pkg.dev
+-> installed local-pkg.dev
+Done.
+### opam show --no-lint --raw -f name,version,synopsis,description,build,extra-files,url.src,url.checksum local-pkg.dev
+name:         "local-pkg"
+version:      "dev"
+synopsis:     "Some descr"
+description:  "More descr"
+build:        ["test" "-f" "standalone-file"]
+              ["test" "!" "-f" "some-extrafile"]
+              ["test" "!" "-f" "dir/some-other-extrafile"]
+extra-files:
+url.src:      "file://${BASEDIR}/local-pkg"
+url.checksum:


### PR DESCRIPTION
2.6 regression from https://github.com/ocaml/opam/commit/c9dda299a1788a87b8dfb71c16425502099d1f64
Fixes #7098 

When pinning packages, "extra-files" (`descr`, `url`, `files/**`) are scanned in the project's directory, however `rec_files` was used indiscriminately on the root directory thus scanning unused files and causing heavy use of memory and time on larger projects (or projects that have uncommited files such as in `_build`, `.git`, …) for nothing.