### PR TITLE
Upgrade the "lockfile" with all the most up-to-date dependencies available

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -76,6 +76,7 @@ users)
 ## Infrastructure
 
 ## Release scripts
+  * Update the OCaml compiler used for release to 4.14.4 [#7116 @kit-ty-kate]
 
 ## Install script
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -71,6 +71,7 @@ users)
 ## VCS
 
 ## Build
+  * Upgrade the download-if-missing dependencies to their latest version available for us to use (ocaml.4.14.4, base64.3.5.2, spdx\_licenses.1.5.0, menhir.20260209, patch.3.1.2, checkseum.0.5.3) [#7116 @kit-ty-kate]
 
 ## Infrastructure
 

--- a/release/Makefile
+++ b/release/Makefile
@@ -8,7 +8,7 @@ VERSION = $(shell git describe $(TAG))
 OPAM_VERSION = $(subst -,~,$(VERSION))
 GIT_URL = ..
 
-OCAMLV = 4.14.2
+OCAMLV = 4.14.4
 FLEXDLLV = 0.44
 # currently hardcoded in Dockerfile.in
 OCAML_URL = https://github.com/ocaml/ocaml/archive/refs/tags/$(OCAMLV).tar.gz

--- a/src_ext/Makefile
+++ b/src_ext/Makefile
@@ -10,8 +10,8 @@ endif
 
 PATCH ?= patch
 
-URL_ocaml = https://github.com/ocaml/ocaml/archive/refs/tags/4.14.2.tar.gz
-MD5_ocaml = b28daefda803b5d5910cecf085b1451c
+URL_ocaml = https://github.com/ocaml/ocaml/archive/refs/tags/4.14.4.tar.gz
+MD5_ocaml = 92d7bd721302001ceb9aa19819712c8b
 
 URL_flexdll = https://github.com/ocaml/flexdll/archive/0.44.tar.gz
 MD5_flexdll = 08731d2a5d6465cf7080a14e43e0752e

--- a/src_ext/Makefile.sources
+++ b/src_ext/Makefile.sources
@@ -4,8 +4,8 @@ MD5_cppo = a197cb393b84f6b30e0ff55080ac429b
 URL_extlib = https://github.com/ygrek/ocaml-extlib/releases/download/1.8.0/extlib-1.8.0.tar.gz
 MD5_extlib = 43fb3bf2989671af1769147b1171d080
 
-URL_base64 = https://github.com/mirage/ocaml-base64/releases/download/v3.5.1/base64-3.5.1.tbz
-MD5_base64 = bfdd16aa8c136412878109df8791fc01
+URL_base64 = https://github.com/mirage/ocaml-base64/releases/download/v3.5.2/base64-3.5.2.tbz
+MD5_base64 = 28a7acd8e8f90ab128b51ee8c0ffc355
 
 URL_re = https://github.com/ocaml/ocaml-re/archive/refs/tags/1.14.0.tar.gz
 MD5_re = 03f4a83100cb9229a796b85c698076e1
@@ -36,8 +36,8 @@ include Makefile.dune
 URL_stdlib-shims = https://github.com/ocaml/stdlib-shims/releases/download/0.3.0/stdlib-shims-0.3.0.tbz
 MD5_stdlib-shims = 09db7af8b4a3a96048a61cb6ae2496ef
 
-URL_spdx_licenses = https://github.com/kit-ty-kate/spdx_licenses/releases/download/v1.4.0/spdx_licenses-1.4.0.tar.gz
-MD5_spdx_licenses = 6accb8029f7401f1face7d4f7efa5fa7
+URL_spdx_licenses = https://github.com/kit-ty-kate/spdx_licenses/releases/download/v1.5.0/spdx_licenses-1.5.0.tar.gz
+MD5_spdx_licenses = 1071f6377ebc872404e3ee0d03838299
 
 URL_uutf = https://erratique.ch/software/uutf/releases/uutf-1.0.4.tbz
 MD5_uutf = 19c8e6d8ae6c70116495a7d44ac75f3d
@@ -51,14 +51,14 @@ MD5_sha = 08bc953d9a26380bc220b05d680791fb
 URL_swhid_core = https://github.com/OCamlPro/swhid_core/archive/refs/tags/0.1.tar.gz
 MD5_swhid_core = 77d88d4b1d96261c866f140c64d89af8
 
-URL_menhir = https://gitlab.inria.fr/fpottier/menhir/-/archive/20250903/archive.tar.gz
-MD5_menhir = 5ecb7f71cf374147d3d3137c6e2fe382
+URL_menhir = https://gitlab.inria.fr/fpottier/menhir/-/archive/20260209/archive.tar.gz
+MD5_menhir = e993231085db95ab011ffe0cd606d9dd
 
-URL_patch = https://github.com/hannesm/patch/releases/download/v3.1.0/patch-3.1.0.tbz
-MD5_patch = afda4079f824f3c2ae69f5064bcf870b
+URL_patch = https://github.com/hannesm/patch/releases/download/v3.1.2/patch-3.1.2.tbz
+MD5_patch = 64838d4076de9825d2046e00d0684789
 
-URL_checkseum = https://github.com/mirage/checkseum/releases/download/v0.5.2/checkseum-0.5.2.tbz
-MD5_checkseum = 2e41c0d1ec16aca3f33b148b06ded014
+URL_checkseum = https://github.com/mirage/checkseum/releases/download/v0.5.3/checkseum-0.5.3.tbz
+MD5_checkseum = 432aa95f12a8eb2bbf298362c9c441e7
 
 URL_optint = https://github.com/mirage/optint/releases/download/v0.3.0/optint-0.3.0.tbz
 MD5_optint = 46cc1b8bd00872529ac01407f908d389


### PR DESCRIPTION
Changes:
- ~dune ¯\\\_(ツ)\_/¯ however it cannot be updated to its current latest version due to https://github.com/ocaml/dune/issues/15340~ EDIT: not updated. There are complications with OCaml 5.6
- base64 removed support for OCaml < 4.07
- spdx_licenses upgraded to Version 3.28.0 of the SPDX License List
- menhir removed support for OCaml < 4.08 and fixed a couple of bugs that do not impact us
- patch fixed an issue arising with handwritten patches https://github.com/hannesm/patch/pull/42
- checkseum fixed some C warnings on recent clang versions
- ~decompress sped up compression~ EDIT: not updated. 32bit support is missing

I noticed the C warnings fixed in the `checkseum` release while building the macOS binaries for 2.6.0\~beta2