### PR TITLE
OpamProcess.create_process_env: Fix empty argument handling when calling a Cygwin binary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -237,7 +237,7 @@ jobs:
         set Path=D:\Cache\ocaml-local\bin;%Path%
         if "${{ matrix.host }}" equ "x86_64-pc-windows" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         if "${{ matrix.host }}" equ "i686-pc-windows" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
-        opam init --yes --bare default git+file://%cd%/../../../opam-repository#${{ env.OPAM_TEST_REPO_SHA }} --no-git-location || exit /b 1
+        opam init --yes --bare -vvv default git+file://%cd%/../../../opam-repository#${{ env.OPAM_TEST_REPO_SHA }} --no-git-location || exit /b 1
         opam switch --yes create default ocaml-system || exit /b 1
         opam env || exit /b 1
         opam pin add -yn git+https://github.com/dra27/ocamlfind.git#c9efeea72743b2ff59ef67d354e0a88a08804a2c || exit /b 1

--- a/master_changes.md
+++ b/master_changes.md
@@ -25,6 +25,9 @@ users)
 ## Install
 
 ## Build (package)
+  * Fix empty argument handling when calling a Cygwin binary [#7128 @kit-ty-kate - fix #6714]
+  * Fix handling of arguments containing a backslash followed by double-quote when calling a Cygwin binary [#7128 @kit-ty-kate]
+  * Fix handling of arguments containing a double-quote as first character when calling a Cygwin binary [#7128 @kit-ty-kate]
 
 ## Remove
 
@@ -130,3 +133,6 @@ users)
 ## opam-format
 
 ## opam-core
+  * `OpamProcess.create_process_env`: Fix empty argument handling when calling a Cygwin binary [#7128 @kit-ty-kate - fix #6714]
+  * Fix handling of arguments containing a backslash followed by double-quote when calling a Cygwin binary [#7128 @kit-ty-kate]
+  * Fix handling of arguments containing a double-quote as first character when calling a Cygwin binary [#7128 @kit-ty-kate]

--- a/master_changes.md
+++ b/master_changes.md
@@ -107,6 +107,7 @@ users)
 
 ## Reftests
 ### Tests
+  * Add a test checking that empty arguments are correctly handled [#7128 @kit-ty-kate]
 
 ### Engine
 

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -70,14 +70,14 @@ let cygwin_create_process_env prog args env fd1 fd2 fd3 =
     let maybe_quote s =
       log ~level:3 "gen_quote: %S" s;
       let isquote_or_issep = function
-        (* See build_argv in newlib-cygwin's dctr0.cc *)
+        (* See build_argv in newlib-cygwin's dcrt0.cc *)
         | '"' | '\'' -> true
         (* See issep in newlib-cygwin's winsup.h *)
         | ' ' | '\t' | '\n' | '\r' -> true
         | _ -> false
       in
       let r =
-        (* See build_argv in newlib-cygwin's dctr0.cc *)
+        (* See build_argv in newlib-cygwin's dcrt0.cc *)
         if s = "" || s.[0] = '@' || OpamCompat.String.exists isquote_or_issep s
         then Filename.quote s
         else s

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -78,7 +78,7 @@ let cygwin_create_process_env prog args env fd1 fd2 fd3 =
       in
       let r =
         (* See build_argv in newlib-cygwin's dctr0.cc *)
-        if s = "" || s.[0] = '@' || String.exists isquote_or_issep s
+        if s = "" || s.[0] = '@' || OpamCompat.String.exists isquote_or_issep s
         then Filename.quote s
         else s
       in

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -68,26 +68,29 @@ let cygwin_create_process_env prog args env fd1 fd2 fd3 =
    *)
   let make_args argv =
     let maybe_quote s =
+      let filename_unix_quote s =
+        (* Taken from the unexposed OCaml's Filename.Unix.quote *)
+        let l = String.length s in
+        let b = Buffer.create (l + 20) in
+        Buffer.add_char b '\'';
+        for i = 0 to l - 1 do
+          if s.[i] = '\''
+          then Buffer.add_string b "'\\''"
+          else Buffer.add_char b s.[i]
+        done;
+        Buffer.add_char b '\'';
+        Buffer.contents b
+      in
       log ~level:3 "gen_quote: %S" s;
-      let isquote_or_issep = function
-        (* See build_argv in newlib-cygwin's dcrt0.cc *)
-        | '"' | '\'' -> true
-        (* See issep in newlib-cygwin's winsup.h *)
-        | ' ' | '\t' | '\n' | '\r' -> true
-        | _ -> false
-      in
-      let r =
-        (* See build_argv in newlib-cygwin's dcrt0.cc *)
-        if s = "" || s.[0] = '@' || OpamCompat.String.exists isquote_or_issep s
-        then Filename.quote s
-        else s
-      in
+      let r = filename_unix_quote s in
       log ~level:3 "result: %S" r;
       r
     in
-    (String.concat " " (List.map maybe_quote argv), true)
+    (String.concat " " (List.map maybe_quote argv), false)
   in
   let (command_line, no_glob) = make_args (Array.to_list args) in
+  if String.length command_line >= 32767 then
+    failwith "command line too long (>32K)";
   log "cygvoke(%sglob): %s" (if no_glob then "no" else "") command_line;
   let env = Array.to_list env in
   let cygwin_set = ref false in

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -67,48 +67,29 @@ let cygwin_create_process_env prog args env fd1 fd2 fd3 =
    * also added later to make sure the native links are used.
    *)
   let make_args argv =
-    let b = Buffer.create 128 in
-    let gen_quote ~quote ~pre ?(post = pre) s =
+    let maybe_quote s =
       log ~level:3 "gen_quote: %S" s;
-      Buffer.clear b;
-      let l = String.length s in
-      let rec f i =
-        let j =
-          try
-            OpamStd.String.find_from (fun c -> try String.index quote c >= 0 with Not_found -> false) s (succ i)
-          with Not_found ->
-            l in
-        Buffer.add_string b (String.sub s i (j - i));
-        if j < l then begin
-          Buffer.add_string b pre;
-          let i = j in
-          let j =
-            try
-              OpamStd.String.find_from (fun c -> try String.index quote c < 0 with Not_found -> true) s (succ i)
-            with Not_found ->
-              l in
-          Buffer.add_string b (String.sub s i (j - i));
-          Buffer.add_string b post;
-          if j < l then
-            f j
-          else
-            Buffer.contents b
-        end else
-          Buffer.contents b in
-      let r =
-        if s = "" then
-          "\"\""
-        else
-          f 0
+      let isquote_or_issep = function
+        (* See build_argv in newlib-cygwin's dctr0.cc *)
+        | '"' | '\'' -> true
+        (* See issep in newlib-cygwin's winsup.h *)
+        | ' ' | '\t' | '\n' | '\r' -> true
+        | _ -> false
       in
-      log ~level:3 "result: %S" r; r in
+      let r =
+        (* See build_argv in newlib-cygwin's dctr0.cc *)
+        if s = "" || s.[0] = '@' || String.exists isquote_or_issep s
+        then Filename.quote s
+        else s
+      in
+      log ~level:3 "result: %S" r;
+      r
+    in
     (* Setting noglob is causing some problems for ocamlbuild invoking Cygwin's
        find. The reason for using it is to try to keep command line lengths
        below the maximum, but for now disable the use of noglob. *)
-    if true || List.exists (fun s -> try String.index s '"' >= 0 with Not_found -> false) argv then
-      ("\"" ^ String.concat "\" \"" (List.map (gen_quote ~quote:"\"" ~pre:"\"'" ~post:"'\"") argv) ^ "\"", false)
-    else
-      (String.concat " " (List.map (gen_quote ~quote:"\b\r\n " ~pre:"\"") argv), true) in
+    (String.concat " " (List.map maybe_quote argv), false)
+  in
   let (command_line, no_glob) = make_args (Array.to_list args) in
   log "cygvoke(%sglob): %s" (if no_glob then "no" else "") command_line;
   let env = Array.to_list env in

--- a/src/core/opamProcess.ml
+++ b/src/core/opamProcess.ml
@@ -85,10 +85,7 @@ let cygwin_create_process_env prog args env fd1 fd2 fd3 =
       log ~level:3 "result: %S" r;
       r
     in
-    (* Setting noglob is causing some problems for ocamlbuild invoking Cygwin's
-       find. The reason for using it is to try to keep command line lengths
-       below the maximum, but for now disable the use of noglob. *)
-    (String.concat " " (List.map maybe_quote argv), false)
+    (String.concat " " (List.map maybe_quote argv), true)
   in
   let (command_line, no_glob) = make_args (Array.to_list args) in
   log "cygvoke(%sglob): %s" (if no_glob then "no" else "") command_line;

--- a/tests/reftests/dune.inc
+++ b/tests/reftests/dune.inc
@@ -1911,25 +1911,25 @@
    (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:pin.test} %{read-lines:testing-env}))))
 
 (rule
- (alias reftest-process-output.unix)
- (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (alias reftest-process-output)
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (action
-  (diff process-output.unix.test process-output.unix.out)))
+  (diff process-output.test process-output.out)))
 
 (alias
  (name reftest)
- (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
- (deps (alias reftest-process-output.unix)))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (deps (alias reftest-process-output)))
 
 (rule
- (targets process-output.unix.out)
+ (targets process-output.out)
  (deps root-N0REP0)
- (enabled_if (and (= %{os_type} "Unix") (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
+ (enabled_if (and  (or (<> %{env:TESTALL=1} 0) (= %{env:TESTN0REP0=0} 1))))
  (package opam)
  (action
   (with-stdout-to
    %{targets}
-   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:process-output.unix.test} %{read-lines:testing-env}))))
+   (run ./run.exe %{exe:../../src/client/opamMain.exe.exe} %{dep:process-output.test} %{read-lines:testing-env}))))
 
 (rule
  (alias reftest-rebuild)

--- a/tests/reftests/process-output.test
+++ b/tests/reftests/process-output.test
@@ -32,3 +32,37 @@ Processing  3/3: [process: true with]
 + true "with" "option" (CWD=${BASEDIR}/OPAM/outputs/.opam-switch/build/process.1)
 -> installed process.1
 Done.
+### : Check that empty argument are correctly handled
+### : as well as double-quotes and backslashes.
+### : Calling cygwin binaries on windows quotes arguments using a custom method
+### : see OpamProcess.cygwin_create_process_env
+### <pkg:process.1>
+opam-version: "2.0"
+build: [
+  ["printf" ""]
+  ["echo" "a" "" "b"]
+  ["echo" "\"x'\""]
+  ["printf" "%s" "\\\\\\\""]
+]
+### opam install process -vv -y | sed-cmd printf echo | no-replace
+The following actions will be performed:
+=== recompile 1 package
+  - recompile process 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/4: [process: printf]
++ printf "" (CWD=${BASEDIR}/OPAM/outputs/.opam-switch/build/process.1)
+- "
+Processing  2/4: [process: echo a]
++ echo "a" "" "b" (CWD=${BASEDIR}/OPAM/outputs/.opam-switch/build/process.1)
+- a " b
+Processing  2/4: [process: echo "x'"]
++ echo "\"x'\"" (CWD=${BASEDIR}/OPAM/outputs/.opam-switch/build/process.1)
+- x"'"
+Processing  2/4: [process: printf %s]
++ printf "%s" "\\\\\\\"" (CWD=${BASEDIR}/OPAM/outputs/.opam-switch/build/process.1)
+- \"'""
+-> compiled  process.1
+-> removed   process.1
+-> installed process.1
+Done.

--- a/tests/reftests/process-output.test
+++ b/tests/reftests/process-output.test
@@ -52,16 +52,15 @@ The following actions will be performed:
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Processing  2/4: [process: printf]
 + printf "" (CWD=${BASEDIR}/OPAM/outputs/.opam-switch/build/process.1)
-- "
 Processing  2/4: [process: echo a]
 + echo "a" "" "b" (CWD=${BASEDIR}/OPAM/outputs/.opam-switch/build/process.1)
-- a " b
+- a  b
 Processing  2/4: [process: echo "x'"]
 + echo "\"x'\"" (CWD=${BASEDIR}/OPAM/outputs/.opam-switch/build/process.1)
-- x"'"
+- "x'"
 Processing  2/4: [process: printf %s]
 + printf "%s" "\\\\\\\"" (CWD=${BASEDIR}/OPAM/outputs/.opam-switch/build/process.1)
-- \"'""
+- \\\"
 -> compiled  process.1
 -> removed   process.1
 -> installed process.1

--- a/tests/reftests/run.ml
+++ b/tests/reftests/run.ml
@@ -144,11 +144,11 @@ let escape_regexps s =
     ) s;
   Buffer.contents buf
 
-let str_replace_path ?escape ?(wrap_whole_path=true) whichway filters s =
+let str_replace_path ?escape ?(wrap_whole_path=true) ?(no_replace=false) whichway filters s =
   let s =
     match escape with
-    | Some `Unescape -> Re.(replace_string (compile @@ str "\\\\") ~by:"\\" s)
-    | Some (`Backslashes | `Regexps) | None -> s
+    | Some `Unescape when not no_replace -> Re.(replace_string (compile @@ str "\\\\") ~by:"\\" s)
+    | Some (`Backslashes | `Regexps | `Unescape) | None -> s
   in
   let escape_backslashes =
     match escape with
@@ -185,7 +185,7 @@ let filters_of_var =
 
 let command
     ?(allowed_codes = [0]) ?(vars=[]) ?(silent=false) ?(filter=[]) ?(sort=false)
-    ?(background=false)
+    ?(background=false) ?(no_replace=false)
     cmd args =
   let env =
     Array.of_list @@
@@ -222,7 +222,7 @@ let command
     match input_line ic with
     | s ->
       let s =
-        str_replace_path ~escape:`Unescape OpamSystem.back_to_forward filter s
+        str_replace_path ~escape:`Unescape ~no_replace OpamSystem.back_to_forward filter s
       in
       if s = "\\c" then filter_output out_buf ic
       else
@@ -329,7 +329,8 @@ type command =
              filter: filter;
              output: string option;
              unordered: bool;
-             sort: bool;}
+             sort: bool;
+             no_replace: bool; }
   | Set_os of string
   | Http_server
   | Export of (string * [`eq | `pluseq | `eqplus] * string) list
@@ -441,21 +442,23 @@ module Parse = struct
           failwith (Printf.sprintf "Bad POSIX regexp: %s" re)
       in
       let rec get_args_rewr acc = function
-        | [] -> List.rev acc, false, false, [], None
+        | [] -> List.rev acc, false, false, false, [], None
         | ("|"|">$") :: _ as rewr ->
-          let rec get_rewr (unordered, sort, acc) = function
+          let rec get_rewr (unordered, sort, no_replace, acc) = function
             | "|" :: re :: "->" :: str :: r ->
-              get_rewr (unordered, sort, (posix_re re, Sed (get_str str)) :: acc) r
+              get_rewr (unordered, sort, no_replace, (posix_re re, Sed (get_str str)) :: acc) r
             | "|" :: "grep" :: "-v" :: re :: r ->
-              get_rewr (unordered, sort, (posix_re re, GrepV) :: acc) r
+              get_rewr (unordered, sort, no_replace, (posix_re re, GrepV) :: acc) r
             | "|" :: "grep" :: re :: r ->
-              get_rewr (unordered, sort, (posix_re re, Grep) :: acc) r
+              get_rewr (unordered, sort, no_replace, (posix_re re, Grep) :: acc) r
             | "|" :: "sort" :: r ->
               if acc <> [] then
                 Printf.printf "Warning: sort should appear _before_ any filters\n%!";
-              get_rewr (unordered, true, acc) r
+              get_rewr (unordered, true, no_replace, acc) r
             | "|" :: "unordered" :: r ->
-              get_rewr (true, sort, acc) r
+              get_rewr (true, sort, no_replace, acc) r
+            | "|" :: "no-replace" :: r ->
+              get_rewr (unordered, sort, true, acc) r
             | "|" :: "sed-cmd" :: cmd :: r ->
               let sandbox cmd =
                 (* Sandbox prefix
@@ -524,7 +527,7 @@ module Parse = struct
                 | cmd :: r -> aux cmd r acc
               in
               let acc, r = aux cmd r acc in
-              get_rewr (unordered, sort, acc) r
+              get_rewr (unordered, sort, no_replace, acc) r
             | "|" :: "sed-hash" :: hash :: r ->
               let length = String.length hash in
               if hash.[0] <> '$'
@@ -536,7 +539,7 @@ module Parse = struct
                    "Bad 'sed-hash' argument (%s), expecting a environment \
                     variable beginning with '$' or a hash of 32, 64, \
                     or 128 characters" hash;
-                 unordered, sort, List.rev acc, None)
+                 unordered, sort, no_replace, List.rev acc, None)
               else
                 let name, r =
                   match r with
@@ -562,22 +565,22 @@ module Parse = struct
                 let acc = (pre_hash, Sed ("/pre/"^name))::acc in
                 let acc = (re_hash, Sed name)::acc in
                 let acc = (pre, Sed "/pre")::acc in
-                get_rewr (unordered, sort, acc) r
+                get_rewr (unordered, sort, no_replace, acc) r
             | ">$" :: output :: [] ->
-              unordered, sort, List.rev acc, Some (get_str output)
+              unordered, sort, no_replace, List.rev acc, Some (get_str output)
             | [] ->
-              unordered, sort, List.rev acc, None
+              unordered, sort, no_replace, List.rev acc, None
             | r ->
               Printf.printf
                 "Bad rewrite %S, expecting '| RE -> STR' or '>$ VAR'\n%!"
                 (String.concat " " r);
-              unordered, sort, List.rev acc, None
+              unordered, sort, no_replace, List.rev acc, None
           in
-          let unordered, sort, rewr, out = get_rewr (false, false, []) rewr in
-          List.rev acc, unordered, sort, rewr, out
+          let unordered, sort, no_replace, rewr, out = get_rewr (false, false, false, []) rewr in
+          List.rev acc, unordered, sort, no_replace, rewr, out
         | arg :: r -> get_args_rewr (arg :: acc) r
       in
-      let args, unordered, sort, rewr, output = get_args_rewr [] args in
+      let args, unordered, sort, no_replace, rewr, output = get_args_rewr [] args in
       match cmd with
       | Some "opam-cat" ->
         Opamfile { files = args; filter = rewr; }
@@ -633,6 +636,7 @@ module Parse = struct
           output;
           unordered;
           sort;
+          no_replace;
         }
       | None ->
         Export varbinds
@@ -759,7 +763,7 @@ let common_filters ?opam dir =
    | None -> []
    | Some opam -> [ str opam.as_seen_in_opam, Sed "${OPAM}" ])
 
-let run_cmd ~opam ~dir ?(vars=[]) ?(filter=[]) ?(silent=false) ?(sort=false) cmd args =
+let run_cmd ~opam ~dir ?(vars=[]) ?(filter=[]) ?(silent=false) ?(sort=false) ?(no_replace=false) cmd args =
   let filter = filter @ common_filters ~opam dir in
   let var_filters = filters_of_var vars in
   let cmd = if cmd = "opam" then opam.as_called else cmd in
@@ -774,7 +778,7 @@ let run_cmd ~opam ~dir ?(vars=[]) ?(filter=[]) ?(silent=false) ?(sort=false) cmd
         Parse.get_str expanded)
       args
   in
-  try command ~vars ~filter ~silent ~sort cmd args, None
+  try command ~vars ~filter ~silent ~sort ~no_replace cmd args, None
   with Command_failure (n,_, out) -> out, Some n
 
 let write_file ~path ~contents =
@@ -1314,10 +1318,10 @@ let run_test ?(vars=[]) ~opam t =
                     in
                     print_file ~filters:(filter @ common_filters dir) files));
           vars
-        | Run {env; cmd; args; filter; output; unordered; sort} ->
+        | Run {env; cmd; args; filter; output; unordered; sort; no_replace} ->
           let silent = output <> None || unordered in
           let r, errcode =
-            run_cmd ~opam ~dir ~vars:(vars @ env) ~filter ~silent ~sort cmd args
+            run_cmd ~opam ~dir ~vars:(vars @ env) ~filter ~silent ~sort ~no_replace cmd args
           in
           (if unordered then
              (* print lines from Result, but respecting order from Expect *)


### PR DESCRIPTION
Fixes #6714 
Tested locally successfully