### PR TITLE
Stop opening tar.gz repositories during installation unless necessary

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -93,6 +93,7 @@ users)
 ## Shell
 
 ## Internal
+  * Add a debug log upon reading an archive [#7131 @kit-ty-kate]
 
 ## Internal: Unix
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -104,6 +104,7 @@ users)
 
 ## Reftests
 ### Tests
+  * Add a test showing the internal actions of `opam install` when installing packages from an http repository [#7131 @kit-ty-kate]
 
 ### Engine
 

--- a/master_changes.md
+++ b/master_changes.md
@@ -23,6 +23,7 @@ users)
 ## Actions
 
 ## Install
+  * Fix a 2.6 performance regression where tar.gz repositories were read entirely twice per package installed [#7131 @kit-ty-kate]
 
 ## Build (package)
 

--- a/src/format/opamFile.ml
+++ b/src/format/opamFile.ml
@@ -3682,31 +3682,31 @@ module OPAM = struct
 
   let get_extra_files ~get_repo_files o =
     let open OpamFilename.Op in
-    let open OpamStd.Option.Op in
-    (match metadata_dir o with
-     | None -> None
-     | Some (None, abs) ->
-       let files_dir = OpamFilename.Dir.of_string abs / OpamPathName.files_d in
-       extra_files o >>| List.map @@ fun (basename, hash) ->
-       let content =
-         let f = OpamFilename.create files_dir basename in
-         if OpamFilename.exists f then
-           Some (lazy (OpamFilename.read f))
-         else
-           None
-       in
-       (basename, content, hash)
-     | Some (Some r, rel) ->
-       let files =
-         get_repo_files r
-           (rel ^ Filename.dir_sep ^ OpamRepositoryPathName.files_d)
-       in
-       extra_files o >>| List.map @@ fun (basename, hash) ->
-       let content =
-         OpamStd.List.assoc_opt OpamFilename.Base.equal basename files
-       in
-       (basename, content, hash))
-    +! []
+    match extra_files o, metadata_dir o with
+    | (None | Some []), _ | _, None -> []
+    | Some extra_files, Some (None, abs) ->
+      let files_dir = OpamFilename.Dir.of_string abs / OpamPathName.files_d in
+      List.map (fun (basename, hash) ->
+          let content =
+            let f = OpamFilename.create files_dir basename in
+            if OpamFilename.exists f then
+              Some (lazy (OpamFilename.read f))
+            else
+              None
+          in
+          (basename, content, hash))
+        extra_files
+    | Some extra_files, Some (Some r, rel) ->
+      let files =
+        get_repo_files r
+          (rel ^ Filename.dir_sep ^ OpamRepositoryPathName.files_d)
+      in
+      List.map (fun (basename, hash) ->
+          let content =
+            OpamStd.List.assoc_opt OpamFilename.Base.equal basename files
+          in
+          (basename, content, hash))
+        extra_files
 
   let print_errors ?file o =
     if o.format_errors <> [] then

--- a/src/repository/opamTar.ml
+++ b/src/repository/opamTar.ml
@@ -94,7 +94,9 @@ let fold_reg_files_aux archive f acc fd =
   run archive fd (Tar_gz.in_gzipped (Tar.fold go acc))
 
 let fold_reg_files f acc archive =
-  let fd = Unix.openfile (OpamFilename.to_string archive) [Unix.O_RDONLY] 0 in
+  let archive_str = OpamFilename.to_string archive in
+  log "Open archive %s" archive_str;
+  let fd = Unix.openfile archive_str [Unix.O_RDONLY] 0 in
   Fun.protect ~finally:(fun () -> Unix.close fd) @@ fun () ->
   fold_reg_files_aux archive f acc fd
 

--- a/tests/reftests/repository-http.test
+++ b/tests/reftests/repository-http.test
@@ -364,12 +364,10 @@ The following actions will be performed:
   - install to-install 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Processing  2/3: [to-install: true]
 + true (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/to-install.1)
 -> compiled  to-install.1
 -> installed to-install.1
-TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Done.
 ### opam install extra-files-no-field | sed-cmd test
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -380,12 +378,10 @@ The following actions will be performed:
   - install extra-files-no-field 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Processing  2/3: [extra-files-no-field: test !]
 + test "!" "-f" "some-file" (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/extra-files-no-field.1)
 -> compiled  extra-files-no-field.1
 -> installed extra-files-no-field.1
-TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Done.
 ### opam install extra-files-legacy-no-field | sed-cmd test
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -396,7 +392,6 @@ The following actions will be performed:
   - install extra-files-legacy-no-field 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Processing  2/3: [extra-files-legacy-no-field: test some-file]
 + test "-f" "some-file" (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/extra-files-legacy-no-field.1)
 [ERROR] The compilation of extra-files-legacy-no-field.1 failed at "test -f some-file".

--- a/tests/reftests/repository-http.test
+++ b/tests/reftests/repository-http.test
@@ -266,4 +266,158 @@ empat   --
 enam    --
 lima    --
 satu    --
+### :VII: Install packages from http repository and extra files handling
+### <repo>
+opam-version: "1.2"
+### <packages/to-install.1/opam>
+opam-version: "2.0"
+build: "true"
+### <packages/extra-files-no-field.1/opam>
+opam-version: "2.0"
+build: [
+  ["test" "!" "-f" "some-file"]
+]
+### <packages/extra-files-no-field.1/files/some-file>
+some file
+### <packages/extra-files-legacy-no-field.1/opam>
+opam-version: "1.2"
+build: [
+  ["test" "-f" "some-file"]
+]
+### <packages/extra-files-legacy-no-field.1/files/some-file>
+some file
+### <packages/extra-files-with-field.1/opam>
+opam-version: "2.0"
+build: [
+  ["test" "-f" "some-file"]
+  ["test" "!" "-f" "some-other-file"]
+]
+### <packages/extra-files-with-field.1/files/some-file>
+some file
+### <packages/extra-files-with-field.1/files/some-other-file>
+some unlisted file
+### <packages/extra-files-legacy-with-field.1/opam>
+opam-version: "1.2"
+build: [
+  ["test" "-f" "some-file"]
+  ["test" "-f" "some-other-file"]
+]
+### <packages/extra-files-legacy-with-field.1/files/some-file>
+some file
+### <packages/extra-files-legacy-with-field.1/files/some-other-file>
+some unlisted file
+### openssl md5 packages/extra-files-no-field.1/files/some-file | '.*= ' -> '' >$ XMD5
+### <extrafile.sh>
+#!/bin/sh
+set -eu
+cat >> "$1" << EOF
+extra-files: ["some-file" "md5=$XMD5"]
+EOF
+### sh extrafile.sh packages/extra-files-with-field.1/opam
+### sh extrafile.sh packages/extra-files-legacy-with-field.1/opam
+### opam admin index
+[WARNING] The repository is at version 1.2, please consider upgrading to 2.0 with 'opam admin upgrade'
+Generating urls.txt...
+Generating index.tar.gz...
+Done.
+### sh remove-timestamp.sh
+### opam update http-repo | "${HTTPSERVERPORT}" -> "port"
+
+<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
+[http-repo] synchronised from http://localhost:port
+Now run 'opam upgrade' to apply any package updates.
+### opam switch create install --empty
+### OPAMDEBUGSECTIONS="TAR RSTATE REPOSITORY REPO_BACKEND UPDATE" OPAMDEBUG=-3 OPAMVERBOSE=2
+### opam install to-install | sed-cmd true
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+The following actions will be performed:
+=== install 1 package
+  - install to-install 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/3: [to-install: true]
++ true (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/to-install.1)
+-> compiled  to-install.1
+-> installed to-install.1
+Done.
+### opam install extra-files-no-field | sed-cmd test
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+The following actions will be performed:
+=== install 1 package
+  - install extra-files-no-field 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/3: [extra-files-no-field: test !]
++ test "!" "-f" "some-file" (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/extra-files-no-field.1)
+-> compiled  extra-files-no-field.1
+-> installed extra-files-no-field.1
+Done.
+### opam install extra-files-legacy-no-field | sed-cmd test
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+The following actions will be performed:
+=== install 1 package
+  - install extra-files-legacy-no-field 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/3: [extra-files-legacy-no-field: test some-file]
++ test "-f" "some-file" (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/extra-files-legacy-no-field.1)
+[ERROR] The compilation of extra-files-legacy-no-field.1 failed at "test -f some-file".
+
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - build extra-files-legacy-no-field 1
++- 
+- No changes have been performed
+'${OPAM} install extra-files-legacy-no-field' failed.
+# Return code 31 #
+### opam install extra-files-with-field | sed-cmd test
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+The following actions will be performed:
+=== install 1 package
+  - install extra-files-with-field 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/3: [extra-files-with-field: test some-file]
++ test "-f" "some-file" (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/extra-files-with-field.1)
+Processing  2/3: [extra-files-with-field: test !]
++ test "!" "-f" "some-other-file" (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/extra-files-with-field.1)
+-> compiled  extra-files-with-field.1
+-> installed extra-files-with-field.1
+Done.
+### opam install extra-files-legacy-with-field | sed-cmd test
+FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
+RSTATE                          Cache found
+The following actions will be performed:
+=== install 1 package
+  - install extra-files-legacy-with-field 1
+
+<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+Processing  2/3: [extra-files-legacy-with-field: test some-file]
++ test "-f" "some-file" (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/extra-files-legacy-with-field.1)
+Processing  2/3: [extra-files-legacy-with-field: test some-other-file]
++ test "-f" "some-other-file" (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/extra-files-legacy-with-field.1)
+[ERROR] The compilation of extra-files-legacy-with-field.1 failed at "test -f some-other-file".
+
+
+
+
+<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
++- The following actions failed
+| - build extra-files-legacy-with-field 1
++- 
+- No changes have been performed
+'${OPAM} install extra-files-legacy-with-field' failed.
+# Return code 31 #
 [[[Killing micro_httpd]]]

--- a/tests/reftests/repository-http.test
+++ b/tests/reftests/repository-http.test
@@ -49,9 +49,12 @@ Processing  1/1: [http-repo: http]
 curl-or-wget -- "http://localhost:port/index.tar.gz"
 REPOSITORY                      http-repo: applying update from scratch at ${BASEDIR}/OPAM/repo/http-repo.tar.gz.new
 [http-repo] Initialised
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 UPDATE                          Repository has new changes
 Processing: [http-repo: loading data]
 RSTATE                          load repo http-repo from tgz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 ### unset OPAMDEBUGSECTIONS
 ### unset OPAMDEBUG
 ### unset OPAMVERBOSE
@@ -86,14 +89,20 @@ RSTATE                          Cache found
 REPOSITORY                      update http-repo from http://localhost:port
 Processing  1/1: [http-repo: http]
 curl-or-wget -- "http://localhost:port/index.tar.gz"
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 REPO_BACKEND                    diff: ${BASEDIR}/OPAM/repo/{http-repo.tar.gz,http-repo.tar.gz.new}
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz.new
 REPO_BACKEND                    Internal diff (non-empty, 3 changed files) done in 0.00s.
 [http-repo] synchronised from http://localhost:port
 REPOSITORY                      http-repo: applying patch update at ${BASEDIR}/OPAM/log/patch-xxx
 TAR                             Writing archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 UPDATE                          Repository has new changes
 Processing: [http-repo: loading data]
 RSTATE                          load repo http-repo from diff
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Now run 'opam upgrade' to apply any package updates.
 ### unset OPAMDEBUGSECTIONS
 ### unset OPAMDEBUG
@@ -125,14 +134,20 @@ RSTATE                          Cache found
 REPOSITORY                      update http-repo from http://localhost:port
 Processing  1/1: [http-repo: http]
 curl-or-wget -- "http://localhost:port/index.tar.gz"
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 REPO_BACKEND                    diff: ${BASEDIR}/OPAM/repo/{http-repo.tar.gz,http-repo.tar.gz.new}
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz.new
 REPO_BACKEND                    Internal diff (non-empty, 1 changed files) done in 0.00s.
 [http-repo] synchronised from http://localhost:port
 REPOSITORY                      http-repo: applying patch update at ${BASEDIR}/OPAM/log/patch-xxx
 TAR                             Writing archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 UPDATE                          Repository has new changes
 Processing: [http-repo: loading data]
 RSTATE                          load repo http-repo from diff
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Now run 'opam upgrade' to apply any package updates.
 ### unset OPAMDEBUGSECTIONS
 ### unset OPAMDEBUG
@@ -165,14 +180,20 @@ RSTATE                          Cache found
 REPOSITORY                      update http-repo from http://localhost:port
 Processing  1/1: [http-repo: http]
 curl-or-wget -- "http://localhost:port/index.tar.gz"
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 REPO_BACKEND                    diff: ${BASEDIR}/OPAM/repo/{http-repo.tar.gz,http-repo.tar.gz.new}
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz.new
 REPO_BACKEND                    Internal diff (non-empty, 1 changed files) done in 0.00s.
 [http-repo] synchronised from http://localhost:port
 REPOSITORY                      http-repo: applying patch update at ${BASEDIR}/OPAM/log/patch-xxx
 TAR                             Writing archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 UPDATE                          Repository has new changes
 Processing: [http-repo: loading data]
 RSTATE                          load repo http-repo from diff
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 ### unset OPAMDEBUGSECTIONS
 ### unset OPAMDEBUG
 ### unset OPAMVERBOSE
@@ -245,14 +266,20 @@ TAR                             Writing archive ${BASEDIR}/OPAM/repo/http-repo.t
 REPOSITORY                      update http-repo from http://localhost:port
 Processing  1/1: [http-repo: http]
 curl-or-wget -- "http://localhost:port/index.tar.gz"
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 REPO_BACKEND                    diff: ${BASEDIR}/OPAM/repo/{http-repo.tar.gz,http-repo.tar.gz.new}
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz.new
 REPO_BACKEND                    Internal diff (non-empty, 4 changed files) done in 0.00s.
 [http-repo] synchronised from http://localhost:port
 REPOSITORY                      http-repo: applying patch update at ${BASEDIR}/OPAM/log/patch-xxx
 TAR                             Writing archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 UPDATE                          Repository has new changes
 Processing: [http-repo: loading data]
 RSTATE                          load repo http-repo from diff
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Now run 'opam upgrade' to apply any package updates.
 ### unset OPAMDEBUGSECTIONS
 ### unset OPAMDEBUG
@@ -337,10 +364,12 @@ The following actions will be performed:
   - install to-install 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Processing  2/3: [to-install: true]
 + true (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/to-install.1)
 -> compiled  to-install.1
 -> installed to-install.1
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Done.
 ### opam install extra-files-no-field | sed-cmd test
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -351,10 +380,12 @@ The following actions will be performed:
   - install extra-files-no-field 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Processing  2/3: [extra-files-no-field: test !]
 + test "!" "-f" "some-file" (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/extra-files-no-field.1)
 -> compiled  extra-files-no-field.1
 -> installed extra-files-no-field.1
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Done.
 ### opam install extra-files-legacy-no-field | sed-cmd test
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -365,6 +396,7 @@ The following actions will be performed:
   - install extra-files-legacy-no-field 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Processing  2/3: [extra-files-legacy-no-field: test some-file]
 + test "-f" "some-file" (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/extra-files-legacy-no-field.1)
 [ERROR] The compilation of extra-files-legacy-no-field.1 failed at "test -f some-file".
@@ -388,12 +420,14 @@ The following actions will be performed:
   - install extra-files-with-field 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Processing  2/3: [extra-files-with-field: test some-file]
 + test "-f" "some-file" (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/extra-files-with-field.1)
 Processing  2/3: [extra-files-with-field: test !]
 + test "!" "-f" "some-other-file" (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/extra-files-with-field.1)
 -> compiled  extra-files-with-field.1
 -> installed extra-files-with-field.1
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Done.
 ### opam install extra-files-legacy-with-field | sed-cmd test
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -404,6 +438,7 @@ The following actions will be performed:
   - install extra-files-legacy-with-field 1
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+TAR                             Open archive ${BASEDIR}/OPAM/repo/http-repo.tar.gz
 Processing  2/3: [extra-files-legacy-with-field: test some-file]
 + test "-f" "some-file" (CWD=${BASEDIR}/OPAM/install/.opam-switch/build/extra-files-legacy-with-field.1)
 Processing  2/3: [extra-files-legacy-with-field: test some-other-file]

--- a/tests/reftests/repository.test
+++ b/tests/reftests/repository.test
@@ -39,6 +39,11 @@ some content
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS=TAR opam update default | grep TAR
 TAR                             creating archive ${BASEDIR}/OPAM/repo/default.tar.gz from ${BASEDIR}/OPAM/repo/default
 TAR                             creating archive ${BASEDIR}/OPAM/repo/default.tar.gz.new from ${BASEDIR}/REPO
+TAR                             Open archive ${BASEDIR}/OPAM/repo/default.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/default.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/default.tar.gz.new
+TAR                             Open archive ${BASEDIR}/OPAM/repo/default.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/default.tar.gz
 ### ls $OPAMROOT/repo
 default.tar.gz
 lock
@@ -76,6 +81,11 @@ some content
 ### sh hash.sh REPO foo.4
 ### OPAMDEBUG=-1 OPAMDEBUGSECTIONS=TAR opam update -vv | grep '^(\+|TAR)' | sed-cmd tar
 TAR                             creating archive ${BASEDIR}/OPAM/repo/tarred.tar.gz.new from ${BASEDIR}/REPO
+TAR                             Open archive ${BASEDIR}/OPAM/repo/tarred.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/tarred.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/tarred.tar.gz.new
+TAR                             Open archive ${BASEDIR}/OPAM/repo/tarred.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/tarred.tar.gz
 ### opam install foo.4 -vv | grep '^\+' | sed-cmd test tar
 + test "-f" "baz" (CWD=${BASEDIR}/OPAM/tarring/.opam-switch/build/foo.4)
 ### mkdir tarred-ext
@@ -1041,9 +1051,11 @@ TAR                             creating archive ${BASEDIR}/OPAM/repo/changes.ta
 TAR                             Writing archive ${BASEDIR}/OPAM/repo/changes.tar.gz.new
 REPOSITORY                      changes: applying update from scratch at ${BASEDIR}/OPAM/repo/changes.tar.gz.new
 [changes] Initialised
+TAR                             Open archive ${BASEDIR}/OPAM/repo/changes.tar.gz
 UPDATE                          Repository has new changes
 Processing: [changes: loading data]
 RSTATE                          load repo changes from tgz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/changes.tar.gz
 ### test -d OPAM/repo/changes
 # Return code 1 #
 ### test -d OPAM/repo/changes/.git
@@ -1165,9 +1177,11 @@ TAR                             creating archive ${BASEDIR}/OPAM/repo/changes.ta
 TAR                             Writing archive ${BASEDIR}/OPAM/repo/changes.tar.gz.new
 REPOSITORY                      changes: applying update from scratch at ${BASEDIR}/OPAM/repo/changes.tar.gz.new
 [changes] Initialised
+TAR                             Open archive ${BASEDIR}/OPAM/repo/changes.tar.gz
 UPDATE                          Repository has new changes
 Processing: [changes: loading data]
 RSTATE                          load repo changes from tgz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/changes.tar.gz
 ### test -f OPAM/repo/changes.tar.gz
 ### opam reinstall sin
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -1178,8 +1192,10 @@ The following actions will be performed:
   - recompile sin 2
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+TAR                             Open archive ${BASEDIR}/OPAM/repo/changes.tar.gz
 -> removed   sin.2
 -> installed sin.2
+TAR                             Open archive ${BASEDIR}/OPAM/repo/changes.tar.gz
 Done.
 ### :: git - local tarred * changes
 ### OPAMREPOSITORYTARRING=1
@@ -1202,14 +1218,19 @@ TAR                             Writing archive ${BASEDIR}/OPAM/repo/changes.tar
 REPOSITORY                      update changes from file://${BASEDIR}/CHG
 TAR                             creating archive ${BASEDIR}/OPAM/repo/changes.tar.gz.new from ${BASEDIR}/CHG
 TAR                             Writing archive ${BASEDIR}/OPAM/repo/changes.tar.gz.new
+TAR                             Open archive ${BASEDIR}/OPAM/repo/changes.tar.gz
 REPO_BACKEND                    diff: ${BASEDIR}/OPAM/repo/{changes.tar.gz,changes.tar.gz.new}
+TAR                             Open archive ${BASEDIR}/OPAM/repo/changes.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/changes.tar.gz.new
 REPO_BACKEND                    Internal diff (non-empty, 2 changed files) done in 0.00s.
 [changes] synchronised from file://${BASEDIR}/CHG
 REPOSITORY                      changes: applying patch update at ${BASEDIR}/OPAM/log/patch-xxx
 TAR                             Writing archive ${BASEDIR}/OPAM/repo/changes.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/changes.tar.gz
 UPDATE                          Repository has new changes
 Processing: [changes: loading data]
 RSTATE                          load repo changes from diff
+TAR                             Open archive ${BASEDIR}/OPAM/repo/changes.tar.gz
 Now run 'opam upgrade' to apply any package updates.
 ### test -d OPAM/repo/changes
 # Return code 1 #
@@ -1225,7 +1246,9 @@ The following actions will be performed:
   - install krad 3
 
 <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+TAR                             Open archive ${BASEDIR}/OPAM/repo/changes.tar.gz
 -> installed krad.3
+TAR                             Open archive ${BASEDIR}/OPAM/repo/changes.tar.gz
 Done.
 ### :: local dir - git * no changes
 ### OPAMREPOSITORYTARRING=0
@@ -1449,9 +1472,11 @@ TAR                             creating archive ${BASEDIR}/OPAM/repo/changes.ta
 TAR                             Writing archive ${BASEDIR}/OPAM/repo/changes.tar.gz.new
 REPOSITORY                      changes: applying update from scratch at ${BASEDIR}/OPAM/repo/changes.tar.gz.new
 [changes] Initialised
+TAR                             Open archive ${BASEDIR}/OPAM/repo/changes.tar.gz
 UPDATE                          Repository has new changes
 Processing: [changes: loading data]
 RSTATE                          load repo changes from tgz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/changes.tar.gz
 ### test -d OPAM/repo/changes
 # Return code 1 #
 ### test -d OPAM/repo/changes/.git
@@ -1488,6 +1513,7 @@ old-tarred/repo
 ### # We need to grep over SUCCESS because of sandbox re enabled on format upgrade reinit, see #6968
 ### opam repo add empty-r ./empty-repo | sed-cmd tar | grep -v SUCCESS | grep -v 'cygpath\.exe' | grep -v 'cygwin'
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+TAR                             Open archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz
 FMT_UPG                         Hard config upgrade, from 2.5.0 to 2.6~alpha
 This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.5.0 to version 2.6~alpha, which can't be reverted.
 You may want to back it up before going further.
@@ -1504,13 +1530,18 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          No cache found
 Processing: [old-tarred: loading data]
 RSTATE                          load repo old-tarred from tgz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz
 RSTATE                          read repo
 RSTATE                          loaded opam files from repo old-tarred in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 TAR                             creating archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz.new from ${BASEDIR}/old-tarred
 TAR                             Writing archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz.new
+TAR                             Open archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz.new
 [old-tarred] no changes from file://${BASEDIR}/old-tarred
+TAR                             Open archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz
 Update done, please now retry your command.
 # Return code 10 #
 ### tar tf OPAM/repo/old-tarred.tar.gz | grep repo
@@ -1542,7 +1573,9 @@ RSTATE                          loaded opam files from repo old-tarred in 0.000s
 TAR                             creating archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz.new from ${BASEDIR}/old-tarred
 TAR                             Writing archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz.new
 [old-tarred] Initialised
+TAR                             Open archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz
 RSTATE                          load repo old-tarred from tgz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz
 RSTATE                          read repo
 ### opam switch create empty --empty
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
@@ -1558,6 +1591,7 @@ opam-root-version: "2.5.0"
 old-tarred/repo
 ### opam update | sed-cmd tar | grep -v SUCCESS | grep -v 'cygpath\.exe' | grep -v 'cygwin'
 FILE(config)                    Read ${BASEDIR}/OPAM/config in 0.000s
+TAR                             Open archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz
 FMT_UPG                         Hard config upgrade, from 2.5.0 to 2.6~alpha
 This version of opam requires an update to the layout of ${BASEDIR}/OPAM from version 2.5.0 to version 2.6~alpha, which can't be reverted.
 You may want to back it up before going further.
@@ -1574,13 +1608,18 @@ RSTATE                          LOAD-REPOSITORY-STATE @ ${BASEDIR}/OPAM
 RSTATE                          No cache found
 Processing: [old-tarred: loading data]
 RSTATE                          load repo old-tarred from tgz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz
 RSTATE                          read repo
 RSTATE                          loaded opam files from repo old-tarred in 0.000s
 
 <><> Updating repositories ><><><><><><><><><><><><><><><><><><><><><><><><><><>
 TAR                             creating archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz.new from ${BASEDIR}/old-tarred
 TAR                             Writing archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz.new
+TAR                             Open archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz
+TAR                             Open archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz.new
 [old-tarred] no changes from file://${BASEDIR}/old-tarred
+TAR                             Open archive ${BASEDIR}/OPAM/repo/old-tarred.tar.gz
 Update done, please now retry your command.
 # Return code 10 #
 ### tar tf OPAM/repo/old-tarred.tar.gz | grep repo


### PR DESCRIPTION
During installation opam will want to copy extra-files. However since opam 2.3 (https://github.com/ocaml/opam/pull/5564), extra-files is no longer an optional field whose content would be automatically concatenated with whatever is in the files/ directory so we can simply trust that an empty extra-files field means we don't have to look into that directory.

Looking into that directory is only required in 1.x to 2.0 file format upgrades which should update the extra-files field anyway. However while testing with opam 2.5, this isn't the case anyway so we are all good.
This might be a regression from 2.3 and can be delt with later.

Avoiding a complete tar.gz read twice per package installed improves performance of installs by at least 500ms per package.