### PR TITLE
release: Ensure 32bit binaries have matching architectures

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -77,6 +77,7 @@ users)
 ## Infrastructure
 
 ## Release scripts
+  * Make x86\_32 binaries take full advantage of i686 [#7120 @kit-ty-kate]
 
 ## Install script
   * Add opam 2.6.0\~rc1 to the install scripts [#7135 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -78,6 +78,7 @@ users)
 
 ## Release scripts
   * Make x86\_32 binaries take full advantage of i686 [#7120 @kit-ty-kate]
+  * Ensure arm32 binaries are really armhf as advertised instead of armv7 [#7120 @kit-ty-kate]
 
 ## Install script
   * Add opam 2.6.0\~rc1 to the install scripts [#7135 @kit-ty-kate]

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -12,8 +12,6 @@ ADD https://github.com/ocaml/ocaml/archive/refs/tags/%OCAMLV%.tar.gz /root/
 WORKDIR /root
 RUN tar xzf %OCAMLV%.tar.gz
 WORKDIR ocaml-%OCAMLV%
-RUN sed -i 's/gnueabi/*eabi/' configure
-RUN sed -i 's/musl/musl*/' configure
 RUN ./configure -prefix /usr/local
 RUN make "-j$(nproc)" && make install && rm -rf /root/ocaml-%OCAMLV% /root/ocaml-%OCAMLV%.tar.gz
 

--- a/release/Dockerfile.in
+++ b/release/Dockerfile.in
@@ -14,7 +14,7 @@ RUN tar xzf %OCAMLV%.tar.gz
 WORKDIR ocaml-%OCAMLV%
 RUN sed -i 's/gnueabi/*eabi/' configure
 RUN sed -i 's/musl/musl*/' configure
-RUN ./configure %CONF% -prefix /usr/local
+RUN ./configure -prefix /usr/local
 RUN make "-j$(nproc)" && make install && rm -rf /root/ocaml-%OCAMLV% /root/ocaml-%OCAMLV%.tar.gz
 
 RUN apk add patch

--- a/release/Makefile
+++ b/release/Makefile
@@ -46,21 +46,19 @@ $(OUTDIR)/opam-full-$(VERSION).tar.gz:
 	rm -rf "$(OUTDIR)/opam-full-$(VERSION)"
 
 build/Dockerfile.x86_64-linux: Dockerfile.in
-	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/x86_64-v$(ALPINE_VERSION)/g' -e 's/%CONF%//g' $^ >$@
+	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/x86_64-v$(ALPINE_VERSION)/g' $^ >$@
 build/Dockerfile.i686-linux: Dockerfile.in
-	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/x86-v$(ALPINE_VERSION)/g' -e 's/%CONF%/-build i586-alpine-linux-musl/g' $^ >$@
-
-# Need to lie about gnueabihf instead of musleabihf, because of a ./configure bug
+	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/x86-v$(ALPINE_VERSION)/g' $^ >$@
 build/Dockerfile.armhf-linux: Dockerfile.in
-	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/armv7-v$(ALPINE_VERSION)/g' -e 's/%CONF%//g' $^ >$@
+	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/armv7-v$(ALPINE_VERSION)/g' $^ >$@
 build/Dockerfile.arm64-linux: Dockerfile.in
-	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/arm64-v$(ALPINE_VERSION)/g' -e 's/%CONF%//g' $^ >$@
+	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/arm64-v$(ALPINE_VERSION)/g' $^ >$@
 build/Dockerfile.ppc64le-linux: Dockerfile.in
-	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/ppc64le-v$(ALPINE_VERSION)/g' -e 's/%CONF%//g' $^ >$@
+	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/ppc64le-v$(ALPINE_VERSION)/g' $^ >$@
 build/Dockerfile.s390x-linux: Dockerfile.in
-	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/s390x-v$(ALPINE_VERSION)/g' -e 's/%CONF%//g' $^ >$@
+	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/s390x-v$(ALPINE_VERSION)/g' $^ >$@
 build/Dockerfile.riscv64-linux: Dockerfile.in
-	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/riscv64-v$(ALPINE_VERSION)/g' -e 's/%CONF%//g' $^ >$@
+	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/riscv64-v$(ALPINE_VERSION)/g' $^ >$@
 
 
 build/%.image: build/Dockerfile.%

--- a/release/Makefile
+++ b/release/Makefile
@@ -50,7 +50,7 @@ build/Dockerfile.x86_64-linux: Dockerfile.in
 build/Dockerfile.i686-linux: Dockerfile.in
 	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/x86-v$(ALPINE_VERSION)/g' $^ >$@
 build/Dockerfile.armhf-linux: Dockerfile.in
-	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/armv7-v$(ALPINE_VERSION)/g' $^ >$@
+	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/armhf-v$(ALPINE_VERSION)/g' $^ >$@
 build/Dockerfile.arm64-linux: Dockerfile.in
 	mkdir -p build && sed -e "s/%OCAMLV%/$(OCAMLV)/g" -e 's/%TARGET_TAG%/arm64-v$(ALPINE_VERSION)/g' $^ >$@
 build/Dockerfile.ppc64le-linux: Dockerfile.in


### PR DESCRIPTION
While having a go at https://github.com/ocaml/opam/issues/5958 i found these quirks of the release script so i'm splitting these off first in this cleanup PR